### PR TITLE
feat(sync): degrade both-sided id-less-localized drift to a conflict (#365, increment 1)

### DIFF
--- a/changelog.d/365-idless-localized-positional-conflict.changed.md
+++ b/changelog.d/365-idless-localized-positional-conflict.changed.md
@@ -1,0 +1,13 @@
+- **`clm slides sync` degrades a both-sided id-less-localized drift to a per-cell
+  conflict instead of a deck-wide error (Issue #365).** A `lang=` cell with no
+  `slide_id` is anchored only by content hash, so an edit to it on *both* halves
+  with no propagation direction established elsewhere used to hard-error and roll
+  the whole deck back. When the two halves' id-less localized cells share the same
+  content-free `(group, kind)` structure — so they pair positionally within their
+  slide group — each both-sided edit is now surfaced as a deferred `conflict`: the
+  watermark still holds and both edits stay on disk, but the run no longer rolls
+  back, so unrelated clean changes still apply, and the divergence is a located
+  per-cell item. (Resolution by side is a follow-up; for now resolve by editing the
+  deck or giving the cell a `slide_id`.) When the structure is *not* parallel, the
+  located deck-wide error (Issue #364) is kept, since positional pairing would be
+  unsound.

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1856,6 +1856,18 @@ written into the file, so a deck stays id-light yet syncs precisely:
   `CLM_SYNC__SHARED_DIVERGENCE=error` to surface it as an error and write nothing
   instead. A neutral cell edited *incompatibly* on both decks (different cells) is
   an error — never silently reverted.
+- **An id-less localized cell edited on *both* decks degrades to a per-cell
+  `conflict` instead of a deck-wide error (since CLM {version}, issue #365).** A
+  `lang=` cell with no `slide_id` is anchored only by content hash, so a both-sided
+  edit with no propagation direction used to hard-error and roll the whole deck back.
+  When the two halves' id-less localized cells share the same structure (so they pair
+  positionally within their slide group), each both-sided edit is now surfaced as a
+  **conflict**: it defers (the watermark holds and both edits stay on disk, exactly as
+  before), but unrelated clean changes in the same run still apply, and the divergence
+  is a located per-cell item rather than an opaque stop. Resolve it by editing the
+  deck, or give the cell a `slide_id` so it pairs precisely. When the halves' id-less
+  localized structure is *not* parallel (a move/add/remove is in play), the located
+  deck-wide error (issue #364) is kept, since positional pairing would be unsound.
 - **Genuinely ambiguous id realignment** (a function renamed *while* a cell was
   split, an unresolvable tie) is left untouched and re-surfaces next run, unless
   you opt in with `--llm-recover` (above).

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -68,6 +68,8 @@ from clm.slides.raw_cells import RawCell, split_cells
 from clm.slides.slug import resolve_collision, slugify
 from clm.slides.sync_code import TranslationOutcome, apply_code_structure
 from clm.slides.sync_plan import (
+    LOCALIZED_CODE_ROLE,
+    LOCALIZED_MARKDOWN_ROLE,
     MEMBERSHIP_ROLES,
     NARRATIVE_ROLES,
     NEUTRAL_CODE_ROLE,
@@ -550,6 +552,26 @@ def _accepted(decisions: dict[int, str] | None, proposal: Proposal) -> bool:
     return decisions.get(id(proposal)) == DECISION_APPLY
 
 
+_IDLESS_LOCALIZED_ROLES = frozenset({LOCALIZED_CODE_ROLE, LOCALIZED_MARKDOWN_ROLE})
+
+
+def _is_idless_localized_conflict(proposal: Proposal) -> bool:
+    """An Issue #365 id-less localized both-decks conflict — resolved by deferral only.
+
+    Such a cell has no ``slide_id`` (the synthetic localized role + ``slide_id None``),
+    so the ``(slide_id, role)`` edit path cannot target it. The classifier degraded the
+    deck-wide error to this per-cell conflict so the rest of the run still applies and
+    the watermark holds; resolving *which side wins* (translating the winner onto the
+    positional twin) is a follow-up. Until then it always defers — never materialized as
+    an edit, so a stray ``de-wins`` / ``en-wins`` decision can never mis-target a cell.
+    """
+    return (
+        proposal.kind == "conflict"
+        and proposal.slide_id is None
+        and proposal.role in _IDLESS_LOCALIZED_ROLES
+    )
+
+
 def _conflict_decision(decisions: dict[int, str] | None, proposal: Proposal) -> str:
     """The resolution for a conflict proposal (defaults to skip/defer)."""
     if decisions is None:
@@ -585,6 +607,13 @@ def _apply_conflict(
     decision defers, recording the key so the per-cell advance keeps its
     pre-conflict baseline and the conflict re-surfaces next run.
     """
+    if _is_idless_localized_conflict(proposal):
+        # Issue #365: id-less localized conflicts are defer-only for now (no positional
+        # resolver yet), so the watermark holds and both edits stay on disk regardless
+        # of any decision — never mis-targeting a cell via the (slide_id, role) path.
+        result.deferred += 1
+        _note_deferred(deferred_keys, proposal)
+        return
     decision = _conflict_decision(decisions, proposal)
     if decision == DECISION_DE_WINS:
         _apply_edit(
@@ -1051,6 +1080,10 @@ def _materialize_edits(
                 proposal, de_state, en_state, de_content, en_content, judge, translator
             )
         elif proposal.kind == "conflict":
+            if _is_idless_localized_conflict(proposal):
+                # Issue #365: defer-only — never materialized as a directed edit (it
+                # has no (slide_id, role) to target). Skip so the execute walk defers it.
+                continue
             decision = _conflict_decision(decisions, proposal)
             if decision in (DECISION_DE_WINS, DECISION_EN_WINS):
                 direction = "de->en" if decision == DECISION_DE_WINS else "en->de"

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -800,6 +800,109 @@ def _drift_cells_clause(de_snippets: list[str], en_snippets: list[str]) -> str:
     return f" ({'; '.join(parts)})" if parts else ""
 
 
+def _idless_localized_kind(cell: Cell) -> str:
+    return "code" if cell.metadata.cell_type == "code" else "markdown"
+
+
+def _idless_localized_pairing(cells: list[Cell], lang: str) -> list[tuple[Cell, str | None, int]]:
+    """Each id-less localized cell of ``lang`` with ``(cell, owning_slide_id, group_index)``.
+
+    The pairing view of :func:`_idless_localized_cells`: it additionally carries the
+    0-based slide-group index, so the ``(group_index, kind)`` *signature* of the two
+    halves can be compared (the cross-half structure check of #269 /
+    :func:`_idless_localized_group_kinds`) before pairing the n-th DE id-less cell with
+    the n-th EN one (Issue #365). ``group_index`` is ``-1`` for a cell before the first
+    slide start.
+    """
+    out: list[tuple[Cell, str | None, int]] = []
+    group_sid: str | None = None
+    group_index = -1
+    for c in cells:
+        if c.metadata.is_slide_start:
+            group_sid = c.metadata.slide_id
+            group_index += 1
+        if not c.metadata.is_j2 and c.metadata.lang == lang and role_of(c.metadata) is None:
+            out.append((c, group_sid, group_index))
+    return out
+
+
+def _idless_localized_signature(
+    pairing: list[tuple[Cell, str | None, int]],
+) -> list[tuple[int, str]]:
+    """The content-free ``(group_index, kind)`` structure of an id-less localized pairing."""
+    return [(group_index, _idless_localized_kind(cell)) for cell, _sid, group_index in pairing]
+
+
+def _classify_idless_localized_conflicts(
+    plan: SyncPlan,
+    de_cells: list[Cell],
+    en_cells: list[Cell],
+    de_baseline: list[str],
+    en_baseline: list[str],
+) -> bool:
+    """Degrade a both-sided id-less localized drift to per-cell conflicts (Issue #365).
+
+    A ``lang=`` cell with no ``slide_id`` is anchored only by content hash, so a
+    both-sided edit with no propagation direction established elsewhere is unpairable
+    and historically hard-errored (the whole deck rolled back). When the two halves'
+    id-less localized cells share the same content-free ``(group_index, kind)``
+    structure — and neither half added or removed one since the baseline — they pair
+    positionally within their slide group: the n-th DE cell corresponds to the n-th EN
+    cell. Each positionally-paired cell that drifted on either side becomes a
+    **conflict** proposal (``slide_id`` ``None``, the synthetic localized role,
+    positionally identified) instead of a deck-wide error. A conflict defers — the
+    watermark holds and both edits stay on disk, exactly like the error did — but it no
+    longer sets ``has_errors``, so unrelated clean changes in the same run still apply,
+    and the divergence is a resolvable per-cell item rather than an opaque deck-wide
+    stop.
+
+    Returns ``True`` when it took ownership (emitted conflicts, or found the drift
+    already in sync), so the caller skips the legacy error. Returns ``False`` when the
+    structure is not pairable (a move/add/remove happened) — the caller keeps the
+    located error, since positional pairing would be unsound.
+    """
+    de_pairing = _idless_localized_pairing(de_cells, "de")
+    en_pairing = _idless_localized_pairing(en_cells, "en")
+    # Positional pairing is only sound when the halves share one structure AND neither
+    # half added/removed an id-less cell since the baseline (so position i still maps to
+    # baseline hash i). Otherwise a move/add/remove is in play -> not pairable here.
+    if _idless_localized_signature(de_pairing) != _idless_localized_signature(en_pairing):
+        return False
+    if len(de_pairing) != len(de_baseline) or len(en_pairing) != len(en_baseline):
+        return False
+
+    emitted = False
+    for i, ((de_cell, owner, _gi), (en_cell, _en_owner, _en_gi)) in enumerate(
+        zip(de_pairing, en_pairing, strict=True)  # equal length: signatures matched above
+    ):
+        de_drift = cell_content_hash(de_cell.content) != de_baseline[i]
+        en_drift = cell_content_hash(en_cell.content) != en_baseline[i]
+        if not de_drift and not en_drift:
+            continue
+        kind = _idless_localized_kind(de_cell)
+        role = LOCALIZED_CODE_ROLE if kind == "code" else LOCALIZED_MARKDOWN_ROLE
+        snippet = _cell_first_line(de_cell.content if de_drift else en_cell.content)
+        plan.proposals.append(
+            Proposal(
+                kind="conflict",
+                role=role,
+                direction=None,
+                slide_id=None,
+                # ``anchor_occ`` carries the cell's index among the deck's id-less
+                # localized cells — the positional identity a resolver targets by (the
+                # n-th such cell of the losing language), mirroring _apply_retag_idless.
+                owning_slide_id=owner,
+                anchor_occ=i,
+                reason=(
+                    f"id-less localized {kind} cell {snippet!r} edited on both decks since "
+                    "last sync — resolve which side wins, or give it a slide_id to pair it"
+                ),
+            )
+        )
+        emitted = True
+    return emitted
+
+
 def _idless_localized_baseline_from_rows(
     rows: list[tuple[int, str | None, str, str, str | None]],
 ) -> list[str]:
@@ -851,6 +954,14 @@ def _classify_idless_localized_drift(
         # each half. Only when there is NO direction signal at all is this a genuine
         # both-sides edit a single-direction sync cannot reconcile -> alert.
         if established is None:
+            # Issue #365: when the halves' id-less localized cells pair positionally
+            # (same content-free structure, no add/remove since baseline), degrade the
+            # deck-wide error to per-cell conflicts the author can resolve. Only fall
+            # back to the (now-localized — #364 item 4) error when pairing is unsound.
+            if _classify_idless_localized_conflicts(
+                plan, de_cells, en_cells, de_baseline, en_baseline
+            ):
+                return
             de_owner, de_snips = _drifted_idless_cells(de_cells, "de", de_baseline)
             en_owner, en_snips = _drifted_idless_cells(en_cells, "en", en_baseline)
             plan.issues.append(

--- a/tests/slides/test_sync_idless_localized_drift_repro.py
+++ b/tests/slides/test_sync_idless_localized_drift_repro.py
@@ -8,14 +8,15 @@ even though the halves were mutually consistent at git HEAD.
 
 This module pins down what master does for each issue, so we can see which concerns
 recent work (the #363 watermark CLI, the ``--baseline`` / ``--rebaseline`` /
-``synced_commit`` staleness work) has already addressed and which remain open:
+``synced_commit`` staleness work) addressed and what these PRs add:
 
-- ``TestBothSidedIdlessDriftStillHardErrors`` (#365) — a both-sided edit to a hash-only
-  id-less localized cell still hard-errors with no single direction; NOT yet degraded to
-  a per-cell / positional conflict (the strict-xfail records that gap).
-- ``TestIdlessDriftErrorIsLocalized`` (#364 item 4, FIXED) — that error now pins to the
-  drifted cell's owning slide group and echoes the offending cell, and steers to
-  ``--rebaseline`` rather than only "assign slide_ids".
+- ``TestBothSidedIdlessDriftDegradesToConflict`` (#365, FIXED increment 1) — a both-sided
+  edit to a hash-only id-less localized cell that pairs positionally degrades to a
+  per-cell, deferred conflict (the deck no longer rolls back); resolution-by-side is a
+  documented follow-up, so the conflict is defer-only for now.
+- ``TestIdlessDriftErrorIsLocalized`` (#364 item 4, FIXED) — when the structure is
+  UNPAIRABLE (so #365 cannot degrade), the deck-wide error now pins to the drifted
+  cell's owning slide group, echoes the offending cell, and steers to ``--rebaseline``.
 
 The reproduction harness mirrors ``tests/slides/test_sync_issue_269.py``.
 """
@@ -29,7 +30,7 @@ from pathlib import Path
 import pytest
 
 from clm.infrastructure.llm.cache import SyncWatermarkCache
-from clm.slides.sync_apply import _record_watermark, apply_plan
+from clm.slides.sync_apply import DECISION_DE_WINS, _record_watermark, apply_plan
 from clm.slides.sync_plan import build_sync_plan
 from clm.slides.sync_translate import StaticSlideTranslator
 
@@ -102,50 +103,116 @@ EN1 = _deck(_title("en"), _idless_code("en", "for q in comparison_queries:\n    
 
 
 # ---------------------------------------------------------------------------
-# #365 — both-sided id-less-localized drift still hard-errors (NOT yet degraded)
+# #365 — both-sided id-less-localized drift degrades to a deferred conflict
+# (when the cells pair positionally) instead of a whole-deck error.
 # ---------------------------------------------------------------------------
 
 
-class TestBothSidedIdlessDriftStillHardErrors:
+class TestBothSidedIdlessDriftDegradesToConflict:
     @pytest.mark.parametrize("baseline", ["git-head", "watermark"])
-    def test_both_sided_idless_edit_errors_with_no_single_direction(
+    def test_both_sided_idless_edit_becomes_a_positional_conflict(
         self, tmp_path: Path, baseline: str
     ):
+        # Issue #365: when the halves' id-less localized cells pair positionally, a
+        # both-sided edit degrades to a per-cell conflict — NOT a whole-deck error.
         plan, result, de_after, en_after = _sync(tmp_path, baseline, DE0, EN0, DE1, EN1)
-        errors = _error_issues(plan)
-        assert errors, "expected the both-sided id-less drift to surface an error"
-        assert any("both decks" in e.reason for e in errors)
-        # The cardinal #269 safety still holds: nothing written, watermark held, both
-        # edits survive on disk (the error is loud, not a silent drop or destructive heal).
+        assert any(p.kind == "conflict" for p in plan.proposals)
+        assert not _error_issues(plan)
+        # The conflict is deferred: watermark held, both edits survive on disk, and
+        # the run did not roll the whole deck back (no error).
         assert not result.watermark_recorded
+        assert result.deferred >= 1
         assert "# DE-edit" in de_after
         assert "# EN-edit" in en_after
 
-    @pytest.mark.xfail(
-        reason="#365: both-sided id-less-localized drift should degrade to a per-cell / "
-        "positional conflict the author can resolve, not a whole-deck hard error.",
-        strict=True,
-    )
-    @pytest.mark.parametrize("baseline", ["git-head", "watermark"])
-    def test_both_sided_idless_edit_degrades_to_positional_conflict(
-        self, tmp_path: Path, baseline: str
-    ):
-        plan, _result, _de_after, _en_after = _sync(tmp_path, baseline, DE0, EN0, DE1, EN1)
-        # Desired (#365): the drift is paired positionally within its slide group and
-        # surfaced as a resolvable conflict proposal, not an irreconcilable error.
-        assert any(p.kind == "conflict" for p in plan.proposals)
-        assert not _error_issues(plan)
+    def test_conflict_is_positionally_identified(self, tmp_path: Path):
+        plan, _result, _de_after, _en_after = _sync(tmp_path, "watermark", DE0, EN0, DE1, EN1)
+        conflicts = [p for p in plan.proposals if p.kind == "conflict"]
+        assert conflicts
+        c = conflicts[0]
+        # id-less: no slide_id, the synthetic localized role, owning group recorded,
+        # and the offending cell named in the reason.
+        assert c.slide_id is None
+        assert c.role in ("localized-code", "localized-markdown")
+        assert c.owning_slide_id == "title"
+        assert "test_queries" in c.reason or "comparison_queries" in c.reason
+
+    def test_conflict_is_defer_only_even_under_a_decision(self, tmp_path: Path):
+        # Issue #365 increment 1: positional resolution is not implemented yet, so an
+        # id-less localized conflict defers regardless of a de-wins decision — it must
+        # never mis-target a cell via the (slide_id, role) path, and both edits stay.
+        db = tmp_path / "clm-llm.sqlite"
+        de_path, en_path = tmp_path / "deck.de.py", tmp_path / "deck.en.py"
+        de_path.write_text(DE0, encoding="utf-8")
+        en_path.write_text(EN0, encoding="utf-8")
+        wm = SyncWatermarkCache(db)
+        _record_watermark(wm, de_path, en_path)
+        wm.close()
+        de_path.write_text(DE1, encoding="utf-8")
+        en_path.write_text(EN1, encoding="utf-8")
+        wm = SyncWatermarkCache(db)
+        try:
+            plan = build_sync_plan(de_path, en_path, watermark_cache=wm)
+            conflicts = [p for p in plan.proposals if p.kind == "conflict"]
+            assert conflicts
+            decisions = {id(p): DECISION_DE_WINS for p in conflicts}
+            result = apply_plan(
+                plan,
+                judge=None,
+                translator=StaticSlideTranslator(default="<<XL>>"),
+                watermark_cache=wm,
+                decisions=decisions,
+            )
+        finally:
+            wm.close()
+        assert not result.errors
+        assert result.deferred >= 1
+        assert not result.watermark_recorded
+        assert "# DE-edit" in de_path.read_text(encoding="utf-8")
+        assert "# EN-edit" in en_path.read_text(encoding="utf-8")
+
+    def test_unpairable_structure_still_errors(self, tmp_path: Path):
+        # When the halves' id-less localized structure is NOT parallel (here DE has an
+        # extra id-less cell EN lacks), positional pairing is unsound, so the located
+        # error (Issue #364 item 4) is kept rather than a mispaired conflict.
+        de0 = _deck(_title("de"), _idless_code("de", "for q in test_queries:\n    run(q)"))
+        en0 = _deck(_title("en"), _idless_code("en", "for q in comparison_queries:\n    run(q)"))
+        de1 = _deck(
+            _title("de"),
+            _idless_code("de", "for q in test_queries:\n    run(q)  # DE-edit"),
+            _idless_code("de", "extra_de()"),
+        )
+        en1 = _deck(
+            _title("en"), _idless_code("en", "for q in comparison_queries:\n    run(q)  # EN")
+        )
+        plan, result, _de_after, _en_after = _sync(tmp_path, "watermark", de0, en0, de1, en1)
+        assert _error_issues(plan) or result.errors
+        assert not result.watermark_recorded
 
 
 # ---------------------------------------------------------------------------
-# #364 item 4 — the id-less-localized error is now localized to a cell (FIXED)
+# #364 item 4 — when the structure is UNPAIRABLE (so #365 cannot degrade to a
+# conflict), the deck-wide error is still localized to a cell (FIXED in #417).
 # ---------------------------------------------------------------------------
+
+# DE grew an extra id-less cell EN lacks: the (group, kind) structure diverges, so
+# positional pairing is unsound and the located error path stays in force.
+DE0_U = _deck(_title("de"), _idless_code("de", "for q in test_queries:\n    run(q)"))
+EN0_U = _deck(_title("en"), _idless_code("en", "for q in comparison_queries:\n    run(q)"))
+DE1_U = _deck(
+    _title("de"),
+    _idless_code("de", "for q in test_queries:\n    run(q)  # DE-edit"),
+    _idless_code("de", "extra_de()"),
+)
+EN1_U = _deck(
+    _title("en"), _idless_code("en", "for q in comparison_queries:\n    run(q)  # EN-edit")
+)
 
 
 class TestIdlessDriftErrorIsLocalized:
     @pytest.mark.parametrize("baseline", ["git-head", "watermark"])
     def test_error_names_owning_group_and_offending_cell(self, tmp_path: Path, baseline: str):
-        plan, _result, _de_after, _en_after = _sync(tmp_path, baseline, DE0, EN0, DE1, EN1)
+        plan, _result, _de_after, _en_after = _sync(tmp_path, baseline, DE0_U, EN0_U, DE1_U, EN1_U)
         errors = _error_issues(plan)
         assert errors
         # Located: the error pins to the drifted cell's owning slide group (was always
@@ -156,6 +223,8 @@ class TestIdlessDriftErrorIsLocalized:
     def test_error_steers_to_rebaseline_not_just_assign_ids(self, tmp_path: Path):
         # #364 item 3: the old message only said "assign slide_ids" (which does not help
         # the stale-watermark case). The new message leads with the actual common fix.
-        plan, _result, _de_after, _en_after = _sync(tmp_path, "watermark", DE0, EN0, DE1, EN1)
+        plan, _result, _de_after, _en_after = _sync(
+            tmp_path, "watermark", DE0_U, EN0_U, DE1_U, EN1_U
+        )
         reason = "\n".join(e.reason for e in _error_issues(plan))
         assert "--rebaseline" in reason

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -1098,6 +1098,8 @@ def test_explain_warns_when_watermark_baseline_errors(tmp_path: Path):
     # Issue #364 item 4: an error against a (possibly stale) watermark baseline can show
     # a clean-looking anchor diff yet still error. --explain must say so up front and
     # point at the git-HEAD / --rebaseline comparison, so the mismatch is not a mystery.
+    # Use an UNPAIRABLE structure (DE has an extra id-less cell EN lacks) so the drift
+    # keeps the deck-wide error path rather than degrading to a conflict (Issue #365).
     de = _slide("de", "a", "# ## A") + _code_localized_idless("de", "for q in test_queries:\n    p")
     en = _slide("en", "a", "# ## A") + _code_localized_idless(
         "en", "for q in comparison_queries:\n    p"
@@ -1106,10 +1108,11 @@ def test_explain_warns_when_watermark_baseline_errors(tmp_path: Path):
     cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
     try:
         _seed(cache, de_path, en_path)
-        # Both halves drift their hash-only id-less localized cell -> both-decks error.
+        # Both halves drift, and DE grows an extra id-less cell -> unpairable -> error.
         de_path.write_text(
             _slide("de", "a", "# ## A")
-            + _code_localized_idless("de", "for q in test_queries:\n    q"),
+            + _code_localized_idless("de", "for q in test_queries:\n    q")
+            + _code_localized_idless("de", "extra()"),
             encoding="utf-8",
         )
         en_path.write_text(


### PR DESCRIPTION
## Summary

**Issue #365, approach 1 (positional pairing), increment 1.** A `lang=` cell with no `slide_id` is anchored only by content hash, so a both-sided edit with no propagation direction established elsewhere was unpairable and **hard-errored — rolling the whole deck back**. This was the incident behind the #364/#365/#366 batch.

When the two halves' id-less localized cells share the same content-free `(group_index, kind)` structure — and neither added/removed one since the baseline — they pair positionally within their slide group. Each positionally-paired cell that drifted on either side now becomes a deferred **`conflict`** proposal instead of a deck-wide error:

- the watermark still **holds** and **both edits stay on disk** (exactly as the error did),
- but `has_errors` is no longer set, so **unrelated clean changes in the same run still apply**, and the divergence is a **located per-cell item** rather than an opaque deck-wide stop.

### Example (`--dry-run`)
```
conflict (id-less)/localized-code — id-less localized code cell 'for q in test_queries:'
edited on both decks since last sync — resolve which side wins, or give it a slide_id to pair it
```

## Scope / safety

- **Resolution-by-side is a follow-up (increment 2).** `_is_idless_localized_conflict` makes these conflicts **defer-only** in apply (`_materialize_edits` skips them; `_apply_conflict` always defers), so a stray `de-wins`/`en-wins` decision can **never** mis-target a cell via the `(slide_id, role)` path. For now resolve by editing the deck or giving the cell a `slide_id`.
- **Unpairable structure keeps the error.** When the halves' id-less localized structure is *not* parallel (a move/add/remove is in play), the located deck-wide error (#364 item 4) is kept — positional pairing would be unsound.
- The completeness invariant in `apply_plan` already holds the *whole* watermark on an unkeyed deferral (`len(deferred_keys) != result.deferred`), so nothing is ever advanced over the divergence.

## Changes
- `sync_plan.py`: `_idless_localized_pairing` / `_idless_localized_signature` / `_classify_idless_localized_conflicts`; wired into the `established is None` branch of `_classify_idless_localized_drift` (degrade-or-keep-error).
- `sync_apply.py`: `_is_idless_localized_conflict` defer-only guard in `_materialize_edits` + `_apply_conflict`.
- `clm info commands`: documents the degrade.
- Tests: `tests/slides/test_sync_idless_localized_drift_repro.py` (conflict degrade, positional identity, defer-only-under-decision, unpairable-still-errors).

## Testing
Full fast suite: **8381 passed, 6 skipped, 1 xfailed** (86s). No #269/#282 regressions — the lenient `_alerted` (which counts `deferred`) absorbed the error→conflict change. Ruff + mypy clean.

Follow-up tracked: increment 2 (resolve a side via positional translation + judge `in_sync` auto-resolve). #366 (git-as-baseline prototype) is next in the batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
