### PR TITLE
fix(sync): localize the id-less-localized both-decks error (#364 item 4)

### DIFF
--- a/changelog.d/364-idless-localized-error-localization.fixed.md
+++ b/changelog.d/364-idless-localized-error-localization.fixed.md
@@ -1,0 +1,10 @@
+- **`clm slides sync` now localizes the "id-less localized cells edited on both
+  decks" error (Issue #364).** The error previously carried `slide_id=None` and
+  named no cell; it now pins to the drifted cell's owning slide group and echoes
+  the offending cell's first line (per half), so the author can find it. The
+  message also leads with the actual common cause — a stale watermark — pointing
+  at `clm slides sync --rebaseline` rather than only the unhelpful "assign
+  slide_ids" steer. `--explain` adds a note when the watermark-baseline diff
+  errors, flagging that the baseline may be stale and to compare against
+  `--baseline HEAD` / `--rebaseline` (a clean-looking diff that still errors is
+  no longer a mystery).

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -742,6 +742,64 @@ def _idless_localized_hashes(cells: list[Cell], lang: str) -> list[str]:
     ]
 
 
+def _idless_localized_cells(cells: list[Cell], lang: str) -> list[tuple[Cell, str | None]]:
+    """Each id-less localized cell of ``lang`` paired with its owning slide-group id.
+
+    Mirrors :func:`_idless_localized_hashes` exactly (same predicate, same document
+    order) but keeps the :class:`Cell` and the slide group it falls under, so a drift
+    alert can name the offending cell and point at its group (Issue #364 item 4) —
+    the hashes alone localize nothing.
+    """
+    out: list[tuple[Cell, str | None]] = []
+    group_sid: str | None = None
+    for c in cells:
+        if c.metadata.is_slide_start:
+            group_sid = c.metadata.slide_id
+        if not c.metadata.is_j2 and c.metadata.lang == lang and role_of(c.metadata) is None:
+            out.append((c, group_sid))
+    return out
+
+
+def _drifted_idless_cells(
+    cells: list[Cell], lang: str, baseline: list[str]
+) -> tuple[str | None, list[str]]:
+    """Locate the id-less localized cells of ``lang`` that drifted from ``baseline``.
+
+    Multiset-diffs the current id-less localized hashes against the ordered baseline
+    hashes (a cell whose hash the baseline can no longer account for is a drift),
+    returning ``(owning_slide_id_of_the_first_drift, [first-line snippets])``. Used to
+    turn the opaque ``slide_id=None`` both-decks error into a located one (Issue #364
+    item 4). Robust to add/remove: it reports the cells present now but unmatched in
+    the baseline, which is exactly what the author edited.
+    """
+    remaining: Counter[str] = Counter(baseline)
+    owner: str | None = None
+    snippets: list[str] = []
+    for cell, group_sid in _idless_localized_cells(cells, lang):
+        chash = cell_content_hash(cell.content)
+        if remaining.get(chash, 0) > 0:
+            remaining[chash] -= 1
+            continue
+        if owner is None:
+            owner = group_sid
+        snippets.append(_cell_first_line(cell.content))
+    return owner, snippets
+
+
+def _drift_cells_clause(de_snippets: list[str], en_snippets: list[str]) -> str:
+    """A `` (DE 'x'; EN 'y')`` clause naming the drifted cells, or ``""`` if none.
+
+    De-duplicates byte-identical snippets per side (two cells that drifted to the same
+    text are named once) so the clause stays a locator, not a wall of repeats.
+    """
+    parts: list[str] = []
+    for label, snippets in (("DE", de_snippets), ("EN", en_snippets)):
+        if snippets:
+            uniq = list(dict.fromkeys(snippets))
+            parts.append(f"{label} " + ", ".join(repr(s) for s in uniq))
+    return f" ({'; '.join(parts)})" if parts else ""
+
+
 def _idless_localized_baseline_from_rows(
     rows: list[tuple[int, str | None, str, str, str | None]],
 ) -> list[str]:
