### PR TITLE
feat(build): dedup repeated errors/warnings in build output

### DIFF
--- a/changelog.d/build-error-dedup.changed.md
+++ b/changelog.d/build-error-dedup.changed.md
@@ -1,0 +1,7 @@
+- **`clm build` no longer repeats identical errors and warnings.** A source
+  slide is processed once per output target and language, so the same finding
+  (e.g. a dropped voiceover narration) used to be printed many times as the
+  build progressed. Each unique error/warning is now shown once in the live
+  stream, and the final summary collapses duplicates into a single entry with
+  a `(N times)` suffix recording how often it occurred. JSON output gains an
+  `occurrence_count` field per error/warning.

--- a/src/clm/cli/build_data_classes.py
+++ b/src/clm/cli/build_data_classes.py
@@ -24,6 +24,11 @@ class BuildError:
         job_id: Optional job ID for tracking
         correlation_id: Optional correlation ID for end-to-end tracing
         details: Additional error details (e.g., cell_number, code_snippet)
+        occurrence_count: How many times an identical error was reported
+            during the build. A single source slide is processed once per
+            output target and language, so the same drop/failure is reported
+            several times; the live stream shows it once and the summary
+            collapses the duplicates into one entry carrying this count.
     """
 
     error_type: Literal["user", "configuration", "infrastructure"]
@@ -35,6 +40,7 @@ class BuildError:
     job_id: int | None = None
     correlation_id: str | None = None
     details: dict[str, Any] = field(default_factory=dict)
+    occurrence_count: int = 1
 
     def __str__(self) -> str:
         """Human-readable error representation."""
@@ -67,12 +73,15 @@ class BuildWarning:
         message: Warning message
         severity: Warning priority level
         file_path: Optional path to the file that caused the warning
+        occurrence_count: How many times an identical warning was reported
+            during the build (see :attr:`BuildError.occurrence_count`).
     """
 
     category: str
     message: str
     severity: Literal["high", "medium", "low"]
     file_path: str | None = None
+    occurrence_count: int = 1
 
     def __str__(self) -> str:
         """Human-readable warning representation."""

--- a/src/clm/cli/build_reporter.py
+++ b/src/clm/cli/build_reporter.py
@@ -56,6 +56,14 @@ class BuildReporter:
         # This prevents spurious errors from being displayed during worker shutdown
         self._build_finished: bool = False
 
+        # Fingerprints of errors/warnings already shown in the live stream.
+        # A source slide is processed once per output target and language, so
+        # the same finding (e.g. a dropped voiceover narration) is reported
+        # several times; we display each unique message once as it occurs and
+        # let the final summary report the aggregate count.
+        self._shown_error_fingerprints: set[tuple[str, str, str]] = set()
+        self._shown_warning_fingerprints: set[tuple[str, str, str]] = set()
+
         # Set when a worker-job timeout aborts the build (issue #143). Carried
         # into BuildSummary.timed_out so the entry point can force a non-zero
         # exit independent of the --fail-on-error policy.
@@ -104,6 +112,10 @@ class BuildReporter:
 
         # Reset build finished flag
         self._build_finished = False
+
+        # Reset live-stream dedup tracking
+        self._shown_error_fingerprints = set()
+        self._shown_warning_fingerprints = set()
 
         # Reset output-write registry summary
         self._output_dedup_count = 0
@@ -235,6 +247,15 @@ class BuildReporter:
 
         self.errors.append(error)
 
+        # Display each unique error once. The same source slide is processed
+        # once per output target and language, so an identical finding is
+        # reported several times; showing every copy floods the stream (the
+        # full count is reported in the summary).
+        fingerprint = self._error_fingerprint(error)
+        if fingerprint in self._shown_error_fingerprints:
+            return
+        self._shown_error_fingerprints.add(fingerprint)
+
         # Display error if appropriate for current output mode
         if self.formatter.should_show_error(error):
             self.formatter.show_error(error)
@@ -260,6 +281,12 @@ class BuildReporter:
             return
 
         self.warnings.append(warning)
