### PR TITLE
feat(serve): Mobile Deck Studio — clean-markdown editor ergonomics

### DIFF
--- a/changelog.d/395-mobile-deck-studio-editor-deprefix.added.md
+++ b/changelog.d/395-mobile-deck-studio-editor-deprefix.added.md
@@ -1,0 +1,7 @@
+- **Mobile Deck Studio — clean-markdown editing.** The phone editor now works in
+  plain markdown (type `# Title`, blank lines) instead of CLM's comment-prefixed
+  source (`# # Title`, `#`); the desktop de-prefixes on read and canonically
+  re-prefixes on write. The conversion is byte-exact for canonical cells (an
+  unedited re-save reproduces the file unchanged), and any cell whose prefixing
+  would not round-trip cleanly falls back to raw editing — so the byte-exact
+  write path is never weakened. (#395)

--- a/docs/claude/design/mobile-deck-studio.md
+++ b/docs/claude/design/mobile-deck-studio.md
@@ -2,11 +2,11 @@
 
 > **Status:** plan of record. **P0–P4 implemented** (browse, the cell-editing
 > concurrency core, structural ops, the bilingual lock, streamed
-> Sync-to-other-language, and the tier-2 preview + installable/offline PWA). The
-> initial phase plan is complete; the remaining items are **Discard** (deferred
-> from P3b) and the **editor de-prefix ergonomics** (deferred from P4) — both by
-> decision. Chosen over the `clm edit` prototype (PR #394, closed as superseded).
-> See §9 for the decision record, steering notes, and the P0/P1–P4 build records.
+> Sync-to-other-language, the tier-2 preview + installable/offline PWA) **plus
+> clean-markdown editor ergonomics** (§9.11). The initial phase plan is complete;
+> the only deliberately-deferred item left is in-app **Discard** (from P3b).
+> Chosen over the `clm edit` prototype (PR #394, closed as superseded). See §9
+> for the decision record, steering notes, and the P0/P1–P4 build records.
 > **Date:** 2026-06-20.
 > **Author:** design draft, worked through interactively.
 > **Scope:** a new **Studio** view on the existing `clm serve` web app
@@ -615,3 +615,43 @@ The preview + PWA phase — **completes the initial plan**. Three pieces:
 Tests: 10 new (`tests/web/studio/test_render_pwa.py`) — j2 expansion, broken-jinja
 fallback, non-j2 passthrough, the render endpoint + auth, and that the manifest /
 icon / app shell are served and `sw.js` carries the root-scope header.
+
+### 9.11 Editor de-prefix ergonomics (2026-06-20)
+
+The P4-deferred editor wart, picked up by decision (full design **with** the
+round-trip-safety fallback). The phone now edits **clean markdown** ("`# Title`",
+blank lines) instead of the comment-prefixed source ("`# # Title`", "`#`"); the
+server de-prefixes on read and canonically re-prefixes on write.
+
+`clm.web.studio.prefix.{deprefix,reprefix,round_trips}` are the conversion +
+safety primitives. `deprefix`/`reprefix` are **exact inverses for canonical
+content** (`# X` ↔ `X`, `#` ↔ blank). `CellView` gains `body_format`; `_cell_views`
+serves a markdown non-j2 cell as `"clean"` **only when `round_trips(content,
+token)`** holds, else `"raw"`. `edit_body` / `insert_cell` take `body_format` and
+re-prefix (`_for_write`) before the byte-exact `FileState` write; the request
+echoes the format. The frontend renders/edit-loads clean bodies directly (no
+client strip), sends the format back, and **skips a no-op save** (textarea ==
+loaded body). Tests: 12 new (`tests/web/studio/test_prefix.py`).
+
+Decisions / landmines:
+
+- **Byte-exact round-trip is the keystone.** Re-saving the exact clean body the
+  editor was given reproduces the file **byte-for-byte** (a dedicated test). This
+  holds because (a) `content` is stripped, so `_rewrite_cell_body` re-applies the
+  original trailing-blank separator regardless, and (b) deprefix∘reprefix is the
+  identity on canonical content.
+- **Non-canonical cells fall back to raw.** A cell whose prefixing does not
+  round-trip (a `"# "` trailing-space line, a missing prefix, `"#Tight"`) is
+  served `"raw"` and edits verbatim — so the de-prefix feature can **never**
+  introduce a spurious diff. Code and `j2` cells are always `"raw"` (code isn't
+  prefixed; j2 needs its `# j2` lines for the tier-2 render).
+- **The heading ambiguity is why `body_format` is explicit.** Clean `# Title`
+  (a real markdown heading) is indistinguishable from a raw comment line, so the
+  server cannot guess — it is told. With the flag, clean `# Title` re-prefixes to
+  `# # Title` (comment + heading), exactly CLM's convention, so headings finally
+  author naturally.
+- **`content_hash` / sync identity untouched.** The hash is still computed over
+  the **raw** content; `body_format` only changes the *displayed/edited* text.
+  The phone passes `content_hash` back opaquely, so the optimistic guard and the
+  sync watermark are unaffected.
+- **Still deferred:** closing this leaves only in-app **Discard** outstanding.

--- a/src/clm/web/static/studio/app.js
+++ b/src/clm/web/static/studio/app.js
@@ -309,9 +309,10 @@ function cellCard(cell, idx, locked) {
   const body = card.querySelector(".cell-body");
   const token = commentTokenFor(currentDeck.deck_id);
   if (cell.cell_type === "markdown") {
-    // CLM markdown is comment-prefixed in the .py; strip it so a body line
-    // renders as prose, not as a heading (tier-1 preview).
-    body.innerHTML = renderMarkdown(stripCommentPrefix(cell.body, token));
+    // "clean" cells arrive already de-prefixed; "raw" cells (non-canonical/j2)
+    // are comment-prefixed, so strip the token for the tier-1 preview.
+    const md = cell.body_format === "clean" ? cell.body : stripCommentPrefix(cell.body, token);
+    body.innerHTML = renderMarkdown(md);
     if (cell.is_j2) renderJ2(cell, body, token); // tier-2: expand macros server-side
   } else {
     body.innerHTML = `<pre><code>${esc(cell.body)}</code></pre>`;
@@ -408,7 +409,7 @@ function openInsertForm(anchor) {
     shareWrap.appendChild(el(`<span>Share id with anchor (e.g. notes for this slide)</span>`));
   }
 
-  const ta = el(`<textarea placeholder="# Title&#10;#&#10;# Body (markdown lines start with &quot;# &quot;)"></textarea>`);
+  const ta = el(`<textarea placeholder="# Title&#10;&#10;Body — plain markdown (code cells: raw code)"></textarea>`);
 
   appEl.appendChild(el(`<div class="muted" style="margin-bottom:6px">New cell ${anchor ? "after " + esc(anchor.slide_id || anchor.role || "") : "at deck start"}</div>`));
   const form = el(`<div class="insert-form"></div>`);
@@ -433,6 +434,8 @@ function openInsertForm(anchor) {
       cell_type: typeSel.value,
       role: roleInput.value.trim(),
       body: ta.value,
+      // Markdown is authored clean (server re-prefixes); code is raw.
+      body_format: typeSel.value === "markdown" ? "clean" : "raw",
       after_slide_id: anchor ? anchor.slide_id : null,
       after_role: anchor ? anchor.role : null,
       expected_deck_version: currentDeck.deck_version,
@@ -481,9 +484,12 @@ function editCell(cell, idx) {
   if (diskChanged) { toast("Deck changed on disk — reload first."); return; }
   appEl.innerHTML = "";
   titleEl.textContent = "Edit " + (cell.slide_id || cell.role);
+  const clean = cell.body_format === "clean";
   const ta = el(`<textarea></textarea>`);
   ta.value = cell.body;
-  appEl.appendChild(el(`<div class="muted" style="margin-bottom:6px">${cell.cell_type} · ${esc(cell.slide_id || "")} · ${esc(cell.role || "")}</div>`));
+  const originalBody = cell.body; // for skip-if-unchanged
+  const hint = clean ? "markdown" : (cell.cell_type === "code" ? "code" : "raw");
+  appEl.appendChild(el(`<div class="muted" style="margin-bottom:6px">${hint} · ${esc(cell.slide_id || "")} · ${esc(cell.role || "")}</div>`));
   appEl.appendChild(ta);
   const actions = el(`<div class="edit-actions"></div>`);
   const save = el(`<button>Save</button>`);
@@ -494,6 +500,7 @@ function editCell(cell, idx) {
 
   cancel.addEventListener("click", renderDeck);
   save.addEventListener("click", async () => {
+    if (ta.value === originalBody) { toast("No changes"); renderDeck(); return; }
     save.disabled = true; cancel.disabled = true;
     try {
       const result = await api("/deck/edit-body", {
@@ -503,6 +510,7 @@ function editCell(cell, idx) {
           slide_id: cell.slide_id,
           role: cell.role,
           new_body: ta.value,
+          body_format: cell.body_format || "raw",
           expected_deck_version: currentDeck.deck_version,
           expected_cell_hash: cell.content_hash,
         }),

--- a/src/clm/web/studio/models.py
+++ b/src/clm/web/studio/models.py
@@ -26,6 +26,10 @@ class CellView(BaseModel):
     tags: list[str] = Field(default_factory=list)
     body: str = Field(description="Cell body text.")
     is_j2: bool = Field(default=False, description="Jinja header/macro cell.")
+    body_format: str = Field(
+        default="raw",
+        description='"clean" → body is de-prefixed markdown (re-prefix on write); "raw" → verbatim.',
+    )
     content_hash: str = Field(description="Hash of the cell body (optimistic-concurrency guard).")
     anchor: str = Field(description="Content-derived stable identity (id:/construct:/hash:).")
     editable: bool = Field(
@@ -126,6 +130,10 @@ class EditBodyRequest(BaseModel):
     slide_id: str = Field(description="Hand-assigned slide id of the target cell.")
     role: str = Field(description="Sync role of the target cell.")
     new_body: str = Field(description="Replacement cell body.")
+    body_format: str = Field(
+        default="raw",
+        description='"clean" → re-prefix before writing (echo the CellView\'s body_format).',
+    )
     expected_deck_version: str = Field(description="deck_version the phone last saw.")
     expected_cell_hash: str = Field(description="content_hash the phone last saw for this cell.")
 
@@ -162,7 +170,11 @@ class InsertCellRequest(BaseModel):
     after_role: str | None = Field(default=None, description="Anchor cell's role.")
     cell_type: str = Field(default="markdown", description='"markdown" or "code".')
     role: str = Field(description="Sync role/tag for the new cell (slide/notes/voiceover/…).")
-    body: str = Field(default="", description="Body of the new cell (raw, comment-prefixed).")
+    body: str = Field(default="", description="Body of the new cell.")
+    body_format: str = Field(
+        default="raw",
+        description='"clean" → re-prefix the markdown body before writing; "raw" → verbatim.',
+    )
     slide_id: str | None = Field(
         default=None, description="Explicit slide id; omitted → minted from the body title."
     )

--- a/src/clm/web/studio/prefix.py
+++ b/src/clm/web/studio/prefix.py
@@ -1,0 +1,40 @@
+"""Comment-prefix ↔ clean-markdown conversion for the Studio editor.
+
+CLM stores markdown cell bodies **comment-prefixed** in the ``.py`` (``# text``,
+and a bare ``#`` for a blank line). The Studio editor offers *clean* markdown
+editing for the cells where that is byte-safe: de-prefix on read, canonically
+re-prefix on write.
+
+:func:`deprefix` and :func:`reprefix` are **exact inverses for canonical
+content**, so a cell edited back to the same text round-trips to identical bytes.
+A *non-canonical* cell (one that does **not** round-trip — e.g. a ``"# "`` line
+with a trailing space, or a line missing the prefix) is detected by
+:func:`round_trips` and kept on the raw edit path instead, so the byte-exact
+write guarantee is never weakened. ``token`` is the deck's line-comment token
+(``"#"`` python/rust, ``"//"`` cpp/csharp/java/typescript).
+"""
+
+from __future__ import annotations
+
+
+def deprefix(body: str, token: str) -> str:
+    """Strip the line-comment ``token`` (plus one following space) from each line."""
+    out: list[str] = []
+    for line in body.split("\n"):
+        if line == token:
+            out.append("")
+        elif line.startswith(token + " "):
+            out.append(line[len(token) + 1 :])
+        else:
+            out.append(line)  # non-canonical; round_trips() will reject it
+    return "\n".join(out)
+
+
+def reprefix(body: str, token: str) -> str:
+    """Re-apply the canonical prefix: ``token`` for a blank line, ``token + " "`` else."""
+    return "\n".join(token if line == "" else f"{token} {line}" for line in body.split("\n"))
+
+
+def round_trips(body: str, token: str) -> bool:
+    """Whether ``body`` survives ``deprefix`` → ``reprefix`` unchanged (canonical)."""
+    return reprefix(deprefix(body, token), token) == body

--- a/src/clm/web/studio/routes.py
+++ b/src/clm/web/studio/routes.py
@@ -142,6 +142,7 @@ async def edit_body(request: Request, req: EditBodyRequest) -> EditResult:
             req.slide_id,
             req.role,
             req.new_body,
+            body_format=req.body_format,
             expected_deck_version=req.expected_deck_version,
             expected_cell_hash=req.expected_cell_hash,
         )
@@ -174,6 +175,7 @@ async def insert_cell(request: Request, req: InsertCellRequest) -> EditResult:
             role=req.role,
             cell_type=req.cell_type,
             body=req.body,
+            body_format=req.body_format,
             after_slide_id=req.after_slide_id,
             after_role=req.after_role,
             slide_id=req.slide_id,

--- a/src/clm/web/studio/service.py
+++ b/src/clm/web/studio/service.py
@@ -262,6 +262,8 @@ class StudioService:
             c_role = role_of(c.metadata)
             if c.slide_id is not None and c_role is not None:
                 key_counts[(c.slide_id, c_role)] += 1
+        from clm.web.studio.prefix import deprefix, round_trips
+
         views: list[CellView] = []
         for index, cell in enumerate(parsed):
             if lang is not None and cell.lang is not None and cell.lang != lang:
@@ -272,6 +274,19 @@ class StudioService:
                 and role is not None
                 and key_counts[(cell.slide_id, role)] == 1
             )
+            # Offer clean (de-prefixed) markdown editing only for plain markdown
+            # cells whose prefixing round-trips exactly — code/j2 stay raw, and a
+            # non-canonical cell falls back to raw so the byte-exact write path is
+            # never weakened. The content_hash is always over the RAW content.
+            token = cell.comment_token
+            if (
+                cell.cell_type == "markdown"
+                and not cell.metadata.is_j2
+                and round_trips(cell.content, token)
+            ):
+                body, body_format = deprefix(cell.content, token), "clean"
+            else:
+                body, body_format = cell.content, "raw"
             views.append(
                 CellView(
                     index=index,
@@ -280,7 +295,8 @@ class StudioService:
                     cell_type=cell.cell_type,
                     lang=cell.lang,
                     tags=list(cell.tags),
-                    body=cell.content,
+                    body=body,
+                    body_format=body_format,
                     is_j2=cell.metadata.is_j2,
                     content_hash=cell_content_hash(cell.content),
                     anchor=anchor_of(cell.metadata, cell.content),
@@ -482,6 +498,20 @@ class StudioService:
         new_hash = cell_content_hash(fresh_cell.body) if fresh_cell is not None else ""
         return EditResult(deck_version=self._deck_version(path), cell_hash=new_hash)
 
+    def _for_write(self, path: Path, body: str, body_format: str) -> str:
+        """Canonically re-prefix a ``clean`` markdown body; pass ``raw`` through.
+
+        The phone edits de-prefixed markdown for ``body_format == "clean"`` cells
+        (see :meth:`_cell_views`); restore the comment prefix before the byte-exact
+        write so the stored form is unchanged for an unedited round-trip.
+        """
+        if body_format == "clean":
+            from clm.notebooks.slide_parser import comment_token_for_path
+            from clm.web.studio.prefix import reprefix
+
+            return reprefix(body, comment_token_for_path(path))
+        return body
+
     def edit_body(
         self,
         deck_id: str,
@@ -489,6 +519,7 @@ class StudioService:
         role: str,
         new_body: str,
         *,
+        body_format: str = "raw",
         expected_deck_version: str,
         expected_cell_hash: str,
     ) -> EditResult:
@@ -497,7 +528,9 @@ class StudioService:
             deck_id, slide_id, role, expected_deck_version, expected_cell_hash
         )
         self._enforce_lock(deck_id, path)
-        if not state.replace_cell_body(slide_id, role, new_body):
+        if not state.replace_cell_body(
+            slide_id, role, self._for_write(path, new_body, body_format)
+        ):
             raise CellNotFoundError(f"{slide_id!r}/{role!r}")
         return self._persist(deck_id, path, state, slide_id, role)
 
@@ -591,6 +624,7 @@ class StudioService:
         role: str,
         cell_type: str = "markdown",
         body: str = "",
+        body_format: str = "raw",
         after_slide_id: str | None = None,
         after_role: str | None = None,
         slide_id: str | None = None,
@@ -612,6 +646,8 @@ class StudioService:
         path, state = self._load_for_structural(deck_id, expected_deck_version)
         self._enforce_lock(deck_id, path)
         resolved_lang = lang or self._infer_lang(state, after_slide_id, after_role)
+        # Mint from the (clean) body so the title extractor sees plain markdown,
+        # then comment-prefix it for storage.
         new_id = self._resolve_or_mint_slide_id(state, slide_id, role, body)
         tags = [] if cell_type == "code" else [role]
         new_cell = build_cell(
@@ -620,7 +656,7 @@ class StudioService:
             lang=resolved_lang,
             tags=tags,
             slide_id=new_id,
-            body=body,
+            body=self._for_write(path, body, body_format),
         )
         if after_slide_id is None:
             state.insert_before_first_sync_cell(new_cell)

--- a/tests/web/studio/test_prefix.py
+++ b/tests/web/studio/test_prefix.py
@@ -1,0 +1,144 @@
+"""Tests for the editor de-prefix ergonomics (clean markdown editing).
+
+The keystone is the **byte-exact round-trip**: a clean cell edited back to the
+same text must reproduce identical file bytes, and a non-canonical cell must fall
+back to raw editing so the write path is never weakened.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.web.studio.prefix import deprefix, reprefix, round_trips
+from clm.web.studio.service import StudioService
+
+from .conftest import Course
+
+
+class TestPrefixHelpers:
+    def test_canonical_round_trips(self):
+        raw = "# # Willkommen\n#\n# Schön, dass du da bist."
+        assert round_trips(raw, "#")
+        clean = deprefix(raw, "#")
+        assert clean == "# Willkommen\n\nSchön, dass du da bist."
+        assert reprefix(clean, "#") == raw
+
+    def test_blank_line_is_bare_token(self):
+        assert reprefix("a\n\nb", "#") == "# a\n#\n# b"
+        assert deprefix("# a\n#\n# b", "#") == "a\n\nb"
+
+    def test_trailing_space_line_is_non_canonical(self):
+        assert round_trips("# ", "#") is False  # "# " → "" → "#" ≠ "# "
+
+    def test_missing_prefix_is_non_canonical(self):
+        assert round_trips("no prefix here", "#") is False
+
+    def test_cpp_token(self):
+        raw = "// // Titel\n//\n// Text"
+        assert round_trips(raw, "//")
+        assert deprefix(raw, "//") == "// Titel\n\nText"
+
+
+class TestCleanCellViews:
+    def test_markdown_cell_is_clean(self, service: StudioService, course: Course):
+        view = service.open_deck(course.deck_id)
+        slide = next(c for c in view.cells if c.role == "slide")
+        assert slide.body_format == "clean"
+        assert slide.body == "Willkommen\n\nSchön, dass du da bist."
+
+    def test_code_cell_stays_raw(self, service: StudioService, course: Course):
+        view = service.open_deck(course.deck_id)
+        code = next(c for c in view.cells if c.cell_type == "code")
+        assert code.body_format == "raw"
+        assert code.body == 'print("hello")'
+
+
+class TestByteExactRoundTrip:
+    def test_resaving_clean_body_is_byte_exact(self, service: StudioService, course: Course):
+        before = course.deck_path.read_text(encoding="utf-8")
+        view = service.open_deck(course.deck_id)
+        slide = next(c for c in view.cells if c.role == "slide")
+        # Re-save the exact clean body the editor was given.
+        service.edit_body(
+            course.deck_id,
+            slide.slide_id,
+            slide.role,
+            slide.body,
+            body_format="clean",
+            expected_deck_version=view.deck_version,
+            expected_cell_hash=slide.content_hash,
+        )
+        after = course.deck_path.read_text(encoding="utf-8")
+        assert after == before  # de-prefix → re-prefix lost nothing
+
+    def test_clean_edit_reprefixes_on_disk(self, service: StudioService, course: Course):
+        view = service.open_deck(course.deck_id)
+        slide = next(c for c in view.cells if c.role == "slide")
+        service.edit_body(
+            course.deck_id,
+            slide.slide_id,
+            slide.role,
+            "# Neuer Titel\n\nNeuer Text.",  # a real markdown heading, clean
+            body_format="clean",
+            expected_deck_version=view.deck_version,
+            expected_cell_hash=slide.content_hash,
+        )
+        text = course.deck_path.read_text(encoding="utf-8")
+        assert "# # Neuer Titel" in text  # md heading stored as comment + heading
+        assert "# Neuer Text." in text
+        # And it reads back clean.
+        reslide = next(c for c in service.open_deck(course.deck_id).cells if c.role == "slide")
+        assert reslide.body == "# Neuer Titel\n\nNeuer Text."
+
+    def test_other_cells_byte_exact_after_clean_edit(self, service: StudioService, course: Course):
+        view = service.open_deck(course.deck_id)
+        slide = next(c for c in view.cells if c.role == "slide")
+        notes_before = course.deck_path.read_text(encoding="utf-8").split("# %%")[2]
+        service.edit_body(
+            course.deck_id,
+            slide.slide_id,
+            slide.role,
+            "Ganz anderer Text.",
+            body_format="clean",
+            expected_deck_version=view.deck_version,
+            expected_cell_hash=slide.content_hash,
+        )
+        notes_after = course.deck_path.read_text(encoding="utf-8").split("# %%")[2]
+        assert notes_after == notes_before  # the notes + code cells are untouched
+
+
+class TestNonCanonicalFallback:
+    def _write_deck(self, course: Course, rel: str, text: str) -> str:
+        path = course.slides_dir / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+        return rel
+
+    def test_non_canonical_cell_served_raw(self, service: StudioService, course: Course):
+        # "#Tight" has no space after the token → does not round-trip → raw.
+        rel = self._write_deck(
+            course,
+            "module_100_basics/topic_010_intro/odd.de.py",
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="odd"\n#Tight\n',
+        )
+        cell = next(c for c in service.open_deck(rel).cells if c.role == "slide")
+        assert cell.body_format == "raw"
+        assert cell.body == "#Tight"
+
+
+class TestCleanInsert:
+    def test_insert_clean_markdown_is_prefixed_on_disk(
+        self, service: StudioService, course: Course
+    ):
+        version = service.open_deck(course.deck_id).deck_version
+        service.insert_cell(
+            course.deck_id,
+            role="slide",
+            cell_type="markdown",
+            body="# Frische Folie\n\nMit Text.",
+            body_format="clean",
+            expected_deck_version=version,
+        )
+        text = course.deck_path.read_text(encoding="utf-8")
+        assert "# # Frische Folie" in text
+        assert "# Mit Text." in text


### PR DESCRIPTION
## Mobile Deck Studio — clean-markdown editing

The P4-deferred editor wart, picked up after discussion (**full design with the round-trip-safety fallback**).

The phone now edits **plain markdown** (`# Title`, blank lines) instead of CLM's comment-prefixed source (`# # Title`, `#`). The desktop de-prefixes on read and canonically re-prefixes on write — scoped to markdown non-`j2` cells (code stays code; `j2` headers keep their `# j2` lines for the tier-2 render).

### How it stays safe
- `clm.web.studio.prefix.{deprefix,reprefix,round_trips}`: `deprefix`/`reprefix` are **exact inverses for canonical content** (`# X` ↔ `X`, `#` ↔ blank line).
- `CellView` gains `body_format`; `_cell_views` serves a cell `"clean"` **only when `round_trips(content, token)`** holds. A non-canonical cell (a `# ` trailing-space line, a missing prefix, `#Tight`) falls back to `"raw"` and edits verbatim — so the de-prefix feature can **never** introduce a spurious diff.
- `edit_body` / `insert_cell` take `body_format` and re-prefix (`_for_write`) before the byte-exact `FileState` write; the request echoes the format.
- **Byte-exact round-trip is the keystone**: re-saving the exact clean body the editor was given reproduces the file **byte-for-byte** (covered by a test).
- The **heading ambiguity** (clean `# Title` vs a raw comment line) is why `body_format` is explicit — with the flag, a clean markdown heading re-prefixes to `# # Title` (CLM's convention), so headings finally author naturally.
- `content_hash` and the sync watermark are **unchanged**: the hash is still over the raw content; `body_format` only changes the displayed/edited text.

### Frontend
Clean bodies are rendered and edit-loaded directly (no client strip), the format is echoed on save, and a **no-op save is skipped**.

### Tests
+12 (`tests/web/studio/test_prefix.py`): helper round-trips (incl. `//`), clean/raw cell views, the byte-exact re-save, clean re-prefix on disk, untouched-cell preservation, non-canonical raw fallback, and clean insert. Full web suite green (198 passed). Ruff + mypy clean.

### Docs
Design `§9.11` build record; changelog. With this, the only deliberately-deferred Studio item left is in-app **Discard**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
