### PR TITLE
fix(calendar): retry transient Google API errors on push

### DIFF
--- a/changelog.d/calendar-push-retry.fixed.md
+++ b/changelog.d/calendar-push-retry.fixed.md
@@ -1,0 +1,1 @@
+- `clm calendar push` now retries transient Google API errors (HTTP 429 and 5xx) with bounded exponential backoff instead of aborting the whole push on the first hiccup. A sync of 100+ events would otherwise die mid-run on a stray `503 backendError`, leaving a partial calendar; non-transient errors (e.g. 403/404) still fail fast.

--- a/src/clm/cohort_calendar/google_sync.py
+++ b/src/clm/cohort_calendar/google_sync.py
@@ -32,6 +32,7 @@ import datetime as dt
 import importlib
 import json
 import logging
+import time
 from pathlib import Path
 from typing import Any
 
@@ -49,6 +50,13 @@ UID_KEY = "clm_uid"
 
 #: Events-only scope — pushing needs event CRUD, never calendar-list management.
 SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+
+#: Transient HTTP statuses worth retrying: rate-limit + the 5xx backend errors
+#: Google routinely returns mid-push for a 100+ event sync.
+_TRANSIENT_STATUS = frozenset({429, 500, 502, 503, 504})
+#: Retries *after* the first attempt, and the base (doubling) backoff delay.
+MAX_RETRIES = 5
+_RETRY_BASE_DELAY = 1.0  # seconds; attempt n waits _RETRY_BASE_DELAY * 2**n
 
 _INSTALL_HINT = (
     "Google Calendar push requires the [gcal] extra: "
@@ -237,13 +245,51 @@ def build_service(credentials: Any) -> Any:
     return discovery.build("calendar", "v3", credentials=credentials, cache_discovery=False)
 
 
-def _execute(request: Any) -> Any:
+def _transient_status(exc: Exception) -> int | None:
+    """The HTTP status of *exc* if it is a retryable transient error, else None.
+
+    Duck-typed so this module needs no ``googleapiclient`` import: an
+    ``HttpError`` exposes the status as ``exc.resp.status`` (and newer versions
+    as ``exc.status_code``).
+    """
+    status = getattr(getattr(exc, "resp", None), "status", None)
+    if status is None:
+        status = getattr(exc, "status_code", None)
     try:
-        return request.execute()
-    except GoogleSyncError:
-        raise
-    except Exception as exc:
-        raise GoogleSyncError(f"Google Calendar API request failed: {exc}") from exc
+        status = int(status)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return status if status in _TRANSIENT_STATUS else None
+
+
+def _execute(request: Any) -> Any:
+    """Execute a Google API request, retrying transient 429/5xx with backoff.
+
+    A single push can issue 100+ event mutations; Google intermittently returns
+    a ``503 backendError`` on one of them. Without retry that aborts the whole
+    push mid-run (leaving a partial calendar that the next run reconciles, but
+    still a failure). Retries are bounded (:data:`MAX_RETRIES`) with exponential
+    backoff; non-transient errors (e.g. 404/403) raise immediately.
+    """
+    for attempt in range(MAX_RETRIES + 1):
+        try:
+            return request.execute()
+        except GoogleSyncError:
+            raise
+        except Exception as exc:
+            status = _transient_status(exc)
+            if status is None or attempt == MAX_RETRIES:
+                raise GoogleSyncError(f"Google Calendar API request failed: {exc}") from exc
+            delay = _RETRY_BASE_DELAY * (2**attempt)
+            logger.warning(
+                "Google Calendar API %s (attempt %d/%d); retrying in %.1fs.",
+                status,
+                attempt + 1,
+                MAX_RETRIES + 1,
+                delay,
+            )
+            time.sleep(delay)
+    raise AssertionError("unreachable")  # pragma: no cover
 
 
 def fetch_managed_events(service: Any, calendar_id: str, namespace: str) -> list[dict[str, Any]]:

--- a/tests/cohort_calendar/test_google_sync.py
+++ b/tests/cohort_calendar/test_google_sync.py
@@ -244,6 +244,65 @@ class FakeService:
         return self._events
 
 
+class _FakeResp:
+    def __init__(self, status):
+        self.status = status
+
+
+class _HttpErrorLike(Exception):
+    """Mimics googleapiclient.errors.HttpError's status surface (``.resp.status``)."""
+
+    def __init__(self, status):
+        super().__init__(f"HTTP {status}")
+        self.resp = _FakeResp(status)
+
+
+class _FlakyRequest:
+    """A request that raises a transient/permanent error N times, then succeeds."""
+
+    def __init__(self, *, fail_times, status=503, result=None):
+        self.calls = 0
+        self._fail_times = fail_times
+        self._status = status
+        self._result = result if result is not None else {"ok": True}
+
+    def execute(self):
+        self.calls += 1
+        if self.calls <= self._fail_times:
+            raise _HttpErrorLike(self._status)
+        return self._result
+
+
+class TestExecuteRetry:
+    def test_retries_transient_then_succeeds(self, monkeypatch):
+        monkeypatch.setattr(gs.time, "sleep", lambda _s: None)
+        req = _FlakyRequest(fail_times=2, status=503)
+        assert gs._execute(req) == {"ok": True}
+        assert req.calls == 3  # two 503s, third try wins
+
+    def test_gives_up_after_max_retries(self, monkeypatch):
+        monkeypatch.setattr(gs.time, "sleep", lambda _s: None)
+        req = _FlakyRequest(fail_times=99, status=503)
+        with pytest.raises(gs.GoogleSyncError, match="HTTP 503"):
+            gs._execute(req)
+        assert req.calls == gs.MAX_RETRIES + 1  # first attempt + MAX_RETRIES
+
+    def test_non_transient_raises_immediately_without_sleeping(self, monkeypatch):
+        slept: list[float] = []
+        monkeypatch.setattr(gs.time, "sleep", slept.append)
+        req = _FlakyRequest(fail_times=99, status=404)
+        with pytest.raises(gs.GoogleSyncError, match="HTTP 404"):
+            gs._execute(req)
+        assert req.calls == 1
+        assert slept == []
+
+    def test_rate_limit_is_retried(self, monkeypatch):
+        monkeypatch.setattr(gs.time, "sleep", lambda _s: None)
+        req = _FlakyRequest(fail_times=1, status=429)
+        assert gs._execute(req) == {"ok": True}
+        assert req.calls == 2
+
+
 class TestFetchManagedEvents:
     def test_filters_by_managed_tag_and_paginates(self):
         pages = [


### PR DESCRIPTION
## Why

`clm calendar push` issues one API call per event mutation. During a live test push of 107 events, Google returned a transient `503 backendError` on one insert — and because there was no retry, the **entire push aborted mid-run** (it had written 59 of 107 events). Re-running reconciled it, but a 100+ event sync is fairly likely to hit a stray 5xx, so this is a real robustness gap.

## What changed

`_execute` — the single chokepoint for every insert/update/delete/list call — now retries **transient** statuses (`429, 500, 502, 503, 504`) with bounded exponential backoff (`MAX_RETRIES=5`, 1s base, doubling: 1/2/4/8/16s). Non-transient errors (403/404/…) still raise immediately. The status is read by duck-typing the `HttpError` (`exc.resp.status`, or `exc.status_code` on newer clients) so the module keeps its lazy `[gcal]` import — no new top-level dependency.

## Tests

New `TestExecuteRetry`: retries-then-succeeds, gives-up-after-max, non-transient-raises-immediately-without-sleeping, rate-limit-is-retried (`time.sleep` monkeypatched). Full `test_google_sync.py` green (25 passed); ruff + mypy clean.

## Verified live

This is the exact failure that aborted the 107-event push during manual testing of #407; with this change the push rides through transient 5xx instead of bailing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