+
+        # Display each unique warning once (see :meth:`report_error`).
+        fingerprint = self._warning_fingerprint(warning)
+        if fingerprint in self._shown_warning_fingerprints:
+            return
+        self._shown_warning_fingerprints.add(fingerprint)
 
         # Display warning if appropriate for current output mode
         if self.formatter.should_show_warning(warning):
@@ -298,57 +325,73 @@ class BuildReporter:
         if language and language not in entry.languages:
             entry.languages.append(language)
 
-    def _deduplicate_errors(self, errors: list[BuildError]) -> list[BuildError]:
-        """Remove duplicate errors based on file_path + category + message prefix.
+    @staticmethod
+    def _error_fingerprint(error: BuildError) -> tuple[str, str, str]:
+        """Identity used to collapse duplicate errors (file + category + message).
 
-        When multiple workers process the same file for different output targets,
-        they may report the same error multiple times. This deduplicates them
-        to avoid cluttering the summary.
+        The message is truncated to its first 200 characters so minor tail
+        variations (e.g. a trailing job id) still fold together.
+        """
+        message_prefix = error.message[:200] if error.message else ""
+        return (error.file_path or "", error.category, message_prefix)
+
+    @staticmethod
+    def _warning_fingerprint(warning: BuildWarning) -> tuple[str, str, str]:
+        """Identity used to collapse duplicate warnings (see _error_fingerprint)."""
+        message_prefix = warning.message[:200] if warning.message else ""
+        return (warning.file_path or "", warning.category, message_prefix)
+
+    def _deduplicate_errors(self, errors: list[BuildError]) -> list[BuildError]:
+        """Collapse duplicate errors, recording how often each one occurred.
+
+        When the same file is processed for several output targets, the same
+        error is reported multiple times. Each unique error is kept once with
+        its ``occurrence_count`` set to the number of times it was reported.
 
         Args:
             errors: List of errors (may contain duplicates)
 
         Returns:
-            List of unique errors
+            List of unique errors, each with ``occurrence_count`` populated
         """
-        seen: set[tuple[str, str, str]] = set()
         unique: list[BuildError] = []
+        by_fingerprint: dict[tuple[str, str, str], BuildError] = {}
 
         for error in errors:
-            # Use first 200 chars of message for fingerprint to handle minor variations
-            message_prefix = error.message[:200] if error.message else ""
-            fingerprint = (error.file_path or "", error.category, message_prefix)
-
-            if fingerprint not in seen:
-                seen.add(fingerprint)
+            fingerprint = self._error_fingerprint(error)
+            representative = by_fingerprint.get(fingerprint)
+            if representative is None:
+                error.occurrence_count = 1
+                by_fingerprint[fingerprint] = error
                 unique.append(error)
+            else:
+                representative.occurrence_count += 1
 
         return unique
 
     def _deduplicate_warnings(self, warnings: list[BuildWarning]) -> list[BuildWarning]:
-        """Remove duplicate warnings based on file_path + category + message prefix.
+        """Collapse duplicate warnings, recording how often each one occurred.
 
-        When multiple workers process the same file for different output targets,
-        they may report the same warning multiple times. This deduplicates them
-        to avoid cluttering the summary.
+        See :meth:`_deduplicate_errors`; warnings are aggregated the same way.
 
         Args:
             warnings: List of warnings (may contain duplicates)
 
         Returns:
-            List of unique warnings
+            List of unique warnings, each with ``occurrence_count`` populated
         """
-        seen: set[tuple[str, str, str]] = set()
         unique: list[BuildWarning] = []
+        by_fingerprint: dict[tuple[str, str, str], BuildWarning] = {}
 
         for warning in warnings:
-            # Use first 200 chars of message for fingerprint to handle minor variations
-            message_prefix = warning.message[:200] if warning.message else ""
-            fingerprint = (warning.file_path or "", warning.category, message_prefix)
-
-            if fingerprint not in seen:
-                seen.add(fingerprint)
+            fingerprint = self._warning_fingerprint(warning)
+            representative = by_fingerprint.get(fingerprint)
+            if representative is None:
+                warning.occurrence_count = 1
+                by_fingerprint[fingerprint] = warning
                 unique.append(warning)
