### PR TITLE
feat(serve): Mobile Deck Studio P3a — bilingual language lock

### DIFF
--- a/changelog.d/395-mobile-deck-studio-p3a.added.md
+++ b/changelog.d/395-mobile-deck-studio-p3a.added.md
@@ -1,0 +1,8 @@
+- **Mobile Deck Studio P3a — bilingual lock.** The phone authoring surface
+  (`clm serve --spec`) now shows a **language toggle** for split DE/EN deck
+  pairs and derives a **watermark-based lock**: a language is editable only when
+  its twin half is clean relative to the last `clm slides sync` baseline, so
+  edits on one side mark the other stale and lock it (surfaced as a banner +
+  stale badge) until a sync reconciles them. Locked writes return **423**. The
+  lock is read-only and LLM-free; in-app *Discard* and *Sync-to-other-language*
+  follow in P3b. (#395)

--- a/docs/claude/design/mobile-deck-studio.md
+++ b/docs/claude/design/mobile-deck-studio.md
@@ -1,10 +1,11 @@
 # Mobile Deck Studio — authoring a course from a phone
 
-> **Status:** plan of record. **P0 + P1 + P2 implemented** (read-only browse,
-> the cell-editing concurrency core, and structural insert/delete/move with
-> id-minting); P3–P4 not yet implemented. Chosen over the `clm edit` prototype
-> (PR #394, closed as superseded). See §9 for the decision record, steering
-> notes, and the P0/P1 and P2 build records.
+> **Status:** plan of record. **P0 + P1 + P2 implemented**, **P3a implemented**
+> (the bilingual language toggle + watermark-derived lock + stale badges + 423
+> enforcement); **P3b** (in-app Sync-to-other-language + Discard) and **P4** not
+> yet implemented. Chosen over the `clm edit` prototype (PR #394, closed as
+> superseded). See §9 for the decision record, steering notes, and the P0/P1,
+> P2, and P3a build records.
 > **Date:** 2026-06-20.
 > **Author:** design draft, worked through interactively.
 > **Scope:** a new **Studio** view on the existing `clm serve` web app
@@ -230,7 +231,8 @@ structural op. No naïve whole-file re-emit.
 | **P0** ✅ | `clm serve` **Studio view** + Tailscale-HTTPS / QR / token auth scaffold; navigation (Recents, search, tree with badges, "Not in spec"); open a deck; **read-only** cell render (client markdown + server-side `is_j2` render); full-text search. Reuses `parse_cells`, `course decks`/`orphans`, `slides search`. No writes. *(Implemented — `is_j2` server render scaffolded; see §9.6.)* |
 | **P1** ✅ | **Cell body/tag editing** + the **concurrency core**: optimistic `deck_version` + `cell_hash` (409/423), atomic `FileState` write-back, `watchfiles` external-change watcher, autosave + 409/disk-change UX. The safety keystone — built and tested first. *(Implemented; 423 language-lock deferred to P3 — see §9.6.)* |
 | **P2** ✅ | **Structural ops** (`insert` / `delete` / `move` / mint-id) via the byte-exact serializer; reorder mode in the UI; byte-exact untouched-cell tests. *(Implemented — see §9.7.)* |
-| **P3** | **Bilingual**: language-view + watermark-derived lock + Discard/unlock + **Sync-to-other-language** (server-side `sync` / `translate` / `assign-ids`, streamed over WS); stale badges. |
+| **P3a** ✅ | **Bilingual lock core**: language toggle (switch to the split twin) + watermark-derived lock (read-only `build_sync_plan`) + stale badges + **423** enforcement on every write. *(Implemented — see §9.8.)* |
+| **P3b** | **Bilingual propagation**: in-app **Discard & unlock** + **Sync-to-other-language** (server-side `sync` / `translate` / `assign-ids`, streamed over WS). The LLM-backed half of P3. |
 | **P4** | **Build-preview** (tier-2 no-exec deck render streamed over WS) + installable PWA + **read-only offline cache** of the last-opened deck. |
 | **Later / optional** | **Full executed single-deck build** (tier 3) for code outputs and rendered diagrams. |
 
@@ -470,3 +472,56 @@ Decisions / landmines:
   insert form asks the author to type prefixed markdown. De-prefix-on-read /
   re-prefix-on-write is a P4 polish item, not a P2 blocker — kept uniform with
   P1 edit rather than introducing an insert-vs-edit inconsistency.
+
+### 9.8 P3a build record (2026-06-20)
+
+The **bilingual lock core** — the deterministic, LLM-free half of P3. A deck's
+two languages live in **separate split files** (`<deck>.de.py` / `<deck>.en.py`);
+the design's earlier "interleaved single `.py`" framing (§3.5) predates the
+split-format migration and is now the *legacy* path (`clm slides suggest-sync`,
+hidden). The lock is built on the **split-pair** model that `clm slides sync`
+uses (912 split decks vs 306 bare `.py` in the live course; the bare ones are
+test/workshop modules, not decks).
+
+What shipped: `LockState` on every `DeckView`; a `StudioService.compute_lock`
+that derives the lock read-only; `_enforce_lock` on **all five** write ops
+(edit-body, edit-tags, insert, delete, move) → `LanguageLockedError` → **423**;
+frontend language toggle (`DE ✎ / EN 🔒`, tap the twin to switch), lock banner,
+stale chip/banner, and controls disabled when locked. Tests: 10 new
+(`tests/web/studio/test_lock.py`).
+
+Decisions / landmines:
+
+- **Lock = watermark, not session state.** `compute_lock` calls
+  `build_sync_plan(de, en, watermark_cache=…)` (in `clm.slides.sync_plan`,
+  read-only, `provider_available=False` → **no LLM, no writes**) and reads
+  `Proposal.direction`: `de->en` ⇒ the **DE** half drifted (DE dirty), `en->de`
+  ⇒ EN dirty, a `conflict` (direction `None`) ⇒ both. **Rule:** a language is
+  editable iff the *other* half is clean → `editable = not other_dirty and not
+  has_conflicts`; the open half being dirty sets `other_stale` (the twin needs a
+  sync). This ties the lock to data-consistency state, so it survives reloads and
+  second devices (design §3.5).
+- **Cache must match the CLI.** `compute_lock` resolves the watermark DB with
+  `resolve_cache_dir()` (cwd-based, no `repo_root`) exactly as `clm slides sync`
+  does, so the lock reads the **same** `.clm-cache/clm-llm.sqlite` the user's
+  sync writes. `clm serve` is expected to run from the course root (same as the
+  CLI). Tests isolate it via `CLM_CACHE_DIR`.
+- **Cold-start = unlocked.** No watermark **and** no git baseline →
+  `baseline_source == "none"` → no drift detectable → both halves editable. Safe
+  because the 409 concurrency guard (P1) — not the lock — is the anti-clobber
+  keystone; the lock is an authoring-discipline aid. In a real git repo the
+  HEAD-fallback baseline makes a Studio edit show as drift immediately, so the
+  lock engages without an explicit sync.
+- **No twin ⇒ no lock.** `derive_split_twin` returns `None` for a deck with no
+  on-disk twin (or a voiceover companion) → `is_pair=False`, fully editable. This
+  is why the single-language P0–P2 fixtures and tests are unaffected — the lock
+  path returns before ever touching the watermark/plan.
+- **Escape hatches are P3b.** With the lock on, the only in-app release today is
+  switching to the editable (source) language; **Discard & unlock** and
+  **Sync-to-other-language** need care (Discard's revert is git-coupled; Sync is
+  the LLM-backed `apply_plan` streamed over WS) and are deferred to P3b. The lock
+  banner names the resolution (sync/discard the other half on the desktop).
+- **Cost.** `compute_lock` runs on every `open_deck` **and** every write (to
+  enforce), each parsing both halves + a sqlite read (+ a `git show` on
+  cold-start HEAD fallback). Fine at deck sizes / workstation use; a cache keyed
+  on `(deck_version_de, deck_version_en)` is an obvious later optimization.

--- a/src/clm/web/static/studio/app.js
+++ b/src/clm/web/static/studio/app.js
@@ -103,7 +103,9 @@ function handleWriteError(e, label) {
     toast("Changed elsewhere — reload.");
     renderDeck();
   } else if (e.status === 423) {
-    toast("Language locked — sync or discard first.");
+    const reason = (e.detail && e.detail.reason) || "Language locked — sync or discard first.";
+    toast(reason);
+    if (currentDeck) openDeck(currentDeck.deck_id); // refresh to surface the lock banner
   } else {
     toast(label + " failed: " + e.message);
   }
@@ -180,6 +182,7 @@ function deckRow(d) {
 
 async function openDeck(deckId) {
   appEl.innerHTML = '<p class="muted">Opening&hellip;</p>';
+  reorderMode = false;
   try {
     currentDeck = await api("/deck?id=" + encodeURIComponent(deckId));
     diskChanged = false;
@@ -189,11 +192,37 @@ async function openDeck(deckId) {
   }
 }
 
+// Language toggle + lock state (P3): DE ⚫ / EN 🔒, tap the twin to switch.
+function languageBar(lock) {
+  const bar = el(`<div class="lang-bar row"></div>`);
+  bar.appendChild(el(`<span class="lang-chip active">${esc((lock.lang || "").toUpperCase())} ${lock.editable ? "✎" : "🔒"}</span>`));
+  if (lock.twin_deck_id) {
+    const other = el(`<button class="lang-chip ghost">${esc((lock.other_lang || "").toUpperCase())} →</button>`);
+    other.addEventListener("click", () => openDeck(lock.twin_deck_id));
+    bar.appendChild(other);
+  }
+  if (lock.other_stale) {
+    bar.appendChild(el(`<span class="spacer"></span>`));
+    bar.appendChild(el(`<span class="chip stale-chip">${esc((lock.other_lang || "").toUpperCase())} stale</span>`));
+  }
+  return bar;
+}
+
 function renderDeck() {
   const deck = currentDeck;
+  const lock = deck.lock || { is_pair: false, editable: true };
+  const locked = lock.is_pair && !lock.editable;
   backEl.style.display = "";
   titleEl.textContent = deck.deck_id.split("/").pop();
   appEl.innerHTML = "";
+
+  if (lock.is_pair) appEl.appendChild(languageBar(lock));
+  if (locked) {
+    appEl.appendChild(el(`<div class="banner warn">🔒 ${esc(lock.locked_reason || "This language is locked.")}</div>`));
+  } else if (lock.other_stale) {
+    appEl.appendChild(el(`<div class="banner stale">${esc((lock.other_lang || "other").toUpperCase())} is stale — your edits aren't propagated yet. Sync from the desktop for now.</div>`));
+  }
+
   if (diskChanged) {
     const b = el(`<div class="banner warn row">Changed on disk — reload to avoid conflicts.
       <span class="spacer"></span></div>`);
@@ -203,26 +232,29 @@ function renderDeck() {
     appEl.appendChild(b);
   }
 
-  // Toolbar: reorder toggle + add-at-start.
-  const bar = el(`<div class="row toolbar"></div>`);
-  const reorderBtn = el(`<button class="ghost">${reorderMode ? "✓ Reordering" : "⇅ Reorder"}</button>`);
-  reorderBtn.addEventListener("click", () => { reorderMode = !reorderMode; renderDeck(); });
-  bar.appendChild(reorderBtn);
-  bar.appendChild(el(`<span class="spacer"></span>`));
-  if (!reorderMode) {
-    const addBtn = el(`<button>+ Add slide</button>`);
-    addBtn.addEventListener("click", () => openInsertForm(null));
-    bar.appendChild(addBtn);
+  // Toolbar: reorder toggle + add-at-start (hidden when the language is locked).
+  if (!locked) {
+    const bar = el(`<div class="row toolbar"></div>`);
+    const reorderBtn = el(`<button class="ghost">${reorderMode ? "✓ Reordering" : "⇅ Reorder"}</button>`);
+    reorderBtn.addEventListener("click", () => { reorderMode = !reorderMode; renderDeck(); });
+    bar.appendChild(reorderBtn);
+    bar.appendChild(el(`<span class="spacer"></span>`));
+    if (!reorderMode) {
+      const addBtn = el(`<button>+ Add slide</button>`);
+      addBtn.addEventListener("click", () => openInsertForm(null));
+      bar.appendChild(addBtn);
+    }
+    appEl.appendChild(bar);
   }
-  appEl.appendChild(bar);
 
-  deck.cells.forEach((cell, i) => appEl.appendChild(cellCard(cell, i)));
+  deck.cells.forEach((cell, i) => appEl.appendChild(cellCard(cell, i, locked)));
 }
 
-function cellCard(cell, idx) {
+function cellCard(cell, idx, locked) {
+  const canEdit = cell.editable && !locked;
   const langChip = cell.lang ? `<span class="chip">${cell.lang}</span>` : "";
   const tagChips = (cell.tags || []).map((t) => `<span class="chip">${esc(t)}</span>`).join("");
-  const card = el(`<div class="cell ${cell.editable && !reorderMode ? "editable" : ""}">
+  const card = el(`<div class="cell ${canEdit && !reorderMode ? "editable" : ""}">
       <div class="cell-head">
         <span class="chip">${cell.cell_type}</span>${langChip}${tagChips}
         <span class="spacer"></span>
@@ -235,8 +267,10 @@ function cellCard(cell, idx) {
   else body.innerHTML = `<pre><code>${esc(cell.body)}</code></pre>`;
 
   const controls = card.querySelector(".cell-controls");
-  if (reorderMode) {
-    if (cell.editable) {
+  if (locked) {
+    controls.appendChild(el(`<span class="muted">🔒 locked</span>`));
+  } else if (reorderMode) {
+    if (canEdit) {
       const up = el(`<button class="ghost icon" title="Move up">↑</button>`);
       const down = el(`<button class="ghost icon" title="Move down">↓</button>`);
       up.addEventListener("click", () => moveCell(cell, "up"));
@@ -245,7 +279,7 @@ function cellCard(cell, idx) {
     } else {
       controls.appendChild(el(`<span class="muted">read-only</span>`));
     }
-  } else if (cell.editable) {
+  } else if (canEdit) {
     const ins = el(`<button class="ghost icon" title="Insert after">＋</button>`);
     const del = el(`<button class="ghost icon" title="Delete">🗑</button>`);
     ins.addEventListener("click", (e) => { e.stopPropagation(); openInsertForm(cell); });

--- a/src/clm/web/static/studio/index.html
+++ b/src/clm/web/static/studio/index.html
@@ -63,6 +63,13 @@
     .banner { padding: 10px 12px; border-radius: 8px; margin: 10px 0; }
     .banner.warn { background: var(--warn-bg); color: var(--warn-fg); }
     .banner.err { background: #fee2e2; color: var(--err); }
+    .banner.stale { background: var(--chip); color: var(--chip-fg); }
+    .lang-bar { margin: 4px 0 8px; gap: 6px; }
+    .lang-chip { font: inherit; font-size: .82rem; padding: 4px 10px; border-radius: 999px;
+      border: 1px solid var(--line); background: var(--card); color: var(--fg); }
+    .lang-chip.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+    button.lang-chip.ghost { background: transparent; color: var(--accent); cursor: pointer; }
+    .stale-chip { background: var(--warn-bg); color: var(--warn-fg); }
     .toast { position: fixed; left: 50%; bottom: 20px; transform: translateX(-50%);
       background: #111827; color: #fff; padding: 10px 16px; border-radius: 999px;
       font-size: .9rem; opacity: 0; transition: opacity .2s; z-index: 20; }

--- a/src/clm/web/studio/models.py
+++ b/src/clm/web/studio/models.py
@@ -33,6 +33,38 @@ class CellView(BaseModel):
     )
 
 
+class LockState(BaseModel):
+    """The bilingual lock state of an opened deck (P3 — design §3.5).
+
+    Derived from the structural sync watermark, not invented session state: a
+    language is editable iff the *other* half is clean relative to the last
+    synced baseline. ``is_pair`` is False for a deck with no split twin on disk
+    (a single-language deck is always editable — no lock applies).
+    """
+
+    is_pair: bool = Field(description="True iff a split DE/EN twin exists on disk.")
+    lang: str | None = Field(default=None, description='This deck\'s language ("de"/"en").')
+    other_lang: str | None = Field(default=None, description="The twin's language.")
+    twin_deck_id: str | None = Field(
+        default=None, description="Slides-dir-relative id of the twin (for the language toggle)."
+    )
+    editable: bool = Field(
+        default=True, description="False when this language is locked (other half is dirty)."
+    )
+    locked_reason: str | None = Field(
+        default=None, description="Human-readable reason this language is locked, if it is."
+    )
+    other_stale: bool = Field(
+        default=False, description="True when this half is dirty so the twin needs a sync."
+    )
+    has_conflicts: bool = Field(
+        default=False, description="Both halves changed since the watermark (locks both)."
+    )
+    baseline: str = Field(
+        default="n/a", description='Baseline source: "watermark"/"git-head"/"none"/"n/a".'
+    )
+
+
 class DeckView(BaseModel):
     """A single deck opened for viewing/editing."""
 
@@ -40,6 +72,10 @@ class DeckView(BaseModel):
     deck_version: str = Field(description="Hash of the whole file (optimistic-concurrency guard).")
     lang: str | None = Field(default=None, description="Language filter applied, if any.")
     cells: list[CellView]
+    lock: LockState = Field(
+        default_factory=lambda: LockState(is_pair=False),
+        description="Bilingual lock state (P3).",
+    )
 
 
 class DeckSummary(BaseModel):

--- a/src/clm/web/studio/routes.py
+++ b/src/clm/web/studio/routes.py
@@ -37,6 +37,7 @@ from clm.web.studio.service import (
     DeckNotFoundError,
     InvalidDeckIdError,
     InvalidStructuralOpError,
+    LanguageLockedError,
     StaleWriteError,
     StudioService,
 )
@@ -69,6 +70,11 @@ def _handle_write(call: Callable[[], EditResult]) -> EditResult:
         raise HTTPException(
             status_code=409,
             detail={"error": "stale", "kind": e.kind, "current": e.current},
+        ) from e
+    except LanguageLockedError as e:
+        raise HTTPException(
+            status_code=423,
+            detail={"error": "locked", "reason": e.reason},
         ) from e
     except CellNotFoundError as e:
         raise HTTPException(status_code=404, detail=f"Cell not found: {e}") from e

--- a/src/clm/web/studio/service.py
+++ b/src/clm/web/studio/service.py
@@ -44,6 +44,7 @@ from clm.web.studio.models import (
     DeckTree,
     DeckView,
     EditResult,
+    LockState,
     SearchHit,
     SearchResults,
 )
@@ -76,6 +77,19 @@ class CellNotFoundError(StudioError):
 
 class InvalidStructuralOpError(StudioError):
     """A structural op (insert/delete/move) had invalid parameters (→ 400)."""
+
+
+class LanguageLockedError(StudioError):
+    """The deck's language is locked because the twin half is dirty (→ 423).
+
+    ``reason`` is a human-readable explanation the phone surfaces; the resolution
+    is to sync or discard the other half (on the desktop, until P3b lands those
+    in-app).
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
 
 
 class StaleWriteError(StudioError):
@@ -273,7 +287,7 @@ class StudioService:
         return views
 
     def open_deck(self, deck_id: str, *, lang: str | None = None) -> DeckView:
-        """Parse a deck for viewing/editing (read-only render)."""
+        """Parse a deck for viewing/editing (read-only render), with lock state."""
         path = self._resolve_deck_id(deck_id)
         if not path.exists():
             raise DeckNotFoundError(deck_id)
@@ -284,7 +298,84 @@ class StudioService:
             deck_version=self._deck_version(path),
             lang=lang,
             cells=self._cell_views(text, lang),
+            lock=self.compute_lock(deck_id, path),
         )
+
+    # ----------------------------------------------------- bilingual lock (P3)
+
+    def compute_lock(self, deck_id: str, path: Path) -> LockState:
+        """Derive the deck's bilingual lock from the structural sync watermark.
+
+        A language is editable iff the *other* split half is **clean** relative to
+        the last synced baseline (design §3.5): editing one half marks the other
+        stale and locks it until a sync (or discard) makes both clean again. The
+        plan build is **read-only and LLM-free** (``provider_available=False``).
+        Returns an unlocked state for any deck with no split twin on disk.
+        """
+        from clm.slides.pairing import derive_split_twin, order_split_pair, split_lang_tag
+
+        lang = split_lang_tag(path)
+        twin = derive_split_twin(path)
+        if lang is None or twin is None or not twin.exists():
+            return LockState(is_pair=False, lang=lang, editable=True, baseline="n/a")
+        ordered = order_split_pair(path, twin)
+        if ordered is None:
+            return LockState(is_pair=False, lang=lang, editable=True, baseline="n/a")
+        de_path, en_path = ordered
+        other_lang = "en" if lang == "de" else "de"
+
+        from clm.infrastructure.llm.cache import (
+            CACHE_DB_NAME,
+            SyncWatermarkCache,
+            resolve_cache_dir,
+        )
+        from clm.slides.sync_plan import build_sync_plan
+
+        cache = SyncWatermarkCache(resolve_cache_dir() / CACHE_DB_NAME)
+        try:
+            plan = build_sync_plan(de_path, en_path, watermark_cache=cache)
+        finally:
+            cache.close()
+
+        # ``direction`` names the half that drifted (the source). de->en ⇒ DE is
+        # dirty; en->de ⇒ EN is dirty. A conflict (both drifted) locks both.
+        de_dirty = any(p.direction == "de->en" for p in plan.proposals)
+        en_dirty = any(p.direction == "en->de" for p in plan.proposals)
+        has_conflicts = plan.count("conflict") > 0
+        this_dirty = de_dirty if lang == "de" else en_dirty
+        other_dirty = en_dirty if lang == "de" else de_dirty
+
+        editable = not other_dirty and not has_conflicts
+        if has_conflicts:
+            reason: str | None = (
+                "Both languages changed since the last sync — resolve on the "
+                "desktop with `clm slides sync`."
+            )
+        elif other_dirty:
+            reason = (
+                f"{other_lang.upper()} has unsynced edits and is the active source; "
+                f"sync or discard it to edit {lang.upper()}."
+            )
+        else:
+            reason = None
+
+        return LockState(
+            is_pair=True,
+            lang=lang,
+            other_lang=other_lang,
+            twin_deck_id=self._rel(twin),
+            editable=editable,
+            locked_reason=reason,
+            other_stale=this_dirty,
+            has_conflicts=has_conflicts,
+            baseline=plan.baseline_source,
+        )
+
+    def _enforce_lock(self, deck_id: str, path: Path) -> None:
+        """Raise :class:`LanguageLockedError` (→ 423) if this language is locked."""
+        lock = self.compute_lock(deck_id, path)
+        if lock.is_pair and not lock.editable:
+            raise LanguageLockedError(lock.locked_reason or "This language is locked.")
 
     # ----------------------------------------------------- concurrency core
 
@@ -346,6 +437,7 @@ class StudioService:
         path, state = self._load_guarded(
             deck_id, slide_id, role, expected_deck_version, expected_cell_hash
         )
+        self._enforce_lock(deck_id, path)
         if not state.replace_cell_body(slide_id, role, new_body):
             raise CellNotFoundError(f"{slide_id!r}/{role!r}")
         return self._persist(deck_id, path, state, slide_id, role)
@@ -364,6 +456,7 @@ class StudioService:
         path, state = self._load_guarded(
             deck_id, slide_id, role, expected_deck_version, expected_cell_hash
         )
+        self._enforce_lock(deck_id, path)
         if not state.replace_cell_tags(slide_id, role, new_tags):
             raise CellNotFoundError(f"{slide_id!r}/{role!r}")
         return self._persist(deck_id, path, state, slide_id, role)
@@ -458,6 +551,7 @@ class StudioService:
             raise InvalidStructuralOpError('a code cell must use role "code"')
 
         path, state = self._load_for_structural(deck_id, expected_deck_version)
+        self._enforce_lock(deck_id, path)
         resolved_lang = lang or self._infer_lang(state, after_slide_id, after_role)
         new_id = self._resolve_or_mint_slide_id(state, slide_id, role, body)
         tags = [] if cell_type == "code" else [role]
@@ -491,6 +585,7 @@ class StudioService:
         path, state = self._load_guarded(
             deck_id, slide_id, role, expected_deck_version, expected_cell_hash
         )
+        self._enforce_lock(deck_id, path)
         if not state.delete_cell(slide_id, role):
             raise CellNotFoundError(f"{slide_id!r}/{role!r}")
         # The cell is gone, so _persist's post-flush lookup yields an empty hash.
@@ -509,6 +604,7 @@ class StudioService:
         if direction not in ("up", "down"):
             raise InvalidStructuralOpError(f"invalid direction: {direction!r}")
         path, state = self._load_for_structural(deck_id, expected_deck_version)
+        self._enforce_lock(deck_id, path)
         if state.find_cell(slide_id, role) is None:
             raise CellNotFoundError(f"{slide_id!r}/{role!r}")
         if not state.move_cell(slide_id, role, direction):

--- a/tests/web/studio/conftest.py
+++ b/tests/web/studio/conftest.py
@@ -34,6 +34,24 @@ DECK_SOURCE = dedent(
 
 DECK_REL = "module_100_basics/topic_010_intro/slides_intro.de.py"
 
+# The EN twin of DECK_SOURCE: same slide_ids/roles, English bodies, shared code.
+DECK_SOURCE_EN = dedent(
+    """\
+    # %% [markdown] lang="en" tags=["slide"] slide_id="intro-welcome"
+    # Welcome
+    #
+    # Glad you're here.
+
+    # %% [markdown] lang="en" tags=["notes"] slide_id="intro-welcome"
+    # Speaker notes here.
+
+    # %%
+    print("hello")
+    """
+)
+
+DECK_REL_EN = "module_100_basics/topic_010_intro/slides_intro.en.py"
+
 
 @dataclass
 class Course:
@@ -76,3 +94,42 @@ def course(tmp_path: Path) -> Course:
 @pytest.fixture()
 def service(course: Course) -> StudioService:
     return StudioService(course.spec_path)
+
+
+@dataclass
+class Bilingual:
+    spec_path: Path
+    slides_dir: Path
+    de_id: str
+    en_id: str
+
+    @property
+    def de_path(self) -> Path:
+        return self.slides_dir / self.de_id
+
+    @property
+    def en_path(self) -> Path:
+        return self.slides_dir / self.en_id
+
+
+@pytest.fixture()
+def bilingual(course: Course, monkeypatch) -> Bilingual:
+    """A DE/EN split twin pair (reuses ``course`` for spec + the .de.py half).
+
+    Isolates the sync watermark cache to a tmp dir via ``CLM_CACHE_DIR`` so the
+    lock derivation never reads or writes a developer's real cache.
+    """
+    monkeypatch.setenv("CLM_CACHE_DIR", str(course.slides_dir.parent / ".clm-cache"))
+    en = course.slides_dir / DECK_REL_EN
+    en.write_text(DECK_SOURCE_EN, encoding="utf-8")
+    return Bilingual(
+        spec_path=course.spec_path,
+        slides_dir=course.slides_dir,
+        de_id=DECK_REL,
+        en_id=DECK_REL_EN,
+    )
+
+
+@pytest.fixture()
+def bilingual_service(bilingual: Bilingual) -> StudioService:
+    return StudioService(bilingual.spec_path)

--- a/tests/web/studio/test_lock.py
+++ b/tests/web/studio/test_lock.py
@@ -1,0 +1,207 @@
+"""Tests for the P3 bilingual lock (design §3.5).
+
+A language is editable iff the *other* split half is clean relative to the sync
+watermark. The lock-logic tests stub ``build_sync_plan`` with a controlled plan
+so the direction→dirty→editable mapping and the 423 enforcement are exercised
+hermetically (no git, no LLM); one test runs the *real* plan build to confirm a
+twin with no baseline is treated as unlocked (cold-start).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from clm.slides.sync_plan import Proposal, SyncPlan
+from clm.web.app import create_app
+from clm.web.studio.service import LanguageLockedError, StudioService
+
+from .conftest import Bilingual, Course
+
+TOKEN = "test-studio-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+
+def _fake_plan(*proposals: Proposal, baseline: str = "git-head"):
+    """A factory that ignores the real paths and returns a fixed plan."""
+
+    def _build(de_path, en_path, **kwargs):  # noqa: ANN001 - test stub
+        return SyncPlan(
+            de_path=de_path,
+            en_path=en_path,
+            baseline_source=baseline,
+            proposals=list(proposals),
+        )
+
+    return _build
+
+
+class TestNoTwinIsUnlocked:
+    def test_single_language_deck_is_not_a_pair(self, service: StudioService, course: Course):
+        view = service.open_deck(course.deck_id)
+        assert view.lock.is_pair is False
+        assert view.lock.editable is True
+
+    def test_writes_unaffected_without_twin(self, service: StudioService, course: Course):
+        view = service.open_deck(course.deck_id)
+        slide = next(c for c in view.cells if c.role == "slide")
+        # No twin → no lock → the P1 edit path still works.
+        result = service.edit_body(
+            course.deck_id,
+            slide.slide_id,
+            slide.role,
+            "# x\n#\n# y",
+            expected_deck_version=view.deck_version,
+            expected_cell_hash=slide.content_hash,
+        )
+        assert result.ok
+
+
+class TestColdStartUnlocked:
+    def test_twin_with_no_baseline_is_editable(
+        self, bilingual_service: StudioService, bilingual: Bilingual
+    ):
+        # Real build_sync_plan: no watermark + no git → baseline "none" → unlocked.
+        view = bilingual_service.open_deck(bilingual.de_id)
+        assert view.lock.is_pair is True
+        assert view.lock.lang == "de"
+        assert view.lock.other_lang == "en"
+        assert view.lock.twin_deck_id == bilingual.en_id
+        assert view.lock.editable is True
+        assert view.lock.baseline == "none"
+
+
+class TestWatermarkDerivedLock:
+    def test_de_dirty_locks_en(
+        self, bilingual_service: StudioService, bilingual: Bilingual, monkeypatch
+    ):
+        # DE drifted (direction de->en) → DE is the source; EN is locked + DE-stale.
+        monkeypatch.setattr(
+            "clm.slides.sync_plan.build_sync_plan",
+            _fake_plan(
+                Proposal(kind="edit", role="slide", direction="de->en", slide_id="intro-welcome")
+            ),
+        )
+        de = bilingual_service.open_deck(bilingual.de_id)
+        en = bilingual_service.open_deck(bilingual.en_id)
+        assert de.lock.editable is True and de.lock.other_stale is True
+        assert en.lock.editable is False
+        assert en.lock.locked_reason and "DE" in en.lock.locked_reason
+
+    def test_conflict_locks_both(
+        self, bilingual_service: StudioService, bilingual: Bilingual, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "clm.slides.sync_plan.build_sync_plan",
+            _fake_plan(
+                Proposal(kind="conflict", role="slide", direction=None, slide_id="intro-welcome")
+            ),
+        )
+        de = bilingual_service.open_deck(bilingual.de_id)
+        en = bilingual_service.open_deck(bilingual.en_id)
+        assert de.lock.editable is False and de.lock.has_conflicts is True
+        assert en.lock.editable is False and en.lock.has_conflicts is True
+
+    def test_clean_pair_both_editable(
+        self, bilingual_service: StudioService, bilingual: Bilingual, monkeypatch
+    ):
+        monkeypatch.setattr("clm.slides.sync_plan.build_sync_plan", _fake_plan())
+        de = bilingual_service.open_deck(bilingual.de_id)
+        en = bilingual_service.open_deck(bilingual.en_id)
+        assert de.lock.editable is True and en.lock.editable is True
+        assert de.lock.other_stale is False and en.lock.other_stale is False
+
+
+class TestLockEnforcement:
+    def test_edit_on_locked_language_raises(
+        self, bilingual_service: StudioService, bilingual: Bilingual, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "clm.slides.sync_plan.build_sync_plan",
+            _fake_plan(
+                Proposal(kind="edit", role="slide", direction="de->en", slide_id="intro-welcome")
+            ),
+        )
+        en = bilingual_service.open_deck(bilingual.en_id)  # EN is locked
+        slide = next(c for c in en.cells if c.role == "slide")
+        with pytest.raises(LanguageLockedError):
+            bilingual_service.edit_body(
+                bilingual.en_id,
+                slide.slide_id,
+                slide.role,
+                "# changed",
+                expected_deck_version=en.deck_version,
+                expected_cell_hash=slide.content_hash,
+            )
+
+    def test_insert_on_locked_language_raises(
+        self, bilingual_service: StudioService, bilingual: Bilingual, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "clm.slides.sync_plan.build_sync_plan",
+            _fake_plan(
+                Proposal(kind="edit", role="slide", direction="de->en", slide_id="intro-welcome")
+            ),
+        )
+        en = bilingual_service.open_deck(bilingual.en_id)
+        with pytest.raises(LanguageLockedError):
+            bilingual_service.insert_cell(
+                bilingual.en_id,
+                role="slide",
+                body="# x",
+                expected_deck_version=en.deck_version,
+            )
+
+    def test_edit_on_source_language_succeeds(
+        self, bilingual_service: StudioService, bilingual: Bilingual, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "clm.slides.sync_plan.build_sync_plan",
+            _fake_plan(
+                Proposal(kind="edit", role="slide", direction="de->en", slide_id="intro-welcome")
+            ),
+        )
+        de = bilingual_service.open_deck(bilingual.de_id)  # DE is the editable source
+        slide = next(c for c in de.cells if c.role == "slide")
+        result = bilingual_service.edit_body(
+            bilingual.de_id,
+            slide.slide_id,
+            slide.role,
+            "# geändert\n#\n# text",
+            expected_deck_version=de.deck_version,
+            expected_cell_hash=slide.content_hash,
+        )
+        assert result.ok
+
+
+class TestLockOverHttp:
+    def test_locked_write_is_423_with_reason(self, bilingual: Bilingual, monkeypatch):
+        monkeypatch.setattr(
+            "clm.slides.sync_plan.build_sync_plan",
+            _fake_plan(
+                Proposal(kind="edit", role="slide", direction="de->en", slide_id="intro-welcome")
+            ),
+        )
+        app = create_app(
+            db_path=bilingual.slides_dir.parent / "jobs.db",
+            spec_path=bilingual.spec_path,
+            studio_token=TOKEN,
+        )
+        client = TestClient(app)
+        body = client.get(f"/api/studio/deck?id={bilingual.en_id}", headers=AUTH).json()
+        assert body["lock"]["editable"] is False  # EN locked, surfaced on open
+        slide = next(c for c in body["cells"] if c["role"] == "slide")
+        r = client.post(
+            "/api/studio/deck/edit-body",
+            headers=AUTH,
+            json={
+                "deck_id": bilingual.en_id,
+                "slide_id": slide["slide_id"],
+                "role": slide["role"],
+                "new_body": "# changed",
+                "expected_deck_version": body["deck_version"],
+                "expected_cell_hash": slide["content_hash"],
+            },
+        )
+        assert r.status_code == 423
+        assert r.json()["detail"]["reason"]


### PR DESCRIPTION
## Mobile Deck Studio — P3a (bilingual lock core)

Builds on P2 (#398, merged). Adds the **deterministic, LLM-free** half of P3: a **language toggle** for split DE/EN deck pairs and a **watermark-derived lock**.

Decks ship as separate split files (`<deck>.de.py` / `<deck>.en.py`) — 912 split vs 306 bare `.py` in the live course (the bare ones are test/workshop modules). The lock is built on the same **split-pair + structural-watermark** model that `clm slides sync` uses. (The design's earlier "interleaved single `.py`" framing in §3.5 predates the split migration and is now the legacy `suggest-sync` path.)

### How the lock works
- `StudioService.compute_lock` calls `clm.slides.sync_plan.build_sync_plan(de, en, watermark_cache=…)` **read-only** (`provider_available=False` → no LLM, no writes) and reads `Proposal.direction`: `de->en` ⇒ DE drifted (dirty), `en->de` ⇒ EN dirty, a `conflict` ⇒ both.
- **Rule:** a language is editable iff the *other* half is **clean** vs the watermark. Editing one half marks the twin **stale**; a conflict locks both.
- **Cold-start** (no watermark + no git baseline) and **no-twin** decks are unlocked — the P1 `409` concurrency guard, not the lock, is the anti-clobber keystone.
- The watermark DB is resolved with `resolve_cache_dir()` exactly as the sync CLI does, so the lock reads the **same** `.clm-cache` the user's `clm slides sync` writes.

### Enforcement & UI
- `LanguageLockedError` → **423** on all five write ops (edit-body, edit-tags, insert, delete, move). Every `DeckView` now carries a `LockState`.
- Frontend: language toggle (`DE ✎ / EN 🔒`, tap the twin to switch), lock banner, stale chip/banner, controls disabled while locked.

### Deferred to P3b
In-app **Discard & unlock** and **Sync-to-other-language** (the LLM-backed `apply_plan` streamed over WS) — Discard's revert is git-coupled and Sync is the LLM-heavy half, so they get their own phase. The lock banner names the desktop resolution in the meantime.

### Tests
+10 (`tests/web/studio/test_lock.py`): direction→dirty→editable mapping (stubbed plan), cold-start unlocked (real plan build), 423 enforcement (service + HTTP), no-twin unaffected. Full web suite green (166 passed). Ruff + mypy clean.

### Docs
Design `§4` (P3a ✅ / P3b split out) + new `§9.8` build record; changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
