### PR TITLE
feat(sync): resolve a one-sided id-less-localized winner instead of deferring (#365 increment 2)

### DIFF
--- a/changelog.d/365-idless-localized-resolve-a-side.changed.md
+++ b/changelog.d/365-idless-localized-resolve-a-side.changed.md
@@ -1,0 +1,14 @@
+- **`clm slides sync` now *resolves* an id-less-localized drift when a side clearly
+  wins, instead of always deferring it (Issue #365, increment 2).** Building on the
+  positional pairing from increment 1: when the two halves' id-less localized cells
+  pair positionally and a paired cell drifted on **exactly one** side since the last
+  sync, sync translates that winning edit onto its positional twin (located by
+  per-language position, since the cell has no `slide_id`) rather than leaving a
+  deferred conflict — so a pass in which every drifted id-less cell has a clear winner
+  reconciles cleanly and advances the watermark. A cell genuinely edited on **both**
+  sides still defers (resolution by side of a true both-sided edit is out of scope),
+  except that a both-edited **markdown** cell the judge finds already equivalent is
+  downgraded to *in-sync* (no write, no defer) so a false conflict no longer holds the
+  watermark. A mixed pass — some cells resolved, some still deferred — flushes the
+  resolved edits but holds the whole watermark until the remaining conflicts are
+  resolved.

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -556,14 +556,16 @@ _IDLESS_LOCALIZED_ROLES = frozenset({LOCALIZED_CODE_ROLE, LOCALIZED_MARKDOWN_ROL
 
 
 def _is_idless_localized_conflict(proposal: Proposal) -> bool:
-    """An Issue #365 id-less localized both-decks conflict — resolved by deferral only.
+    """A genuine both-sided id-less localized conflict (Issue #365) — defer, or in_sync.
 
     Such a cell has no ``slide_id`` (the synthetic localized role + ``slide_id None``),
-    so the ``(slide_id, role)`` edit path cannot target it. The classifier degraded the
-    deck-wide error to this per-cell conflict so the rest of the run still applies and
-    the watermark holds; resolving *which side wins* (translating the winner onto the
-    positional twin) is a follow-up. Until then it always defers — never materialized as
-    an edit, so a stray ``de-wins`` / ``en-wins`` decision can never mis-target a cell.
+    so the ``(slide_id, role)`` edit path cannot target it. The classifier emits a
+    *conflict* only for the cell edited on **both** halves — a one-sided winner becomes a
+    resolvable id-less localized edit instead (increment 2). Resolving *which side wins*
+    of a genuine both-sided edit is out of scope, so it defers regardless of any
+    ``de-wins`` / ``en-wins`` decision (never mis-targeting a cell via the (slide_id,
+    role) path). The lone exception: a *markdown* false conflict the judge finds already
+    equivalent is downgraded to ``in_sync`` (no write, no defer) so the watermark advances.
     """
     return (
         proposal.kind == "conflict"
@@ -608,9 +610,16 @@ def _apply_conflict(
     pre-conflict baseline and the conflict re-surfaces next run.
     """
     if _is_idless_localized_conflict(proposal):
-        # Issue #365: id-less localized conflicts are defer-only for now (no positional
-        # resolver yet), so the watermark holds and both edits stay on disk regardless
-        # of any decision — never mis-targeting a cell via the (slide_id, role) path.
+        # Issue #365: a *genuine* both-sided id-less localized conflict defers — the
+        # watermark holds and both edits stay on disk regardless of any de/en-wins
+        # decision, never mis-targeting via the (slide_id, role) path (resolve-a-side
+        # of a both-sided edit is out of scope). Increment 2: a *markdown* false
+        # conflict whose halves the judge found already equivalent was materialized as
+        # in_sync up front — downgrade it (no write, no defer) so the watermark advances.
+        outcome = edit_outcomes.get(id(proposal))
+        if outcome is not None and outcome.verdict == "in_sync":
+            result.in_sync += 1
+            return
         result.deferred += 1
         _note_deferred(deferred_keys, proposal)
         return
@@ -1081,8 +1090,16 @@ def _materialize_edits(
             )
         elif proposal.kind == "conflict":
             if _is_idless_localized_conflict(proposal):
-                # Issue #365: defer-only — never materialized as a directed edit (it
-                # has no (slide_id, role) to target). Skip so the execute walk defers it.
+                # Issue #365: a both-sided id-less conflict is never materialized as a
+                # directed edit (no (slide_id, role) to target, and resolve-a-side of a
+                # genuine both-sided edit is out of scope). Increment 2: probe a
+                # *markdown* false conflict — if the judge finds the halves already
+                # equivalent, record in_sync so the execute walk downgrades it (no write,
+                # no defer); code stays defer-only (no judge for runnable code).
+                if proposal.role == LOCALIZED_MARKDOWN_ROLE and _idless_conflict_already_equivalent(
+                    proposal, de_state, en_state, judge
+                ):
+                    outcomes[id(proposal)] = _EditOutcome("in_sync")
                 continue
             decision = _conflict_decision(decisions, proposal)
             if decision in (DECISION_DE_WINS, DECISION_EN_WINS):
@@ -1211,6 +1228,78 @@ def _resolve_narrative_edit(
     return _EditOutcome("update", proposed_text=sync_proposal.proposed_text)
 
 
+def _resolve_idless_localized_edit(
+    proposal: Proposal,
+    de_state: FileState,
+    en_state: FileState,
+    judge: SyncJudge | None,
+    translator: SlideTranslator | None,
+) -> _EditOutcome:
+    """Resolve a one-sided id-less localized edit (Issue #365 increment 2).
+
+    The winning side drifted; re-translate its body — read by ``source_position``
+    among the source deck's non-j2 cells, the cell having no ``(slide_id, role)``
+    key — for the positional twin. A localized **code** cell is re-translated (the
+    markdown judge's prompt does not fit runnable code); a localized **markdown**
+    cell goes through the judge against the stale target body, so a no-op edit
+    records ``in_sync``. The writeback (:func:`_apply_edit`) targets the twin by
+    ``target_position``, refusing if that cell is no longer id-less localized.
+    """
+    if proposal.source_position is None or proposal.target_position is None:
+        return _EditOutcome("blocked", error=f"edit (id-less {proposal.role}): missing position")
+    if proposal.direction == "de->en":
+        source_state, source_lang, target_lang = de_state, "de", "en"
+        target_state = en_state
+    else:
+        source_state, source_lang, target_lang = en_state, "en", "de"
+        target_state = de_state
+    source_body = source_state.idless_localized_body_at(source_lang, proposal.source_position)
+    if source_body is None:
+        return _EditOutcome(
+            "blocked",
+            error=f"edit (id-less {proposal.role}) at {source_lang} #{proposal.source_position}: "
+            "source cell not found or not id-less localized",
+        )
+    if proposal.role == LOCALIZED_CODE_ROLE:
+        if translator is None:
+            return _EditOutcome(
+                "blocked", error=f"edit (id-less {proposal.role}): no translator (LLM unavailable)"
+            )
+        try:
+            new_body = translator.translate(
+                source_body=source_body.rstrip("\n"),
+                source_lang=source_lang,
+                target_lang=target_lang,
+                role=CODE_ROLE,
+            )
+        except TranslationError as exc:
+            return _EditOutcome(
+                "blocked", error=f"edit (id-less {proposal.role}): translation failed: {exc}"
+            )
+        return _EditOutcome("update", proposed_text=new_body)
+    if judge is None:
+        return _EditOutcome(
+            "blocked", error=f"edit (id-less {proposal.role}): no judge (LLM unavailable)"
+        )
+    target_body = target_state.idless_localized_body_at(target_lang, proposal.target_position)
+    if target_body is None:
+        return _EditOutcome(
+            "blocked",
+            error=f"edit (id-less {proposal.role}) at {target_lang} #{proposal.target_position}: "
+            "target cell not found or not id-less localized",
+        )
+    try:
+        sync_proposal = judge.propose(
+            source_body, target_body, source_lang=source_lang, target_lang=target_lang
+        )
+    except OllamaError as exc:
+        logger.info("id-less localized edit judge failed (%s): %s", proposal.role, exc)
+        return _EditOutcome("blocked", error=f"edit (id-less {proposal.role}): {exc}")
+    if sync_proposal.verdict != "update":
+        return _EditOutcome("in_sync")
+    return _EditOutcome("update", proposed_text=sync_proposal.proposed_text)
+
+
 def _resolve_edit(
     proposal: Proposal,
     de_state: FileState,
@@ -1230,6 +1319,8 @@ def _resolve_edit(
     """
     if proposal.role in NARRATIVE_ROLES and proposal.slide_id is None:
         return _resolve_narrative_edit(proposal, de_state, en_state, judge)
+    if proposal.role in _IDLESS_LOCALIZED_ROLES and proposal.slide_id is None:
+        return _resolve_idless_localized_edit(proposal, de_state, en_state, judge, translator)
     if proposal.slide_id is None:
         return _EditOutcome("blocked", error=f"edit {proposal.role}: proposal has no slide_id")
     sid = proposal.slide_id
@@ -1318,8 +1409,24 @@ def _apply_edit(
         else:
             result.errors.append(f"edit {proposal.role}: target narrative not found by anchor")
         return
+    if proposal.role in _IDLESS_LOCALIZED_ROLES and proposal.slide_id is None:
+        # Issue #365 increment 2: a one-sided id-less localized winner has no
+        # (slide_id, role) key, so write the re-translated body onto the positional
+        # twin by its non-j2 target position. The writeback refuses (→ error, no
+        # advance) if that cell drifted out of the id-less localized set since planning.
+        target_lang = "en" if proposal.direction == "de->en" else "de"
+        if proposal.target_position is not None and target_state.replace_idless_localized_body(
+            target_lang, proposal.target_position, outcome.proposed_text or ""
+        ):
+            result.applied_edit += 1
+        else:
+            result.errors.append(
+                f"edit (id-less {proposal.role}) at {target_lang} #{proposal.target_position}: "
+                "target cell not found or not id-less localized"
+            )
+        return
     sid = proposal.slide_id
-    if sid is None:  # unreachable: an id-less edit resolves to "blocked" above
+    if sid is None:  # unreachable: an id-less edit is narrative/localized (handled above)
         result.errors.append(f"edit {proposal.role}: proposal has no slide_id")
         return
     if target_state.replace_cell_body(sid, proposal.role, outcome.proposed_text or ""):
@@ -1353,6 +1460,40 @@ def _conflict_already_equivalent(
     key = (proposal.slide_id, proposal.role)
     de_body = de_content.get(key, "")
     en_body = en_content.get(key, "")
+    if not de_body or not en_body:
+        return False
+    try:
+        if judge.propose(de_body, en_body, source_lang="de", target_lang="en").verdict == "update":
+            return False
+        if judge.propose(en_body, de_body, source_lang="en", target_lang="de").verdict == "update":
+            return False
+    except OllamaError:
+        return False
+    return True
+
+
+def _idless_conflict_already_equivalent(
+    proposal: Proposal,
+    de_state: FileState,
+    en_state: FileState,
+    judge: SyncJudge | None,
+) -> bool:
+    """Whether a both-edited id-less localized **markdown** conflict's halves are equivalent.
+
+    The id-less positional counterpart of :func:`_conflict_already_equivalent`
+    (Issue #4 / #365 increment 2): a both-edited markdown cell is often a *false*
+    conflict (both halves independently reworded to the same meaning). The cell has no
+    ``(slide_id, role)`` key, so both bodies are read by their carried non-j2 positions
+    (``source_position`` on de, ``target_position`` on en — as the classifier emitted
+    them). The judge's ``in_sync`` verdict in **both** directions means each half
+    already reflects the other, so the conflict downgrades. Conservative by design: no
+    judge, a missing body, or a judge error keeps the conflict — never auto-resolving
+    on uncertainty.
+    """
+    if judge is None or proposal.source_position is None or proposal.target_position is None:
+        return False
+    de_body = de_state.idless_localized_body_at("de", proposal.source_position)
+    en_body = en_state.idless_localized_body_at("en", proposal.target_position)
     if not de_body or not en_body:
         return False
     try:

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -833,6 +833,64 @@ def _idless_localized_signature(
     return [(group_index, _idless_localized_kind(cell)) for cell, _sid, group_index in pairing]
 
 
+def _idless_localized_lang_positions(cells: list[Cell], lang: str) -> list[int]:
+    """For each id-less localized cell of ``lang`` (document order), its non-j2 index.
+
+    The watermark, :func:`_localized_lang_cells`, and the writeback primitives
+    (:meth:`FileState.replace_idless_localized_body` /
+    :meth:`FileState.replace_idless_localized_tags`) all locate an id-less localized
+    cell by its position among the deck's **non-j2 ``lang`` cells** — which differs
+    from its index among *id-less* cells when id-carrying localized cells are
+    interleaved. This yields, in lock-step with :func:`_idless_localized_pairing`
+    (same predicate, same order), the position a resolver must target on that half
+    (Issue #365 increment 2).
+    """
+    out: list[int] = []
+    pos = -1
+    for c in cells:
+        if c.metadata.is_j2 or c.metadata.lang != lang:
+            continue
+        pos += 1
+        if role_of(c.metadata) is None:
+            out.append(pos)
+    return out
+
+
+def _idless_localized_edit(
+    role: str,
+    direction: str,
+    owner: str | None,
+    occ: int,
+    source_position: int,
+    target_position: int,
+    snippet: str,
+    kind: str,
+) -> Proposal:
+    """A resolvable id-less localized one-sided edit (Issue #365 increment 2).
+
+    Only one half drifted since the baseline, so there is a clear winner: the apply
+    re-translates the winning side's body (by ``source_position``) onto its positional
+    twin (by ``target_position``) — both per-language non-j2 indices, since the cell
+    has no ``(slide_id, role)`` key. ``slide_id`` stays ``None``; the localized role +
+    positions are the whole identity.
+    """
+    winner = direction.split("->")[0].upper()
+    return Proposal(
+        kind="edit",
+        role=role,
+        direction=direction,
+        slide_id=None,
+        owning_slide_id=owner,
+        anchor_occ=occ,
+        source_position=source_position,
+        target_position=target_position,
+        reason=(
+            f"id-less localized {kind} cell {snippet!r} edited only on {winner} since "
+            f"last sync — translating the {winner} edit onto its positional twin"
+        ),
+    )
+
+
 def _classify_idless_localized_conflicts(
     plan: SyncPlan,
     de_cells: list[Cell],
@@ -840,7 +898,7 @@ def _classify_idless_localized_conflicts(
     de_baseline: list[str],
     en_baseline: list[str],
 ) -> bool:
-    """Degrade a both-sided id-less localized drift to per-cell conflicts (Issue #365).
+    """Reconcile a both-sided id-less localized drift per-cell (Issue #365).
 
     A ``lang=`` cell with no ``slide_id`` is anchored only by content hash, so a
     both-sided edit with no propagation direction established elsewhere is unpairable
@@ -848,18 +906,28 @@ def _classify_idless_localized_conflicts(
     id-less localized cells share the same content-free ``(group_index, kind)``
     structure — and neither half added or removed one since the baseline — they pair
     positionally within their slide group: the n-th DE cell corresponds to the n-th EN
-    cell. Each positionally-paired cell that drifted on either side becomes a
-    **conflict** proposal (``slide_id`` ``None``, the synthetic localized role,
-    positionally identified) instead of a deck-wide error. A conflict defers — the
-    watermark holds and both edits stay on disk, exactly like the error did — but it no
-    longer sets ``has_errors``, so unrelated clean changes in the same run still apply,
-    and the divergence is a resolvable per-cell item rather than an opaque deck-wide
-    stop.
+    cell. Each positionally-paired cell that drifted is then classified per-cell:
 
-    Returns ``True`` when it took ownership (emitted conflicts, or found the drift
-    already in sync), so the caller skips the legacy error. Returns ``False`` when the
-    structure is not pairable (a move/add/remove happened) — the caller keeps the
-    located error, since positional pairing would be unsound.
+    - **one-sided** drift (only DE *or* only EN changed since baseline) has a clear
+      winner, so it becomes a resolvable **edit** (increment 2): the apply
+      re-translates the winning side's body onto its positional twin. Each side's
+      non-j2 ``lang`` index is carried as ``source_position`` / ``target_position``.
+    - **both-sided** drift (the same cell edited on each half) has no winner, so it
+      stays a defer-only **conflict** (increment 1) — the watermark holds and both
+      edits stay on disk. ``source_position`` / ``target_position`` are carried so the
+      apply can probe the judge for a false-conflict ``in_sync`` downgrade (markdown).
+
+    Neither sets ``has_errors``, so unrelated clean changes in the same run still
+    apply, and the divergence is resolvable/located per cell rather than an opaque
+    deck-wide stop. A pass that resolves *every* drifted cell (no conflict deferred)
+    is clean and advances the whole watermark; a mixed pass holds the watermark via
+    the completeness invariant (an id-less deferral carries no ``(slide_id, role)``
+    key) while still flushing the resolved edits.
+
+    Returns ``True`` when it took ownership (emitted edits/conflicts, or found the
+    drift already in sync), so the caller skips the legacy error. Returns ``False``
+    when the structure is not pairable (a move/add/remove happened) — the caller keeps
+    the located error, since positional pairing would be unsound.
     """
     de_pairing = _idless_localized_pairing(de_cells, "de")
     en_pairing = _idless_localized_pairing(en_cells, "en")
@@ -870,6 +938,11 @@ def _classify_idless_localized_conflicts(
         return False
     if len(de_pairing) != len(de_baseline) or len(en_pairing) != len(en_baseline):
         return False
+    # Per-language non-j2 indices (in lock-step with the pairings): the position a
+    # resolver targets on each half, which differs from the id-less index ``i`` when
+    # id-carrying localized cells are interleaved.
+    de_lang_pos = _idless_localized_lang_positions(de_cells, "de")
+    en_lang_pos = _idless_localized_lang_positions(en_cells, "en")
 
     emitted = False
     for i, ((de_cell, owner, _gi), (en_cell, _en_owner, _en_gi)) in enumerate(
@@ -881,24 +954,56 @@ def _classify_idless_localized_conflicts(
             continue
         kind = _idless_localized_kind(de_cell)
         role = LOCALIZED_CODE_ROLE if kind == "code" else LOCALIZED_MARKDOWN_ROLE
-        snippet = _cell_first_line(de_cell.content if de_drift else en_cell.content)
-        plan.proposals.append(
-            Proposal(
-                kind="conflict",
-                role=role,
-                direction=None,
-                slide_id=None,
-                # ``anchor_occ`` carries the cell's index among the deck's id-less
-                # localized cells — the positional identity a resolver targets by (the
-                # n-th such cell of the losing language), mirroring _apply_retag_idless.
-                owning_slide_id=owner,
-                anchor_occ=i,
-                reason=(
-                    f"id-less localized {kind} cell {snippet!r} edited on both decks since "
-                    "last sync — resolve which side wins, or give it a slide_id to pair it"
-                ),
+        if de_drift and not en_drift:
+            plan.proposals.append(
+                _idless_localized_edit(
+                    role,
+                    "de->en",
+                    owner,
+                    i,
+                    de_lang_pos[i],
+                    en_lang_pos[i],
+                    _cell_first_line(de_cell.content),
+                    kind,
+                )
             )
-        )
+        elif en_drift and not de_drift:
+            plan.proposals.append(
+                _idless_localized_edit(
+                    role,
+                    "en->de",
+                    owner,
+                    i,
+                    en_lang_pos[i],
+                    de_lang_pos[i],
+                    _cell_first_line(en_cell.content),
+                    kind,
+                )
+            )
+        else:
+            # Both halves edited the *same* cell — no winner. Defer-only (increment 1),
+            # carrying both positions so the apply can probe the judge for a false
+            # conflict ``in_sync`` downgrade (markdown only; code stays deferred).
+            snippet = _cell_first_line(de_cell.content)
+            plan.proposals.append(
+                Proposal(
+                    kind="conflict",
+                    role=role,
+                    direction=None,
+                    slide_id=None,
+                    # ``anchor_occ`` carries the cell's index among the deck's id-less
+                    # localized cells; the positions carry each half's non-j2 index.
+                    owning_slide_id=owner,
+                    anchor_occ=i,
+                    source_position=de_lang_pos[i],
+                    target_position=en_lang_pos[i],
+                    reason=(
+                        f"id-less localized {kind} cell {snippet!r} edited on both decks "
+                        "since last sync — resolve which side wins, or give it a slide_id "
+                        "to pair it"
+                    ),
+                )
+            )
         emitted = True
     return emitted
 

--- a/src/clm/slides/sync_writeback.py
+++ b/src/clm/slides/sync_writeback.py
@@ -391,6 +391,66 @@ class FileState:
             return True
         return False
 
+    def idless_localized_body_at(self, lang: str, position: int) -> str | None:
+        """The body of the ``position``-th ``lang`` cell, if it is id-less localized.
+
+        The read counterpart of :meth:`replace_idless_localized_body`: it locates
+        the cell by its **position** among the deck's non-j2 ``lang`` cells (the
+        per-language ordinal the watermark records — the same convention
+        :meth:`replace_idless_localized_tags` uses) and returns its body verbatim
+        (header and trailing blanks excluded), exactly as the parser produced it.
+
+        Returns ``None`` when ``position`` is out of range **or** the cell there is
+        *not* id-less localized (an id-carrying cell sits there — the stream drifted
+        since the plan was built), so the caller surfaces it rather than reading the
+        wrong cell's body. Issue #365 increment 2 reads a one-sided winner's source
+        body here to translate onto its positional twin.
+        """
+        idx = -1
+        for cell in self.cells:
+            meta = cell.metadata
+            if meta.is_j2 or meta.lang != lang:
+                continue
+            idx += 1
+            if idx != position:
+                continue
+            if role_of(meta) is not None:
+                return None  # an id-carrying cell sits here — stream drifted; refuse
+            return cell.body
+        return None
+
+    def replace_idless_localized_body(self, lang: str, position: int, new_text: str) -> bool:
+        """Rewrite the body of the ``position``-th ``lang`` cell, if id-less localized.
+
+        The body counterpart of :meth:`replace_idless_localized_tags` (Issue #365
+        increment 2): an id-less localized cell (a ``lang=`` cell with no
+        ``slide_id``, so :func:`role_of` is ``None``) has no ``(slide_id, role)``
+        key, so :meth:`replace_cell_body` cannot find it. The classifier instead
+        identifies it by its **position** among the deck's non-j2 ``lang`` cells —
+        the same per-language ordinal the watermark records — and this method
+        rewrites only that cell's body (header, ``lang``, cell type, and trailing
+        blanks verbatim), exactly like :meth:`replace_cell_body`.
+
+        Returns ``False`` (and dirties nothing) when ``position`` is out of range
+        **or** the cell there is *not* id-less localized — a mismatch means the
+        stream drifted since the plan was built, so the caller surfaces it as an
+        error rather than rewriting the wrong cell.
+        """
+        idx = -1
+        for cell in self.cells:
+            meta = cell.metadata
+            if meta.is_j2 or meta.lang != lang:
+                continue
+            idx += 1
+            if idx != position:
+                continue
+            if role_of(meta) is not None:
+                return False  # an id-carrying cell sits here — stream drifted; refuse
+            self._rewrite_cell_body(cell, new_text)
+            self.dirty = True
+            return True
+        return False
+
     def delete_cell(self, slide_id: str, role: str) -> bool:
         """Remove the ``(slide_id, role)`` cell, lines and all.
 

--- a/tests/slides/test_sync_idless_localized_drift_repro.py
+++ b/tests/slides/test_sync_idless_localized_drift_repro.py
@@ -11,9 +11,17 @@ recent work (the #363 watermark CLI, the ``--baseline`` / ``--rebaseline`` /
 ``synced_commit`` staleness work) addressed and what these PRs add:
 
 - ``TestBothSidedIdlessDriftDegradesToConflict`` (#365, FIXED increment 1) — a both-sided
-  edit to a hash-only id-less localized cell that pairs positionally degrades to a
-  per-cell, deferred conflict (the deck no longer rolls back); resolution-by-side is a
-  documented follow-up, so the conflict is defer-only for now.
+  edit to *one* hash-only id-less localized cell that pairs positionally degrades to a
+  per-cell, deferred conflict (the deck no longer rolls back); a genuine both-sided edit
+  stays defer-only even under a de-wins decision.
+- ``TestOneSidedIdlessWinnerResolves`` (#365, FIXED increment 2) — when paired cells each
+  drifted on exactly one side (a clear winner per cell), sync translates the winning edit
+  onto its positional twin instead of deferring, and a fully-resolved pass advances the
+  watermark.
+- ``TestBothSidedMarkdownDowngradesToInSync`` (#365, increment 2) — a both-edited
+  *markdown* cell the judge finds already equivalent downgrades to in_sync (no write, no
+  defer); a divergent one, and any both-sided *code* cell (no judge for runnable code),
+  still defers.
 - ``TestIdlessDriftErrorIsLocalized`` (#364 item 4, FIXED) — when the structure is
   UNPAIRABLE (so #365 cannot degrade), the deck-wide error now pins to the drifted
   cell's owning slide group, echoes the offending cell, and steers to ``--rebaseline``.
@@ -30,6 +38,7 @@ from pathlib import Path
 import pytest
 
 from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.infrastructure.llm.ollama_client import StaticSyncJudge, SyncProposal
 from clm.slides.sync_apply import DECISION_DE_WINS, _record_watermark, apply_plan
 from clm.slides.sync_plan import build_sync_plan
 from clm.slides.sync_translate import StaticSlideTranslator
@@ -51,6 +60,11 @@ def _idless_code(lang: str, body: str) -> str:
     return f'# %% lang="{lang}"\n{body}\n'
 
 
+def _idless_md(lang: str, body: str) -> str:
+    """A hash-only id-less localized markdown cell — no slide_id, no narrative role."""
+    return f'# %% [markdown] lang="{lang}"\n# {body}\n'
+
+
 def _deck(*parts: str) -> str:
     return "\n".join(parts)
 
@@ -59,7 +73,7 @@ def _git(cwd: Path, *args: str) -> None:
     subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True, text=True)
 
 
-def _sync(tmp: Path, baseline: str, de0: str, en0: str, de1: str, en1: str):
+def _sync(tmp: Path, baseline: str, de0: str, en0: str, de1: str, en1: str, *, judge=None):
     """Establish a baseline, apply the edits, return ``(plan, result, de_after, en_after)``."""
     db = tmp / "clm-llm.sqlite"
     de_path, en_path = tmp / "deck.de.py", tmp / "deck.en.py"
@@ -81,11 +95,24 @@ def _sync(tmp: Path, baseline: str, de0: str, en0: str, de1: str, en1: str):
     try:
         plan = build_sync_plan(de_path, en_path, watermark_cache=wm)
         result = apply_plan(
-            plan, judge=None, translator=StaticSlideTranslator(default="<<XL>>"), watermark_cache=wm
+            plan,
+            judge=judge,
+            translator=StaticSlideTranslator(default="<<XL>>"),
+            watermark_cache=wm,
         )
     finally:
         wm.close()
     return plan, result, de_path.read_text(encoding="utf-8"), en_path.read_text(encoding="utf-8")
+
+
+def _in_sync_judge() -> StaticSyncJudge:
+    """A judge that always declares the two halves already equivalent (no edit needed)."""
+    return StaticSyncJudge(default_proposal=SyncProposal(verdict="in_sync", proposed_text=""))
+
+
+def _update_judge(text: str) -> StaticSyncJudge:
+    """A judge that always proposes ``text`` as the reconciled target body."""
+    return StaticSyncJudge(default_proposal=SyncProposal(verdict="update", proposed_text=text))
 
 
 def _error_issues(plan):
@@ -228,3 +255,120 @@ class TestIdlessDriftErrorIsLocalized:
         )
         reason = "\n".join(e.reason for e in _error_issues(plan))
         assert "--rebaseline" in reason
+
+
+# ---------------------------------------------------------------------------
+# #365 increment 2 — resolve a side: a per-cell *one-sided* winner inside a
+# both-sided deck drift is translated onto its positional twin (not just
+# deferred), and a both-sided *markdown* false conflict the judge finds already
+# equivalent downgrades to in_sync. Both let the watermark advance.
+# ---------------------------------------------------------------------------
+
+
+# Two id-less code cells; DE edits ONLY the first, EN edits ONLY the second. Each
+# half's stream drifts (so the deck-level both-sided branch fires) yet every cell
+# drifted on exactly one side — a clear per-cell winner.
+ONE_DE0 = _deck(_title("de"), _idless_code("de", "a = 1"), _idless_code("de", "b = 2"))
+ONE_EN0 = _deck(_title("en"), _idless_code("en", "a = 1"), _idless_code("en", "b = 2"))
+ONE_DE1 = _deck(_title("de"), _idless_code("de", "a = 1  # DE"), _idless_code("de", "b = 2"))
+ONE_EN1 = _deck(_title("en"), _idless_code("en", "a = 1"), _idless_code("en", "b = 2  # EN"))
+
+
+class TestOneSidedIdlessWinnerResolves:
+    @pytest.mark.parametrize("baseline", ["git-head", "watermark"])
+    def test_one_sided_cells_resolve_as_edits_not_conflicts(self, tmp_path: Path, baseline: str):
+        plan, result, de_after, en_after = _sync(
+            tmp_path, baseline, ONE_DE0, ONE_EN0, ONE_DE1, ONE_EN1
+        )
+        # No deck-wide error and NO conflict: each cell had a clear winner, so the
+        # classifier emits resolvable id-less localized edits instead of deferrals.
+        assert not _error_issues(plan)
+        assert not any(p.kind == "conflict" for p in plan.proposals)
+        edits = [p for p in plan.proposals if p.kind == "edit" and p.role == "localized-code"]
+        assert len(edits) == 2
+        assert {p.direction for p in edits} == {"de->en", "en->de"}
+        # Both edits applied, nothing deferred.
+        assert result.applied_edit >= 2
+        assert result.deferred == 0
+        # The winning side's edit survives; the losing twin is overwritten by the
+        # static translation of the winner ("<<XL>>").
+        assert "# DE" in de_after  # DE's edit to cell 0 stays
+        assert "# EN" in en_after  # EN's edit to cell 1 stays
+        assert "<<XL>>" in en_after  # cell 0 EN twin re-translated from DE
+        assert "<<XL>>" in de_after  # cell 1 DE twin re-translated from EN
+
+    def test_fully_resolved_pass_advances_the_watermark(self, tmp_path: Path):
+        # Every drifted cell resolved (no deferral) → a clean pass → full advance, so a
+        # re-run sees no drift (the stale-baseline incident is fully reconciled).
+        _plan, result, _de, _en = _sync(tmp_path, "watermark", ONE_DE0, ONE_EN0, ONE_DE1, ONE_EN1)
+        assert result.watermark_recorded
+        assert not result.errors
+
+    def test_one_sided_markdown_winner_uses_the_judge(self, tmp_path: Path):
+        # A markdown one-sided winner reconciles through the judge (not the code
+        # translator): DE edits cell 0, EN edits cell 1; the judge proposes the target.
+        de0 = _deck(_title("de"), _idless_md("de", "Eins"), _idless_md("de", "Zwei"))
+        en0 = _deck(_title("en"), _idless_md("en", "One"), _idless_md("en", "Two"))
+        de1 = _deck(_title("de"), _idless_md("de", "Eins geaendert"), _idless_md("de", "Zwei"))
+        en1 = _deck(_title("en"), _idless_md("en", "One"), _idless_md("en", "Two changed"))
+        plan, result, de_after, en_after = _sync(
+            tmp_path, "watermark", de0, en0, de1, en1, judge=_update_judge("# RECONCILED")
+        )
+        assert not _error_issues(plan)
+        assert not any(p.kind == "conflict" for p in plan.proposals)
+        assert result.applied_edit >= 2
+        assert result.deferred == 0
+        assert "RECONCILED" in de_after and "RECONCILED" in en_after
+
+
+class TestBothSidedMarkdownDowngradesToInSync:
+    def test_judge_equivalent_both_sided_markdown_downgrades(self, tmp_path: Path):
+        # One id-less markdown cell edited on BOTH halves (no winner) → a conflict.
+        # Increment 2: the judge finds the halves already equivalent, so it downgrades
+        # to in_sync (no write, no defer) and the watermark advances.
+        de0 = _deck(_title("de"), _idless_md("de", "Hallo"))
+        en0 = _deck(_title("en"), _idless_md("en", "Hello"))
+        de1 = _deck(_title("de"), _idless_md("de", "Hallo Welt"))
+        en1 = _deck(_title("en"), _idless_md("en", "Hello World"))
+        plan, result, de_after, en_after = _sync(
+            tmp_path, "watermark", de0, en0, de1, en1, judge=_in_sync_judge()
+        )
+        # The classifier still emits a (both-sided) conflict; the apply downgrades it.
+        assert any(p.kind == "conflict" and p.role == "localized-markdown" for p in plan.proposals)
+        assert result.in_sync >= 1
+        assert result.deferred == 0
+        assert result.watermark_recorded
+        # No write: both edited bodies are left exactly as authored.
+        assert "Hallo Welt" in de_after and "Hello World" in en_after
+
+    def test_judge_divergent_both_sided_markdown_still_defers(self, tmp_path: Path):
+        # The conservative side: the judge proposes an update (a genuine divergence), so
+        # the both-sided conflict is NOT downgraded — it defers, holding the watermark.
+        de0 = _deck(_title("de"), _idless_md("de", "Hallo"))
+        en0 = _deck(_title("en"), _idless_md("en", "Hello"))
+        de1 = _deck(_title("de"), _idless_md("de", "Komplett anders"))
+        en1 = _deck(_title("en"), _idless_md("en", "Totally different"))
+        _plan, result, de_after, en_after = _sync(
+            tmp_path, "watermark", de0, en0, de1, en1, judge=_update_judge("# x")
+        )
+        assert result.in_sync == 0
+        assert result.deferred >= 1
+        assert not result.watermark_recorded
+        # Defer-only: both edits stay on disk, nothing overwritten.
+        assert "Komplett anders" in de_after and "Totally different" in en_after
+
+    def test_both_sided_code_has_no_judge_path_and_defers(self, tmp_path: Path):
+        # Code cannot be judged for equivalence (the markdown judge prompt does not fit
+        # runnable code), so a both-sided id-less *code* conflict always defers even with
+        # a judge present — the increment-1 safety floor is preserved.
+        de0 = _deck(_title("de"), _idless_code("de", "x = 1"))
+        en0 = _deck(_title("en"), _idless_code("en", "x = 1"))
+        de1 = _deck(_title("de"), _idless_code("de", "x = 1  # DE"))
+        en1 = _deck(_title("en"), _idless_code("en", "x = 1  # EN"))
+        _plan, result, de_after, en_after = _sync(
+            tmp_path, "watermark", de0, en0, de1, en1, judge=_in_sync_judge()
+        )
+        assert result.in_sync == 0
+        assert result.deferred >= 1
+        assert not result.watermark_recorded
+        assert "# DE" in de_after and "# EN" in en_after


### PR DESCRIPTION
## Summary

**Increment 2 of #365 ("resolve a side").** Increment 1 (PR #418) degraded a both-sided id-less-localized drift from a deck-wide error to a **defer-only** per-cell conflict. This increment *resolves* the cases that have a clear winner, so the divergence no longer just sits deferred.

A `lang=` cell with no `slide_id` is anchored only by content hash, so when both halves' id-less localized streams drift with no established propagation direction, the cells pair positionally within their slide group (the increment-1 gate: same content-free `(group, kind)` structure, no add/remove since baseline). Each paired drifted cell is then classified per-cell:

- **One-sided drift** (only DE *or* only EN changed since baseline) → a clear winner. Sync re-translates the winning side's body onto its positional twin — a resolvable `kind="edit"` carrying each side's per-language **non-j2 position** (the cell has no `(slide_id, role)` key). A pass where *every* drifted id-less cell has a winner reconciles cleanly and **advances the watermark**.
- **Both-sided drift** (the same cell edited on each half) → no winner, stays a defer-only conflict (increment 1). The one exception: a both-edited **markdown** cell the judge finds already equivalent downgrades to **in_sync** (no write, no defer), so a false conflict no longer holds the watermark. **Code** both-sided cells have no judge path (the markdown prompt doesn't fit runnable code) and always defer — the increment-1 safety floor.

Scope was confirmed as *in_sync + one-sided winner*; resolving a genuine both-sided edit (picking/merging a winner) is intentionally out of scope. A **mixed pass** (some resolved, some deferred) flushes the resolved edits to disk but holds the whole watermark via the completeness invariant (an id-less deferral carries no `(slide_id, role)` key) until the remaining conflicts are resolved — documented residual, no data loss.

## Changes

- **`sync_writeback.py`** — `idless_localized_body_at` / `replace_idless_localized_body`: positional read/write, the body analogs of `replace_idless_localized_tags`, with the same "refuse if the cell drifted out of the id-less localized set" safety.
- **`sync_plan.py`** — `_classify_idless_localized_conflicts` now splits per paired cell (one-sided → resolvable edit; both-sided → defer-only conflict carrying both positions for the judge probe). New `_idless_localized_lang_positions` (non-j2 index, accounting for interleaved id'd cells) and `_idless_localized_edit` helpers.
- **`sync_apply.py`** — id-less-localized edit path in `_resolve_edit` (translate code / judge markdown by position) and `_apply_edit` (write by position); markdown `in_sync` downgrade for id-less conflicts via `_idless_conflict_already_equivalent`.

## Tests

- `TestOneSidedIdlessWinnerResolves` — one-sided winners resolve as edits (code via translator, markdown via judge); a fully-resolved pass advances the watermark.
- `TestBothSidedMarkdownDowngradesToInSync` — judge-equivalent markdown downgrades to in_sync; a divergent markdown, and any both-sided code cell, still defer.
- All increment-1 tests stay green (the single-cell both-sided repro still defers).

Full `tests/slides/` suite passes (1792); ruff + mypy clean. The one pre-push failure was an unrelated, known xdist worker-test flake (`test_worker_updates_status`, #163) that passed in isolation and on retry.

Companion issues: #363, #364, #366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