+            else:
+                representative.occurrence_count += 1
 
         return unique
 

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -375,6 +375,13 @@ then re-extract, or `clm slides sync`), or pass `--no-fail-on-error` to
 tolerate it. `clm validate`'s #162 detectives catch the underlying
 divergence earlier (pre-commit), before it reaches a build.
 
+Because a slide is processed once per output target and language, a single
+dropped narration would otherwise be reported several times. Since CLM
+{version} the build prints each unique error (and warning) **once** in the
+live stream and collapses the duplicates in the final summary into one entry
+with a `(N times)` suffix; JSON output carries the same multiplicity as an
+`occurrence_count` field per error/warning.
+
 #### Kernel execution telemetry and the flake list (CLM {version}+)
 
 Notebook execution retries up to 6 times with a fresh kernel per attempt.

--- a/src/clm/cli/output_formatter.py
+++ b/src/clm/cli/output_formatter.py
@@ -26,6 +26,17 @@ from clm.cli.build_data_classes import BuildError, BuildSummary, BuildWarning
 from clm.cli.text_utils import format_error_path, strip_ansi
 
 
+def _occurrence_note(count: int) -> str:
+    """Return a ``" (N times)"`` suffix for findings reported more than once.
+
+    A source slide is processed once per output target and language, so an
+    identical error/warning is collapsed into a single summary entry whose
+    ``occurrence_count`` records the multiplicity. Returns ``""`` for a single
+    occurrence so the common case stays clean.
+    """
+    return f" ({count} times)" if count > 1 else ""
+
+
 class OutputMode(Enum):
     """Output mode for build reporting."""
 
@@ -451,7 +462,7 @@ class DefaultOutputFormatter(OutputFormatter):
 
                 self.console.print(
                     f"  [{error_type_color}]{i}. [{error.error_type.title()}][/{error_type_color}] "
-                    f"{location_info}"
+                    f"{location_info}[dim]{_occurrence_note(error.occurrence_count)}[/dim]"
                 )
                 self.console.print(f"     {error_msg}")
 
@@ -486,13 +497,16 @@ class DefaultOutputFormatter(OutputFormatter):
                     display_path = format_error_path(warning.file_path)
                     location = f" ({display_path})"
 
-                # Format the message with severity and location
+                # Format the message with severity, location, and repeat count
+                note = _occurrence_note(warning.occurrence_count)
                 if severity_label:
                     self.console.print(
-                        f"  [{color}]{i}. {severity_label} {warning.message}{location}[/{color}]"
+                        f"  [{color}]{i}. {severity_label} {warning.message}{location}{note}[/{color}]"
                     )
                 else:
-                    self.console.print(f"  [{color}]{i}. {warning.message}{location}[/{color}]")
+                    self.console.print(
+                        f"  [{color}]{i}. {warning.message}{location}{note}[/{color}]"
+                    )
 
             if len(summary.warnings) > max_warnings_to_show:
                 self.console.print(
@@ -683,8 +697,9 @@ class VerboseOutputFormatter(DefaultOutputFormatter):
             for i, warning in enumerate(summary.warnings, 1):
                 display_path = format_error_path(warning.file_path) if warning.file_path else ""
                 location = f" ({display_path})" if display_path else ""
+                note = _occurrence_note(warning.occurrence_count)
                 self.console.print(
-                    f"  [yellow]{i}. [{warning.severity}] {warning.message}{location}[/yellow]"
+                    f"  [yellow]{i}. [{warning.severity}] {warning.message}{location}{note}[/yellow]"
                 )
 
         self._show_flaky_files(summary)
@@ -721,7 +736,8 @@ class VerboseOutputFormatter(DefaultOutputFormatter):
             location_info += ")"
 
         self.console.print(
-            f"\n  [{error_type_color}]{index}. [{error.error_type.title()} Error - {error.category}][/{error_type_color}]"
+            f"\n  [{error_type_color}]{index}. [{error.error_type.title()} Error - {error.category}]"
+            f"[/{error_type_color}][dim]{_occurrence_note(error.occurrence_count)}[/dim]"
         )
         self.console.print(f"     File: {location_info}")
 
@@ -985,6 +1001,7 @@ class JSONOutputFormatter(OutputFormatter):
             "job_id": error.job_id,
             "correlation_id": error.correlation_id,
             "details": clean_details,
+            "occurrence_count": error.occurrence_count,
         }
 
     def _warning_to_dict(self, warning: BuildWarning) -> dict[str, Any]:
