### PR TITLE
feat(sync): reusable structural write-gate for ledger/watermark writes (#455)

### DIFF
--- a/src/clm/slides/sync_verify.py
+++ b/src/clm/slides/sync_verify.py
@@ -73,6 +73,13 @@ class VerifyViolation:
     kind: str  # "unify" | "dropped-id"
     message: str
     slide_id: str | None = None
+    # The cell role this finding is keyed to, when the check is per-(slide_id, role)
+    # (only ``duplicate-id`` today). ``None`` means role-agnostic — a slide-level
+    # finding (``id-asymmetry``) or a whole-deck one (``unify``). Used by
+    # :func:`structural_gate` to scope a per-slide write gate; it is *not* part of
+    # the CLI ``verify`` output (the JSON/human serializers enumerate fields
+    # explicitly), so adding it does not change that surface.
+    role: str | None = None
 
 
 @dataclass
@@ -125,6 +132,66 @@ def structural_violations(de_text: str, en_text: str, comment_token: str) -> lis
     violations.extend(_duplicate_id_violations(de_keys, "DE"))
     violations.extend(_duplicate_id_violations(en_keys, "EN"))
     return violations
+
+
+def structural_gate(
+    de_text: str,
+    en_text: str,
+    comment_token: str,
+    *,
+    slide_id: str | None = None,
+    role: str | None = None,
+) -> list[VerifyViolation]:
+    """Error-severity structural violations, optionally scoped to one ``(slide_id, role)``.
+
+    The reusable **write-gate** (Issue #455): a ledger / watermark write must never
+    record a pair — or a single slide — as in-sync while it fails a structural
+    invariant, because that would mask a genuine divergence as "trusted". The return
+    value is the *error* subset of :func:`structural_violations` — the exact
+    invariants ``clm slides sync verify`` enforces, computed from the **same**
+    function, so the gate and the CLI can never drift. An **empty list means "safe to
+    record"**; a non-empty list is the reason it is not. It works on in-memory text
+    (no file/git read), so the apply path can gate a watermark write on the
+    post-apply :class:`~clm.slides.split` state without a re-read.
+
+    **Whole-deck** (``slide_id is None``): every structural error in the pair — the
+    gate for batch ``bless`` and the apply-path full watermark write.
+
+    **Scoped** (``slide_id`` given): only the errors attributable to that ``slide_id``
+    — the per-slide guard for ``accept --record`` (design note §11.4), where a
+    corruption *elsewhere* in the deck must not block recording the one slide an agent
+    just reconciled. With ``role`` also given, a duplicate-``(slide_id, role)`` error
+    is limited to that exact role (a slide and its inline ``voiceover`` / ``notes``
+    companion legitimately share an id under different roles); role-agnostic errors —
+    a missing twin (``id-asymmetry``) — always apply to the slide. The whole-deck
+    byte-identity oracle (``unify``) carries no ``slide_id``, so it is reported only
+    in the whole-deck mode; a scoped call relies on the id symmetry / uniqueness
+    checks, which is sufficient because an id'd cell is *localized* (its halves differ
+    by translation by design) — byte-identity governs only the id-less neutral cells,
+    which carry no ``slide_id`` to scope to.
+    """
+    errors = [
+        v for v in structural_violations(de_text, en_text, comment_token) if v.severity == "error"
+    ]
+    if slide_id is None:
+        return errors
+    return [v for v in errors if _scoped_to(v, slide_id, role)]
+
+
+def _scoped_to(violation: VerifyViolation, slide_id: str, role: str | None) -> bool:
+    """Whether ``violation`` falls within the ``(slide_id, role)`` scope of a per-slide gate.
+
+    A violation is in scope only if it names this ``slide_id``. When ``role`` is also
+    given, a role-keyed finding (``duplicate-id``, which carries a ``role``) must match
+    that role, while a role-agnostic finding (``role is None`` — e.g. ``id-asymmetry``)
+    always applies to the slide. When ``role`` is ``None`` the gate covers every role
+    under the ``slide_id``.
+    """
+    if violation.slide_id != slide_id:
+        return False
+    if role is None:
+        return True
+    return violation.role is None or violation.role == role
 
 
 def _id_symmetry_violations(de_ids: list[str], en_ids: list[str]) -> list[VerifyViolation]:
@@ -191,6 +258,7 @@ def _duplicate_id_violations(
                         "(sync keys on it)"
                     ),
                     slide_id=sid,
+                    role=role,
                 )
             )
     return out

