### PR TITLE
chore(skills): add clm-release and ship-a-pr project skills

### DIFF
--- a/.claude/skills/clm-release/SKILL.md
+++ b/.claude/skills/clm-release/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: clm-release
+description: "Cut a release of the CLM PACKAGE to PyPI (bump the version, publish coding-academy-lecture-manager). Use when asked to release/publish CLM, bump its version (patch/minor/major), or ship a new clm version to PyPI. This is the PYTHON PACKAGE release, NOT publishing course content to a cohort (that is course-release). Publishing is AUTOMATED — landing a `Bump version …` commit on master (via merge commit) triggers .github/workflows/release.yml, which gates on CI-green then publishes via OIDC and creates the GitHub Release. Your job is docs + CHANGELOG + version bump; never run `uv publish` / `gh release create` by hand. Source of truth: docs/developer-guide/releasing.md."
+---
+
+# Release the CLM package to PyPI
+
+**Publishing is automated.** Landing a `Bump version X.Y.Z → A.B.C` commit on
+`master` (a **merge commit**, or a pushed `vX.Y.Z` tag) triggers
+`.github/workflows/release.yml`, which **gates on CI being green for that commit**,
+then publishes to PyPI via OIDC Trusted Publishing and creates the GitHub Release.
+Your job is the **docs + CHANGELOG + version bump**; the workflow does the rest.
+
+**Source of truth: `docs/developer-guide/releasing.md`.** Read it for the full
+procedure; this skill is the ordered checklist + the hard guardrails.
+
+## The hard rules (never violate)
+
+- **Never publish without updating documentation first.**
+- **Never publish if any local test fails** (`uv run pytest -m "not docker"`).
+- **Never publish unless CI is green for the released commit.**
+- **Never `uv publish` / `gh release create` by hand** — the workflow owns
+  publishing. (A manual fallback exists in releasing.md *only* if the workflow is
+  unavailable, and only after confirming CI is green on the tagged commit.)
+- **Merge the bump PR with a MERGE COMMIT, not squash/rebase** — the workflow
+  recognises the release by finding the `Bump version …` commit in the push;
+  squash/rebase rewrites it and the release won't trigger.
+- **Do not push tags.** `bump-my-version` is `tag = false`; the server creates the
+  `vX.Y.Z` tag *after* the CI-green gate, so a red commit is never tagged.
+
+## The ordered steps
+
+1. **Docs first** (commit before the bump so they're in the release commit):
+   - **CHANGELOG**: `python scripts/collect_changelog.py X.Y.Z` folds the
+     `changelog.d/` fragments into a `## [X.Y.Z]` section. Then **cross-check
+     every merged PR is represented**: `git log <last-tag>..HEAD --merges` vs the
+     generated section; backfill any PR that merged without a fragment.
+   - README, AGENTS.md (guardrails only), `clm info` topics (if spec/CLI/migration
+     changed), `docs/user-guide` + `docs/developer-guide` as relevant.
+2. **Test**: `uv run pytest -m "not docker"` — all must pass (Docker tests are
+   CI-only). If a test fails, fix the root cause; do not loop-retry.
+3. **Bump** (merge-driven, recommended):
+   ```
+   git switch -c claude/release-A.B.C
+   uv run bump-my-version bump patch        # or minor / major
+   git push -u origin claude/release-A.B.C
+   # open PR → CI green → merge with a MERGE COMMIT
+   ```
+   Preview first with `uv run bump-my-version bump patch --dry-run --verbose`.
+4. **Watch the release workflow**:
+   ```
+   gh run watch "$(gh run list --workflow=Release --limit 1 --json databaseId --jq '.[0].databaseId')"
+   ```
+   It resolves → waits for CI green → tags + builds + publishes to PyPI + creates
+   the GitHub Release (all idempotent — a re-run never double-publishes).
+
+## If a hook rejects a commit
+
+The commit did **not** happen — fix the issue, re-stage, make a **new** commit.
+Never `--amend` a hook-rejected commit.
+
+## Escalate to the user
+
+- Any release where CI is not green, or where you cannot confirm docs reflect the
+  shipped code.
+- A major version bump (breaking changes) — confirm scope/timing first.
+- The manual fallback path (hand `uv publish`) — only with explicit instruction.

--- a/.claude/skills/ship-a-pr/SKILL.md
+++ b/.claude/skills/ship-a-pr/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: ship-a-pr
+description: "Ship a finished change in the CLM repo as a PR, the autonomous way: branch → commit → push (fast-suite gate) → PR → CI-gated auto-merge. Use when a feature/fix/docs change is complete and ready to land, especially from a git worktree. Encodes the CLM-specific landmines: a worktree must NEVER switch to literal master (reset its OWN branch off origin/master); commit/PR trailers; changelog goes in changelog.d/ NOT the CHANGELOG [Unreleased] section; update the matching `clm info` topic for any CLI/spec/behavior change; the pre-push hook runs the fast suite (cap xdist workers to dodge contention flakes); never edit files during a backgrounded push; auto-merge is CI-gated; open a PR fresh off master (don't stack) to avoid the retarget-no-CI gap."
+---
+
+# Ship a CLM change as a PR
+
+The autonomous flow for landing finished work. Commit, push, and open PRs
+**without waiting for a go-ahead** — only genuinely destructive ops (force-push
+to a shared branch, history rewrites, pushes to `master` itself) warrant asking.
+
+## Before you commit (the easy-to-forget bits)
+
+- **Changelog**: never edit `CHANGELOG.md`'s `[Unreleased]` section (it caused
+  constant merge conflicts). Add a fragment `changelog.d/<pr-or-issue>-<slug>.<type>.md`
+  (`type` = added | changed | deprecated | removed | fixed | security) with the
+  finished bullet(s). See `changelog.d/README.md`.
+- **Info topics**: if you changed a CLI command/flag, the spec format, or
+  user-visible behavior, update the matching `src/clm/cli/info_topics/*.md`
+  (`commands.md` / `spec-files.md` / `migration.md`). Downstream agents rely on
+  these; stale topics produce wrong output.
+- **Tests + lint**: the pre-commit hook runs ruff + mypy; make sure they pass.
+
+## Branching (worktree-safe)
+
+**A worktree must NEVER switch to literal `master`** — `master` is checked out in
+the main repo and git forbids it in two worktrees. To start fresh work off the
+latest master content, reset onto `origin/master`:
+
+```
+git fetch origin
+git switch -C claude/issue-NNN-slug origin/master      # fresh branch off master
+```
+
+When work depends on nothing unmerged, **branch off `origin/master`, don't stack**
+on another open PR's branch — a stacked PR that gets auto-retargeted when its base
+merges does **not** fire a CI run, leaving it BLOCKED with no checks.
+
+## Commit
+
+Make focused commits. **End every commit message with the two trailers your
+environment specifies** (the `Co-Authored-By:` line and the `Claude-Session:` URL
+given in your session instructions). If a hook **rejects** a commit, the commit
+did not happen — fix, re-stage, make a **new** commit; never `--amend` a
+hook-rejected commit.
+
+## Push (the fast-suite gate)
+
+The **pre-push** hook runs the fast test suite (~72s). Cap xdist workers to avoid
+unrelated contention flakes on a busy machine:
+
+```
+PYTEST_XDIST_AUTO_NUM_WORKERS=4 git push -u origin claude/issue-NNN-slug
+```
+
+**Never edit files while a push is running in the background** — a concurrent edit
+makes the pre-commit/pre-push hook abort (`files were modified by this hook`).
+Push a clean tree in the foreground, or wait for a backgrounded push to finish
+before touching anything. **Never `--no-verify`** unless the user explicitly asks.
+
+## PR + auto-merge
+
+```
+gh pr create --base master --head <branch> --title "…" --body-file -   # heredoc body
+gh pr merge <N> --merge --auto                                          # CI-gated auto-merge
+```
+
+- End the **PR body** with the generation trailer your environment specifies.
+- Auto-merge is **CI-gated** (the repo has a "Require CI green" ruleset +
+  merge-commit-only), so `--merge --auto` waits for green — `BLOCKED` immediately
+  after arming is normal (waiting on checks), not a failure.
+- A PR opened **fresh off master** fires its CI `pull_request` run normally;
+  confirm with `gh run list --branch <branch> --limit 1`.
+
+## If CI never starts
+
+Usually the retarget-no-CI gap: the PR's base was auto-changed (a base PR merged)
+without a new push, so no `pull_request` event fired. Fix by rebasing onto current
+master and force-pushing (`--force-with-lease`), which re-triggers CI.
+
+## Don't ask permission for
+
+Committing, pushing, opening PRs, arming auto-merge when the work is complete. Do
+ask before: force-pushing a shared branch, history rewrites, or pushing to
+`master` directly.


