### PR TITLE
feat(serve): Mobile Deck Studio P2 — structural editing (insert/delete/move)

### DIFF
--- a/changelog.d/395-mobile-deck-studio-p2.added.md
+++ b/changelog.d/395-mobile-deck-studio-p2.added.md
@@ -1,0 +1,8 @@
+- **Mobile Deck Studio P2 — structural editing.** The phone authoring surface
+  (`clm serve --spec`) gained **insert**, **delete**, and **move/reorder** of
+  cells, with automatic `slide_id` minting (or inheriting an anchor slide's id
+  for companion `notes`/`voiceover` cells). All structural writes route through
+  the same byte-exact serializer as cell edits, so untouched cells never shift,
+  and stay guarded by optimistic concurrency (`409` on a stale `deck_version`).
+  The UI adds a reorder mode (up/down chevrons) plus per-cell insert/delete
+  controls. (#395)

--- a/docs/claude/design/mobile-deck-studio.md
+++ b/docs/claude/design/mobile-deck-studio.md
@@ -1,9 +1,10 @@
 # Mobile Deck Studio — authoring a course from a phone
 
-> **Status:** plan of record. **P0 + P1 implemented** (read-only browse +
-> the cell-editing concurrency core); P2–P4 not yet implemented. Chosen over
-> the `clm edit` prototype (PR #394, closed as superseded). See §9 for the
-> decision record, implementation steering notes, and the P0/P1 build record.
+> **Status:** plan of record. **P0 + P1 + P2 implemented** (read-only browse,
+> the cell-editing concurrency core, and structural insert/delete/move with
+> id-minting); P3–P4 not yet implemented. Chosen over the `clm edit` prototype
+> (PR #394, closed as superseded). See §9 for the decision record, steering
+> notes, and the P0/P1 and P2 build records.
 > **Date:** 2026-06-20.
 > **Author:** design draft, worked through interactively.
 > **Scope:** a new **Studio** view on the existing `clm serve` web app
@@ -228,7 +229,7 @@ structural op. No naïve whole-file re-emit.
 |---|---|
 | **P0** ✅ | `clm serve` **Studio view** + Tailscale-HTTPS / QR / token auth scaffold; navigation (Recents, search, tree with badges, "Not in spec"); open a deck; **read-only** cell render (client markdown + server-side `is_j2` render); full-text search. Reuses `parse_cells`, `course decks`/`orphans`, `slides search`. No writes. *(Implemented — `is_j2` server render scaffolded; see §9.6.)* |
 | **P1** ✅ | **Cell body/tag editing** + the **concurrency core**: optimistic `deck_version` + `cell_hash` (409/423), atomic `FileState` write-back, `watchfiles` external-change watcher, autosave + 409/disk-change UX. The safety keystone — built and tested first. *(Implemented; 423 language-lock deferred to P3 — see §9.6.)* |
-| **P2** | **Structural ops** (`insert` / `delete` / `move` / mint-id) via the byte-exact serializer; reorder mode in the UI; byte-exact untouched-cell tests. |
+| **P2** ✅ | **Structural ops** (`insert` / `delete` / `move` / mint-id) via the byte-exact serializer; reorder mode in the UI; byte-exact untouched-cell tests. *(Implemented — see §9.7.)* |
 | **P3** | **Bilingual**: language-view + watermark-derived lock + Discard/unlock + **Sync-to-other-language** (server-side `sync` / `translate` / `assign-ids`, streamed over WS); stale badges. |
 | **P4** | **Build-preview** (tier-2 no-exec deck render streamed over WS) + installable PWA + **read-only offline cache** of the last-opened deck. |
 | **Later / optional** | **Full executed single-deck build** (tier 3) for code outputs and rendered diagrams. |
@@ -423,3 +424,49 @@ taken while building, several resolving open calls left by §9.1–§9.5:
   the `[edit]`→`[web]` adaptation); the byte-exact "untouched cells unchanged"
   test pattern was re-authored against `FileState`. `DeckFile`, routes, and
   templates were **not** reused.
+
+### 9.7 P2 build record (2026-06-20)
+
+Structural ops — `insert` / `delete` / `move` (reorder) with id-minting — all
+routed through the same byte-exact `FileState` serializer the cell edits use, so
+untouched cells never shift. New backend ops live on `StudioService`
+(`insert_cell` / `delete` / `move`); new endpoints are `POST
+/api/studio/deck/{insert,delete,move}` (JSON body, not path segments — same
+greedy-`:path` avoidance as P1). Frontend adds a deck **toolbar** (reorder
+toggle + "Add slide"), per-cell **insert (＋) / delete (🗑)** controls, and
+**up/down chevrons** in reorder mode. Tests: 19 new (`tests/web/studio/`) + 7
+unit (`tests/slides/test_sync_writeback_structural.py`).
+
+Decisions / landmines:
+
+- **Two new `FileState` primitives.** `move_cell(slide_id, role, direction)`
+  swaps a cell with its neighbour; `build_cell(comment_token, …)` mints a fresh
+  cell header in the normalizer's canonical attribute order
+  (`[markdown] lang=… tags=[…] slide_id=…`). `delete` reuses the existing
+  `delete_cell`; `insert` reuses `insert_after` /
+  `insert_before_first_sync_cell`. **The terminal-newline artifact** (`split_cells`
+  parks the file's final `\n` as a trailing `""` on the last cell) is the move
+  landmine: when a swap moves a cell into/out of the last slot, the new last cell
+  is reset to **0** trailing blanks (flush restores the `\n`) and the displaced
+  cell gets the deck separator — mirroring `_place_inserted`. Covered by a
+  dedicated "move into last position keeps a single terminal newline" test.
+- **Id-minting vs inheriting (the resolved P2 design question).** A *new slide*
+  mints a unique kebab slug from the body title (the same `slugify` +
+  `resolve_collision` + `classify` extractor `assign-ids` uses). But a companion
+  cell (`notes` / `voiceover`) **must share its slide's `slide_id`** to group
+  correctly in the build — so `insert` accepts an **explicit `slide_id`** (the
+  frontend's "Share id with anchor" checkbox passes the anchor's id). The guard:
+  an explicit `(slide_id, role)` that already exists is rejected (`400`) — it
+  would create a duplicate, un-addressable key, breaking the keystone invariant.
+- **Optimistic concurrency.** `insert` and `move` change the cell *set*, so they
+  guard on `deck_version` only (no prior cell hash for a cell that doesn't exist
+  yet / whose content isn't changing). `delete` guards on **both**
+  `deck_version` + `cell_hash` (you must be deleting the cell you saw). A
+  boundary move (already first/last) is a `400`, not a 409.
+- **`lang` inference.** A new cell inherits the anchor cell's `lang`, else the
+  deck's dominant `lang` — correct for the per-language-file reality.
+- **Editor ergonomics wart (carried over from P1, deferred to P4).** Cell bodies
+  cross the wire **raw** (markdown lines keep their `# ` comment prefix), so the
+  insert form asks the author to type prefixed markdown. De-prefix-on-read /
+  re-prefix-on-write is a P4 polish item, not a P2 blocker — kept uniform with
+  P1 edit rather than introducing an insert-vs-edit inconsistency.

--- a/src/clm/slides/sync_writeback.py
+++ b/src/clm/slides/sync_writeback.py
@@ -27,6 +27,7 @@ __all__ = [
     "CODE_ROLE",
     "FileState",
     "anchor_of",
+    "build_cell",
     "build_twin_cell",
     "cell_content_hash",
     "construct_of",
@@ -218,6 +219,47 @@ def swap_lang(header: str, lang: str) -> str:
     # either comment family.
     marker = "// %%" if header.startswith("// %%") else "# %%"
     return header.replace(marker, f'{marker} lang="{lang}"', 1)
+
+
+def build_cell(
+    comment_token: str,
+    *,
+    cell_type: str,
+    lang: str | None,
+    tags: Sequence[str],
+    slide_id: str,
+    body: str,
+) -> RawCell:
+    """Build a brand-new cell from scratch (the P2 structural-insert factory).
+
+    Unlike :func:`build_twin_cell`, which clones an existing header, this mints a
+    header in the canonical attribute order the normalizer emits
+    (``[markdown] lang=… tags=[…] slide_id=…``) for a fresh cell that has no
+    source to copy from. ``comment_token`` is the deck's line-comment token
+    (``"#"`` / ``"//"``) — the percent marker is ``"<token> %%"``. ``body`` is
+    used bare (leading/trailing blank lines stripped); the caller's insert
+    primitive grants the deck's separator based on final position.
+    """
+    marker = f"{comment_token} %%"
+    parts = [marker]
+    if cell_type == "markdown":
+        parts.append("[markdown]")
+    if lang is not None:
+        parts.append(f'lang="{lang}"')
+    if tags:
+        parts.append("tags=[" + ", ".join(f'"{t}"' for t in tags) + "]")
+    parts.append(f'slide_id="{slide_id}"')
+    header = " ".join(parts)
+    body_lines = body.split("\n")
+    while body_lines and body_lines[0] == "":
+        body_lines.pop(0)
+    while body_lines and body_lines[-1] == "":
+        body_lines.pop()
+    return RawCell(
+        lines=[header, *body_lines],
+        line_number=0,
+        metadata=parse_cell_header(header, comment_token),
+    )
 
 
 def build_twin_cell(source_cell: RawCell, target_lang: str, target_body: str) -> RawCell:
@@ -419,6 +461,34 @@ class FileState:
         self.cells.append(new_cell)
         self.dirty = True
         self._place_inserted(new_cell, original_last, sep)
+
+    def move_cell(self, slide_id: str, role: str, direction: str) -> bool:
+        """Swap the ``(slide_id, role)`` cell with its neighbour (``"up"``/``"down"``).
+
+        The reorder primitive behind the Studio P2 up/down chevrons. Returns
+        ``False`` when the cell is absent or already at the requested boundary.
+        Both swapped cells keep their bytes verbatim — only their order changes —
+        so untouched cells stay byte-for-byte identical. When the swap moves a
+        cell into or out of the last position, the terminal-newline artifact
+        ``split_cells`` parked on the last cell is normalised exactly as for an
+        insert (cell now last → no explicit trailing blank, restored by
+        :meth:`flush`; the displaced cell → the deck separator).
+        """
+        idx = next((i for i, c in enumerate(self.cells) if _cell_matches(c, slide_id, role)), None)
+        if idx is None:
+            return False
+        target = idx - 1 if direction == "up" else idx + 1
+        if target < 0 or target >= len(self.cells):
+            return False
+        sep = self.separator_blanks()
+        original_last = self.cells[-1] if self.cells else None
+        self.cells[idx], self.cells[target] = self.cells[target], self.cells[idx]
+        self.dirty = True
+        if self.cells and self.cells[-1] is not original_last:
+            _set_trailing_blanks(self.cells[-1], 0)
+            if original_last is not None:
+                self.normalize_displaced_last(original_last, sep)
+        return True
 
     def _place_inserted(self, new_cell: RawCell, original_last: RawCell | None, sep: int) -> None:
         """Give ``new_cell`` the deck's separator (or none, if it is now last).

--- a/src/clm/web/static/studio/app.js
+++ b/src/clm/web/static/studio/app.js
@@ -94,6 +94,20 @@ function el(html) { const t = document.createElement("template"); t.innerHTML = 
 // --- state --------------------------------------------------------------------
 let currentDeck = null; // { deck_id, deck_version, cells: [...] }
 let diskChanged = false;
+let reorderMode = false;
+
+// Shared write-error handling for every mutating call.
+function handleWriteError(e, label) {
+  if (e.status === 409) {
+    diskChanged = true;
+    toast("Changed elsewhere — reload.");
+    renderDeck();
+  } else if (e.status === 423) {
+    toast("Language locked — sync or discard first.");
+  } else {
+    toast(label + " failed: " + e.message);
+  }
+}
 
 // --- views --------------------------------------------------------------------
 async function showHome() {
@@ -188,27 +202,173 @@ function renderDeck() {
     b.appendChild(r);
     appEl.appendChild(b);
   }
+
+  // Toolbar: reorder toggle + add-at-start.
+  const bar = el(`<div class="row toolbar"></div>`);
+  const reorderBtn = el(`<button class="ghost">${reorderMode ? "✓ Reordering" : "⇅ Reorder"}</button>`);
+  reorderBtn.addEventListener("click", () => { reorderMode = !reorderMode; renderDeck(); });
+  bar.appendChild(reorderBtn);
+  bar.appendChild(el(`<span class="spacer"></span>`));
+  if (!reorderMode) {
+    const addBtn = el(`<button>+ Add slide</button>`);
+    addBtn.addEventListener("click", () => openInsertForm(null));
+    bar.appendChild(addBtn);
+  }
+  appEl.appendChild(bar);
+
   deck.cells.forEach((cell, i) => appEl.appendChild(cellCard(cell, i)));
 }
 
 function cellCard(cell, idx) {
   const langChip = cell.lang ? `<span class="chip">${cell.lang}</span>` : "";
   const tagChips = (cell.tags || []).map((t) => `<span class="chip">${esc(t)}</span>`).join("");
-  const card = el(`<div class="cell ${cell.editable ? "editable" : ""}">
+  const card = el(`<div class="cell ${cell.editable && !reorderMode ? "editable" : ""}">
       <div class="cell-head">
         <span class="chip">${cell.cell_type}</span>${langChip}${tagChips}
         <span class="spacer"></span>
-        ${cell.editable ? '<span class="muted">tap to edit</span>' : '<span class="muted">read-only</span>'}
+        <span class="cell-controls"></span>
       </div>
       <div class="cell-body"></div>
     </div>`);
   const body = card.querySelector(".cell-body");
   if (cell.cell_type === "markdown") body.innerHTML = renderMarkdown(cell.body);
   else body.innerHTML = `<pre><code>${esc(cell.body)}</code></pre>`;
-  if (cell.editable) {
+
+  const controls = card.querySelector(".cell-controls");
+  if (reorderMode) {
+    if (cell.editable) {
+      const up = el(`<button class="ghost icon" title="Move up">↑</button>`);
+      const down = el(`<button class="ghost icon" title="Move down">↓</button>`);
+      up.addEventListener("click", () => moveCell(cell, "up"));
+      down.addEventListener("click", () => moveCell(cell, "down"));
+      controls.appendChild(up); controls.appendChild(down);
+    } else {
+      controls.appendChild(el(`<span class="muted">read-only</span>`));
+    }
+  } else if (cell.editable) {
+    const ins = el(`<button class="ghost icon" title="Insert after">＋</button>`);
+    const del = el(`<button class="ghost icon" title="Delete">🗑</button>`);
+    ins.addEventListener("click", (e) => { e.stopPropagation(); openInsertForm(cell); });
+    del.addEventListener("click", (e) => { e.stopPropagation(); deleteCell(cell); });
+    controls.appendChild(el(`<span class="muted">tap to edit</span>`));
+    controls.appendChild(ins); controls.appendChild(del);
     card.querySelector(".cell-head").addEventListener("click", () => editCell(cell, idx));
+  } else {
+    controls.appendChild(el(`<span class="muted">read-only</span>`));
   }
   return card;
+}
+
+async function moveCell(cell, direction) {
+  if (diskChanged) { toast("Deck changed on disk — reload first."); return; }
+  try {
+    await api("/deck/move", {
+      method: "POST",
+      body: JSON.stringify({
+        deck_id: currentDeck.deck_id,
+        slide_id: cell.slide_id,
+        role: cell.role,
+        direction,
+        expected_deck_version: currentDeck.deck_version,
+      }),
+    });
+    await openDeck(currentDeck.deck_id); // reload: fresh order + guards
+    reorderMode = true; renderDeck();    // openDeck reset the view; stay in reorder
+  } catch (e) {
+    if (e.status === 400) { toast("Already at the " + (direction === "up" ? "top" : "bottom") + "."); }
+    else handleWriteError(e, "Move");
+  }
+}
+
+async function deleteCell(cell) {
+  if (diskChanged) { toast("Deck changed on disk — reload first."); return; }
+  if (!window.confirm(`Delete this ${cell.role || "cell"} (${cell.slide_id || ""})?`)) return;
+  try {
+    await api("/deck/delete", {
+      method: "POST",
+      body: JSON.stringify({
+        deck_id: currentDeck.deck_id,
+        slide_id: cell.slide_id,
+        role: cell.role,
+        expected_deck_version: currentDeck.deck_version,
+        expected_cell_hash: cell.content_hash,
+      }),
+    });
+    toast("Deleted");
+    await openDeck(currentDeck.deck_id);
+  } catch (e) {
+    handleWriteError(e, "Delete");
+  }
+}
+
+// Insert a new cell after `anchor` (or at the deck start when anchor is null).
+function openInsertForm(anchor) {
+  if (diskChanged) { toast("Deck changed on disk — reload first."); return; }
+  appEl.innerHTML = "";
+  titleEl.textContent = anchor ? "Insert after " + (anchor.slide_id || anchor.role) : "Add slide";
+
+  const typeSel = el(`<select><option value="markdown">markdown</option><option value="code">code</option></select>`);
+  const roleInput = el(`<input type="text" value="slide" />`);
+  // Markdown narrative roles are common; "code" is forced for code cells.
+  typeSel.addEventListener("change", () => {
+    if (typeSel.value === "code") { roleInput.value = "code"; roleInput.disabled = true; }
+    else { roleInput.disabled = false; if (roleInput.value === "code") roleInput.value = "slide"; }
+  });
+
+  let shareWrap = null, shareChk = null;
+  if (anchor && anchor.slide_id) {
+    shareChk = el(`<input type="checkbox" />`);
+    shareWrap = el(`<label class="row" style="gap:6px"></label>`);
+    shareWrap.appendChild(shareChk);
+    shareWrap.appendChild(el(`<span>Share id with anchor (e.g. notes for this slide)</span>`));
+  }
+
+  const ta = el(`<textarea placeholder="# Title&#10;#&#10;# Body (markdown lines start with &quot;# &quot;)"></textarea>`);
+
+  appEl.appendChild(el(`<div class="muted" style="margin-bottom:6px">New cell ${anchor ? "after " + esc(anchor.slide_id || anchor.role || "") : "at deck start"}</div>`));
+  const form = el(`<div class="insert-form"></div>`);
+  form.appendChild(labeled("Type", typeSel));
+  form.appendChild(labeled("Role / tag", roleInput));
+  if (shareWrap) form.appendChild(shareWrap);
+  appEl.appendChild(form);
+  appEl.appendChild(ta);
+
+  const actions = el(`<div class="edit-actions"></div>`);
+  const save = el(`<button>Insert</button>`);
+  const cancel = el(`<button class="ghost">Cancel</button>`);
+  actions.appendChild(save); actions.appendChild(cancel);
+  appEl.appendChild(actions);
+  ta.focus();
+
+  cancel.addEventListener("click", renderDeck);
+  save.addEventListener("click", async () => {
+    save.disabled = true; cancel.disabled = true;
+    const payload = {
+      deck_id: currentDeck.deck_id,
+      cell_type: typeSel.value,
+      role: roleInput.value.trim(),
+      body: ta.value,
+      after_slide_id: anchor ? anchor.slide_id : null,
+      after_role: anchor ? anchor.role : null,
+      expected_deck_version: currentDeck.deck_version,
+    };
+    if (shareChk && shareChk.checked) payload.slide_id = anchor.slide_id;
+    try {
+      await api("/deck/insert", { method: "POST", body: JSON.stringify(payload) });
+      toast("Inserted");
+      await openDeck(currentDeck.deck_id);
+    } catch (e) {
+      save.disabled = false; cancel.disabled = false;
+      handleWriteError(e, "Insert");
+    }
+  });
+}
+
+function labeled(label, control) {
+  const wrap = el(`<label class="field"></label>`);
+  wrap.appendChild(el(`<span class="muted">${esc(label)}</span>`));
+  wrap.appendChild(control);
+  return wrap;
 }
 
 function editCell(cell, idx) {
@@ -249,15 +409,7 @@ function editCell(cell, idx) {
       renderDeck();
     } catch (e) {
       save.disabled = false; cancel.disabled = false;
-      if (e.status === 409) {
-        diskChanged = true;
-        toast("Changed elsewhere — reload.");
-        renderDeck();
-      } else if (e.status === 423) {
-        toast("Language locked — sync or discard first.");
-      } else {
-        toast("Save failed: " + e.message);
-      }
+      handleWriteError(e, "Save");
     }
   });
 }

--- a/src/clm/web/static/studio/index.html
+++ b/src/clm/web/static/studio/index.html
@@ -70,6 +70,14 @@
     .edit-actions { display: flex; gap: 8px; margin-top: 8px; }
     .spacer { flex: 1; }
     a { color: var(--accent); }
+    .toolbar { margin: 4px 0 10px; }
+    .cell-controls { display: flex; align-items: center; gap: 4px; }
+    button.icon { padding: 4px 8px; font-size: 1rem; line-height: 1; }
+    select { font: inherit; color: var(--fg); background: var(--card);
+      border: 1px solid var(--line); border-radius: 8px; padding: 8px; }
+    .insert-form { display: flex; flex-direction: column; gap: 10px; margin-bottom: 10px; }
+    .field { display: flex; flex-direction: column; gap: 4px; }
+    .field .muted { font-size: .78rem; }
   </style>
 </head>
 <body>

--- a/src/clm/web/studio/models.py
+++ b/src/clm/web/studio/models.py
@@ -105,12 +105,73 @@ class EditTagsRequest(BaseModel):
     expected_cell_hash: str
 
 
+class InsertCellRequest(BaseModel):
+    """An ``insert`` write: add a new cell, minting (or inheriting) a slide_id.
+
+    Position is given by an anchor: the new cell lands immediately **after** the
+    ``(after_slide_id, after_role)`` cell, or — when ``after_slide_id`` is
+    omitted — ahead of the deck's first sync cell (it becomes the first slide).
+
+    ``slide_id`` is optional: omit it for a new slide (the server mints a unique
+    slug from the body title), or pass the anchor slide's id to add a companion
+    cell (e.g. ``notes``) that must share its slide's identity to group
+    correctly. Only ``expected_deck_version`` guards the write — there is no
+    prior cell hash for a cell that does not yet exist.
+    """
+
+    deck_id: str = Field(description="Slides-dir-relative deck path.")
+    after_slide_id: str | None = Field(
+        default=None, description="Anchor cell's slide_id; omit to insert at the deck start."
+    )
+    after_role: str | None = Field(default=None, description="Anchor cell's role.")
+    cell_type: str = Field(default="markdown", description='"markdown" or "code".')
+    role: str = Field(description="Sync role/tag for the new cell (slide/notes/voiceover/…).")
+    body: str = Field(default="", description="Body of the new cell (raw, comment-prefixed).")
+    slide_id: str | None = Field(
+        default=None, description="Explicit slide id; omitted → minted from the body title."
+    )
+    lang: str | None = Field(
+        default=None, description="Language; omitted → inherited from the anchor/deck."
+    )
+    expected_deck_version: str = Field(description="deck_version the phone last saw.")
+
+
+class DeleteCellRequest(BaseModel):
+    """A ``delete`` write, carrying the optimistic-concurrency expectations."""
+
+    deck_id: str
+    slide_id: str
+    role: str
+    expected_deck_version: str
+    expected_cell_hash: str = Field(description="content_hash the phone last saw for this cell.")
+
+
+class MoveCellRequest(BaseModel):
+    """A ``move`` (reorder) write: swap a cell with its neighbour.
+
+    The cell content does not change, so only ``expected_deck_version`` guards
+    the write — a mismatch (any concurrent edit) yields 409 so the phone
+    re-fetches before reordering a stale view.
+    """
+
+    deck_id: str
+    slide_id: str
+    role: str
+    direction: str = Field(description='"up" or "down".')
+    expected_deck_version: str
+
+
 class EditResult(BaseModel):
-    """Result of a successful write: the fresh guards for the next edit."""
+    """Result of a successful write: the fresh guards for the next edit.
+
+    ``slide_id`` is populated on an ``insert`` (the minted or inherited id the
+    phone must adopt to address the new cell); it is ``None`` for in-place edits.
+    """
 
     ok: bool = True
     deck_version: str
     cell_hash: str
+    slide_id: str | None = None
 
 
 class RenderCellRequest(BaseModel):

--- a/src/clm/web/studio/routes.py
+++ b/src/clm/web/studio/routes.py
@@ -22,9 +22,12 @@ from clm.web.studio.auth import token_matches
 from clm.web.studio.models import (
     DeckTree,
     DeckView,
+    DeleteCellRequest,
     EditBodyRequest,
     EditResult,
     EditTagsRequest,
+    InsertCellRequest,
+    MoveCellRequest,
     RenderCellRequest,
     RenderCellResult,
     SearchResults,
@@ -33,6 +36,7 @@ from clm.web.studio.service import (
     CellNotFoundError,
     DeckNotFoundError,
     InvalidDeckIdError,
+    InvalidStructuralOpError,
     StaleWriteError,
     StudioService,
 )
@@ -70,6 +74,8 @@ def _handle_write(call: Callable[[], EditResult]) -> EditResult:
         raise HTTPException(status_code=404, detail=f"Cell not found: {e}") from e
     except DeckNotFoundError as e:
         raise HTTPException(status_code=404, detail=f"Deck not found: {e}") from e
+    except InvalidStructuralOpError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid structural op: {e}") from e
     except InvalidDeckIdError as e:
         raise HTTPException(status_code=400, detail=f"Invalid deck id: {e}") from e
 
@@ -144,6 +150,55 @@ async def edit_tags(request: Request, req: EditTagsRequest) -> EditResult:
             req.new_tags,
             expected_deck_version=req.expected_deck_version,
             expected_cell_hash=req.expected_cell_hash,
+        )
+    )
+
+
+@router.post("/deck/insert", response_model=EditResult, dependencies=[Depends(require_token)])
+async def insert_cell(request: Request, req: InsertCellRequest) -> EditResult:
+    """Insert a new cell, minting (or inheriting) its slide_id (optimistic concurrency)."""
+    service = get_service(request)
+    return _handle_write(
+        lambda: service.insert_cell(
+            req.deck_id,
+            role=req.role,
+            cell_type=req.cell_type,
+            body=req.body,
+            after_slide_id=req.after_slide_id,
+            after_role=req.after_role,
+            slide_id=req.slide_id,
+            lang=req.lang,
+            expected_deck_version=req.expected_deck_version,
+        )
+    )
+
+
+@router.post("/deck/delete", response_model=EditResult, dependencies=[Depends(require_token)])
+async def delete_cell(request: Request, req: DeleteCellRequest) -> EditResult:
+    """Delete a cell (optimistic concurrency)."""
+    service = get_service(request)
+    return _handle_write(
+        lambda: service.delete(
+            req.deck_id,
+            req.slide_id,
+            req.role,
+            expected_deck_version=req.expected_deck_version,
+            expected_cell_hash=req.expected_cell_hash,
+        )
+    )
+
+
+@router.post("/deck/move", response_model=EditResult, dependencies=[Depends(require_token)])
+async def move_cell(request: Request, req: MoveCellRequest) -> EditResult:
+    """Reorder a cell up/down by one (optimistic concurrency)."""
+    service = get_service(request)
+    return _handle_write(
+        lambda: service.move(
+            req.deck_id,
+            req.slide_id,
+            req.role,
+            req.direction,
+            expected_deck_version=req.expected_deck_version,
         )
     )
 

--- a/src/clm/web/studio/service.py
+++ b/src/clm/web/studio/service.py
@@ -17,8 +17,10 @@ Identity rules (the keystone — see design §3.6 / §9.1):
 * All writes go through :class:`FileState` (one write path — design §9.2);
   untouched cells are left byte-for-byte unchanged.
 
-P1 only edits cells already addressable by ``(slide_id, role)``; id-less
-cells are read-only until structural ops / id-minting land in P2.
+P1 edits cells already addressable by ``(slide_id, role)``. P2 adds the
+structural ops — ``insert_cell`` (minting or inheriting a slide_id),
+``delete``, and ``move`` (reorder) — all routed through the same byte-exact
+:class:`FileState` serializer so untouched cells never shift.
 """
 
 from __future__ import annotations
@@ -28,10 +30,11 @@ import logging
 import time
 from pathlib import Path
 
-from clm.notebooks.slide_parser import parse_cells
+from clm.notebooks.slide_parser import comment_token_for_path, parse_cells
 from clm.slides.sync_writeback import (
     FileState,
     anchor_of,
+    build_cell,
     cell_content_hash,
     role_of,
 )
@@ -69,6 +72,10 @@ class DeckNotFoundError(StudioError):
 
 class CellNotFoundError(StudioError):
     """No cell with the given ``(slide_id, role)`` exists in the deck."""
+
+
+class InvalidStructuralOpError(StudioError):
+    """A structural op (insert/delete/move) had invalid parameters (→ 400)."""
 
 
 class StaleWriteError(StudioError):
@@ -359,4 +366,151 @@ class StudioService:
         )
         if not state.replace_cell_tags(slide_id, role, new_tags):
             raise CellNotFoundError(f"{slide_id!r}/{role!r}")
+        return self._persist(deck_id, path, state, slide_id, role)
+
+    # ------------------------------------------------------- structural ops (P2)
+
+    def _load_for_structural(
+        self, deck_id: str, expected_deck_version: str
+    ) -> tuple[Path, FileState]:
+        """Resolve + deck-version-guard a deck for a structural op (no cell guard).
+
+        Insert/move change the cell set, so the only optimistic guard is the
+        whole-file ``deck_version`` — any concurrent change yields a 409 so the
+        phone re-fetches before mutating a stale view.
+        """
+        path = self._resolve_deck_id(deck_id)
+        if not path.exists():
+            raise DeckNotFoundError(deck_id)
+        current_version = self._deck_version(path)
+        if current_version != expected_deck_version:
+            raise StaleWriteError("deck_version", current_version)
+        return path, FileState.load(path)
+
+    @staticmethod
+    def _infer_lang(
+        state: FileState, after_slide_id: str | None, after_role: str | None
+    ) -> str | None:
+        """Language for a new cell: the anchor's, else the deck's dominant lang."""
+        if after_slide_id is not None and after_role is not None:
+            anchor = state.find_cell(after_slide_id, after_role)
+            if anchor is not None and anchor.metadata.lang is not None:
+                return anchor.metadata.lang
+        from collections import Counter
+
+        langs = [c.metadata.lang for c in state.cells if c.metadata.lang is not None]
+        if langs:
+            return Counter(langs).most_common(1)[0][0]
+        return None
+
+    @staticmethod
+    def _resolve_or_mint_slide_id(
+        state: FileState, slide_id: str | None, role: str, body: str
+    ) -> str:
+        """Validate an explicit slide_id, or mint a unique one from the body title.
+
+        An explicit id (used to attach e.g. ``notes`` to an existing slide, which
+        must share the slide's identity to group correctly) must be a valid slug
+        and must not already pair with ``role`` in this file — that would create a
+        duplicate ``(slide_id, role)`` key, which is un-addressable. With no id,
+        mint a kebab slug from the body title (the same extractor ``assign-ids``
+        uses), suffixed to stay unique among existing ids.
+        """
+        from clm.slides.headingless import classify
+        from clm.slides.slug import is_valid_slug, resolve_collision, slugify
+
+        existing = {c.metadata.slide_id for c in state.cells if c.metadata.slide_id is not None}
+        if slide_id is not None:
+            if not is_valid_slug(slide_id):
+                raise InvalidStructuralOpError(f"invalid slide_id: {slide_id!r}")
+            for c in state.cells:
+                if c.metadata.slide_id == slide_id and role_of(c.metadata) == role:
+                    raise InvalidStructuralOpError(
+                        f"duplicate (slide_id, role): {slide_id!r}/{role!r}"
+                    )
+            return slide_id
+        base = slugify(getattr(classify(body), "text", "") or "") or "cell"
+        return resolve_collision(base, existing)
+
+    def insert_cell(
+        self,
+        deck_id: str,
+        *,
+        role: str,
+        cell_type: str = "markdown",
+        body: str = "",
+        after_slide_id: str | None = None,
+        after_role: str | None = None,
+        slide_id: str | None = None,
+        lang: str | None = None,
+        expected_deck_version: str,
+    ) -> EditResult:
+        """Insert a new cell after an anchor (or at the deck start), minting its id.
+
+        Returns an :class:`EditResult` whose ``slide_id`` carries the minted (or
+        inherited) id the phone must adopt to address the new cell.
+        """
+        if cell_type not in ("markdown", "code"):
+            raise InvalidStructuralOpError(f"invalid cell_type: {cell_type!r}")
+        if not role:
+            raise InvalidStructuralOpError("role is required")
+        if cell_type == "code" and role != "code":
+            raise InvalidStructuralOpError('a code cell must use role "code"')
+
+        path, state = self._load_for_structural(deck_id, expected_deck_version)
+        resolved_lang = lang or self._infer_lang(state, after_slide_id, after_role)
+        new_id = self._resolve_or_mint_slide_id(state, slide_id, role, body)
+        tags = [] if cell_type == "code" else [role]
+        new_cell = build_cell(
+            comment_token_for_path(path),
+            cell_type=cell_type,
+            lang=resolved_lang,
+            tags=tags,
+            slide_id=new_id,
+            body=body,
+        )
+        if after_slide_id is None:
+            state.insert_before_first_sync_cell(new_cell)
+        elif not state.insert_after(after_slide_id, after_role or "", new_cell):
+            raise CellNotFoundError(f"{after_slide_id!r}/{after_role!r}")
+
+        result = self._persist(deck_id, path, state, new_id, role)
+        result.slide_id = new_id
+        return result
+
+    def delete(
+        self,
+        deck_id: str,
+        slide_id: str,
+        role: str,
+        *,
+        expected_deck_version: str,
+        expected_cell_hash: str,
+    ) -> EditResult:
+        """Remove the ``(slide_id, role)`` cell, guarded by optimistic concurrency."""
+        path, state = self._load_guarded(
+            deck_id, slide_id, role, expected_deck_version, expected_cell_hash
+        )
+        if not state.delete_cell(slide_id, role):
+            raise CellNotFoundError(f"{slide_id!r}/{role!r}")
+        # The cell is gone, so _persist's post-flush lookup yields an empty hash.
+        return self._persist(deck_id, path, state, slide_id, role)
+
+    def move(
+        self,
+        deck_id: str,
+        slide_id: str,
+        role: str,
+        direction: str,
+        *,
+        expected_deck_version: str,
+    ) -> EditResult:
+        """Swap the ``(slide_id, role)`` cell with its neighbour (``"up"``/``"down"``)."""
+        if direction not in ("up", "down"):
+            raise InvalidStructuralOpError(f"invalid direction: {direction!r}")
+        path, state = self._load_for_structural(deck_id, expected_deck_version)
+        if state.find_cell(slide_id, role) is None:
+            raise CellNotFoundError(f"{slide_id!r}/{role!r}")
+        if not state.move_cell(slide_id, role, direction):
+            raise InvalidStructuralOpError(f"cannot move {direction!r}: cell at boundary")
         return self._persist(deck_id, path, state, slide_id, role)

--- a/tests/slides/test_sync_writeback_structural.py
+++ b/tests/slides/test_sync_writeback_structural.py
@@ -1,0 +1,102 @@
+"""Unit tests for the P2 structural primitives on :class:`FileState`.
+
+Covers ``move_cell`` (including the terminal-newline normalization when a cell
+moves into/out of the last position) and the ``build_cell`` factory — the
+pieces behind the Mobile Deck Studio reorder/insert ops. The Studio service
+tests cover the integration; these pin the byte-exact serializer contract that
+makes structural edits safe (untouched cells never shift).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+from clm.slides.raw_cells import split_cells
+from clm.slides.sync_writeback import FileState, build_cell, role_of
+
+DECK = dedent(
+    """\
+    # %% [markdown] lang="de" tags=["slide"] slide_id="a"
+    # A
+
+    # %% [markdown] lang="de" tags=["slide"] slide_id="b"
+    # B
+
+    # %% [markdown] lang="de" tags=["slide"] slide_id="c"
+    # C
+    """
+)
+
+
+def _write(tmp_path: Path) -> Path:
+    p = tmp_path / "deck.de.py"
+    p.write_text(DECK, encoding="utf-8")
+    return p
+
+
+def test_move_into_last_position_keeps_single_terminal_newline(tmp_path: Path):
+    path = _write(tmp_path)
+    state = FileState.load(path)
+    assert state.move_cell("b", "slide", "down") is True
+    state.flush()
+
+    text = path.read_text(encoding="utf-8")
+    # Order is now a, c, b; the file ends with exactly one trailing newline.
+    _, cells = split_cells(text)
+    assert [c.metadata.slide_id for c in cells] == ["a", "c", "b"]
+    assert text.endswith("# B\n")
+    assert not text.endswith("# B\n\n")
+
+
+def test_move_leaves_untouched_cell_byte_exact(tmp_path: Path):
+    path = _write(tmp_path)
+    _, before = split_cells(path.read_text(encoding="utf-8"))
+    a_before = "\n".join(next(c for c in before if c.metadata.slide_id == "a").lines)
+
+    state = FileState.load(path)
+    state.move_cell("b", "slide", "down")
+    state.flush()
+
+    _, after = split_cells(path.read_text(encoding="utf-8"))
+    a_after = "\n".join(next(c for c in after if c.metadata.slide_id == "a").lines)
+    assert a_after == a_before
+
+
+def test_move_at_boundary_returns_false(tmp_path: Path):
+    state = FileState.load(_write(tmp_path))
+    assert state.move_cell("a", "slide", "up") is False
+    assert state.dirty is False
+
+
+def test_move_missing_cell_returns_false(tmp_path: Path):
+    state = FileState.load(_write(tmp_path))
+    assert state.move_cell("nope", "slide", "down") is False
+
+
+def test_build_cell_markdown_header_and_role(tmp_path: Path):
+    cell = build_cell(
+        "#",
+        cell_type="markdown",
+        lang="de",
+        tags=["slide"],
+        slide_id="new-one",
+        body="# Titel\n#\n# Text.\n\n",  # trailing blanks stripped by build_cell
+    )
+    assert cell.lines[0] == '# %% [markdown] lang="de" tags=["slide"] slide_id="new-one"'
+    assert cell.lines[-1] == "# Text."  # no trailing blank retained
+    assert cell.metadata.slide_id == "new-one"
+    assert role_of(cell.metadata) == "slide"
+
+
+def test_build_cell_code_header_is_addressable(tmp_path: Path):
+    cell = build_cell(
+        "#", cell_type="code", lang="de", tags=[], slide_id="snippet", body='print("hi")'
+    )
+    assert cell.lines[0] == '# %% lang="de" slide_id="snippet"'
+    assert role_of(cell.metadata) == "code"
+
+
+def test_build_cell_respects_comment_token(tmp_path: Path):
+    cell = build_cell("//", cell_type="code", lang="en", tags=[], slide_id="x", body="int x = 1;")
+    assert cell.lines[0] == '// %% lang="en" slide_id="x"'

--- a/tests/web/studio/test_routes.py
+++ b/tests/web/studio/test_routes.py
@@ -106,3 +106,117 @@ class TestWriteEndpoints:
         detail = r.json()["detail"]
         assert detail["kind"] == "deck_version"
         assert detail["current"]  # fresh guard handed back for retry
+
+
+class TestStructuralEndpoints:
+    def _version(self, client: TestClient, course: Course) -> str:
+        return client.get(f"/api/studio/deck?id={course.deck_id}", headers=AUTH).json()[
+            "deck_version"
+        ]
+
+    def test_insert_returns_minted_slide_id(self, client: TestClient, course: Course):
+        r = client.post(
+            "/api/studio/deck/insert",
+            headers=AUTH,
+            json={
+                "deck_id": course.deck_id,
+                "role": "slide",
+                "cell_type": "markdown",
+                "body": "# Frisch\n#\n# Inhalt.",
+                "expected_deck_version": self._version(client, course),
+            },
+        )
+        assert r.status_code == 200
+        assert r.json()["slide_id"] == "frisch"
+
+    def test_insert_bad_cell_type_is_400(self, client: TestClient, course: Course):
+        r = client.post(
+            "/api/studio/deck/insert",
+            headers=AUTH,
+            json={
+                "deck_id": course.deck_id,
+                "role": "slide",
+                "cell_type": "diagram",
+                "body": "# x",
+                "expected_deck_version": self._version(client, course),
+            },
+        )
+        assert r.status_code == 400
+
+    def test_delete_then_open_drops_cell(self, client: TestClient, course: Course):
+        body = client.get(f"/api/studio/deck?id={course.deck_id}", headers=AUTH).json()
+        notes = next(c for c in body["cells"] if c["role"] == "notes")
+        r = client.post(
+            "/api/studio/deck/delete",
+            headers=AUTH,
+            json={
+                "deck_id": course.deck_id,
+                "slide_id": notes["slide_id"],
+                "role": notes["role"],
+                "expected_deck_version": body["deck_version"],
+                "expected_cell_hash": notes["content_hash"],
+            },
+        )
+        assert r.status_code == 200
+        reopened = client.get(f"/api/studio/deck?id={course.deck_id}", headers=AUTH).json()
+        assert all(c["role"] != "notes" for c in reopened["cells"])
+
+    def test_move_down_is_200(self, client: TestClient, course: Course):
+        body = client.get(f"/api/studio/deck?id={course.deck_id}", headers=AUTH).json()
+        slide = next(c for c in body["cells"] if c["role"] == "slide")
+        r = client.post(
+            "/api/studio/deck/move",
+            headers=AUTH,
+            json={
+                "deck_id": course.deck_id,
+                "slide_id": slide["slide_id"],
+                "role": slide["role"],
+                "direction": "down",
+                "expected_deck_version": body["deck_version"],
+            },
+        )
+        assert r.status_code == 200
+        assert r.json()["deck_version"] != body["deck_version"]
+
+    def test_move_boundary_is_400(self, client: TestClient, course: Course):
+        body = client.get(f"/api/studio/deck?id={course.deck_id}", headers=AUTH).json()
+        slide = next(c for c in body["cells"] if c["role"] == "slide")  # first cell
+        r = client.post(
+            "/api/studio/deck/move",
+            headers=AUTH,
+            json={
+                "deck_id": course.deck_id,
+                "slide_id": slide["slide_id"],
+                "role": slide["role"],
+                "direction": "up",
+                "expected_deck_version": body["deck_version"],
+            },
+        )
+        assert r.status_code == 400
+
+    def test_insert_stale_is_409(self, client: TestClient, course: Course):
+        r = client.post(
+            "/api/studio/deck/insert",
+            headers=AUTH,
+            json={
+                "deck_id": course.deck_id,
+                "role": "slide",
+                "body": "# x",
+                "expected_deck_version": "staleversion00000",
+            },
+        )
+        assert r.status_code == 409
+        assert r.json()["detail"]["kind"] == "deck_version"
+
+    def test_structural_requires_token(self, client: TestClient, course: Course):
+        r = client.post(
+            "/api/studio/deck/move",
+            json={
+                "deck_id": course.deck_id,
+                "slide_id": "intro-welcome",
+                "role": "slide",
+                "direction": "down",
+                "expected_deck_version": "x",
+            },
+        )
+        assert r.status_code == 401

--- a/tests/web/studio/test_service.py
+++ b/tests/web/studio/test_service.py
@@ -14,6 +14,7 @@ from clm.web.studio.service import (
     CellNotFoundError,
     DeckNotFoundError,
     InvalidDeckIdError,
+    InvalidStructuralOpError,
     StaleWriteError,
     StudioService,
 )
@@ -173,6 +174,198 @@ class TestConcurrencyCore:
         assert result.cell_hash == slide.content_hash
         assert result.deck_version != view.deck_version
         assert 'tags=["slide", "keep"]' in course.deck_path.read_text(encoding="utf-8")
+
+
+class TestStructuralInsert:
+    def _open_version(self, service: StudioService, course: Course) -> str:
+        return service.open_deck(course.deck_id).deck_version
+
+    def test_insert_at_start_mints_id_and_becomes_first_slide(
+        self, service: StudioService, course: Course
+    ):
+        version = self._open_version(service, course)
+        result = service.insert_cell(
+            course.deck_id,
+            role="slide",
+            cell_type="markdown",
+            body="# Neue Folie\n#\n# Inhalt hier.",
+            expected_deck_version=version,
+        )
+        assert result.slide_id == "neue-folie"
+        view = service.open_deck(course.deck_id)
+        # New slide is first, addressable, and editable.
+        first = next(c for c in view.cells if c.role == "slide")
+        assert first.slide_id == "neue-folie"
+        assert first.editable
+        assert view.cells[0].slide_id == "neue-folie"
+        assert len(view.cells) == 4
+
+    def test_insert_leaves_existing_cells_byte_exact(self, service: StudioService, course: Course):
+        before = course.deck_path.read_text(encoding="utf-8")
+        _, before_cells = split_cells(before)
+        version = self._open_version(service, course)
+        service.insert_cell(
+            course.deck_id,
+            role="slide",
+            body="# Brandneu\n#\n# Text.",
+            expected_deck_version=version,
+        )
+        _, after_cells = split_cells(course.deck_path.read_text(encoding="utf-8"))
+        # The three originals survive verbatim (the new cell is the only addition).
+        after_ids = ["\n".join(c.lines) for c in after_cells]
+        for b in before_cells:
+            assert "\n".join(b.lines) in after_ids
+
+    def test_insert_after_with_shared_id_groups_notes(self, service: StudioService, course: Course):
+        version = self._open_version(service, course)
+        # Add a *second* notes-style aux cell sharing the slide's id but a new role.
+        result = service.insert_cell(
+            course.deck_id,
+            role="voiceover",
+            body="# Sprechtext.",
+            after_slide_id="intro-welcome",
+            after_role="slide",
+            slide_id="intro-welcome",
+            expected_deck_version=version,
+        )
+        assert result.slide_id == "intro-welcome"
+        view = service.open_deck(course.deck_id)
+        vo = next(c for c in view.cells if c.role == "voiceover")
+        assert vo.slide_id == "intro-welcome" and vo.editable
+
+    def test_insert_duplicate_key_rejected(self, service: StudioService, course: Course):
+        version = self._open_version(service, course)
+        with pytest.raises(InvalidStructuralOpError):
+            service.insert_cell(
+                course.deck_id,
+                role="slide",
+                body="# x",
+                slide_id="intro-welcome",  # (intro-welcome, slide) already exists
+                expected_deck_version=version,
+            )
+
+    def test_insert_stale_deck_version_rejected(self, service: StudioService, course: Course):
+        with pytest.raises(StaleWriteError) as exc:
+            service.insert_cell(
+                course.deck_id,
+                role="slide",
+                body="# x",
+                expected_deck_version="deadbeefdeadbeef",
+            )
+        assert exc.value.kind == "deck_version"
+
+    def test_insert_unknown_anchor_raises(self, service: StudioService, course: Course):
+        version = self._open_version(service, course)
+        with pytest.raises(CellNotFoundError):
+            service.insert_cell(
+                course.deck_id,
+                role="notes",
+                body="# x",
+                after_slide_id="no-such-id",
+                after_role="slide",
+                expected_deck_version=version,
+            )
+
+
+class TestStructuralDelete:
+    def test_delete_removes_cell_and_keeps_others_byte_exact(
+        self, service: StudioService, course: Course
+    ):
+        before = course.deck_path.read_text(encoding="utf-8")
+        _, before_cells = split_cells(before)
+        view = service.open_deck(course.deck_id)
+        notes = next(c for c in view.cells if c.role == "notes")
+        service.delete(
+            course.deck_id,
+            notes.slide_id,
+            notes.role,
+            expected_deck_version=view.deck_version,
+            expected_cell_hash=notes.content_hash,
+        )
+        reopened = service.open_deck(course.deck_id)
+        assert all(c.role != "notes" for c in reopened.cells)
+        assert len(reopened.cells) == 2
+        # Surviving cells are byte-for-byte identical to their originals.
+        _, after_cells = split_cells(course.deck_path.read_text(encoding="utf-8"))
+        survivors = {"\n".join(c.lines) for c in after_cells}
+        kept = [c for c in before_cells if c.metadata.tags != ["notes"]]
+        for c in kept:
+            assert "\n".join(c.lines) in survivors
+
+    def test_delete_stale_cell_hash_rejected(self, service: StudioService, course: Course):
+        view = service.open_deck(course.deck_id)
+        slide = next(c for c in view.cells if c.role == "slide")
+        with pytest.raises(StaleWriteError) as exc:
+            service.delete(
+                course.deck_id,
+                slide.slide_id,
+                slide.role,
+                expected_deck_version=view.deck_version,
+                expected_cell_hash="0" * 64,
+            )
+        assert exc.value.kind == "cell_hash"
+
+
+class TestStructuralMove:
+    def test_move_down_reorders_and_preserves_bytes(self, service: StudioService, course: Course):
+        before = course.deck_path.read_text(encoding="utf-8")
+        _, before_cells = split_cells(before)
+        view = service.open_deck(course.deck_id)
+        slide = next(c for c in view.cells if c.role == "slide")
+        result = service.move(
+            course.deck_id,
+            slide.slide_id,
+            slide.role,
+            "down",
+            expected_deck_version=view.deck_version,
+        )
+        assert result.deck_version != view.deck_version
+        reopened = service.open_deck(course.deck_id)
+        # slide now sits after notes.
+        roles = [c.role for c in reopened.cells]
+        assert roles.index("notes") < roles.index("slide")
+        # Every original cell's bytes survive (only the order changed).
+        _, after_cells = split_cells(course.deck_path.read_text(encoding="utf-8"))
+        before_blocks = sorted("\n".join(c.lines) for c in before_cells)
+        after_blocks = sorted("\n".join(c.lines) for c in after_cells)
+        assert before_blocks == after_blocks
+
+    def test_move_up_at_boundary_rejected(self, service: StudioService, course: Course):
+        view = service.open_deck(course.deck_id)
+        slide = next(c for c in view.cells if c.role == "slide")  # already first
+        with pytest.raises(InvalidStructuralOpError):
+            service.move(
+                course.deck_id,
+                slide.slide_id,
+                slide.role,
+                "up",
+                expected_deck_version=view.deck_version,
+            )
+
+    def test_move_stale_deck_version_rejected(self, service: StudioService, course: Course):
+        view = service.open_deck(course.deck_id)
+        slide = next(c for c in view.cells if c.role == "slide")
+        with pytest.raises(StaleWriteError) as exc:
+            service.move(
+                course.deck_id,
+                slide.slide_id,
+                slide.role,
+                "down",
+                expected_deck_version="deadbeefdeadbeef",
+            )
+        assert exc.value.kind == "deck_version"
+
+    def test_move_bad_direction_rejected(self, service: StudioService, course: Course):
+        view = service.open_deck(course.deck_id)
+        slide = next(c for c in view.cells if c.role == "slide")
+        with pytest.raises(InvalidStructuralOpError):
+            service.move(
+                course.deck_id,
+                slide.slide_id,
+                slide.role,
+                "sideways",
+                expected_deck_version=view.deck_version,
+            )
 
 
 class TestSelfWriteHint:


### PR DESCRIPTION
## Mobile Deck Studio — P2 (structural ops)

Builds on P0/P1 (#397). Adds phone-side **structural authoring** to the Studio surface (`clm serve --spec`): **insert**, **delete**, and **move/reorder** of cells with automatic `slide_id` minting.

Every structural write routes through the **same byte-exact `FileState` serializer** as P1's cell edits, so untouched cells never shift, and stays guarded by optimistic concurrency (`409` on a stale `deck_version`).

### Backend
- New `FileState` primitives in `sync_writeback`: `move_cell()` (neighbour swap, with terminal-newline normalization when a cell moves into/out of the last slot) and `build_cell()` (mints a canonical-order header).
- `StudioService.{insert_cell, delete, move}` + routes `POST /api/studio/deck/{insert,delete,move}` (JSON body, not path segments — same greedy-`:path` avoidance as P1).
- **Id-minting:** a *new slide* mints a unique kebab slug from the body title (same `slugify` + `resolve_collision` + `classify` extractor as `assign-ids`); a companion `notes`/`voiceover` cell can pass an **explicit `slide_id`** to share its slide's identity (required so it groups correctly in the build). A duplicate `(slide_id, role)` is rejected (`400`) — it would break the unique-key keystone.
- **Guards:** `insert`/`move` guard `deck_version` only (cell set changes / content unchanged); `delete` guards both `deck_version` + `cell_hash`. A boundary move is `400`.

### Frontend
- Deck toolbar (reorder toggle + "Add slide"), per-cell insert (＋) / delete (🗑) controls, and up/down chevrons in reorder mode.

### Tests
- +19 studio tests (service + routes) and +7 unit tests (`tests/slides/test_sync_writeback_structural.py`), including the **move terminal-newline invariant** and **byte-exact untouched-cell** checks. Full web + sync regression suite green (288 passed).

### Docs
- Design `§4` phase table (P2 ✅) + new `§9.7` build record; changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