@@ -793,13 +851,20 @@ def _classify_idless_localized_drift(
         # each half. Only when there is NO direction signal at all is this a genuine
         # both-sides edit a single-direction sync cannot reconcile -> alert.
         if established is None:
+            de_owner, de_snips = _drifted_idless_cells(de_cells, "de", de_baseline)
+            en_owner, en_snips = _drifted_idless_cells(en_cells, "en", en_baseline)
             plan.issues.append(
                 PlanIssue(
                     severity="error",
-                    slide_id=None,
+                    # Locate the alert at the first drifted cell's slide group (was
+                    # always None — Issue #364 item 4) so it is no longer placeless.
+                    slide_id=de_owner or en_owner,
                     reason="id-less localized cells (lang= cells with no slide_id) were "
-                    "edited on both decks; sync cannot determine a single direction — "
-                    "resolve manually or assign slide_ids so the cells can be paired",
+                    f"edited on both decks{_drift_cells_clause(de_snips, en_snips)}; sync "
+                    "cannot determine a single direction. If the halves are already "
+                    "consistent the watermark is likely stale — reset it with "
+                    "`clm slides sync --rebaseline`; otherwise resolve the divergence "
+                    "manually (or give the cells slide_ids so they pair per-cell)",
                 )
             )
         return
@@ -808,12 +873,16 @@ def _classify_idless_localized_drift(
     # different cell classes in opposite directions — not safely applicable in one
     # pass, so alert rather than overwrite one side's edit.
     if established is not None and established != direction:
+        drift_cells, drift_lang = (de_cells, "de") if de_drifted else (en_cells, "en")
+        drift_base = de_baseline if de_drifted else en_baseline
+        owner, snips = _drifted_idless_cells(drift_cells, drift_lang, drift_base)
+        clause = _drift_cells_clause(snips, []) if de_drifted else _drift_cells_clause([], snips)
         plan.issues.append(
             PlanIssue(
                 severity="error",
-                slide_id=None,
-                reason=f"an id-less localized cell drifted {direction} but other cells "
-                f"drifted {established}; sync cannot apply both directions at once — "
+                slide_id=owner,
+                reason=f"an id-less localized cell drifted {direction}{clause} but other "
+                f"cells drifted {established}; sync cannot apply both directions at once — "
                 "resolve manually",
             )
         )
@@ -3650,6 +3719,17 @@ def render_explain(
         f"anchor diff — {de_path.name} / {en_path.name}",
         f"baseline: {plan.baseline_source}",
     ]
+    # Issue #364 item 4: the anchor diff below is computed against the *watermark*
+    # baseline. When that baseline is stale (both halves edited + committed without an
+    # intervening sync) the diff can look clean yet the plan still carries an error —
+    # the classifier compares against the same stale baseline. Say so up front, and
+    # point at the git-HEAD diff, so a clean-looking diff that errors is not a mystery.
+    if plan.has_errors and plan.baseline_source == "watermark":
+        lines.append(
+            "  note: errors below are against the recorded watermark, which may be stale; "
+            "compare against committed state with `--baseline HEAD` "
+            "(or `--rebaseline` if the halves are already consistent)."
+        )
     has_baseline = watermark_cache is not None and watermark_cache.has_pair(
         str(de_path), str(en_path)
     )

--- a/tests/slides/test_sync_idless_localized_drift_repro.py
+++ b/tests/slides/test_sync_idless_localized_drift_repro.py
@@ -1,0 +1,161 @@
+"""Reproduction / characterization tests for issues #364, #365, #366.
+
+These three issues all stem from one incident: a split deck whose two halves were
+edited and committed twice *without* an intervening ``clm slides sync``, so the
+structural watermark fell behind. A later sync then errored against the stale
+baseline with an opaque ``id-less localized cells ... edited on both decks`` message,
+even though the halves were mutually consistent at git HEAD.
+
+This module pins down what master does for each issue, so we can see which concerns
+recent work (the #363 watermark CLI, the ``--baseline`` / ``--rebaseline`` /
+``synced_commit`` staleness work) has already addressed and which remain open:
+
+- ``TestBothSidedIdlessDriftStillHardErrors`` (#365) — a both-sided edit to a hash-only
+  id-less localized cell still hard-errors with no single direction; NOT yet degraded to
+  a per-cell / positional conflict (the strict-xfail records that gap).
+- ``TestIdlessDriftErrorIsLocalized`` (#364 item 4, FIXED) — that error now pins to the
+  drifted cell's owning slide group and echoes the offending cell, and steers to
+  ``--rebaseline`` rather than only "assign slide_ids".
+
+The reproduction harness mirrors ``tests/slides/test_sync_issue_269.py``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.slides.sync_apply import _record_watermark, apply_plan
+from clm.slides.sync_plan import build_sync_plan
+from clm.slides.sync_translate import StaticSlideTranslator
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git not available")
+
+
+# ---------------------------------------------------------------------------
+# Deck builders (a valid split pair)
+# ---------------------------------------------------------------------------
+
+
+def _title(lang: str, sid: str = "title", txt: str = "T") -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{sid}"\n# # {txt}\n'
+
+
+def _idless_code(lang: str, body: str) -> str:
+    """A hash-only id-less localized code cell — no slide_id, no nameable construct."""
+    return f'# %% lang="{lang}"\n{body}\n'
+
+
+def _deck(*parts: str) -> str:
+    return "\n".join(parts)
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True, text=True)
+
+
+def _sync(tmp: Path, baseline: str, de0: str, en0: str, de1: str, en1: str):
+    """Establish a baseline, apply the edits, return ``(plan, result, de_after, en_after)``."""
+    db = tmp / "clm-llm.sqlite"
+    de_path, en_path = tmp / "deck.de.py", tmp / "deck.en.py"
+    de_path.write_text(de0, encoding="utf-8")
+    en_path.write_text(en0, encoding="utf-8")
+    if baseline == "git-head":
+        _git(tmp, "init", "-q")
+        _git(tmp, "config", "user.email", "t@example.com")
+        _git(tmp, "config", "user.name", "Test")
+        _git(tmp, "add", "-A")
+        _git(tmp, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "baseline")
+    else:
+        wm = SyncWatermarkCache(db)
+        _record_watermark(wm, de_path, en_path)
+        wm.close()
+    de_path.write_text(de1, encoding="utf-8")
+    en_path.write_text(en1, encoding="utf-8")
+    wm = SyncWatermarkCache(db)
+    try:
+        plan = build_sync_plan(de_path, en_path, watermark_cache=wm)
+        result = apply_plan(
+            plan, judge=None, translator=StaticSlideTranslator(default="<<XL>>"), watermark_cache=wm
+        )
+    finally:
+        wm.close()
+    return plan, result, de_path.read_text(encoding="utf-8"), en_path.read_text(encoding="utf-8")
+
+
+def _error_issues(plan):
+    return [i for i in plan.issues if i.severity == "error"]
+
+
+# The reproduction of the incident shape: two hash-only id-less localized code cells
+# whose DE/EN text legitimately differs (test_queries vs comparison_queries — the real
+# `Abfrage` vs `Query` divergence), edited on BOTH halves with no other change to
+# establish a direction.
+DE0 = _deck(_title("de"), _idless_code("de", "for q in test_queries:\n    run(q)"))
+EN0 = _deck(_title("en"), _idless_code("en", "for q in comparison_queries:\n    run(q)"))
+DE1 = _deck(_title("de"), _idless_code("de", "for q in test_queries:\n    run(q)  # DE-edit"))
+EN1 = _deck(_title("en"), _idless_code("en", "for q in comparison_queries:\n    run(q)  # EN-edit"))
+
+
+# ---------------------------------------------------------------------------
+# #365 — both-sided id-less-localized drift still hard-errors (NOT yet degraded)
+# ---------------------------------------------------------------------------
+
+
+class TestBothSidedIdlessDriftStillHardErrors:
+    @pytest.mark.parametrize("baseline", ["git-head", "watermark"])
+    def test_both_sided_idless_edit_errors_with_no_single_direction(
+        self, tmp_path: Path, baseline: str
+    ):
+        plan, result, de_after, en_after = _sync(tmp_path, baseline, DE0, EN0, DE1, EN1)
+        errors = _error_issues(plan)
+        assert errors, "expected the both-sided id-less drift to surface an error"
+        assert any("both decks" in e.reason for e in errors)
+        # The cardinal #269 safety still holds: nothing written, watermark held, both
+        # edits survive on disk (the error is loud, not a silent drop or destructive heal).
+        assert not result.watermark_recorded
+        assert "# DE-edit" in de_after
+        assert "# EN-edit" in en_after
+
+    @pytest.mark.xfail(
+        reason="#365: both-sided id-less-localized drift should degrade to a per-cell / "
+        "positional conflict the author can resolve, not a whole-deck hard error.",
+        strict=True,
+    )
+    @pytest.mark.parametrize("baseline", ["git-head", "watermark"])
+    def test_both_sided_idless_edit_degrades_to_positional_conflict(
+        self, tmp_path: Path, baseline: str
+    ):
+        plan, _result, _de_after, _en_after = _sync(tmp_path, baseline, DE0, EN0, DE1, EN1)
+        # Desired (#365): the drift is paired positionally within its slide group and
+        # surfaced as a resolvable conflict proposal, not an irreconcilable error.
+        assert any(p.kind == "conflict" for p in plan.proposals)
+        assert not _error_issues(plan)
+
+
+# ---------------------------------------------------------------------------
+# #364 item 4 — the id-less-localized error is now localized to a cell (FIXED)
+# ---------------------------------------------------------------------------
+
+
+class TestIdlessDriftErrorIsLocalized:
+    @pytest.mark.parametrize("baseline", ["git-head", "watermark"])
+    def test_error_names_owning_group_and_offending_cell(self, tmp_path: Path, baseline: str):
+        plan, _result, _de_after, _en_after = _sync(tmp_path, baseline, DE0, EN0, DE1, EN1)
+        errors = _error_issues(plan)
+        assert errors
+        # Located: the error pins to the drifted cell's owning slide group (was always
+        # None) AND echoes the offending cell's first line so the author can find it.
+        assert any(e.slide_id == "title" for e in errors)
+        assert any("test_queries" in e.reason or "comparison_queries" in e.reason for e in errors)
+
+    def test_error_steers_to_rebaseline_not_just_assign_ids(self, tmp_path: Path):
+        # #364 item 3: the old message only said "assign slide_ids" (which does not help
+        # the stale-watermark case). The new message leads with the actual common fix.
+        plan, _result, _de_after, _en_after = _sync(tmp_path, "watermark", DE0, EN0, DE1, EN1)
+        reason = "\n".join(e.reason for e in _error_issues(plan))
+        assert "--rebaseline" in reason

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -1092,3 +1092,36 @@ def test_explain_without_watermark_reads_everything_as_new(tmp_path: Path):
 
     assert "no watermark for this pair" in text
     assert "+  " in text  # at least one cell marked new
+
+
+def test_explain_warns_when_watermark_baseline_errors(tmp_path: Path):
+    # Issue #364 item 4: an error against a (possibly stale) watermark baseline can show
+    # a clean-looking anchor diff yet still error. --explain must say so up front and
+    # point at the git-HEAD / --rebaseline comparison, so the mismatch is not a mystery.
+    de = _slide("de", "a", "# ## A") + _code_localized_idless("de", "for q in test_queries:\n    p")
+    en = _slide("en", "a", "# ## A") + _code_localized_idless(
+        "en", "for q in comparison_queries:\n    p"
+    )
+    de_path, en_path = _write_pair(tmp_path, de, en)
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        _seed(cache, de_path, en_path)
+        # Both halves drift their hash-only id-less localized cell -> both-decks error.
+        de_path.write_text(
+            _slide("de", "a", "# ## A")
+            + _code_localized_idless("de", "for q in test_queries:\n    q"),
+            encoding="utf-8",
+        )
+        en_path.write_text(
+            _slide("en", "a", "# ## A")
+            + _code_localized_idless("en", "for q in comparison_queries:\n    q"),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        text = render_explain(de_path, en_path, plan=plan, watermark_cache=cache)
+    finally:
+        cache.close()
+
+    assert plan.has_errors
+    assert "may be stale" in text
+    assert "--rebaseline" in text


### PR DESCRIPTION
## Summary

Addresses **item 4 of #364** — make the `id-less localized cells … edited on both decks` error self-explanatory. The other #364 items (record git commit, stale-watermark hint, manual auto-heal) already landed earlier via `--baseline`/`--rebaseline`/`synced_commit` and the `clm slides watermark` CLI (#363); this closes the remaining "the error names no cell and steers you wrong" gap.

### Before
```
issue-error: id-less localized cells (lang= cells with no slide_id) were edited on
both decks; sync cannot determine a single direction — resolve manually or assign
slide_ids so the cells can be paired
```
`slide_id=None`, no cell named, and "assign slide_ids" does **not** help the real common cause (a stale watermark).

### After
- The error pins to the **drifted cell's owning slide group** and echoes the **offending cell's first line** (per half) so it is locatable.
- The message **leads with the stale-watermark cause** and `clm slides sync --rebaseline`, keeping "assign slide_ids" as the secondary structural option.
- `--explain` adds a note when the watermark-baseline plan errors — flagging the baseline may be stale and to compare against `--baseline HEAD` / `--rebaseline`, so a clean-looking anchor diff that still errors (critique #4) is no longer a mystery.

## Changes
- `sync_plan.py`: `_idless_localized_cells` / `_drifted_idless_cells` / `_drift_cells_clause` helpers; both error branches of `_classify_idless_localized_drift` now localize; `render_explain` stale-baseline note.
- Tests: new `tests/slides/test_sync_idless_localized_drift_repro.py` (investigation/repro for #364/#365 — the #364 localization passes; a **strict-xfail** records the still-open #365 gap), plus a `render_explain` note test in `test_sync_limitations.py`.

## Investigation note (#364/#365/#366)
This PR is the first slice of a larger triage. Findings:
- **#364** — ~75% already shipped; this PR finishes item 4.
- **#365** (degrade both-sided id-less drift to a positional conflict) — not started; the strict-xfail here marks it. Next up (approach 1: positional pairing).
- **#366** — only option (D) auto-heal (`--rebaseline`) shipped; (A) git-as-baseline to be prototyped.

## Testing
`pytest tests/slides/test_sync_idless_localized_drift_repro.py tests/slides/test_sync_limitations.py tests/slides/test_sync_issue_269.py` → 121 passed, 2 xfailed. Ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
