### PR TITLE
feat(serve): Mobile Deck Studio P4 — tier-2 preview + installable PWA

### DIFF
--- a/changelog.d/395-mobile-deck-studio-p4.added.md
+++ b/changelog.d/395-mobile-deck-studio-p4.added.md
@@ -1,0 +1,8 @@
+- **Mobile Deck Studio P4 — preview + installable PWA.** The phone authoring
+  surface (`clm serve --spec`) now renders cell previews correctly (markdown
+  bodies no longer show every line as a heading) and **expands Jinja header
+  macros** server-side (no kernel) so `is_j2` cells preview as the real header
+  instead of raw `{{ … }}`. The Studio is now an **installable PWA** with a
+  read-only **offline cache** of opened decks (view the last decks you opened
+  when the desktop is briefly unreachable; editing still requires the desktop).
+  (#395)

--- a/docs/claude/design/mobile-deck-studio.md
+++ b/docs/claude/design/mobile-deck-studio.md
@@ -1,11 +1,12 @@
 # Mobile Deck Studio — authoring a course from a phone
 
-> **Status:** plan of record. **P0–P3 implemented** (browse, the cell-editing
-> concurrency core, structural ops, the bilingual lock, and streamed
-> Sync-to-other-language). **Discard** (deferred from P3b by decision) and **P4**
-> not yet implemented. Chosen over the `clm edit` prototype (PR #394, closed as
-> superseded). See §9 for the decision record, steering notes, and the
-> P0/P1–P3b build records.
+> **Status:** plan of record. **P0–P4 implemented** (browse, the cell-editing
+> concurrency core, structural ops, the bilingual lock, streamed
+> Sync-to-other-language, and the tier-2 preview + installable/offline PWA). The
+> initial phase plan is complete; the remaining items are **Discard** (deferred
+> from P3b) and the **editor de-prefix ergonomics** (deferred from P4) — both by
+> decision. Chosen over the `clm edit` prototype (PR #394, closed as superseded).
+> See §9 for the decision record, steering notes, and the P0/P1–P4 build records.
 > **Date:** 2026-06-20.
 > **Author:** design draft, worked through interactively.
 > **Scope:** a new **Studio** view on the existing `clm serve` web app
@@ -233,7 +234,7 @@ structural op. No naïve whole-file re-emit.
 | **P2** ✅ | **Structural ops** (`insert` / `delete` / `move` / mint-id) via the byte-exact serializer; reorder mode in the UI; byte-exact untouched-cell tests. *(Implemented — see §9.7.)* |
 | **P3a** ✅ | **Bilingual lock core**: language toggle (switch to the split twin) + watermark-derived lock (read-only `build_sync_plan`) + stale badges + **423** enforcement on every write. *(Implemented — see §9.8.)* |
 | **P3b** ✅ | **Sync-to-other-language**: a streamed server-side `clm slides sync` subprocess (LLM reconciliation) over WS; the lock releases when it completes. *(Implemented — see §9.9. **Discard & unlock deferred** by decision: its revert is git-coupled and risky — use the desktop.)* |
-| **P4** | **Build-preview** (tier-2 no-exec deck render streamed over WS) + installable PWA + **read-only offline cache** of the last-opened deck. |
+| **P4** ✅ | **Tier-2 preview** (no-exec Jinja macro/header expansion per cell) + tier-1 comment-prefix fix + **installable PWA** + **read-only offline cache** of opened decks. *(Implemented — see §9.10. Editor de-prefix ergonomics deferred.)* |
 | **Later / optional** | **Full executed single-deck build** (tier 3) for code outputs and rendered diagrams. |
 
 ---
@@ -572,3 +573,45 @@ Decisions / landmines:
   P3b: its only revert is git-coupled (restore the dirty half from HEAD), which
   would risk clobbering legitimate uncommitted desktop edits. The lock's in-app
   release is now **sync**; discard stays a desktop/git operation.
+
+### 9.10 P4 build record (2026-06-20)
+
+The preview + PWA phase — **completes the initial plan**. Three pieces:
+
+1. **Tier-1 preview correctness (the real bug).** CLM markdown is **comment-
+   prefixed** in the `.py` (`# Willkommen`, `#`, `# Schön…`). The P0 client fed
+   that raw to the markdown renderer, so *every* body line became an `<h1>`. The
+   client now strips the deck's comment token (`#` / `//`, inferred from the deck
+   id) per line before rendering — bodies render as prose. **The edit textarea
+   still shows the raw prefixed source** (it round-trips to the byte-exact write
+   path unchanged); only the *preview* de-prefixes. Closing that editor/preview
+   asymmetry — true de-prefix-on-read + re-prefix-on-write — stays the deferred
+   ergonomics item (it touches the write path; out of scope for a preview phase).
+2. **Tier-2 render (`render.py`).** `render_j2_cell` builds a Jinja `Environment`
+   with the **same** bundled `PackageLoader("clm.workers.notebook",
+   templates_<prog_lang>)` + `line_statement_prefix=jinja_prefix_for(...)` the
+   build uses, plus a `FileSystemLoader` on the deck dir for sibling
+   `{% include %}`s, and expands the cell **with no kernel**. The wired
+   `/api/studio/deck/render-cell` (now carrying `deck_id` + `lang`) returns the
+   expanded text; the frontend calls it only for `is_j2` cells and injects the
+   result. LANDMINES: (a) **lenient `Undefined`**, not the build's
+   `StrictUndefined` — a preview must not crash on build-only course context;
+   (b) any failure returns `rendered=false` + the original body so the phone
+   falls back to tier-1; (c) a header macro emits **HTML** (logo `<img>` +
+   centered title) wrapped in a `# %% [markdown]` boundary, so the client strips
+   prefixes, drops the `%%` remnant line, and injects as **HTML** (trusted — it's
+   the user's own deck from their own desktop over an authed channel).
+3. **PWA + offline (`manifest.json`, `icon.svg`, `sw.js`).** Installable
+   (standalone, SVG maskable icon, `theme-color`). The service worker caches the
+   `/studio/` app shell **cache-first** and `/api/studio/deck{,s}` **network-
+   first with a cache fallback** (read-only away-from-desk viewing; writes are
+   never cached, so the optimistic guards stay authoritative). LANDMINE: a SW at
+   `/studio/sw.js` defaults to `/studio/` scope and *cannot* see `/api/studio/`;
+   it is served by an **explicit route** (registered before the `StaticFiles`
+   mount) with **`Service-Worker-Allowed: /`** and registered with `{scope:"/"}`
+   so it can intercept the API. Secure-context only (Tailscale HTTPS / localhost);
+   registration fails silently on plain HTTP.
+
+Tests: 10 new (`tests/web/studio/test_render_pwa.py`) — j2 expansion, broken-jinja
+fallback, non-j2 passthrough, the render endpoint + auth, and that the manifest /
+icon / app shell are served and `sw.js` carries the root-scope header.

--- a/src/clm/web/app.py
+++ b/src/clm/web/app.py
@@ -102,6 +102,21 @@ def create_app(
 
         studio_static = Path(__file__).parent / "static" / "studio"
         if studio_static.exists():
+            # The service worker must be served with `Service-Worker-Allowed: /`
+            # so it can register with root scope (intercepting both /studio/ and
+            # /api/studio/ for the P4 offline cache). This explicit route is added
+            # BEFORE the StaticFiles mount so it wins over the mount's handler.
+            sw_file = studio_static / "sw.js"
+            if sw_file.exists():
+
+                @app.get("/studio/sw.js", include_in_schema=False)
+                async def studio_service_worker() -> FileResponse:
+                    return FileResponse(
+                        sw_file,
+                        media_type="text/javascript",
+                        headers={"Service-Worker-Allowed": "/", "Cache-Control": "no-cache"},
+                    )
+
             app.mount(
                 "/studio",
                 StaticFiles(directory=studio_static, html=True),

--- a/src/clm/web/static/studio/app.js
+++ b/src/clm/web/static/studio/app.js
@@ -77,6 +77,36 @@ function inline(s) {
     .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
 }
 
+// --- comment-prefix handling (CLM markdown is `# `/`// ` prefixed in the .py) --
+function commentTokenFor(deckId) {
+  return /\.(cpp|cc|cxx|h|hpp|cs|java|ts|tsx)$/i.test(deckId || "") ? "//" : "#";
+}
+function stripCommentPrefix(text, token) {
+  return text.split("\n").map((line) => {
+    if (!line.startsWith(token)) return line;
+    let rest = line.slice(token.length);
+    if (rest.startsWith(" ")) rest = rest.slice(1);
+    return rest;
+  }).join("\n");
+}
+
+// Tier-2 (P4): ask the server to expand an is_j2 cell's Jinja, then inject the
+// expanded HTML (header macros emit trusted HTML from our own desktop). Falls
+// back silently to the tier-1 markdown already shown.
+function renderJ2(cell, bodyEl, token) {
+  api("/deck/render-cell", {
+    method: "POST",
+    body: JSON.stringify({ deck_id: currentDeck.deck_id, body: cell.body, is_j2: true, lang: cell.lang }),
+  }).then((res) => {
+    if (!res.rendered) return;
+    const html = stripCommentPrefix(res.body, token)
+      .split("\n")
+      .filter((l) => !l.trimStart().startsWith("%%")) // drop cell-boundary remnants
+      .join("\n");
+    bodyEl.innerHTML = html;
+  }).catch(() => {});
+}
+
 // --- UI helpers ---------------------------------------------------------------
 const appEl = document.getElementById("app");
 const titleEl = document.getElementById("title");
@@ -277,8 +307,15 @@ function cellCard(cell, idx, locked) {
       <div class="cell-body"></div>
     </div>`);
   const body = card.querySelector(".cell-body");
-  if (cell.cell_type === "markdown") body.innerHTML = renderMarkdown(cell.body);
-  else body.innerHTML = `<pre><code>${esc(cell.body)}</code></pre>`;
+  const token = commentTokenFor(currentDeck.deck_id);
+  if (cell.cell_type === "markdown") {
+    // CLM markdown is comment-prefixed in the .py; strip it so a body line
+    // renders as prose, not as a heading (tier-1 preview).
+    body.innerHTML = renderMarkdown(stripCommentPrefix(cell.body, token));
+    if (cell.is_j2) renderJ2(cell, body, token); // tier-2: expand macros server-side
+  } else {
+    body.innerHTML = `<pre><code>${esc(cell.body)}</code></pre>`;
+  }
 
   const controls = card.querySelector(".cell-controls");
   if (locked) {
@@ -508,6 +545,14 @@ function connectWs() {
     }
   });
   ws.addEventListener("close", () => setTimeout(connectWs, 3000));
+}
+
+// --- service worker (P4): installable PWA + offline read-only cache -----------
+// Registered with root scope (the sw is served with Service-Worker-Allowed: /)
+// so it can cache both the /studio/ app shell and /api/studio/deck reads. Only
+// works in a secure context (Tailscale HTTPS / localhost); fails silently else.
+if ("serviceWorker" in navigator) {
+  navigator.serviceWorker.register("/studio/sw.js", { scope: "/" }).catch(() => {});
 }
 
 // --- wiring -------------------------------------------------------------------

--- a/src/clm/web/static/studio/icon.svg
+++ b/src/clm/web/static/studio/icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="CLM Deck Studio">
+  <rect width="512" height="512" rx="96" fill="#2563eb"/>
+  <text x="50%" y="52%" dominant-baseline="middle" text-anchor="middle"
+        font-family="-apple-system, Segoe UI, Roboto, sans-serif" font-weight="700"
+        font-size="180" fill="#ffffff">CLM</text>
+  <text x="50%" y="74%" dominant-baseline="middle" text-anchor="middle"
+        font-family="-apple-system, Segoe UI, Roboto, sans-serif" font-weight="500"
+        font-size="58" fill="#bfdbfe">studio</text>
+</svg>

--- a/src/clm/web/static/studio/index.html
+++ b/src/clm/web/static/studio/index.html
@@ -4,6 +4,13 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="color-scheme" content="light dark" />
+  <meta name="theme-color" content="#2563eb" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-title" content="Deck Studio" />
+  <link rel="manifest" href="./manifest.json" />
+  <link rel="icon" href="./icon.svg" />
+  <link rel="apple-touch-icon" href="./icon.svg" />
   <title>CLM — Mobile Deck Studio</title>
   <style>
     :root {

--- a/src/clm/web/static/studio/manifest.json
+++ b/src/clm/web/static/studio/manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "CLM Mobile Deck Studio",
+  "short_name": "Deck Studio",
+  "description": "Author CLM course decks from a phone.",
+  "start_url": "./",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#0f172a",
+  "theme_color": "#2563eb",
+  "icons": [
+    {
+      "src": "./icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/src/clm/web/static/studio/sw.js
+++ b/src/clm/web/static/studio/sw.js
@@ -1,0 +1,68 @@
+/*
+ * Mobile Deck Studio service worker (P4) — installable PWA + read-only offline.
+ *
+ * Registered with root scope (served with `Service-Worker-Allowed: /`) so it can
+ * cache both the `/studio/` app shell and `/api/studio/deck{,s}` reads. Strategy:
+ *   - app shell  → cache-first  (instant load, works offline)
+ *   - deck reads → network-first, fall back to cache when offline (read-only)
+ *   - writes / everything else → passthrough (never cached; the optimistic
+ *     concurrency guards stay authoritative)
+ *
+ * "Offline" here is the away-from-desk fallback (design §1): view the last decks
+ * you opened when the desktop is briefly unreachable. Editing requires the
+ * desktop — writes are never served from cache.
+ */
+"use strict";
+
+const SHELL_CACHE = "clm-studio-shell-v1";
+const API_CACHE = "clm-studio-api-v1";
+const SHELL = [
+  "/studio/",
+  "/studio/index.html",
+  "/studio/app.js",
+  "/studio/manifest.json",
+  "/studio/icon.svg",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches.open(SHELL_CACHE).then((cache) => cache.addAll(SHELL)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.filter((k) => k !== SHELL_CACHE && k !== API_CACHE).map((k) => caches.delete(k))
+      )
+    ).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const req = event.request;
+  if (req.method !== "GET") return; // writes pass through, never cached
+  const url = new URL(req.url);
+
+  // App shell: cache-first.
+  if (url.pathname.startsWith("/studio/")) {
+    event.respondWith(caches.match(req).then((hit) => hit || fetch(req)));
+    return;
+  }
+
+  // Deck reads: network-first, cache fallback when offline.
+  if (url.pathname === "/api/studio/deck" || url.pathname === "/api/studio/decks") {
+    event.respondWith(
+      fetch(req)
+        .then((resp) => {
+          const copy = resp.clone();
+          caches.open(API_CACHE).then((cache) => cache.put(req, copy));
+          return resp;
+        })
+        .catch(() => caches.match(req))
+    );
+    return;
+  }
+  // Everything else: default network handling.
+});

--- a/src/clm/web/studio/models.py
+++ b/src/clm/web/studio/models.py
@@ -229,21 +229,22 @@ class SyncStartResult(BaseModel):
 
 
 class RenderCellRequest(BaseModel):
-    """Tier-2 (no-exec) render request for one cell."""
+    """Tier-2 (no-exec) render request for one ``is_j2`` cell (P4)."""
 
-    body: str
-    is_j2: bool = False
+    deck_id: str = Field(description="Slides-dir-relative deck path (for prog-lang + includes).")
+    body: str = Field(description="Raw cell body (comment-prefixed, with the j2 lines).")
+    is_j2: bool = Field(default=False, description="Only is_j2 cells are server-rendered.")
+    lang: str | None = Field(default=None, description='"de"/"en" Jinja global for the macros.')
 
 
 class RenderCellResult(BaseModel):
-    """Tier-2 render result.
+    """Tier-2 render result (P4).
 
-    P0/P1 ship tier-1 (client-side markdown) as the working preview; this
-    server endpoint is scaffolded and currently echoes the body with
-    ``rendered=False`` for ``is_j2`` cells. Wiring the jupytext+Jinja no-exec
-    expansion is a focused follow-up (still within the P0 design scope).
+    ``rendered`` True → ``body`` is the Jinja-expanded text (still markdown the
+    client renders); False → ``body`` is the original and ``error`` (if any) says
+    why, so the phone falls back to tier-1 client markdown.
     """
 
     rendered: bool
-    html: str | None = None
     body: str
+    error: str | None = None

--- a/src/clm/web/studio/render.py
+++ b/src/clm/web/studio/render.py
@@ -1,0 +1,74 @@
+"""Tier-2 (no-execution) cell render — design §3.8.
+
+Expands the Jinja in an ``is_j2`` cell (header macros, ``{{ … }}`` expressions)
+server-side using the **same** bundled ``macros.j2`` and line-statement prefix as
+the build pipeline, but **without a kernel** — so the phone sees an expanded
+header instead of raw ``{{ header_de("…") }}``. Plain (non-j2) cells need no
+round-trip; the client renders their markdown directly (tier 1).
+
+This is best-effort preview: any Jinja error (a macro that needs build-only
+context, a missing include) is caught and returned as ``ok=False`` with the body
+unchanged, so the preview degrades to tier-1 rather than failing. It also runs
+with a **lenient** ``Undefined`` (not the build's ``StrictUndefined``) so a
+missing course variable renders empty instead of raising — preview, not parity.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Identity globals the build injects from the course; a header macro only needs
+#: them to be *defined* for a preview, so placeholders are fine.
+_PREVIEW_AUTHOR = "Preview"
+_PREVIEW_ORG = ""
+
+
+def render_j2_cell(deck_path: Path, body: str, lang: str | None) -> tuple[bool, str | None, str]:
+    """Expand the Jinja in ``body`` for ``deck_path``. Returns ``(ok, error, text)``.
+
+    ``ok`` True → ``text`` is the expanded body; False → ``text`` is ``body``
+    unchanged and ``error`` explains why (the client falls back to tier-1). Never
+    raises — a preview must not crash the request.
+    """
+    try:
+        from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PackageLoader
+
+        from clm.infrastructure.utils.path_utils import path_to_prog_lang
+        from clm.workers.notebook.utils.prog_lang_utils import jinja_prefix_for
+    except Exception as exc:  # noqa: BLE001 - missing optional dep → tier-1 fallback
+        return False, f"render unavailable: {exc}", body
+
+    try:
+        prog_lang = path_to_prog_lang(deck_path)
+    except (KeyError, ValueError):
+        prog_lang = "python"
+
+    try:
+        loaders: list = [PackageLoader("clm.workers.notebook", f"templates_{prog_lang}")]
+        deck_dir = deck_path.parent
+        if deck_dir.exists():
+            # Lets the cell `{% include %}` a sibling file shown in a slide.
+            loaders.append(FileSystemLoader(str(deck_dir)))
+        env = Environment(
+            loader=ChoiceLoader(loaders) if len(loaders) > 1 else loaders[0],
+            autoescape=False,
+            line_statement_prefix=jinja_prefix_for(prog_lang),
+            keep_trailing_newline=True,
+        )
+        template = env.from_string(
+            body,
+            globals={
+                "is_notebook": False,
+                "is_html": True,
+                "lang": lang or "de",
+                "author": _PREVIEW_AUTHOR,
+                "organization": _PREVIEW_ORG,
+            },
+        )
+        return True, None, template.render()
+    except Exception as exc:  # noqa: BLE001 - preview must never crash the request
+        logger.debug("Studio tier-2 render failed for %s: %s", deck_path, exc)
+        return False, str(exc), body

--- a/src/clm/web/studio/routes.py
+++ b/src/clm/web/studio/routes.py
@@ -251,10 +251,17 @@ async def sync_deck(request: Request, req: SyncRequest) -> SyncStartResult:
     dependencies=[Depends(require_token)],
 )
 async def render_cell(request: Request, req: RenderCellRequest) -> RenderCellResult:
-    """Tier-2 (no-exec) render of one cell.
+    """Tier-2 (no-exec) render of one ``is_j2`` cell (P4).
 
-    P0/P1 use client-side markdown (tier 1) as the working preview; this
-    endpoint is scaffolded and echoes the body with ``rendered=False`` until
-    the jupytext+Jinja no-exec expansion is wired (a focused follow-up).
+    Expands the cell's Jinja (header macros, ``{{ … }}``) server-side through the
+    build's bundled macros, no kernel. Plain cells (or any failure) return the
+    body unchanged with ``rendered=False`` so the phone falls back to tier-1.
     """
-    return RenderCellResult(rendered=False, html=None, body=req.body)
+    service = get_service(request)
+    try:
+        rendered, error, text = service.render_cell(
+            req.deck_id, req.body, is_j2=req.is_j2, lang=req.lang
+        )
+    except InvalidDeckIdError as e:
+        raise HTTPException(status_code=400, detail=f"Invalid deck id: {e}") from e
+    return RenderCellResult(rendered=rendered, body=text, error=error)

--- a/src/clm/web/studio/service.py
+++ b/src/clm/web/studio/service.py
@@ -407,6 +407,24 @@ class StudioService:
         cmd = [sys.executable, "-m", "clm", "slides", "sync", str(de_path), "--yes"]
         return cmd, self._rel(de_path), self._rel(en_path)
 
+    # ------------------------------------------------------- tier-2 render (P4)
+
+    def render_cell(
+        self, deck_id: str, body: str, *, is_j2: bool, lang: str | None = None
+    ) -> tuple[bool, str | None, str]:
+        """Tier-2 (no-exec) render of one cell. Returns ``(rendered, error, text)``.
+
+        Only ``is_j2`` cells are expanded server-side (through the build's bundled
+        macros); plain cells are returned unchanged for the client to render as
+        markdown (tier 1). Never raises — preview degrades to tier-1 on failure.
+        """
+        if not is_j2:
+            return False, None, body
+        from clm.web.studio.render import render_j2_cell
+
+        path = self._resolve_deck_id(deck_id)
+        return render_j2_cell(path, body, lang)
+
     def try_begin_sync(self, key: str) -> bool:
         """Claim the in-flight slot for ``key`` (the DE deck id). False if taken."""
         if key in self._sync_inflight:

--- a/tests/web/studio/test_render_pwa.py
+++ b/tests/web/studio/test_render_pwa.py
@@ -1,0 +1,106 @@
+"""Tests for P4 — tier-2 (no-exec) render + the PWA / offline assets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from clm.web.app import create_app
+from clm.web.studio.render import render_j2_cell
+from clm.web.studio.service import StudioService
+
+from .conftest import Course
+
+TOKEN = "test-studio-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+# A real CLM j2 header cell: a line-statement import + a macro call expression.
+J2_HEADER = "# j2 from 'macros.j2' import header_de\n# {{ header_de(\"Hallo Welt\") }}"
+
+
+class TestTier2Render:
+    def test_j2_header_expands(self, tmp_path: Path):
+        ok, error, text = render_j2_cell(tmp_path / "slides_x.de.py", J2_HEADER, "de")
+        assert ok and error is None
+        assert "Hallo Welt" in text
+        assert "{{" not in text  # the macro call was expanded, not echoed
+
+    def test_broken_jinja_falls_back(self, tmp_path: Path):
+        bad = "# {{ this is not valid jinja "
+        ok, error, text = render_j2_cell(tmp_path / "slides_x.de.py", bad, "de")
+        assert ok is False
+        assert error  # explains why
+        assert text == bad  # body returned unchanged for tier-1 fallback
+
+    def test_service_skips_non_j2(self, service: StudioService, course: Course):
+        ok, error, text = service.render_cell(course.deck_id, "# plain", is_j2=False)
+        assert ok is False and text == "# plain"
+
+
+class TestRenderEndpoint:
+    @pytest.fixture()
+    def client(self, course: Course) -> TestClient:
+        app = create_app(
+            db_path=course.slides_dir.parent / "jobs.db",
+            spec_path=course.spec_path,
+            studio_token=TOKEN,
+        )
+        return TestClient(app)
+
+    def test_render_cell_expands_j2(self, client: TestClient, course: Course):
+        r = client.post(
+            "/api/studio/deck/render-cell",
+            headers=AUTH,
+            json={"deck_id": course.deck_id, "body": J2_HEADER, "is_j2": True, "lang": "de"},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["rendered"] is True
+        assert "Hallo Welt" in data["body"]
+
+    def test_render_cell_non_j2_passthrough(self, client: TestClient, course: Course):
+        r = client.post(
+            "/api/studio/deck/render-cell",
+            headers=AUTH,
+            json={"deck_id": course.deck_id, "body": "# plain", "is_j2": False},
+        )
+        assert r.status_code == 200 and r.json()["rendered"] is False
+
+    def test_render_cell_requires_token(self, client: TestClient, course: Course):
+        r = client.post(
+            "/api/studio/deck/render-cell",
+            json={"deck_id": course.deck_id, "body": J2_HEADER, "is_j2": True},
+        )
+        assert r.status_code == 401
+
+
+class TestPwaAssets:
+    @pytest.fixture()
+    def client(self, course: Course) -> TestClient:
+        app = create_app(
+            db_path=course.slides_dir.parent / "jobs.db",
+            spec_path=course.spec_path,
+            studio_token=TOKEN,
+        )
+        return TestClient(app)
+
+    def test_manifest_served(self, client: TestClient):
+        r = client.get("/studio/manifest.json")
+        assert r.status_code == 200
+        assert r.json()["display"] == "standalone"
+
+    def test_icon_served(self, client: TestClient):
+        assert client.get("/studio/icon.svg").status_code == 200
+
+    def test_service_worker_has_root_scope_header(self, client: TestClient):
+        # The sw.js route must override the static mount and grant root scope.
+        r = client.get("/studio/sw.js")
+        assert r.status_code == 200
+        assert r.headers.get("Service-Worker-Allowed") == "/"
+        assert "caches" in r.text  # it is the actual service worker
+
+    def test_app_shell_served(self, client: TestClient):
+        assert client.get("/studio/app.js").status_code == 200
+        assert client.get("/studio/").status_code == 200


### PR DESCRIPTION
## Mobile Deck Studio — P4 (preview + PWA)

Builds on P3b (#400, merged) and **completes the initial Studio plan**. Three pieces:

### 1. Tier-1 preview correctness (a real bug)
CLM markdown is **comment-prefixed** in the `.py` (`# Willkommen`, `#`, `# Schön…`), so the P0 client fed that raw to the markdown renderer and every body line became an `<h1>`. The client now strips the deck's comment token (`#` / `//`, inferred from the deck id) per line before rendering — bodies render as prose. The **edit textarea still shows the raw prefixed source** (it round-trips to the byte-exact write path unchanged); only the *preview* de-prefixes.

### 2. Tier-2 render (no kernel)
New `clm.web.studio.render.render_j2_cell` builds a Jinja `Environment` with the **same** bundled macros (`PackageLoader` on `templates_<prog_lang>`) + `line_statement_prefix` the build uses, plus a `FileSystemLoader` on the deck dir for sibling `{% include %}`s, and expands `is_j2` cells. `/api/studio/deck/render-cell` (now carrying `deck_id` + `lang`) returns the expansion; the frontend calls it only for `is_j2` cells and injects the result. Runs with a **lenient `Undefined`** (not the build's `StrictUndefined`) and returns the original body on any failure, so the preview never crashes (falls back to tier-1).

### 3. Installable PWA + read-only offline cache
`manifest.json` + an SVG maskable icon make the Studio installable; a service worker caches the `/studio/` app shell (cache-first) and `/api/studio/deck{,s}` (network-first, cache fallback) for away-from-desk viewing. **Writes are never cached** — the optimistic guards stay authoritative. The sw is served with **`Service-Worker-Allowed: /`** (an explicit route registered before the static mount) and registered with root scope so it can intercept the API; secure-context only (Tailscale HTTPS / localhost), fails silently on plain HTTP.

### Tests
+10 (`tests/web/studio/test_render_pwa.py`): j2 expansion, broken-jinja fallback, non-j2 passthrough, the render endpoint + auth, and that the manifest / icon / app shell are served and `sw.js` carries the root-scope header. Full web suite green (186 passed). Ruff + mypy clean.

### Docs
Design `§4` (P4 ✅) + new `§9.10` build record; changelog.

### Deferred by decision (optional follow-ups)
- In-app **Discard & unlock** (git-coupled revert).
- **Editor de-prefix ergonomics** — true de-prefix-on-read + re-prefix-on-write (touches the write path; out of scope for a preview phase).
- **Tier-3** full executed single-deck build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
