### PR TITLE
feat(slides): reconcile-vo-ids — symmetrize voiceover ids across a split pair (#403 fix #3)

### DIFF
--- a/changelog.d/403-reconcile-vo-ids.added.md
+++ b/changelog.d/403-reconcile-vo-ids.added.md
@@ -1,0 +1,10 @@
+- **`clm slides reconcile-vo-ids`** — a new command that symmetrizes the voiceover /
+  notes `slide_id` convention across the two halves of a split deck (Issue #403 fix #3).
+  When a deck drifts into an asymmetric state — one half's paired voiceovers id-less, the
+  other's id'd — this makes them agree, either stripping the id'd side (`--to id-less`,
+  the default) or copying the id'd side's *existing* id onto the id-less side
+  (`--to ids`). It is the safe alternative to `assign-ids` on a split half: it pairs the
+  halves' voiceovers by the same occurrence-under-slide identity `clm slides sync` uses
+  and never derives an id from per-file content, so the two halves can never diverge (the
+  #162 hazard `assign-ids` carries). Accepts a single half, both halves, or a directory;
+  supports `--dry-run` / `--json`.

--- a/src/clm/cli/commands/slides/__init__.py
+++ b/src/clm/cli/commands/slides/__init__.py
@@ -21,6 +21,7 @@ from clm.cli.commands.slides.coverage import coverage_cmd  # noqa: E402
 from clm.cli.commands.slides.coverage_report import coverage_report_cmd  # noqa: E402
 from clm.cli.commands.slides.language_view import language_view_cmd  # noqa: E402
 from clm.cli.commands.slides.normalize import normalize_slides_cmd  # noqa: E402
+from clm.cli.commands.slides.reconcile_vo_ids import reconcile_vo_ids_cmd  # noqa: E402
 from clm.cli.commands.slides.referenced_by import referenced_by_cmd  # noqa: E402
 from clm.cli.commands.slides.rules import authoring_rules_cmd  # noqa: E402
 from clm.cli.commands.slides.search import search_slides_cmd  # noqa: E402
@@ -41,6 +42,7 @@ slides_group.add_command(unify_cmd, name="unify")
 slides_group.add_command(language_view_cmd, name="language-view")
 slides_group.add_command(suggest_sync_cmd, name="suggest-sync")
 slides_group.add_command(slides_sync_cmd, name="sync")
+slides_group.add_command(reconcile_vo_ids_cmd, name="reconcile-vo-ids")
 slides_group.add_command(slides_translate_cmd, name="translate")
 # `bootstrap` is the cold-start direction of `translate`; keep it
 # invocable but list the command only once in --help.

--- a/src/clm/cli/commands/slides/reconcile_vo_ids.py
+++ b/src/clm/cli/commands/slides/reconcile_vo_ids.py
@@ -1,0 +1,222 @@
+"""``clm slides reconcile-vo-ids`` — symmetrize voiceover ids across a split pair.
+
+Issue #403 fix #3. When a deck's two halves (``<deck>.de.<ext>`` / ``<deck>.en.<ext>``)
+disagree on whether their paired voiceover / notes cells carry a ``slide_id`` — one half
+id-less, the other id'd — this command makes them agree, *safely*. It pairs the halves'
+narratives by the same occurrence-under-slide identity ``clm slides sync`` uses (NOT the
+per-file slug ``assign-ids`` derives, which diverges DE/EN), then strips or stamps the
+``slide_id`` so both halves share one convention.
+
+Exit codes:
+
+- ``0`` — reconciled (or already symmetric / would reconcile in ``--report-only``)
+- ``2`` — usage error (no twin found, bad path)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from clm.notebooks.slide_parser import comment_token_for_path
+from clm.slides.pairing import (
+    derive_split_pair,
+    derive_split_twin,
+    find_split_slide_files_recursive,
+    iter_split_pairs,
+    split_lang_tag,
+)
+from clm.slides.reconcile_vo_ids import (
+    TO_IDLESS,
+    TO_IDS,
+    ReconcileResult,
+    reconcile_voiceover_ids,
+)
+
+
+@click.command("reconcile-vo-ids")
+@click.argument("path", type=click.Path(exists=True, path_type=Path))
+@click.argument(
+    "en_path", required=False, type=click.Path(exists=True, dir_okay=False, path_type=Path)
+)
+@click.option(
+    "--to",
+    "direction",
+    type=click.Choice([TO_IDLESS, TO_IDS]),
+    default=TO_IDLESS,
+    show_default=True,
+    help=(
+        "Which convention to resolve an asymmetric voiceover pair toward: "
+        f"'{TO_IDLESS}' strips the id'd side (the engine's canonical, collision-proof "
+        f"form), '{TO_IDS}' stamps the id'd side's existing id onto the id-less side."
+    ),
+)
+@click.option(
+    "--report-only",
+    "--dry-run",
+    "report_only",
+    is_flag=True,
+    help="Report what would change without modifying files.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit a JSON report.")
+def reconcile_vo_ids_cmd(
+    path: Path,
+    en_path: Path | None,
+    direction: str,
+    report_only: bool,
+    as_json: bool,
+) -> None:
+    """Symmetrize voiceover/notes slide_ids between the two halves of a split deck.
+
+    \b
+    PATH is one half of a split pair (``<deck>.de.<ext>`` / ``<deck>.en.<ext>`` — the
+    twin is found on disk), both halves passed explicitly, or a directory (every split
+    pair under it is reconciled).
+
+    \b
+    Only *paired* narratives that disagree on id-ness are touched — a pair that already
+    agrees (both id-less or both id'd) is left alone, and a narrative present on one half
+    only is left to ``clm slides sync``. Unlike ``assign-ids`` (which slugs per file and
+    so mints divergent ids on the two halves), this never derives an id from content:
+    it strips, or copies the twin's existing id, so the halves can never diverge.
+    """
+    try:
+        pairs = _resolve_pairs(path, en_path)
+    except click.UsageError:
+        raise
+    except ValueError as exc:
+        _fail(str(exc), as_json)
+
+    results: list[tuple[Path, Path, ReconcileResult]] = []
+    for de, en in pairs:
+        results.append(
+            (de, en, _reconcile_pair(de, en, direction=direction, write=not report_only))
+        )
+
+    if as_json:
+        click.echo(
+            json.dumps(_to_dict(results, direction=direction, report_only=report_only), indent=2)
+        )
+    else:
+        _print_human(results, report_only=report_only)
+
+
+def _resolve_pairs(path: Path, en_path: Path | None) -> list[tuple[Path, Path]]:
+    """Resolve the CLI arguments to an ordered list of ``(de, en)`` pairs."""
+    if path.is_dir():
+        if en_path is not None:
+            raise click.UsageError(
+                f"{path} is a directory (batch mode); do not pass a second path."
+            )
+        pairs, _solos = iter_split_pairs(find_split_slide_files_recursive(path))
+        if not pairs:
+            raise click.UsageError(f"no split deck pairs found under {path}")
+        return pairs
+
+    if en_path is not None:
+        pair = derive_split_pair(path) or derive_split_pair(en_path)
+        if pair is None or {pair[0], pair[1]} != {path, en_path}:
+            raise click.UsageError(
+                f"{path.name} and {en_path.name} are not the two halves of one split deck."
+            )
+        return [pair]
+
+    tag = split_lang_tag(path)
+    if tag is None:
+        raise click.UsageError(
+            f"{path.name} has no .de/.en language tag; pass a split half "
+            "(<deck>.de.<ext>), both halves, or a directory."
+        )
+    twin = derive_split_twin(path)
+    if twin is None:
+        other = "EN" if tag == "de" else "DE"
+        raise click.UsageError(
+            f"no {other} twin found next to {path.name}; pass both halves explicitly."
+        )
+    return [(path, twin) if tag == "de" else (twin, path)]
+
+
+def _reconcile_pair(de: Path, en: Path, *, direction: str, write: bool) -> ReconcileResult:
+    de_text = de.read_text(encoding="utf-8")
+    en_text = en.read_text(encoding="utf-8")
+    de_out, en_out, result = reconcile_voiceover_ids(
+        de_text,
+        en_text,
+        comment_token_for_path(de),
+        comment_token_for_path(en),
+        direction=direction,
+    )
+    if write:
+        if de_out != de_text:
+            de.write_text(de_out, encoding="utf-8", newline="\n")
+        if en_out != en_text:
+            en.write_text(en_out, encoding="utf-8", newline="\n")
+    return result
+
+
+def _fail(message: str, as_json: bool) -> None:
+    if as_json:
+        click.echo(json.dumps({"error": message}, indent=2))
+    else:
+        click.echo(f"error: {message}", err=True)
+    sys.exit(2)
+
+
+def _print_human(results: list[tuple[Path, Path, ReconcileResult]], *, report_only: bool) -> None:
+    prefix = "[report-only] " if report_only else ""
+    verb = "would change" if report_only else "changed"
+    total = 0
+    for de, _en, result in results:
+        if result.is_noop:
+            note = "already symmetric" if result.already_symmetric else "no paired narratives"
+            click.echo(f"{de.name}: {note}")
+            continue
+        total += len(result.changes)
+        click.echo(f"{prefix}{de.name}: {verb} {len(result.changes)} voiceover id(s)")
+        for c in result.changes:
+            verbed = "stripped id from" if c.action == "strip" else f"stamped id={c.new_id!r} onto"
+            click.echo(
+                f"    {c.lang} L{c.line_number} {c.role} under "
+                f"{c.owning_slide_id!r}#{c.occurrence}: {verbed} it"
+            )
+        if result.unpaired:
+            click.echo(
+                f"    ({result.unpaired} narrative(s) present on one half only — "
+                "left to `clm slides sync`)"
+            )
+    if len(results) > 1:
+        click.echo(f"{prefix}{len(results)} pair(s), {total} voiceover id(s) {verb}")
+
+
+def _to_dict(
+    results: list[tuple[Path, Path, ReconcileResult]], *, direction: str, report_only: bool
+) -> dict[str, object]:
+    return {
+        "direction": direction,
+        "report_only": report_only,
+        "pairs": [
+            {
+                "de": str(de),
+                "en": str(en),
+                "changes": [
+                    {
+                        "lang": c.lang,
+                        "line_number": c.line_number,
+                        "role": c.role,
+                        "owning_slide_id": c.owning_slide_id,
+                        "occurrence": c.occurrence,
+                        "action": c.action,
+                        "old_id": c.old_id,
+                        "new_id": c.new_id,
+                    }
+                    for c in result.changes
+                ],
+                "unpaired": result.unpaired,
+                "already_symmetric": result.already_symmetric,
+            }
+            for de, en, result in results
+        ],
+    }

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1549,6 +1549,57 @@ clm slides assign-ids slides/ --accept-content-derived --shipping-only
 clm slides assign-ids slides/ --report-only --report-refusals --context
 ```
 
+### `clm slides reconcile-vo-ids`
+
+*Added in CLM {version}.*
+
+Make the two halves of a split deck **agree** on whether their paired voiceover /
+notes cells carry a `slide_id`. A deck can drift into an asymmetric state — the DE
+half's voiceovers are id-less (`# %% [markdown] lang="de" tags=["voiceover"]`) while
+the EN half's are id'd (`… slide_id="…"`), or vice versa. `clm slides sync` is no
+longer *destructive* in that state (it pairs the two by position rather than
+duplicating the track), but the asymmetry is still confusing; this command cleans it
+up.
+
+It is the **safe** alternative to `clm slides assign-ids` on a split half: `assign-ids`
+slugs each id from that file's own heading, so running it on the DE and EN halves
+independently mints **divergent** ids for the same cell (the #162 hazard). This command
+instead pairs the halves' voiceovers by the *same* occurrence-under-slide identity sync
+uses — the n-th voiceover under its owning slide — and then either strips the id'd side
+or copies the id'd side's **existing** id onto the id-less side. It never derives an id
+from content, so the two halves can never diverge.
+
+```bash
+clm slides reconcile-vo-ids [OPTIONS] PATH [EN_PATH]
+```
+
+`PATH` is one half of a split pair (`<deck>.de.<ext>` / `<deck>.en.<ext>` — the twin is
+found on disk), both halves passed explicitly, or a directory (every split pair under it
+is reconciled).
+
+| Option | Effect |
+|---|---|
+| `--to id-less\|ids` | Which convention to resolve an asymmetric pair toward. `id-less` (default) strips the id'd side — the engine's canonical, collision-proof form; `ids` stamps the id'd side's existing id onto the id-less side. |
+| `--report-only`, `--dry-run` | Report what would change without modifying files. |
+| `--json` | Emit a JSON report. |
+
+Only **paired** narratives that *disagree* on id-ness are touched. A pair that already
+agrees (both id-less, or both id'd) is left alone, and a voiceover present on one half
+only is left to `clm slides sync` (it is a structural difference, not an id-symmetry
+one). Edits rewrite only the narrative cell's header line — slides, code, and all bodies
+are byte-preserved.
+
+```bash
+# Preview: which voiceover ids would change to make the halves agree
+clm slides reconcile-vo-ids slides_pe_03a_chain_of_thought.de.py --dry-run
+# Apply (default: strip the id'd side to id-less)
+clm slides reconcile-vo-ids slides_pe_03a_chain_of_thought.de.py
+# Keep ids instead — stamp the id'd half's id onto the id-less half
+clm slides reconcile-vo-ids slides_pe_03b_few_shot.de.py --to ids
+# Reconcile every split pair under a tree
+clm slides reconcile-vo-ids slides/module_410_ai_dev/
+```
+
 ### `clm slides slug-report`
 
 *Added in CLM {version}.*

--- a/src/clm/slides/reconcile_vo_ids.py
+++ b/src/clm/slides/reconcile_vo_ids.py
@@ -1,0 +1,190 @@
+"""Symmetrize voiceover / notes ``slide_id``s across the two halves of a split deck.
+
+Issue #403 fix #3 (the AI-dev DE/EN sync report, §10). Within a single deck the two
+halves can disagree on whether a *narrative* cell (``voiceover`` / ``notes``) carries a
+``slide_id``: e.g. the DE half's voiceovers are id-less
+(``# %% [markdown] lang="de" tags=["voiceover"]``) while the EN half's twins carry
+``slide_id="…"``. Phase B made ``clm slides sync`` *non-destructive* for this case — it
+now pairs the two by occurrence-under-slide instead of duplicating the German track —
+but the asymmetry itself is still messy and confusing.
+
+This reconciler makes the two halves **agree** on the voiceover-id convention, *safely*.
+The documented ``assign-ids`` is unsafe on a single split half: it slugs each id from
+that file's own heading, so running it on the DE and EN halves independently mints
+**divergent** ids for the same logical cell (the #162 hazard). This reconciler instead
+pairs the halves' narratives by the **same occurrence-under-slide identity** the Phase B
+sync engine uses — the n-th narrative of its role under its owning slide — and then
+either strips the id from the id'd side or stamps the id'd side's *existing* id onto the
+id-less side. It never mints a fresh id and never derives one from per-file content, so
+the two halves can never diverge.
+
+Only **paired** narratives that *disagree* on id-ness are touched. A narrative present on
+only one half (a structural difference — ``sync``'s job) is left alone, as is a pair that
+already agrees (both id-less, or both id'd).
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+
+from attrs import define, field
+
+from clm.notebooks.slide_parser import parse_cell_header
+from clm.slides.anchor_primitives import owning_group
+from clm.slides.raw_cells import RawCell, reconstruct, split_cells
+from clm.slides.sync_writeback import role_of
+
+# The narrative identity used to pair the two halves: the n-th narrative of its role
+# under its owning slide (the Phase B occurrence-under-slide key — stable under a
+# sibling-cell insertion, and language-agnostic so DE pairs with EN).
+_NarrKey = tuple[str | None, str, int]
+
+#: Reconcile direction — strip the id'd side to id-less, or stamp the id-less side id'd.
+TO_IDLESS = "id-less"
+TO_IDS = "ids"
+
+_SLIDE_ID_RE = re.compile(r'\s*slide_id="[^"]*"')
+
+
+@define
+class VoiceoverIdChange:
+    """One narrative cell whose ``slide_id`` was added or removed to match its twin."""
+
+    lang: str  # "de" / "en" — the half that was edited
+    line_number: int  # 1-based header line, for human-locatable reporting
+    role: str  # "voiceover" / "notes"
+    owning_slide_id: str | None  # the slide the narrative sits under
+    occurrence: int  # its index among same-role narratives under that slide
+    action: str  # "strip" / "stamp"
+    old_id: str | None
+    new_id: str | None
+
+
+@define
+class ReconcileResult:
+    """The outcome of one pair's reconciliation."""
+
+    changes: list[VoiceoverIdChange] = field(factory=list)
+    unpaired: int = 0  # narratives present on one half only (left to ``sync``)
+    already_symmetric: int = 0  # paired narratives that already agreed
+
+    @property
+    def de_changed(self) -> bool:
+        return any(c.lang == "de" for c in self.changes)
+
+    @property
+    def en_changed(self) -> bool:
+        return any(c.lang == "en" for c in self.changes)
+
+    @property
+    def is_noop(self) -> bool:
+        return not self.changes
+
+
+def _narrative_index(cells: list[RawCell]) -> dict[_NarrKey, tuple[int, RawCell]]:
+    """Index a half's narratives by ``(owning_slide_id, role, occurrence)``.
+
+    Counts the occurrence over *all* narratives under a slide — id-less and id'd alike —
+    so the n-th voiceover on DE pairs with the n-th on EN regardless of which side
+    carries an id (that is exactly the asymmetry we are reconciling). Mirrors
+    :func:`clm.slides.sync_apply._narrative_keys_by_index`, but does not filter by
+    id-ness.
+    """
+    out: dict[_NarrKey, tuple[int, RawCell]] = {}
+    seen: Counter[tuple[str | None, str]] = Counter()
+    for idx, cell in enumerate(cells):
+        meta = cell.metadata
+        if meta.is_j2 or not meta.is_narrative:
+            continue
+        role = role_of(meta)
+        if role is None:
+            continue
+        owning, _bounds = owning_group(cells, idx, meta.lang)
+        base = (owning, role)
+        out[(owning, role, seen[base])] = (idx, cell)
+        seen[base] += 1
+    return out
+
+
+def _strip_slide_id(cell: RawCell) -> None:
+    """Remove ``slide_id="…"`` from a cell header in place (byte-preserving)."""
+    new_header = _SLIDE_ID_RE.sub("", cell.lines[0]).rstrip()
+    cell.lines[0] = new_header
+    cell.metadata = parse_cell_header(new_header)
+
+
+def _stamp_slide_id(cell: RawCell, slide_id: str) -> None:
+    """Set ``slide_id="…"`` on a cell header in place (canonical trailing position)."""
+    stripped = _SLIDE_ID_RE.sub("", cell.lines[0]).rstrip()
+    new_header = f'{stripped} slide_id="{slide_id}"'
+    cell.lines[0] = new_header
+    cell.metadata = parse_cell_header(new_header)
+
+
+def reconcile_voiceover_ids(
+    de_text: str,
+    en_text: str,
+    de_token: str,
+    en_token: str,
+    *,
+    direction: str = TO_IDLESS,
+) -> tuple[str, str, ReconcileResult]:
+    """Symmetrize the voiceover/notes ``slide_id`` convention across a split pair.
+
+    Pairs the halves' narratives by occurrence-under-slide and, for each pair that
+    *disagrees* on id-ness, resolves it toward ``direction``:
+
+    - :data:`TO_IDLESS` (default) — strip the id from whichever half carries one, so the
+      pair ends up id-less (the engine's post-#6 canonical form, and collision-proof);
+    - :data:`TO_IDS` — stamp the id'd half's *existing* ``slide_id`` onto the id-less
+      half, so the pair ends up id'd under the **same** id on both halves.
+
+    Returns ``(de_text', en_text', result)``; a half's text is returned unchanged
+    (byte-identical) when it had no change. Only narrative headers are ever rewritten —
+    slides, code, and bodies are untouched.
+    """
+    if direction not in (TO_IDLESS, TO_IDS):
+        raise ValueError(f"direction must be {TO_IDLESS!r} or {TO_IDS!r}, got {direction!r}")
+
+    de_pre, de_cells = split_cells(de_text, de_token)
+    en_pre, en_cells = split_cells(en_text, en_token)
+    de_index = _narrative_index(de_cells)
+    en_index = _narrative_index(en_cells)
+
+    result = ReconcileResult()
+    for key in sorted(set(de_index) | set(en_index), key=lambda k: (str(k[0]), k[1], k[2])):
+        de_entry = de_index.get(key)
+        en_entry = en_index.get(key)
+        if de_entry is None or en_entry is None:
+            result.unpaired += 1  # present on one half only — a structural diff (sync's job)
+            continue
+        _de_i, de_cell = de_entry
+        _en_i, en_cell = en_entry
+        de_id = de_cell.metadata.slide_id
+        en_id = en_cell.metadata.slide_id
+        if (de_id is None) == (en_id is None):
+            result.already_symmetric += 1  # both id-less or both id'd — leave alone
+            continue
+
+        owning, role, occ = key
+        if direction == TO_IDLESS:
+            lang, cell, old = (
+                ("de", de_cell, de_id) if de_id is not None else ("en", en_cell, en_id)
+            )
+            _strip_slide_id(cell)
+            result.changes.append(
+                VoiceoverIdChange(lang, cell.line_number, role, owning, occ, "strip", old, None)
+            )
+        else:  # TO_IDS — copy the id'd twin's existing id onto the id-less side
+            src_id = de_id if de_id is not None else en_id
+            assert src_id is not None  # exactly one side is id'd in this branch
+            lang, cell = ("en", en_cell) if de_id is not None else ("de", de_cell)
+            _stamp_slide_id(cell, src_id)
+            result.changes.append(
+                VoiceoverIdChange(lang, cell.line_number, role, owning, occ, "stamp", None, src_id)
+            )
+
+    de_out = reconstruct(de_pre, de_cells) if result.de_changed else de_text
+    en_out = reconstruct(en_pre, en_cells) if result.en_changed else en_text
+    return de_out, en_out, result

--- a/tests/slides/test_reconcile_vo_ids.py
+++ b/tests/slides/test_reconcile_vo_ids.py
@@ -1,0 +1,237 @@
+"""Issue #403 fix #3 — `clm slides reconcile-vo-ids` voiceover-id symmetrizer.
+
+When a split deck's two halves disagree on whether their paired voiceover cells carry a
+`slide_id` (one id-less, one id'd), this command makes them agree by occurrence-under-slide
+pairing — strip the id'd side (default) or stamp the id'd side's existing id onto the
+id-less side — without ever deriving an id from per-file content (the `assign-ids` hazard).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands.slides.reconcile_vo_ids import reconcile_vo_ids_cmd
+from clm.slides.reconcile_vo_ids import TO_IDLESS, TO_IDS, reconcile_voiceover_ids
+
+
+def _title(lang: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="intro"\n# # T\n'
+
+
+def _code(lang: str, body: str, sid: str) -> str:
+    return f'# %% lang="{lang}" tags=["keep"] slide_id="{sid}"\n{body}\n'
+
+
+def _vo(lang: str, body: str, sid: str | None = None) -> str:
+    s = f' slide_id="{sid}"' if sid else ""
+    return f'# %% [markdown] lang="{lang}" tags=["voiceover"]{s}\n{body}\n'
+
+
+def _deck(*parts: str) -> str:
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Core: reconcile_voiceover_ids
+# ---------------------------------------------------------------------------
+
+
+class TestCore:
+    def test_to_idless_strips_the_idd_side(self):
+        de = _deck(_title("de"), _code("de", "print(1)", "c1"), _vo("de", "# Hallo"))
+        en = _deck(_title("en"), _code("en", "print(1)", "c1"), _vo("en", "# Hello", sid="intro"))
+        de_out, en_out, result = reconcile_voiceover_ids(de, en, "#", "#", direction=TO_IDLESS)
+        assert de_out == de  # DE already id-less — byte-identical, untouched
+        assert 'tags=["voiceover"]\n' in en_out and "slide_id" not in en_out.split("voiceover")[1]
+        assert [c.action for c in result.changes] == ["strip"]
+        assert result.changes[0].lang == "en"
+        assert result.changes[0].old_id == "intro"
+
+    def test_to_ids_stamps_the_twins_existing_id(self):
+        de = _deck(_title("de"), _code("de", "print(1)", "c1"), _vo("de", "# Hallo"))
+        en = _deck(_title("en"), _code("en", "print(1)", "c1"), _vo("en", "# Hello", sid="intro"))
+        de_out, _en_out, result = reconcile_voiceover_ids(de, en, "#", "#", direction=TO_IDS)
+        # The DE voiceover gets the EN twin's *existing* id — never a per-file slug.
+        assert '# %% [markdown] lang="de" tags=["voiceover"] slide_id="intro"' in de_out
+        assert result.changes[0].action == "stamp"
+        assert result.changes[0].new_id == "intro"
+
+    def test_both_symmetric_is_noop(self):
+        de = _deck(_title("de"), _vo("de", "# Hallo"))
+        en = _deck(_title("en"), _vo("en", "# Hello"))
+        de_out, en_out, result = reconcile_voiceover_ids(de, en, "#", "#")
+        assert result.is_noop and result.already_symmetric == 1
+        assert de_out == de and en_out == en  # byte-identical
+
+    def test_only_the_header_line_changes(self):
+        # Byte-preservation: stripping an id rewrites exactly the header line, nothing else.
+        de = _deck(_title("de"), _vo("de", "# Hallo\n#\n# mehr text"))
+        en = _deck(_title("en"), _vo("en", "# Hello\n#\n# more text", sid="intro"))
+        _de_out, en_out, _result = reconcile_voiceover_ids(de, en, "#", "#")
+        assert "# Hello\n#\n# more text" in en_out  # body verbatim
+
+    def test_occurrence_pairs_several_voiceovers_under_one_slide(self):
+        # Two voiceovers under the slide: the n-th DE pairs with the n-th EN.
+        de = _deck(
+            _title("de"),
+            _code("de", "print(1)", "c1"),
+            _vo("de", "# eins"),
+            _code("de", "print(2)", "c2"),
+            _vo("de", "# zwei"),
+        )
+        en = _deck(
+            _title("en"),
+            _code("en", "print(1)", "c1"),
+            _vo("en", "# one", sid="intro"),
+            _code("en", "print(2)", "c2"),
+            _vo("en", "# two", sid="intro"),
+        )
+        _de_out, en_out, result = reconcile_voiceover_ids(de, en, "#", "#")
+        assert len(result.changes) == 2  # both EN voiceovers stripped
+        # The slide + the two code cells keep their ids; neither voiceover does.
+        assert en_out.count("slide_id") == 3
+        assert 'voiceover"] slide_id' not in en_out
+
+    def test_unpaired_narrative_is_left_alone(self):
+        # A voiceover present on EN only (a genuine add) is not an id-symmetry issue.
+        de = _deck(_title("de"), _vo("de", "# Hallo"))
+        en = _deck(_title("en"), _vo("en", "# Hello"), _vo("en", "# extra", sid="intro"))
+        de_out, en_out, result = reconcile_voiceover_ids(de, en, "#", "#")
+        assert result.unpaired == 1
+        assert "extra" in en_out and result.is_noop  # the extra EN voiceover untouched
+        assert de_out == de
+
+    def test_mirror_direction_de_idd_en_idless(self):
+        # The asymmetry can point either way; the id'd side is detected, not assumed.
+        de = _deck(_title("de"), _vo("de", "# Hallo", sid="intro"))
+        en = _deck(_title("en"), _vo("en", "# Hello"))
+        de_out, _en_out, result = reconcile_voiceover_ids(de, en, "#", "#", direction=TO_IDLESS)
+        assert result.changes[0].lang == "de" and result.changes[0].action == "strip"
+        assert "slide_id" not in de_out.split("voiceover")[1]
+
+    def test_invalid_direction_raises(self):
+        with pytest.raises(ValueError, match="direction must be"):
+            reconcile_voiceover_ids("", "", "#", "#", direction="sideways")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _write_pair(tmp: Path, de: str, en: str) -> tuple[Path, Path]:
+    de_path, en_path = tmp / "deck.de.py", tmp / "deck.en.py"
+    de_path.write_text(de, encoding="utf-8")
+    en_path.write_text(en, encoding="utf-8")
+    return de_path, en_path
+
+
+class TestCli:
+    def test_single_half_resolves_twin_and_applies(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _deck(_title("de"), _vo("de", "# Hallo")),
+            _deck(_title("en"), _vo("en", "# Hello", sid="intro")),
+        )
+        res = CliRunner().invoke(reconcile_vo_ids_cmd, [str(de_path)])
+        assert res.exit_code == 0, res.output
+        assert "slide_id" not in en_path.read_text().split("voiceover")[1]
+
+    def test_dry_run_does_not_write(self, tmp_path: Path):
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _deck(_title("de"), _vo("de", "# Hallo")),
+            _deck(_title("en"), _vo("en", "# Hello", sid="intro")),
+        )
+        before = en_path.read_text()
+        res = CliRunner().invoke(reconcile_vo_ids_cmd, [str(de_path), "--dry-run"])
+        assert res.exit_code == 0
+        assert "would change" in res.output
+        assert en_path.read_text() == before  # unchanged
+
+    def test_to_ids_via_cli(self, tmp_path: Path):
+        de_path, _en = _write_pair(
+            tmp_path,
+            _deck(_title("de"), _vo("de", "# Hallo")),
+            _deck(_title("en"), _vo("en", "# Hello", sid="intro")),
+        )
+        res = CliRunner().invoke(reconcile_vo_ids_cmd, [str(de_path), "--to", TO_IDS])
+        assert res.exit_code == 0, res.output
+        assert 'tags=["voiceover"] slide_id="intro"' in de_path.read_text()
+
+    def test_directory_batch(self, tmp_path: Path):
+        for name in ("a", "b"):
+            (tmp_path / f"slides_{name}.de.py").write_text(
+                _deck(_title("de"), _vo("de", "# Hallo")), encoding="utf-8"
+            )
+            (tmp_path / f"slides_{name}.en.py").write_text(
+                _deck(_title("en"), _vo("en", "# Hello", sid="intro")), encoding="utf-8"
+            )
+        res = CliRunner().invoke(reconcile_vo_ids_cmd, [str(tmp_path)])
+        assert res.exit_code == 0, res.output
+        assert "2 pair(s)" in res.output
+        assert "slide_id" not in (tmp_path / "slides_a.en.py").read_text().split("voiceover")[1]
+
+    def test_json_output(self, tmp_path: Path):
+        import json
+
+        de_path, _en = _write_pair(
+            tmp_path,
+            _deck(_title("de"), _vo("de", "# Hallo")),
+            _deck(_title("en"), _vo("en", "# Hello", sid="intro")),
+        )
+        res = CliRunner().invoke(reconcile_vo_ids_cmd, [str(de_path), "--json", "--dry-run"])
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+        assert payload["direction"] == TO_IDLESS
+        assert payload["pairs"][0]["changes"][0]["action"] == "strip"
+
+    def test_missing_twin_is_usage_error(self, tmp_path: Path):
+        solo = tmp_path / "deck.de.py"
+        solo.write_text(_deck(_title("de"), _vo("de", "# Hallo")), encoding="utf-8")
+        res = CliRunner().invoke(reconcile_vo_ids_cmd, [str(solo)])
+        assert res.exit_code == 2
+        assert "no EN twin" in res.output
+
+
+# ---------------------------------------------------------------------------
+# Integration: a reconciled deck syncs cleanly (the whole point of fix #3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git not available")
+class TestUnblocksSync:
+    def test_reconciled_pair_syncs_without_change(self, tmp_path: Path):
+        from clm.infrastructure.llm.cache import SyncWatermarkCache
+        from clm.slides.sync_apply import _record_watermark, apply_plan
+        from clm.slides.sync_plan import build_sync_plan
+        from clm.slides.sync_translate import StaticSlideTranslator
+
+        # Asymmetric pair (DE id-less, EN id'd). Reconcile to id-less, then sync.
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _deck(_title("de"), _code("de", "print(1)", "c1"), _vo("de", "# Hallo")),
+            _deck(_title("en"), _code("en", "print(1)", "c1"), _vo("en", "# Hello", sid="intro")),
+        )
+        assert CliRunner().invoke(reconcile_vo_ids_cmd, [str(de_path)]).exit_code == 0
+
+        db = tmp_path / "clm-llm.sqlite"
+        wm = SyncWatermarkCache(db)
+        _record_watermark(wm, de_path, en_path)
+        plan = build_sync_plan(de_path, en_path, watermark_cache=wm)
+        result = apply_plan(
+            plan, judge=None, translator=StaticSlideTranslator(default="<<XL>>"), watermark_cache=wm
+        )
+        wm.close()
+        assert plan.is_noop  # no spurious add/edit after reconciliation
+        assert result.errors == []
+        assert en_path.read_text().count('tags=["voiceover"]') == 1  # not doubled
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True, text=True)


### PR DESCRIPTION
## Issue #403 fix #3 — `clm slides reconcile-vo-ids`

The third suggestion from the AI-dev DE/EN sync field report (§10). A split deck can drift into an **asymmetric** state: one half's paired voiceover/notes cells are id-less (`# %% [markdown] lang="de" tags=["voiceover"]`), the other's carry `slide_id="…"`. Phase B (PR #408) already made `clm slides sync` **non-destructive** in that state — it pairs the two by occurrence-under-slide instead of duplicating the track — but the asymmetry itself is still confusing. This command cleans it up.

### Why a dedicated command (not `assign-ids`)

The report explicitly flags that `assign-ids` is **unsafe on a single split half**: it slugs each id from that file's own heading, so running it on the DE and EN halves independently mints **divergent** ids for the same logical cell (the #162 hazard). `reconcile-vo-ids` instead pairs the halves' narratives by the **same occurrence-under-slide identity** the sync engine uses — the n-th voiceover under its owning slide — then:

- `--to id-less` (default) — strips the id from the id'd side (the engine's canonical, collision-proof form), or
- `--to ids` — copies the id'd side's **existing** id onto the id-less side.

It never derives an id from content and never mints a fresh one, so the two halves can never diverge.

### Scope / safety

- Only **paired** narratives that *disagree* on id-ness are touched. A pair that already agrees (both id-less or both id'd) is left alone; a voiceover present on one half only is left to `sync` (it's a structural diff, not an id-symmetry one).
- Byte-preserving: only the narrative cell's **header line** is ever rewritten — slides, code, and all bodies are untouched.
- Accepts a single half (twin found on disk), both halves explicitly, or a **directory** (batch over every split pair). `--dry-run` / `--json`.

### Changes

| File | What |
|---|---|
| `src/clm/slides/reconcile_vo_ids.py` | `reconcile_voiceover_ids(...)` core + byte-preserving header strip/stamp |
| `src/clm/cli/commands/slides/reconcile_vo_ids.py` | the `clm slides reconcile-vo-ids` command |
| `src/clm/cli/info_topics/commands.md` | documents the new command (per the info-topics maintenance rule) |
| `changelog.d/403-reconcile-vo-ids.added.md` | changelog fragment |
| `tests/slides/test_reconcile_vo_ids.py` | core + CLI + an **integration test** that a reconciled pair then syncs clean (no doubling) |

Builds on #408 (Phase B). Full `tests/slides` + `tests/cli` green (3515 passed); ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