--- a/tests/cli/test_slides_sync_verify.py
+++ b/tests/cli/test_slides_sync_verify.py
@@ -22,6 +22,7 @@ from clm.cli.commands.slides.sync import slides_sync_cmd
 from clm.slides.sync_verify import (
     VerifyViolation,
     dropped_id_violations,
+    structural_gate,
     structural_violations,
     verify_pair,
 )
@@ -129,6 +130,71 @@ class TestStructuralViolations:
         de = _half(_md("de", "s1", "Hallo"), '# %% lang="de"\nx = 1\n')
         en = _half(_md("en", "s1", "Hello"), '# %% lang="en"\nx = 1\n')
         assert structural_violations(de, en, "#") == []
+
+
+class TestStructuralGate:
+    """Issue #455 — the reusable structural write-gate (whole-deck + scoped)."""
+
+    def test_valid_pair_is_safe_to_record(self):
+        # Empty list == "safe to record".
+        assert structural_gate(_valid_de(), _valid_en(), "#") == []
+
+    def test_whole_deck_is_the_error_subset_of_verify(self, tmp_path):
+        # The gate and the CLI verify must not drift: the gate over in-memory text
+        # equals the error-severity violations verify_pair surfaces on the same pair.
+        de = _md("de", "s1", "Hallo")
+        en = _md("en", "s2", "Hello")  # id-asymmetry on both s1 and s2
+        de_path, en_path = _write(tmp_path, de, en)
+        gate = structural_gate(de, en, "#")
+        verify_errors = verify_pair(de_path, en_path).errors
+        assert [(v.kind, v.slide_id, v.message) for v in gate] == [
+            (v.kind, v.slide_id, v.message) for v in verify_errors
+        ]
+        assert gate  # non-empty (it is a real corruption)
+
+    def test_whole_deck_surfaces_unify_error(self):
+        de = _half(_md("de", "s1", "Hallo"), _shared("print(1)"))
+        en = _half(_md("en", "s1", "Hello"), _shared("print(2)"))  # shared diverges
+        assert [v.kind for v in structural_gate(de, en, "#")] == ["unify"]
+
+    def test_scoped_ignores_a_corruption_under_another_slide(self):
+        # s2 is dropped from DE (id-asymmetry on s2). Recording s1 must stay safe.
+        de = _md("de", "s1", "Hallo")
+        en = _half(_md("en", "s1", "Hello"), _md("en", "s2", "World"))
+        assert structural_gate(de, en, "#", slide_id="s1") == []
+        scoped_s2 = structural_gate(de, en, "#", slide_id="s2")
+        assert [(v.kind, v.slide_id) for v in scoped_s2] == [("id-asymmetry", "s2")]
+
+    def test_scoped_asymmetry_is_role_agnostic(self):
+        # id-asymmetry carries no role, so it applies to the slide under any role filter.
+        de = _md("de", "s1", "Hallo")
+        en = _half(_md("en", "s1", "Hello"), _md("en", "s2", "World"))
+        scoped = structural_gate(de, en, "#", slide_id="s2", role="slide")
+        assert [(v.kind, v.slide_id) for v in scoped] == [("id-asymmetry", "s2")]
+
+    def test_scoped_duplicate_is_role_aware(self):
+        # (s1, voiceover) is duplicated; (s1, slide) is unique. Recording the slide is
+        # safe; recording the voiceover companion is not.
+        de = _half(_md("de", "s1", "Hallo"), _vo("de", "s1", "# a"), _vo("de", "s1", "# b"))
+        en = _half(_md("en", "s1", "Hello"), _vo("en", "s1", "# a"), _vo("en", "s1", "# b"))
+        # sanity: the only errors are the (s1, voiceover) dups, one per half.
+        whole = structural_gate(de, en, "#")
+        assert {(v.kind, v.role) for v in whole} == {("duplicate-id", "voiceover")}
+        assert structural_gate(de, en, "#", slide_id="s1", role="slide") == []
+        vo_scoped = structural_gate(de, en, "#", slide_id="s1", role="voiceover")
+        assert [v.kind for v in vo_scoped] == ["duplicate-id", "duplicate-id"]
+        # role=None covers every role under the slide_id.
+        any_role = structural_gate(de, en, "#", slide_id="s1")
+        assert [v.kind for v in any_role] == ["duplicate-id", "duplicate-id"]
+
+    def test_scoped_excludes_whole_deck_unify(self):
+        # The byte-identity oracle (unify) has no slide_id, so it is whole-deck only:
+        # a scoped call relies on the id symmetry/uniqueness checks (sufficient because
+        # an id'd cell is localized — byte-identity governs only id-less neutral cells).
+        de = _half(_md("de", "s1", "Hallo"), _shared("print(1)"))
+        en = _half(_md("en", "s1", "Hello"), _shared("print(2)"))
+        assert structural_gate(de, en, "#", slide_id="s1") == []
+        assert [v.kind for v in structural_gate(de, en, "#")] == ["unify"]
 
 
 class TestDroppedIdViolations:


### PR DESCRIPTION
Closes #455. **P0 prerequisite** for the per-slide consistency ledger (#448) — see the design note §4.3 / §11.4 / §11.5 (every ledger write is gated on a structural verify).

## Why
The structural-invariant check (`structural_violations` / `verify_pair`) was reachable only from the CLI `clm slides sync verify` (and `bless`, which already calls `verify_pair` before `record_baseline`). The ledger/watermark *apply path* needs the same gate: you must never record a pair — or a single slide — as in-sync while it fails a structural invariant, or a genuine divergence is silently baselined as "trusted".

## What changed (`src/clm/slides/sync_verify.py`)
- **`structural_gate(de_text, en_text, comment_token, *, slide_id=None, role=None) -> list[VerifyViolation]`** — the reusable write-gate. Returns the **error** subset of `structural_violations` (the exact invariants the CLI `verify` enforces, from the *same* function — so the gate and the CLI can never drift). **Empty list == safe to record.** Operates on in-memory text (no file/git read), so the apply path can gate the post-apply split state without a re-read.
  - **Whole-deck** (default): every structural error in the pair — the gate for batch `bless` and the apply-path full watermark write.
  - **Scoped** (`slide_id` given): only the errors attributable to that slide_id — the per-slide guard for `accept --record` (§11.4), where a corruption *elsewhere* in the deck must not block recording the one slide an agent just reconciled. Role-aware: a duplicate-`(slide_id, role)` is limited to that exact role (a slide and its inline `voiceover`/`notes` companion legitimately share an id under different roles); `id-asymmetry` is role-agnostic. The whole-deck `unify` byte-identity oracle carries no slide_id, so it is whole-deck only — sufficient, because an id'd cell is *localized* (byte-identity governs only the id-less neutral cells).
- Adds an optional **`role`** to `VerifyViolation` (populated by the duplicate-id check). It is **not** part of the CLI `verify` output — both the JSON (`_verify_to_dict`) and human serializers enumerate fields explicitly, so the surface is unchanged.

No CLI/flag/spec change and no user-visible behavior change (internal gate; the consumer — re-keying ledger entries at the write sites — lands with the ledger MVP, #448 P1). Hence **no `clm info` topic update and no changelog fragment**.

## Tests (`tests/cli/test_slides_sync_verify.py`, new `TestStructuralGate`)
- valid pair → safe (empty);
- whole-deck gate **equals** `verify_pair(...).errors` on the same pair (no drift);
- whole-deck surfaces `unify`;
- scoped ignores a corruption under another slide; `id-asymmetry` is role-agnostic; duplicate-id is role-aware (`slide` clean, `voiceover` flagged, `role=None` covers all);
- scoped excludes the whole-deck `unify` (documents the limitation).
- Full local fast suite green; ruff + mypy clean.

Unblocks the #448 P1 ledger write-gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