@@ -994,6 +1011,7 @@ class JSONOutputFormatter(OutputFormatter):
             "message": strip_ansi(warning.message),
             "severity": warning.severity,
             "file_path": warning.file_path,
+            "occurrence_count": warning.occurrence_count,
         }
 
     def cleanup(self) -> None:

--- a/tests/cli/test_build_output.py
+++ b/tests/cli/test_build_output.py
@@ -227,6 +227,129 @@ class TestBuildReporter:
         assert reporter.warnings[0] == warning
 
 
+class _RecordingFormatter(QuietOutputFormatter):
+    """Formatter that records how often the live show hooks fire.
+
+    Used to assert the live-stream deduplication in :class:`BuildReporter`
+    (a source slide is processed once per output target and language, so the
+    same finding is reported several times — each must be shown only once).
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.shown_errors: list[BuildError] = []
+        self.shown_warnings: list[BuildWarning] = []
+
+    def should_show_warning(self, warning: BuildWarning) -> bool:
+        return True
+
+    def show_error(self, error: BuildError) -> None:
+        self.shown_errors.append(error)
+
+    def show_warning(self, warning: BuildWarning) -> None:
+        self.shown_warnings.append(warning)
+
+
+class TestBuildReporterDeduplication:
+    """Live-stream dedup + summary occurrence counts (repeated-error spam)."""
+
+    def test_identical_errors_shown_once_in_live_stream(self):
+        formatter = _RecordingFormatter()
+        reporter = BuildReporter(output_formatter=formatter)
+
+        for _ in range(5):
+            reporter.report_error(
+                _make_error(file_path="slides/mcp.de.py", message="narration dropped")
+            )
+
+        # Shown once live, but every occurrence is still collected.
+        assert len(formatter.shown_errors) == 1
+        assert len(reporter.errors) == 5
+
+    def test_distinct_errors_each_shown(self):
+        formatter = _RecordingFormatter()
+        reporter = BuildReporter(output_formatter=formatter)
+
+        reporter.report_error(_make_error(message="first problem"))
+        reporter.report_error(_make_error(message="second problem"))
+        reporter.report_error(_make_error(message="first problem"))  # dup of #1
+
+        assert len(formatter.shown_errors) == 2
+
+    def test_summary_collapses_duplicates_with_occurrence_count(self):
+        formatter = _RecordingFormatter()
+        reporter = BuildReporter(output_formatter=formatter)
+        reporter.start_build("course", total_files=1)
+
+        for _ in range(5):
+            reporter.report_error(
+                _make_error(file_path="slides/mcp.de.py", message="narration dropped")
+            )
+
+        summary = reporter.finish_build()
+        assert len(summary.errors) == 1
+        assert summary.errors[0].occurrence_count == 5
+
+    def test_identical_warnings_shown_once_and_counted(self):
+        formatter = _RecordingFormatter()
+        reporter = BuildReporter(output_formatter=formatter)
+        reporter.start_build("course", total_files=1)
+
+        for _ in range(3):
+            reporter.report_warning(
+                BuildWarning(category="voiceover", message="same warning", severity="high")
+            )
+
+        summary = reporter.finish_build()
+        assert len(formatter.shown_warnings) == 1
+        assert len(summary.warnings) == 1
+        assert summary.warnings[0].occurrence_count == 3
+
+    def test_start_build_resets_live_dedup_state(self):
+        formatter = _RecordingFormatter()
+        reporter = BuildReporter(output_formatter=formatter)
+
+        reporter.start_build("course", total_files=1)
+        reporter.report_error(_make_error(message="boom"))
+        reporter.finish_build()
+
+        # A fresh build must show the same error again, not suppress it.
+        reporter.start_build("course", total_files=1)
+        reporter.report_error(_make_error(message="boom"))
+        assert len(formatter.shown_errors) == 2
+
+
+class TestOccurrenceCountInSummaries:
+    """The '(N times)' suffix surfaces in the human-readable summaries."""
+
+    def test_default_summary_shows_times_suffix(self, capsys):
+        err = _make_error()
+        err.occurrence_count = 4
+        summary = BuildSummary(duration=1.0, total_files=1, errors=[err])
+        DefaultOutputFormatter(show_progress=False, use_color=False).show_summary(summary)
+        assert "(4 times)" in capsys.readouterr().err
+
+    def test_default_summary_omits_suffix_for_single_occurrence(self, capsys):
+        summary = BuildSummary(duration=1.0, total_files=1, errors=[_make_error()])
+        DefaultOutputFormatter(show_progress=False, use_color=False).show_summary(summary)
+        assert "times)" not in capsys.readouterr().err
+
+    def test_verbose_summary_shows_times_suffix(self, capsys):
+        err = _make_error()
+        err.occurrence_count = 7
+        summary = BuildSummary(duration=1.0, total_files=1, errors=[err])
+        VerboseOutputFormatter(show_progress=False, use_color=False).show_summary(summary)
+        assert "(7 times)" in capsys.readouterr().err
+
+    def test_json_summary_includes_occurrence_count(self, capsys):
+        err = _make_error()
+        err.occurrence_count = 6
+        summary = BuildSummary(duration=1.0, total_files=1, errors=[err])
+        JSONOutputFormatter().show_summary(summary)
+        data = json.loads(capsys.readouterr().out)
+        assert data["errors"][0]["occurrence_count"] == 6
+
+
 class TestEnhancedErrorParsing:
     """Test enhanced error parsing capabilities."""
 


### PR DESCRIPTION
## Problem

`clm build` surfaces every error a slide produces, but a source slide is
processed **once per output target and language**, so an identical finding is
reported many times. In a real Python-courses build a single dropped companion
voiceover narration printed ~28 identical `✗ [User Error]` blocks (16× DE, 12×
EN) while the build ran — pure noise, since the same errors reappear in the
end-of-build summary anyway.

## Change

- **Live stream:** `BuildReporter` now shows each unique error/warning **once**
  as it occurs (fingerprint = `file_path` + `category` + first 200 chars of the
  message), instead of once per processing pass.
- **Summary:** duplicates collapse into a single entry annotated with a
  `(N times)` suffix recording how often the finding occurred. (The summary
  already deduplicated; it now reports the multiplicity it was previously
  discarding.)
- **JSON output:** each error/warning gains an additive `occurrence_count`
  field.

The full error list is still collected internally, so `--fail-on-error` exit
codes, `failed_files`/`successful_files`, and the sweep-skip logic are
unchanged.

### Before (live stream)

```
✗ [User Error]  File: …/slides_45_mcp_servers.de.py  …dropped…
✗ [User Error]  File: …/slides_45_mcp_servers.de.py  …dropped…
   … (28 identical blocks) …
```

### After

```
✗ [User Error]  File: …/slides_45_mcp_servers.de.py  …dropped…
✗ [User Error]  File: …/slides_45_mcp_servers.en.py  …dropped…

Errors:
  1. [User] …/slides_45_mcp_servers.de.py (16 times)
  2. [User] …/slides_45_mcp_servers.en.py (12 times)
```

## Tests

- New `TestBuildReporterDeduplication` and `TestOccurrenceCountInSummaries` in
  `tests/cli/test_build_output.py` cover live-stream dedup, summary collapse +
  counts (errors and warnings), JSON `occurrence_count`, and per-build reset.
- Full fast suite green (8441 passed).

Also updates the `commands` info topic and adds a `changed` changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
