### PR TITLE
docs(agents): add a Document Placement convention to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,33 @@ When you need information, go to its canonical home rather than guessing:
 recommending a command or flag**, verify it exists in `clm info commands` —
 do not fabricate options.
 
+<!-- DOCS-LAYOUT:BEGIN (managed by /docs-layout) -->
+## Document Placement
+
+Companion to the **Documentation Map** above: that says where to *find*
+canonical info; this says where to *put* a new document. This is CLM's target
+layout — some existing docs predate it and are being migrated toward it, so
+prefer these homes for anything new.
+
+| Kind of document | Home | Naming |
+|---|---|---|
+| Agent session guide | `AGENTS.md` (root); `CLAUDE.md` only does `@AGENTS.md` | fixed |
+| User-facing docs | `docs/user-guide/` | kebab-case |
+| Developer / contributor docs | `docs/developer-guide/` | kebab-case |
+| Agent design docs / decisions | `docs/claude/design/` | kebab-case `<topic>.md` |
+| Handover docs | `docs/claude/handovers/` | `<feature>-handover.md` (+ `<feature>-handover-archive.md`) |
+| Investigations / analyses / cross-session notes | `docs/claude/` (deeper: `docs/claude/analysis/`, `docs/claude/requirements/`) | `<topic>-investigation.md` |
+| Proposals (pre-design exploration) | `docs/proposals/` | kebab-case |
+| Retired / historical docs | `docs/archive/` | under a topic subfolder |
+| Changelog | `CHANGELOG.md`; unreleased entries as fragments in `changelog.d/` | `<pr-or-issue>-<slug>.<type>.md` |
+| Version-accurate info topics | `src/clm/cli/info_topics/` (code-adjacent — do not move) | `<topic>.md` |
+| Top-level meta | repo root | `README.md`, `LICENSE`, `CONTRIBUTING.md` |
+
+CLM uses `docs/claude/` (not the agent-neutral `docs/agent/` other repos use)
+because the path is referenced from source code and the version-accurate
+`info_topics`; renaming it is a separate, deliberate migration.
+<!-- DOCS-LAYOUT:END -->
+
 ## Working in this Repo (Windows-first)
 
 CLM is developed primarily on Windows (Git Bash + `cmd.exe` available). A few
@@ -212,4 +239,4 @@ practical consequences:
 
 **Repository**: https://github.com/hoelzl/clm/ | **Issues**: https://github.com/hoelzl/clm/issues
 
-**Last Updated**: 2026-06-21
+**Last Updated**: 2026-06-23


### PR DESCRIPTION
## What

Adds a **Document Placement** section to `AGENTS.md` (companion to the existing
Documentation Map) stating where each kind of document belongs, wrapped in
`<!-- DOCS-LAYOUT:BEGIN/END -->` markers so it can be regenerated idempotently.

This is the first, convention-only step of a broader effort to give a consistent
documentation layout and naming scheme across repositories. A `/docs-layout`
command establishes this convention per repo and, in follow-ups, migrates
existing docs to match it.

## Why `docs/claude/` (not `docs/agent/`)

The shared scheme uses an agent-neutral `docs/agent/`. CLM deliberately keeps
`docs/claude/`: that path is referenced **133× across 65 files** — including
~17 source/test/script files and the version-accurate
`src/clm/cli/info_topics/` content — so renaming it is a separate, deliberate
migration, not a doc-only change.

## Scope

- **Convention only.** No files moved, no references changed, no behavior change.
- Pre-commit/mypy/pytest hooks correctly no-op (Markdown-only change).
- For context, the audit found **180 tracked `.md` files under `docs/`**, mixing
  kebab-case, SCREAMING_SNAKE, and several archive locations.

## Deferred to follow-up PR(s)

The physical reorganization toward the documented layout — consolidating
archives, normalizing SCREAMING_CASE filenames, grouping handovers under
`docs/claude/handovers/`, and relocating the loose `docs/*.md` stragglers — will
be done in reviewable chunks. `CHANGELOG.md` historical references will be left
as-is (point-in-time records); the `MEMORY.md` pointer sweep is part of that
work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
