### PR TITLE
fix(slides): reconcile-vo-ids polish from cloud review (#403)

### DIFF
--- a/changelog.d/403-reconcile-vo-ids-polish.fixed.md
+++ b/changelog.d/403-reconcile-vo-ids-polish.fixed.md
@@ -1,0 +1,7 @@
+- **`clm slides reconcile-vo-ids` polish (Issue #403).** Directory mode now warns about
+  stranded `.de`/`.en` halves with no twin (instead of silently reporting only the
+  healthy pairs), matching `clm slides sync`; a usage error under `--json` is now emitted
+  as a `{"error": …}` envelope rather than plain text; two explicit halves spelled with a
+  mix of absolute and relative paths are now accepted (they are resolved before the
+  same-deck check); and the `--dry-run` report uses future-tense wording and always
+  surfaces the unpaired-narrative count, even for an already-symmetric pair.

--- a/src/clm/cli/commands/slides/reconcile_vo_ids.py
+++ b/src/clm/cli/commands/slides/reconcile_vo_ids.py
@@ -85,10 +85,13 @@ def reconcile_vo_ids_cmd(
     """
     try:
         pairs = _resolve_pairs(path, en_path)
-    except click.UsageError:
+    except click.UsageError as exc:
+        # Honor the --json contract for usage errors too: emit the {"error": …}
+        # envelope (exit 2) instead of click's plain-text rendering; otherwise
+        # re-raise so click prints the usual message.
+        if as_json:
+            _fail(exc.format_message(), as_json)
         raise
-    except ValueError as exc:
-        _fail(str(exc), as_json)
 
     results: list[tuple[Path, Path, ReconcileResult]] = []
     for de, en in pairs:
@@ -111,12 +114,23 @@ def _resolve_pairs(path: Path, en_path: Path | None) -> list[tuple[Path, Path]]:
             raise click.UsageError(
                 f"{path} is a directory (batch mode); do not pass a second path."
             )
-        pairs, _solos = iter_split_pairs(find_split_slide_files_recursive(path))
+        pairs, solos = iter_split_pairs(find_split_slide_files_recursive(path))
+        # A stranded half (no twin under the tree) is itself an asymmetry this command
+        # exists to surface — warn and skip it, the same as `clm slides sync`, rather
+        # than silently reporting only the healthy pairs.
+        for solo in solos:
+            other = "EN" if split_lang_tag(solo) == "de" else "DE"
+            click.echo(
+                f"warning: skipping {solo.name} — no {other} twin found under {path}.", err=True
+            )
         if not pairs:
             raise click.UsageError(f"no split deck pairs found under {path}")
         return pairs
 
     if en_path is not None:
+        # Resolve both halves so a mixed absolute/relative spelling of the same two
+        # files compares equal (Path compares by string form, not by target).
+        path, en_path = path.resolve(), en_path.resolve()
         pair = derive_split_pair(path) or derive_split_pair(en_path)
         if pair is None or {pair[0], pair[1]} != {path, en_path}:
             raise click.UsageError(
@@ -173,15 +187,21 @@ def _print_human(results: list[tuple[Path, Path, ReconcileResult]], *, report_on
         if result.is_noop:
             note = "already symmetric" if result.already_symmetric else "no paired narratives"
             click.echo(f"{de.name}: {note}")
-            continue
-        total += len(result.changes)
-        click.echo(f"{prefix}{de.name}: {verb} {len(result.changes)} voiceover id(s)")
-        for c in result.changes:
-            verbed = "stripped id from" if c.action == "strip" else f"stamped id={c.new_id!r} onto"
-            click.echo(
-                f"    {c.lang} L{c.line_number} {c.role} under "
-                f"{c.owning_slide_id!r}#{c.occurrence}: {verbed} it"
-            )
+        else:
+            total += len(result.changes)
+            click.echo(f"{prefix}{de.name}: {verb} {len(result.changes)} voiceover id(s)")
+            for c in result.changes:
+                if c.action == "strip":
+                    verbed = "would strip id from" if report_only else "stripped id from"
+                else:
+                    did = "would stamp" if report_only else "stamped"
+                    verbed = f"{did} id={c.new_id!r} onto"
+                click.echo(
+                    f"    {c.lang} L{c.line_number} {c.role} under "
+                    f"{c.owning_slide_id!r}#{c.occurrence}: {verbed} it"
+                )
+        # Reported for every pair (including a no-op one), so an unpaired narrative —
+        # which `sync` must handle — is never hidden, matching the --json output.
         if result.unpaired:
             click.echo(
                 f"    ({result.unpaired} narrative(s) present on one half only — "

--- a/tests/slides/test_reconcile_vo_ids.py
+++ b/tests/slides/test_reconcile_vo_ids.py
@@ -8,8 +8,7 @@ id-less side — without ever deriving an id from per-file content (the `assign-
 
 from __future__ import annotations
 
-import shutil
-import subprocess
+import json
 from pathlib import Path
 
 import pytest
@@ -178,8 +177,6 @@ class TestCli:
         assert "slide_id" not in (tmp_path / "slides_a.en.py").read_text().split("voiceover")[1]
 
     def test_json_output(self, tmp_path: Path):
-        import json
-
         de_path, _en = _write_pair(
             tmp_path,
             _deck(_title("de"), _vo("de", "# Hallo")),
@@ -198,13 +195,75 @@ class TestCli:
         assert res.exit_code == 2
         assert "no EN twin" in res.output
 
+    def test_json_usage_error_emits_envelope(self, tmp_path: Path):
+        # A usage error under --json is reported as a JSON {"error": …} envelope, not
+        # click's plain text (the --json contract holds for failures too).
+        solo = tmp_path / "deck.de.py"
+        solo.write_text(_deck(_title("de"), _vo("de", "# Hallo")), encoding="utf-8")
+        res = CliRunner().invoke(reconcile_vo_ids_cmd, [str(solo), "--json"])
+        assert res.exit_code == 2
+        assert json.loads(res.output)["error"].startswith("no EN twin")
+
+    def test_directory_warns_on_solo_half(self, tmp_path: Path):
+        # A healthy pair plus a stranded .de.py half: the pair is reconciled and the
+        # solo is surfaced as a warning, not silently dropped.
+        (tmp_path / "slides_a.de.py").write_text(
+            _deck(_title("de"), _vo("de", "# Hallo")), encoding="utf-8"
+        )
+        (tmp_path / "slides_a.en.py").write_text(
+            _deck(_title("en"), _vo("en", "# Hello", sid="intro")), encoding="utf-8"
+        )
+        (tmp_path / "slides_b.de.py").write_text(
+            _deck(_title("de"), _vo("de", "# allein")), encoding="utf-8"
+        )
+        res = CliRunner().invoke(reconcile_vo_ids_cmd, [str(tmp_path)])
+        assert res.exit_code == 0, res.output
+        assert "skipping slides_b.de.py" in res.output
+        assert "no EN twin" in res.output
+
+    def test_mixed_absolute_relative_paths_accepted(self, tmp_path: Path, monkeypatch):
+        # The two halves spelled with different normalizations (one absolute, one
+        # relative) still resolve to the same split deck.
+        de_path, en_path = _write_pair(
+            tmp_path,
+            _deck(_title("de"), _vo("de", "# Hallo")),
+            _deck(_title("en"), _vo("en", "# Hello", sid="intro")),
+        )
+        monkeypatch.chdir(tmp_path)
+        res = CliRunner().invoke(reconcile_vo_ids_cmd, [str(de_path), en_path.name])
+        assert res.exit_code == 0, res.output
+        assert 'voiceover"] slide_id' not in en_path.read_text()
+
+    def test_dry_run_uses_future_tense(self, tmp_path: Path):
+        de_path, _en = _write_pair(
+            tmp_path,
+            _deck(_title("de"), _vo("de", "# Hallo")),
+            _deck(_title("en"), _vo("en", "# Hello", sid="intro")),
+        )
+        res = CliRunner().invoke(reconcile_vo_ids_cmd, [str(de_path), "--dry-run"])
+        assert res.exit_code == 0, res.output
+        assert "would strip id from" in res.output
+        assert "stripped id from it" not in res.output  # no past tense in a preview
+
+    def test_unpaired_reported_even_when_symmetric(self, tmp_path: Path):
+        # DE has two id-less voiceovers, EN one: the pair is "already symmetric" (both
+        # id-less) but the unpaired second DE voiceover must still be surfaced.
+        de_path, _en = _write_pair(
+            tmp_path,
+            _deck(_title("de"), _vo("de", "# eins"), _vo("de", "# zwei")),
+            _deck(_title("en"), _vo("en", "# one")),
+        )
+        res = CliRunner().invoke(reconcile_vo_ids_cmd, [str(de_path)])
+        assert res.exit_code == 0, res.output
+        assert "already symmetric" in res.output
+        assert "present on one half only" in res.output
+
 
 # ---------------------------------------------------------------------------
 # Integration: a reconciled deck syncs cleanly (the whole point of fix #3)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(shutil.which("git") is None, reason="git not available")
 class TestUnblocksSync:
     def test_reconciled_pair_syncs_without_change(self, tmp_path: Path):
         from clm.infrastructure.llm.cache import SyncWatermarkCache
@@ -231,7 +290,3 @@ class TestUnblocksSync:
         assert plan.is_noop  # no spurious add/edit after reconciliation
         assert result.errors == []
         assert en_path.read_text().count('tags=["voiceover"]') == 1  # not doubled
-
-
-def _git(cwd: Path, *args: str) -> None:
-    subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True, text=True)


### PR DESCRIPTION
Addresses the **5 findings from the cloud review of #412** (`reconcile-vo-ids`). All were severity **nit** — no correctness or data-loss defects; the command reconciles correctly on every pair it touches. These are the cheap-now-annoying-later polish items the review flagged.

| # | Finding | Fix |
|---|---|---|
| bug_011 | Directory mode silently dropped stranded `.de`/`.en` halves (no twin) | Warn and skip each solo, like `clm slides sync` |
| bug_003 | Dead `try/except` — `_resolve_pairs` raises `UsageError`, never `ValueError`, so `_fail`'s `--json` envelope was never reached | Route `UsageError` through `_fail` when `--json` (emit `{"error": …}`), else re-raise |
| bug_008 | Two explicit halves spelled mixed absolute/relative compared unequal → misleading "not the two halves of one split deck" | `.resolve()` both before the set comparison |
| merged_bug_002 | `--dry-run` detail lines used past tense ("stripped"); unpaired count hidden behind the `is_noop` early `continue` while `--json` reported it | Future-tense verbs under dry-run; surface unpaired for every pair |
| bug_005 | Test file: misleading `skipif(git)` on `TestUnblocksSync` (it uses the watermark cache, not git) + dead `_git` helper/imports | Drop both |

New tests cover each: JSON usage-error envelope, directory solo warning, mixed abs/rel paths, dry-run tense, and unpaired-on-symmetric reporting.

Follows up #412 (merged). Full `tests/slides/test_reconcile_vo_ids.py` + `tests/cli` green (1767 passed); ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