### PR DESCRIPTION
## What

Two **project skills** under `.claude/skills/` that encode the high-stakes, landmine-heavy CLM development workflows, so any Claude Code session applies them consistently — and other contributors get them with the repo.

| Skill | Covers | Points at |
|---|---|---|
| `clm-release` | Cut a CLM **package** release to PyPI | `docs/developer-guide/releasing.md` |
| `ship-a-pr` | Land a finished change as a PR (worktree-safe) | AGENTS.md git workflow |

## Why

These are exactly the tasks where forgetting a step is costly:
- **clm-release** front-loads the guardrails: publishing is **automated** via a merge-commit `Bump version …` (never `uv publish` / `gh release create` by hand), merge-commit-not-squash, the `collect_changelog` PR cross-check, never publish without docs/tests/CI-green, don't push tags.
- **ship-a-pr** encodes the worktree rules (never switch to literal `master`; reset own branch off `origin/master`), the `changelog.d/` fragment convention, the info-topic update rule, the fast-suite pre-push gate with an xdist worker cap, no-edits-during-a-background-push, CI-gated auto-merge, and the retarget-no-CI fix.

Both are **thin orchestration that reference the version-accurate sources** rather than duplicating them, so they age with the docs, not against them. Companion **personal** skills (`deck-sync`, `course-release`) cover the course-repo workflows — `deck-sync` is grounded in a real dogfood of the agent-first `clm slides sync` loop.

## Note on layout

First skills in the repo — `.claude/skills/<name>/SKILL.md` (the standard Claude Code project-skill layout, alongside the existing tracked `.claude/agents/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
