### PR TITLE
feat(sync): capture the id-migration map in ApplyResult (#454)

### DIFF
--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -213,6 +213,14 @@ class ApplyResult:
     # Per-deferral detail for cold-start mint/adopt (#231) — why the pair
     # was refused, incl. the rejected SlidePair headings on a verifier "no".
     cold_deferrals: list[ColdDeferralDetail] = field(default_factory=list)
+    # Issue #454: every ``old_id -> new_id`` a migration rewrote this pass (the §9
+    # deterministic id-migration and the §10 recovery alignment). The *carrier* for a
+    # later ledger/watermark re-key (#448 P3 / #366): an entry keyed by the old id can
+    # follow the slide to its new id instead of cold-starting. Only a non-None ->
+    # non-None *rename* is recorded — an adoption (None -> id) has no prior entry and a
+    # drop (id -> None) no destination, so both fall back to the safe cold-start. Not
+    # consumed yet (this issue is the capture; the consumer lands with the ledger MVP).
+    id_migrations: dict[str, str] = field(default_factory=dict)
 
     @property
     def applied(self) -> int:
@@ -2831,6 +2839,21 @@ def _extract_heading(body: str) -> str:
     return ""
 
 
+def _record_id_migration(result: ApplyResult, old_id: str | None, new_id: str | None) -> None:
+    """Record an ``old_id -> new_id`` slide_id rewrite in ``result`` (Issue #454).
+
+    The capture behind the future ledger/watermark re-key (#448 P3 / #366): a slide
+    that already carries a recorded entry under ``old_id`` can have that entry follow
+    it to ``new_id`` instead of cold-starting. Only a non-None -> non-None **rename**
+    is a carry — an adoption (``None -> id``, a fresh id onto a new cell) has no prior
+    entry to move, and a drop (``id -> None``) has no destination — so those fall back
+    to the safe cold-start and are deliberately not recorded in this old->new map. A
+    no-op (``old_id == new_id``) is skipped.
+    """
+    if old_id is not None and new_id is not None and old_id != new_id:
+        result.id_migrations[old_id] = new_id
+
+
 def _stamp_slide_id(cell: RawCell, slide_id: str) -> None:
     """Write ``slide_id="…"`` onto a cell header (mirrors assign-ids)."""
     stripped = _SLIDE_ID_RE.sub("", cell.lines[0]).rstrip()
@@ -3338,9 +3361,13 @@ def _migrate_one_deck(
         current_construct = construct_of(cell.metadata, cell.body)
         assert sid is not None and current_construct is not None  # guaranteed by _migration_target
         base_construct = baseline_constructs[sid]
-        _stamp_slide_id(target, sid)  # the id follows its construct
+        _stamp_slide_id(target, sid)  # the id follows its construct (target was id-less)
         new_slug = resolve_collision(current_construct, used_ids)
         used_ids.add(new_slug)
+        # The orphan's id (``sid``) moved to ``new_slug``: its recorded trust describes
+        # the orphan's content, so carry it there (#454). ``target`` adopting ``sid`` is
+        # a new cell — no prior entry, cold-start is correct — so it is not recorded.
+        _record_id_migration(result, sid, new_slug)
         _stamp_slide_id(cell, new_slug)  # the orphan gets a fresh content slug
         state.dirty = True
         result.applied_migrate += 1
@@ -3477,6 +3504,10 @@ def _migrate_localized_paired(
         _stamp_slide_id(en_targets[0], sid)
         new_slug = resolve_collision(de_cur, used_ids)  # de_cur == en_cur (neutral construct)
         used_ids.add(new_slug)
+        # Both orphans move ``sid -> new_slug`` (one logical rename, written to both
+        # halves); the targets adopting ``sid`` are new cells, so only the rename is
+        # recorded for a later ledger re-key (#454).
+        _record_id_migration(result, sid, new_slug)
         _stamp_slide_id(de_cell, new_slug)  # both orphans get the same fresh slug
         _stamp_slide_id(en_cell, new_slug)
         de_state.dirty = True
@@ -3851,6 +3882,11 @@ def _apply_alignment(
             desired = target  # a base id (continuation)
         if desired == current_id:
             continue
+        # Carry a recorded entry across the realign (#454): a continuation (an id'd cell
+        # re-identified to a base id) or a re-id onto a minted slug. The helper records
+        # only a non-None -> non-None rename, so a cleared id (drop) and a NEW id minted
+        # onto a previously id-less cell (adoption) are correctly skipped.
+        _record_id_migration(result, current_id, desired)
         if desired is None:
             _clear_slide_id(cell)
         else:

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -1245,3 +1245,127 @@ def test_explain_warns_when_watermark_baseline_errors(tmp_path: Path):
     assert plan.has_errors
     assert "may be stale" in text
     assert "--rebaseline" in text
+
+
+# ---------------------------------------------------------------------------
+# Issue #454 — ApplyResult.id_migrations captures every old_id -> new_id an
+# id-migration rewrote (the carrier for a later ledger/watermark re-key, #448
+# P3 / #366). No behavior change — the map is captured, not yet consumed.
+# ---------------------------------------------------------------------------
+
+
+def test_issue454_neutral_migration_records_old_to_new(tmp_path: Path):
+    # The deterministic §9 neutral migration (the def-my-fun shape): the id is left
+    # on the split-out import and a new id-less cell carries the def. The migration
+    # moves the id onto the def and re-ids the orphan import -> the orphan's rename
+    # (def-my-fun -> import-time) is the carried entry; the def adopting def-my-fun is
+    # a new cell (no prior entry), so it is NOT recorded.
+    de = _slide("de", "s", "# ## S") + _code_idd_neutral(
+        "def-my-fun", 'def my_fun():\n    print("foo")'
+    )
+    en = _slide("en", "s", "# ## S") + _code_idd_neutral(
+        "def-my-fun", 'def my_fun():\n    print("foo")'
+    )
+    de_path, en_path = _write_pair(tmp_path, de, en)
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        _seed(cache, de_path, en_path)
+        de_path.write_text(
+            _slide("de", "s", "# ## S")
+            + _code_idd_neutral("def-my-fun", "import time")
+            + _code_shared('def my_fun():\n    time.sleep(1)\n    print("foo")'),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(
+            plan, judge=CountingJudge(), translator=CountingTranslator(), watermark_cache=cache
+        )
+    finally:
+        cache.close()
+
+    assert result.applied_migrate == 1
+    assert result.id_migrations == {"def-my-fun": "import-time"}
+
+
+def test_issue454_localized_paired_migration_records_old_to_new(tmp_path: Path):
+    # The Phase 5d paired localized migration writes the same logical move to both
+    # decks; the dict dedups, so one old->new pair is recorded.
+    de0 = _slide("de", "g", "# ## G") + _code_localized_idd(
+        "de", "greet", 'def greet():\n    print("Hallo")'
+    )
+    en0 = _slide("en", "g", "# ## G") + _code_localized_idd(
+        "en", "greet", 'def greet():\n    print("Hello")'
+    )
+    de_path, en_path = _write_pair(tmp_path, de0, en0)
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        _seed(cache, de_path, en_path)
+        de_path.write_text(
+            _slide("de", "g", "# ## G erweitert")
+            + _code_localized_idd("de", "greet", "import time")
+            + _code_localized_idless("de", 'def greet():\n    time.sleep(1)\n    print("Hallo")'),
+            encoding="utf-8",
+        )
+        en_path.write_text(
+            _slide("en", "g", "# ## G")
+            + _code_localized_idd("en", "greet", "import time")
+            + _code_localized_idless("en", 'def greet():\n    time.sleep(1)\n    print("Hello")'),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(
+            plan, judge=CountingJudge(), translator=CountingTranslator(), watermark_cache=cache
+        )
+    finally:
+        cache.close()
+
+    assert result.applied_migrate == 2  # one logical move, written to both decks
+    assert result.id_migrations == {"greet": "import-time"}
+
+
+def test_issue454_recovery_alignment_records_rename(tmp_path: Path):
+    # The §10 bounded-LLM recovery (the renamed-def split): the recoverer maps the
+    # import to a NEW slug and the renamed def as the def-my-fun continuation. Only
+    # the import's rename (def-my-fun -> import-time) is a carry; the renamed def
+    # *adopting* def-my-fun was id-less (None -> id), so it is not recorded.
+    de_path, en_path, cache = _split_renamed_both_decks(tmp_path)
+    recoverer = StaticAlignmentRecoverer(mapping={0: NEW, 1: "def-my-fun"})
+    try:
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(
+            plan,
+            judge=CountingJudge(),
+            translator=CountingTranslator(),
+            watermark_cache=cache,
+            recoverer=recoverer,
+        )
+    finally:
+        cache.close()
+
+    assert result.applied_migrate == 4  # 2 cells re-identified on each of 2 decks
+    assert result.id_migrations == {"def-my-fun": "import-time"}
+    assert "import-time" not in result.id_migrations  # the adoption (None -> id) is not a key
+
+
+def test_issue454_clean_pass_records_no_migration(tmp_path: Path):
+    # A pass with no id churn (a neutral code edit that only propagates) leaves the
+    # map empty — nothing was rewritten.
+    de = _slide("de", "a", "# ## A") + _code_shared("import time")
+    en = _slide("en", "a", "# ## A") + _code_shared("import time")
+    de_path, en_path = _write_pair(tmp_path, de, en)
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        _seed(cache, de_path, en_path)
+        de_path.write_text(
+            _slide("de", "a", "# ## A") + _code_shared("import time\nx = 1"),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        result = apply_plan(
+            plan, judge=CountingJudge(), translator=CountingTranslator(), watermark_cache=cache
+        )
+    finally:
+        cache.close()
+
+    assert result.applied_migrate == 0
+    assert result.id_migrations == {}


### PR DESCRIPTION
Closes #454. **P0 prerequisite** for the per-slide consistency ledger (#448) — see the design note §6 / §11.5 (slide_id churn is the sharpest ledger risk).

## Problem
The ledger keys on `(slide_id, role)`. When an id migrates during realign, the apply engine rewrites slide_ids **in place** and returned nothing, so any ledger/watermark entry keyed by the old id is **silently orphaned** → the slide cold-starts even though it was previously synced. That is the fail-safe direction, but it erodes the incremental win and can mask drift (worse: an entry left under the old id could later attach to a *new* cell that adopted that id, asserting false trust). To carry an entry across the migration, the engine has to surface what it rewrote.

## What changed (`src/clm/slides/sync_apply.py`)
- **`ApplyResult.id_migrations: dict[str, str]`** (old_id → new_id).
- **`_record_id_migration(result, old_id, new_id)`** populates it at every site that rewrites a cell's slide_id:
  - `_migrate_one_deck` — the §9 deterministic neutral migration (the orphan's `sid → new_slug`);
  - `_migrate_localized_paired` — the Phase 5d paired localized migration (one logical move written to both decks; the dict dedups to one pair);
  - `_apply_alignment` — the §10 recovery alignment (a continuation re-id or a re-id onto a minted slug).
- Only a **non-None → non-None rename** is recorded — an *adoption* (`None → id`, a fresh id stamped onto a new cell) has no prior entry to carry, and a *drop* (`id → None`) has no destination — so both correctly fall back to the safe cold-start and are excluded from this old→new map.

This is the **carrier**; the **consumer** (re-keying ledger entries at the `_record_watermark` / `bless` / `accept --record` write sites) lands with the ledger MVP (#448 P1). **No behavior change** — the map is captured, not consumed.

No CLI/flag/spec change and no user-visible behavior, so **no `clm info` topic update and no changelog fragment**.

## Tests (`tests/slides/test_sync_limitations.py`)
- neutral migration records exactly `{def-my-fun: import-time}`;
- localized paired migration records one pair (`{greet: import-time}`);
- recovery alignment records the import's rename and **not** the renamed-def's adoption (`None → def-my-fun`);
- a clean pass (neutral edit, no churn) records nothing.
- Adjacent sync suites (`test_sync_apply` / `test_sync_recover` / `test_sync_accept` / `test_sync_apply_modelfree`, 182 tests) green — confirms no behavior change; ruff + mypy clean.

Unblocks the #448 P3 "id-migration carries ledger entries across realign (#366)" item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
