### PR TITLE
fix(sync): two silent narrative bugs from Phase B edit-detection (#403)

### DIFF
--- a/changelog.d/403-phaseb-narrative-bugfixes.fixed.md
+++ b/changelog.d/403-phaseb-narrative-bugfixes.fixed.md
@@ -1,0 +1,13 @@
+- **`clm slides sync`: fixed two silent narrative-handling bugs in the Phase B
+  voiceover edit-detection (Issue #403).** (1) Removing (or editing) several voiceovers
+  under one slide in a single sync could mis-target the second and later cells: the
+  apply step recomputed each narrative's occurrence ordinal over the *already-mutated*
+  deck, so after deleting the first the survivors renumbered and the next operation hit
+  the wrong cell — leaving one narrative behind plus an error that held the watermark, so
+  the stale state recurred every run. Apply now resolves narrative targets from a
+  pre-mutation snapshot and edits/deletes by object identity. (2) A voiceover sitting
+  under the macro-generated title slide whose nearest predecessor is a non-slide content
+  cell (e.g. a leading intro cell carrying a `slide_id`) failed to pair against its
+  baseline — its owning slide was recovered as "none" on the baseline side but "title" on
+  the current side — so a one-sided edit to it was silently dropped. The baseline
+  owning-slide recovery now mirrors the live computation for the title group.

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -348,18 +348,34 @@ def apply_plan(
     # is a reconciliation decision — "the target already reflects the source",
     # per SyncProposal — so it advances, the same as on a fully clean pass; were
     # it preserved it would re-surface every run forever (the judge re-declines).
+    # Issue #403 Phase B (bugfix): snapshot the id-less narrative cells by their
+    # occurrence key BEFORE the dispatch loop mutates anything. The edit/remove
+    # appliers resolve their narrative target from here and mutate it by object
+    # identity, so deleting the first of several narratives under one slide does not
+    # shift the (recomputed) ordinal of the next one onto the wrong cell.
+    narrative_targets = {
+        "de": narrative_cells_by_key(de_state.cells),
+        "en": narrative_cells_by_key(en_state.cells),
+    }
     deferred_keys: set[tuple[str, str]] = set()
     for proposal in plan.proposals:
         kind = proposal.kind
         if kind == "remove":
             if _accepted(decisions, proposal):
-                _apply_remove(proposal, de_state, en_state, result)
+                _apply_remove(proposal, de_state, en_state, result, narrative_targets)
             else:
                 result.deferred += 1
                 _note_deferred(deferred_keys, proposal)
         elif kind == "edit":
             if _accepted(decisions, proposal):
-                _apply_edit(proposal, de_state, en_state, edit_outcomes[id(proposal)], result)
+                _apply_edit(
+                    proposal,
+                    de_state,
+                    en_state,
+                    edit_outcomes[id(proposal)],
+                    result,
+                    narrative_targets,
+                )
             else:
                 result.deferred += 1
                 _note_deferred(deferred_keys, proposal)
@@ -377,7 +393,14 @@ def apply_plan(
                 _note_deferred(deferred_keys, proposal)
         elif kind == "conflict":
             _apply_conflict(
-                proposal, decisions, de_state, en_state, edit_outcomes, result, deferred_keys
+                proposal,
+                decisions,
+                de_state,
+                en_state,
+                edit_outcomes,
+                result,
+                deferred_keys,
+                narrative_targets,
             )
         elif kind == "refuse":
             # A structural refusal the resolver decided at plan time (#216): the
@@ -552,6 +575,7 @@ def _apply_conflict(
     edit_outcomes: dict[int, _EditOutcome],
     result: ApplyResult,
     deferred_keys: set[tuple[str, str]],
+    narrative_targets: dict[str, dict[tuple[str | None, str, int], RawCell]],
 ) -> None:
     """Resolve a conflict per its decision, or defer it.
 
@@ -569,6 +593,7 @@ def _apply_conflict(
             en_state,
             edit_outcomes[id(proposal)],
             result,
+            narrative_targets,
         )
     elif decision == DECISION_EN_WINS:
         _apply_edit(
@@ -577,6 +602,7 @@ def _apply_conflict(
             en_state,
             edit_outcomes[id(proposal)],
             result,
+            narrative_targets,
         )
     else:
         outcome = edit_outcomes.get(id(proposal))
@@ -904,14 +930,16 @@ def _apply_remove(
     de_state: FileState,
     en_state: FileState,
     result: ApplyResult,
+    narrative_targets: dict[str, dict[tuple[str | None, str, int], RawCell]],
 ) -> None:
     target_state = en_state if proposal.direction == "de->en" else de_state
     if proposal.role in NARRATIVE_ROLES and proposal.slide_id is None:
         # Issue #403 Phase B: an id-less narrative removal targets its positional twin,
-        # located by identity rather than (slide_id, role).
+        # resolved from the pre-mutation snapshot (so several removes under one slide do
+        # not shift each other's occurrence) and deleted by object identity.
         target_lang = "en" if proposal.direction == "de->en" else "de"
         key = (proposal.owning_slide_id, proposal.role, proposal.anchor_occ)
-        target_cell = _find_narrative_cell(target_state, key, target_lang)
+        target_cell = narrative_targets[target_lang].get(key)
         if target_cell is not None and target_state.delete_cell_obj(target_cell):
             result.applied_remove += 1
         else:
@@ -1082,6 +1110,9 @@ def _find_narrative_cell(
     counterpart of the plan's occurrence pairing (Issue #403 Phase B). Because a plan
     edit/remove is emitted only for a *paired* narrative (the twins share the same key,
     or they would not have paired), the same key locates the twin here.
+
+    Used during *materialization* (pre-mutation). The execute-time appliers must NOT
+    recompute occurrence over a half-mutated deck — see :func:`narrative_cells_by_key`.
     """
     keys = _narrative_keys_by_index(state.cells)
     for idx, cell_key in keys.items():
@@ -1090,6 +1121,21 @@ def _find_narrative_cell(
         if cell_key == key:
             return state.cells[idx]
     return None
+
+
+def narrative_cells_by_key(
+    cells: list[RawCell],
+) -> dict[tuple[str | None, str, int], RawCell]:
+    """Snapshot ``(owning_slide_id, role, occ) -> RawCell`` for a deck's id-less narratives.
+
+    Issue #403 Phase B (bugfix): the occurrence ordinal is a *position* among same-slide
+    narratives, so it shifts the moment one is deleted. The execute-time edit/remove
+    appliers must therefore resolve their target from a snapshot taken **before** any
+    mutation — looking up the stable :class:`RawCell` object once and mutating it by
+    identity — rather than recomputing the ordinal over the partially-mutated deck (which
+    silently mis-targets the second of several removes/edits under one slide).
+    """
+    return {key: cells[idx] for idx, key in _narrative_keys_by_index(cells).items()}
 
 
 def _resolve_narrative_edit(
@@ -1207,6 +1253,7 @@ def _apply_edit(
     en_state: FileState,
     outcome: _EditOutcome,
     result: ApplyResult,
+    narrative_targets: dict[str, dict[tuple[str | None, str, int], RawCell]],
 ) -> None:
     """Write a pre-materialized edit (mechanical — no judge/translator here).
 
@@ -1224,11 +1271,13 @@ def _apply_edit(
         return
     target_state = en_state if proposal.direction == "de->en" else de_state
     if proposal.role in NARRATIVE_ROLES and proposal.slide_id is None:
-        # Issue #403 Phase B: an id-less narrative edit's target is located by its
-        # positional identity (the twin shares the key), not by (slide_id, role).
+        # Issue #403 Phase B: an id-less narrative edit's target is resolved from the
+        # pre-mutation snapshot by its positional identity (the twin shares the key) and
+        # rewritten by object identity — so a co-applied remove under the same slide
+        # cannot shift the occurrence onto the wrong cell.
         target_lang = "en" if proposal.direction == "de->en" else "de"
         key = (proposal.owning_slide_id, proposal.role, proposal.anchor_occ)
-        target_cell = _find_narrative_cell(target_state, key, target_lang)
+        target_cell = narrative_targets[target_lang].get(key)
         if target_cell is not None and target_state.replace_cell_body_obj(
             target_cell, outcome.proposed_text or ""
         ):

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -40,12 +40,8 @@ from typing import TYPE_CHECKING, TypeVar
 logger = logging.getLogger(__name__)
 
 from clm.notebooks.slide_parser import Cell, CellMetadata, comment_token_for_path, parse_cells
-from clm.slides.anchor_primitives import (
-    TITLE_MACRO_ANCHOR,
-    narrative_anchor_token,
-    owning_group,
-)
-from clm.slides.pairing import TITLE_SLIDE_ID
+from clm.slides.anchor_primitives import narrative_anchor_token, owning_group
+from clm.slides.pairing import TITLE_SLIDE_ID, is_title_macro_cell
 from clm.slides.raw_cells import RawCell, split_cells
 from clm.slides.sync_writeback import (
     cell_content_hash,
@@ -1045,25 +1041,29 @@ def _resolve_divergence_winner(plan: SyncPlan, de_path: Path, en_path: Path) -> 
 
 def _baseline_owning_by_position(
     rows: list[tuple[int, str | None, str, str, str | None]],
-    anchors_by_position: dict[int, str],
+    has_title_macro: bool,
 ) -> dict[int, str | None]:
     """Recover each row's owning slide id by walking the ordered watermark rows.
 
     Slide / subslide rows precede their narrative companions, so tracking the last
     slide-start's id assigns every following narrative its owning slide (Issue #403
-    Phase B). A leading greeting (a narrative recorded before any slide, whose anchor
-    is the title-macro token) is normalized to :data:`TITLE_SLIDE_ID` so it matches
-    the current cell, whose :func:`owning_group` returns the same.
+    Phase B). This must mirror :func:`anchor_primitives.owning_group` *exactly*, or a
+    narrative's baseline key won't pair with its current key and a one-sided edit is
+    silently dropped: before the first slide-start, ``owning_group`` returns
+    :data:`TITLE_SLIDE_ID` when the deck has a j2 title macro (the title group),
+    regardless of the narrative's predecessor — so the walk seeds ``cur_owning`` with
+    it. The seed covers a leading greeting (no content predecessor) *and* a narrative
+    whose predecessor is a non-slide content cell still under the title group (bug:
+    that case has an ``id:``/``fp:`` anchor, not the title-macro token, so keying on
+    the anchor alone left it ``None`` and unpaired). j2 cells are excluded from the
+    watermark, so the title-macro presence is passed in from the current deck.
     """
     owning_by_pos: dict[int, str | None] = {}
-    cur_owning: str | None = None
+    cur_owning: str | None = TITLE_SLIDE_ID if has_title_macro else None
     for pos, sid, role, _chash, _construct in rows:
         if role in _SLIDE_ROLES:
             cur_owning = sid
-        if anchors_by_position.get(pos) == TITLE_MACRO_ANCHOR:
-            owning_by_pos[pos] = TITLE_SLIDE_ID
-        else:
-            owning_by_pos[pos] = cur_owning
+        owning_by_pos[pos] = cur_owning
     return owning_by_pos
 
 
@@ -1071,6 +1071,7 @@ def _baseline_from_watermark(
     rows: list[tuple[int, str | None, str, str, str | None]],
     tags_by_position: dict[int, frozenset[str]] | None = None,
     anchors_by_position: dict[int, str] | None = None,
+    has_title_macro: bool = False,
 ) -> list[BaselineCell]:
     # Drop the membership-widened rows (Issue #190 §5.3) and **re-index** the
     # survivors into the legacy-only position space. The stored positions count
@@ -1093,7 +1094,7 @@ def _baseline_from_watermark(
     # anchor map -> no narrative edit detection (degrades to add-only, as before).
     tbp = tags_by_position or {}
     abp = anchors_by_position or {}
-    owning_by_pos = _baseline_owning_by_position(rows, abp)
+    owning_by_pos = _baseline_owning_by_position(rows, has_title_macro)
     legacy = [
         (pos, sid, role, chash)
         for (pos, sid, role, chash, _construct) in rows
@@ -3091,10 +3092,17 @@ def build_sync_plan(
     # Issue #403 Phase B: narrative identity (owning slide + positional anchor),
     # computed over the byte-level RawCell stream so a narrative is keyed the same way
     # its baseline was recorded. ``parse_cells`` / ``split_cells`` align by index.
-    de_identity = narrative_identity_map(split_cells(de_text, de_token)[1])
-    en_identity = narrative_identity_map(split_cells(en_text, en_token)[1])
+    de_raw = split_cells(de_text, de_token)[1]
+    en_raw = split_cells(en_text, en_token)[1]
+    de_identity = narrative_identity_map(de_raw)
+    en_identity = narrative_identity_map(en_raw)
     de_current = ordered_sync_cells(de_cells, "de", de_identity)
     en_current = ordered_sync_cells(en_cells, "en", en_identity)
+    # Whether each half has a j2 title macro (excluded from the watermark, so the
+    # baseline owning-slide recovery must be told from the current deck — Issue #403,
+    # so a narrative under the title group keys identically on both baseline + current).
+    de_has_title = any(is_title_macro_cell(c) for c in de_raw)
+    en_has_title = any(is_title_macro_cell(c) for c in en_raw)
 
     de_baseline: list[BaselineCell] | None = None
     en_baseline: list[BaselineCell] | None = None
@@ -3136,10 +3144,10 @@ def build_sync_plan(
     if bundle is not None:
         source = bundle.source
         de_baseline = _baseline_from_watermark(
-            bundle.rows["de"], bundle.tags["de"], bundle.anchors["de"]
+            bundle.rows["de"], bundle.tags["de"], bundle.anchors["de"], de_has_title
         )
         en_baseline = _baseline_from_watermark(
-            bundle.rows["en"], bundle.tags["en"], bundle.anchors["en"]
+            bundle.rows["en"], bundle.tags["en"], bundle.anchors["en"], en_has_title
         )
         # Ordered content hashes of the baseline's neutral cells (position order),
         # matching _shared_hashes — see align_anchored for why this is a sequence,

--- a/tests/slides/test_sync_narrative_anchor.py
+++ b/tests/slides/test_sync_narrative_anchor.py
@@ -251,5 +251,96 @@ class TestAnchorRecording:
         assert de_anchors == {2: "id:c1#0"}
 
 
+def _j2_title(lang: str) -> str:
+    return f'# %% [markdown]\n# {{{{ header_{lang}("T") }}}}\n'
+
+
+def _md(lang: str, body: str, sid: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["markdown"] slide_id="{sid}"\n{body}\n'
+
+
+# ---------------------------------------------------------------------------
+# Cloud-review regressions (bugs found in the Phase B PR)
+# ---------------------------------------------------------------------------
+
+
+class TestStaleOccurrenceOrdinal:
+    """Removing several narratives under one slide must not mis-target later ones.
+
+    The apply-time `_find_narrative_cell` used to recompute the occurrence ordinal over
+    the half-mutated deck, so after deleting occ=0 the surviving cells renumbered and the
+    next remove (occ=1) hit the wrong cell — one narrative survived plus a spurious error,
+    and (error → watermark held) the stale cell re-surfaced every run. Fixed by resolving
+    targets from a pre-mutation snapshot and mutating by object identity.
+    """
+
+    def test_remove_all_voiceovers_under_one_slide(self, tmp_path: Path):
+        de0 = _deck(
+            _slide("de", "s", "S"),
+            _code("de", "print(1)", "c1"),
+            _vo("de", "# a"),
+            _code("de", "print(2)", "c2"),
+            _vo("de", "# b"),
+            _code("de", "print(3)", "c3"),
+            _vo("de", "# c"),
+        )
+        en0 = de0.replace('lang="de"', 'lang="en"')
+        # DE removes all three voiceovers; the removal must propagate cleanly to EN.
+        de1 = _deck(
+            _slide("de", "s", "S"),
+            _code("de", "print(1)", "c1"),
+            _code("de", "print(2)", "c2"),
+            _code("de", "print(3)", "c3"),
+        )
+        plan, result, _de, en_after = _sync(tmp_path, de0, en0, de1, en0)
+        assert result.errors == []
+        assert result.applied_remove == 3
+        assert _vo_count(en_after) == 0  # all three removed, none mis-targeted/survived
+
+    def test_remove_a_middle_voiceover_targets_correctly(self, tmp_path: Path):
+        # Remove only the *middle* of three voiceovers: occurrence-keyed, the engine
+        # decomposes it as edit/edit/remove, but every target must be located correctly
+        # (no error, no stale-ordinal mis-hit) and the EN track ends with two cells.
+        de0 = _deck(
+            _slide("de", "s", "S"),
+            _code("de", "print(1)", "c1"),
+            _vo("de", "# a"),
+            _vo("de", "# b"),
+            _vo("de", "# c"),
+        )
+        en0 = de0.replace('lang="de"', 'lang="en"')
+        de1 = _deck(
+            _slide("de", "s", "S"),
+            _code("de", "print(1)", "c1"),
+            _vo("de", "# a"),
+            _vo("de", "# c"),
+        )
+        _plan, result, _de, en_after = _sync(tmp_path, de0, en0, de1, en0, update_to="# x")
+        assert result.errors == []
+        assert _vo_count(en_after) == 2  # one fewer, correctly targeted (no error)
+
+
+class TestTitleGroupBaselineOwning:
+    """A voiceover under the title group must key identically on baseline + current.
+
+    `owning_group` returns `TITLE_SLIDE_ID` for any narrative before the first slide-start
+    when the deck has a j2 title macro. The baseline owning-slide recovery used to return
+    `None` unless the recorded anchor was the title-macro token, so a voiceover whose
+    predecessor is a non-slide content cell (with an `id:` anchor) under the title group
+    never paired — a one-sided edit was silently dropped. Fixed by seeding the baseline
+    walk with `TITLE_SLIDE_ID` when the deck has a title macro.
+    """
+
+    def test_edit_voiceover_under_title_group_with_idd_predecessor(self, tmp_path: Path):
+        de0 = _deck(_j2_title("de"), _md("de", "# Intro", "intro"), _vo("de", "# Hallo"))
+        en0 = _deck(_j2_title("en"), _md("en", "# Intro", "intro"), _vo("en", "# Hello"))
+        de1 = _deck(_j2_title("de"), _md("de", "# Intro", "intro"), _vo("de", "# Hallo EDIT"))
+        plan, result, _de, en_after = _sync(tmp_path, de0, en0, de1, en0, update_to="# Hello EDIT")
+        assert [p.kind for p in plan.proposals] == ["edit"]
+        assert plan.proposals[0].owning_slide_id == "title"
+        assert result.applied_edit == 1
+        assert "# Hello EDIT" in en_after  # not silently dropped
+
+
 def _git(cwd: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True, text=True)


### PR DESCRIPTION
Fixes two silent data-loss bugs the **cloud code review of #408 (Phase B)** found in the new narrative occurrence-keying. Both ship green (no existing test covered the multi-narrative-per-slide path the occurrence ordinal was introduced for).

## 1. Stale occurrence ordinal on multi-narrative remove/edit

`_apply_edit` / `_apply_remove` resolved their target via `_find_narrative_cell`, which **recomputes** the occurrence ordinal over the *live, mutated* deck. Removing several voiceovers under one slide therefore mis-targeted: after deleting `occ=0` the survivors renumber, so the next remove (`occ=1`) deleted the cell originally at `occ=2`, and a third (`occ=2`) errored `target narrative not found by anchor`. Net: one narrative survived, the error held the watermark, and the stale state recurred every run.

**Fix:** snapshot the id-less narratives `{(owning, role, occ) -> RawCell}` once **before** the dispatch loop (`narrative_cells_by_key`) and resolve/mutate by object identity, so a deletion can't shift another target's ordinal.

```
before: remove 3 voiceovers under one slide -> applied_remove=2, error, EN keeps all 3
after:  remove 3 voiceovers under one slide -> applied_remove=3, no error, EN has 0
```

## 2. Baseline owning-slide drop for the title group

`owning_group` returns `TITLE_SLIDE_ID` for any narrative before the first slide-start when the deck has a j2 title macro. But `_baseline_owning_by_position` only normalized to `TITLE_SLIDE_ID` when the *recorded anchor* was the title-macro token. So a voiceover whose nearest predecessor is a **non-slide content cell** (an `id:`/`fp:` anchor) under the title group recovered `owning=None` on the baseline side while the current side said `title` — the two keys never paired, and a one-sided edit was **silently dropped** (`is_noop`, no error).

**Fix:** seed the baseline walk with `TITLE_SLIDE_ID` when the deck has a title macro (passed in from the current deck, since j2 cells are excluded from the watermark), mirroring `owning_group` exactly. This also subsumes the old leading-greeting special case.

## Tests

`tests/slides/test_sync_narrative_anchor.py` gains `TestStaleOccurrenceOrdinal` (remove-all + middle-remove) and `TestTitleGroupBaselineOwning`. Full `tests/slides` + cache suites green (1806 passed); ruff + mypy clean.

Stacks on #408 (merged). Independent of #412 (fix #3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
