### PR TITLE
test(sync): run the corpus mutation + no-op oracles in CI (#443 Phase B/C)

### DIFF
--- a/docs/claude/sync-corpus-mutation-443-investigation-handover.md
+++ b/docs/claude/sync-corpus-mutation-443-investigation-handover.md
@@ -1,18 +1,47 @@
 # Handover — `test_sync_corpus_mutation` failures (#443) + the CI-coverage gap
 
-> Status: **investigation not started** — this document is the brief.
-> Created 2026-06-23 while cutting the CLM 1.16.0 release; **refreshed
-> 2026-06-24** against current `master`. Author had full context; you have
-> none, so this is your sole source of truth. Read it top to bottom before
-> touching code.
+> ## ✅ RESOLVED (2026-06-24)
 >
-> **Re-confirmed on current `master` (2026-06-24).** A later run on PR #468
+> Both problems are fixed and merged. This document is kept as the record of the
+> investigation; the boxed status below is the outcome, the body is the trail.
+>
+> - **The bug (#443) — FIXED, PR #471 (merged `a374e304`).** The §2 hypothesis
+>   below (the `vo_anchor` narrative-diversion path) was **refuted**. The real
+>   cause is an **asymmetric companion**: in the trigger deck the voiceover is
+>   **id-less on DE but id'd on EN**. `_index_by_key` routes the id'd half to the
+>   keyed diff and the id-less half to the anchor pass;
+>   `_reconcile_idless_idd_narratives` (`sync_plan.py`) then pairs the EN id'd
+>   `add` with the DE id-less `add` and **cancels both unconditionally** — never
+>   comparing the id'd half to its baseline, so a one-sided edit/removal
+>   vanishes. The fix adds `_alert_asymmetric_companion_drift`, which detects
+>   baseline drift on the id'd half and **alerts** (an `error`-severity
+>   `PlanIssue` that holds the watermark, pointing the author at `assign-ids`)
+>   instead of dropping it. Chose *alert* over *propagate* because propagating
+>   across the id-less↔id'd boundary is exactly the destructive doubling the
+>   reconcile (report #10 / #199) guards against. Bundled fast regression tests:
+>   `test_issue443_*` in `tests/slides/test_sync_limitations.py`.
+> - **The CI-coverage gap (Phase B/C) — CLOSED, this PR.** The corpus-mutation
+>   oracle and the no-op invariant now run in CI on a committed synthetic corpus
+>   (`tests/data/sync_corpus/`), no longer skipped. See §4 for what shipped.
+>
+> Everything below is the **original brief, as written before the fix** (with
+> 2026-06-24 line-anchor refreshes). Read it as the investigation trail, not as
+> open work. The §2 hypothesis is preserved but **wrong** — see the box above.
+
+---
+
+> Status (historical): **investigation not started** — this document was the brief.
+> Created 2026-06-23 while cutting the CLM 1.16.0 release; refreshed 2026-06-24
+> against `master`. Author had full context; the investigator had none, so this
+> was the sole source of truth.
+>
+> **Was re-confirmed on `master` before the fix (2026-06-24).** A run on PR #468
 > independently hit the *same* two failures against the live PythonCourses
-> corpus and verified (via `git stash`) that they fail **identically on clean
+> corpus and verified (via `git stash`) that they failed **identically on clean
 > `master`** — i.e. after the entire #448 consistency-ledger program (P1/P2,
 > PRs #463–#468) landed on top of 1.16.0. The ledger work touched
 > `sync_plan.py`/`sync_verify.py`/`sync_apply.py` but did **not** address this
-> bug. The line references in §2 below are updated to current `master`.
+> bug. The line references in §2 are as of `master` on 2026-06-24.
 
 ---
 
@@ -146,7 +175,13 @@ so it is the only `vo` cell the test selects.
 
 ## 4. Phase breakdown
 
-### Phase A — Root-cause and fix the sync bug (#443) — [TODO] (start here)
+### Phase A — Root-cause and fix the sync bug (#443) — ✅ DONE (PR #471)
+> **Outcome.** Root cause was the **asymmetric (id-less DE ↔ id'd EN) companion**,
+> not the `vo_anchor` path this section hypothesised. Fixed by
+> `_alert_asymmetric_companion_drift` (alert, not propagate). Bundled fast tests
+> `test_issue443_*` in `tests/slides/test_sync_limitations.py`. See the RESOLVED
+> box at the top. The original goal/components/acceptance are kept below as written.
+
 - **Goal.** A one-sided edit *or* removal of a keyed voiceover/notes companion
   (sharing its slide's id) is propagated to the other half, or alerted
   (deferred / issue), never silently dropped.
@@ -166,7 +201,25 @@ so it is the only `vo` cell the test selects.
   engine limitations the same way. `clm slides sync verify` stays green; no
   #269/#282 regressions (run the existing sync suites).
 
-### Phase B — Close the CI-coverage gap — [TODO]
+### Phase B — Close the CI-coverage gap — ✅ DONE
+> **Outcome — Option 1 (committed synthetic corpus), as recommended.** Added
+> `tests/data/sync_corpus/` — one bilingual deck (`deck_features.{de,en}.py`)
+> in post-sync-clean shape carrying all four mutation cell classes (neutral
+> shared code, id-less localized markdown, a **shared-id** voiceover companion,
+> keyed markdown). `_corpus_dir()` in `test_sync_corpus_mutation.py` now returns
+> `(root, is_bundled)` and falls back to this corpus when no real PythonCourses
+> checkout is found (env / maintainer path still win, preserving release-time
+> realism). The `skipif` is gone.
+>
+> **Second blocker found and fixed:** the tests were also `slow`, and **every CI
+> job excludes `slow`** (`ci.yml`: fast/integration/e2e all carry `and not
+> slow`). So un-skipping alone would not have run them in CI. The `slow` marker
+> is now **conditional** — applied only on the real corpus (genuinely slow, and
+> CI doesn't have it), dropped on the tiny bundled corpus (~2 s) so the
+> **`integration` CI job runs all six mutation tests**. Verified: all 6 pass
+> against the bundled corpus in ~2 s; the real-corpus path is unchanged
+> (`slow`+`integration`, still in the `-m "not docker"` release gate).
+
 - **Goal.** Mutation-oracle coverage of the real sync invariants runs **in CI**,
   not only on a developer's machine at release time.
 - **Options to weigh (pick + justify):**
@@ -190,7 +243,22 @@ so it is the only `vo` cell the test selects.
   shared-id-companion mutation. Whatever is bounded/sampled is `log`-stated, not
   silent.
 
-### Phase C — (optional) audit sibling oracles — [TODO]
+### Phase C — audit sibling oracles — ✅ DONE
+> **Outcome — split decision.** `tests/slides/test_sync_corpus_noop.py` had the
+> same `slow`+`skipif`-on-corpus gap, so it gets the same `(root, is_bundled)`
+> fallback + conditional `slow`. **But** its assertions are two kinds: a
+> *scale-independent invariant* (`test_noop_plans_apply_with_zero_bytes_and_zero_llm`
+> — a no-op plan must write zero bytes / make zero LLM calls) and *corpus-scale
+> measurement floors* (`total_pairs >= 100`, `item2_population > 1000`, the
+> no-op-pair floor — all tuned to the 212-pair real corpus). The floors would be
+> **vacuous and misleading on one synthetic pair**, so they stay gated to a real
+> corpus via `@_real_corpus_only` (`skipif(_BUNDLED)`); only the invariant runs
+> on the bundled corpus in CI. That closes the safety gap (a "nothing to do" plan
+> that nonetheless writes is caught in CI) without faking the measurement floors.
+> Verified: the invariant passes on the bundled corpus; the real-corpus run is
+> unchanged. No other `CLM_SYNC_CORPUS_DIR` / corpus-`skipif` users remain (grep
+> confirmed only these two files).
+
 - `tests/slides/test_sync_corpus_noop.py` (the no-op backstop) uses the **same**
   `skipif`-on-corpus pattern and is therefore **also CI-invisible**. Decide
   whether it should ride on the Phase B synthetic corpus too. Grep for other

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -397,6 +397,12 @@ ignore_missing_imports = true
 line-length = 100
 target-version = "py310"
 src = ["src"]
+# Slide-deck fixtures in jupytext *percent* format: their markdown cell bodies
+# are plain prose, not valid Python, so ruff must not lint or format them.
+# ``force-exclude`` makes the exclude hold even when pre-commit passes the file
+# paths explicitly.
+extend-exclude = ["tests/data/sync_corpus"]
+force-exclude = true
 
 [tool.ruff.lint]
 select = [

--- a/tests/data/sync_corpus/deck_features.de.py
+++ b/tests/data/sync_corpus/deck_features.de.py
@@ -1,0 +1,14 @@
+# %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+# # Einführung
+
+# %% [markdown] lang="de" tags=["voiceover"] slide_id="intro"
+Willkommen zur Einführung.
+
+# %% [markdown] lang="de" tags=["subslide"] slide_id="details"
+# ## Details
+
+# %% [markdown] lang="de"
+Ein lokalisierter Hinweis ohne Bezeichner.
+
+# %% tags=["keep"]
+x = 1

--- a/tests/data/sync_corpus/deck_features.en.py
+++ b/tests/data/sync_corpus/deck_features.en.py
@@ -1,0 +1,14 @@
+# %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+# # Introduction
+
+# %% [markdown] lang="en" tags=["voiceover"] slide_id="intro"
+Welcome to the introduction.
+
+# %% [markdown] lang="en" tags=["subslide"] slide_id="details"
+# ## Details
+
+# %% [markdown] lang="en"
+A localized note without an identifier.
+
+# %% tags=["keep"]
+x = 1

--- a/tests/slides/test_sync_corpus_mutation.py
+++ b/tests/slides/test_sync_corpus_mutation.py
@@ -40,30 +40,56 @@ _XL = "<<CORPUS-XL-9bd1>>"  # the static translator's output for a re-translatio
 _JUDGED = f"# {_MARKER}-judged"  # the static judge's proposed target body
 
 
-def _corpus_dir() -> Path | None:
-    """The sync corpus root, or ``None`` when unavailable (mirrors the noop test)."""
-    candidates: list[Path] = []
+# A tiny in-repo corpus (one bilingual deck carrying every mutation cell class,
+# in post-sync-clean shape) committed so the oracle runs in CI — see Phase B of
+# ``docs/claude/sync-corpus-mutation-443-investigation-handover.md``. It is the
+# *fallback*: a real PythonCourses checkout (env or the maintainer path) still
+# wins so the release-time run keeps its full-scale realism.
+_BUNDLED_CORPUS = Path(__file__).resolve().parents[1] / "data" / "sync_corpus"
+
+
+def _has_pair(cand: Path) -> bool:
+    if not cand.is_dir():
+        return False
+    for de_path in cand.rglob("*.de.py"):
+        if de_path.with_name(de_path.name[: -len(".de.py")] + ".en.py").exists():
+            return True
+    return False
+
+
+def _corpus_dir() -> tuple[Path, bool] | None:
+    """Resolve the sync corpus root and whether it is the bundled synthetic one.
+
+    Order: ``CLM_SYNC_CORPUS_DIR`` env, the maintainer's local PythonCourses
+    checkout, then the committed synthetic corpus (always present). Returns
+    ``(root, is_bundled)`` — ``is_bundled`` drives the ``slow`` marker below.
+    """
+    external: list[Path] = []
     env = os.environ.get("CLM_SYNC_CORPUS_DIR")
     if env:
-        candidates.append(Path(env))
-    candidates.append(Path(r"C:\Users\tc\Programming\Python\Courses\Own\PythonCourses\slides"))
-    for cand in candidates:
-        if not cand.is_dir():
-            continue
-        for de_path in cand.rglob("*.de.py"):
-            en_path = de_path.with_name(de_path.name[: -len(".de.py")] + ".en.py")
-            if en_path.exists():
-                return cand
+        external.append(Path(env))
+    external.append(Path(r"C:\Users\tc\Programming\Python\Courses\Own\PythonCourses\slides"))
+    bundled = _BUNDLED_CORPUS.resolve()
+    for cand in external:
+        if _has_pair(cand):
+            return cand, cand.resolve() == bundled
+    if _has_pair(_BUNDLED_CORPUS):
+        return _BUNDLED_CORPUS, True
     return None
 
 
-_CORPUS = _corpus_dir()
+_resolved = _corpus_dir()
+_CORPUS = _resolved[0] if _resolved else None
+_BUNDLED = _resolved[1] if _resolved else False
 
-pytestmark = [
-    pytest.mark.slow,
-    pytest.mark.integration,
-    pytest.mark.skipif(_CORPUS is None, reason="PythonCourses sync corpus not available"),
-]
+# The real PythonCourses corpus is large (rglob + a plan build per pair) — hence
+# ``slow``, and CI (which excludes ``slow`` from every job) never runs it. The
+# bundled synthetic corpus is one tiny deck and runs in ~2 s, so on the fallback
+# we drop ``slow`` and the ``integration`` CI job picks the oracle up. No
+# ``skipif``: the bundled corpus is always present.
+pytestmark = [pytest.mark.integration]
+if not _BUNDLED:
+    pytestmark.append(pytest.mark.slow)
 
 
 class _StaticJudge:

--- a/tests/slides/test_sync_corpus_noop.py
+++ b/tests/slides/test_sync_corpus_noop.py
@@ -39,36 +39,56 @@ _PHASE0_NOOP_PAIRS = 81
 _NOOP_FLOOR = 40
 
 
-def _corpus_dir() -> Path | None:
-    """The sync corpus root, or ``None`` when unavailable (skip).
+# The committed synthetic corpus shared with ``test_sync_corpus_mutation.py``
+# (one tiny in-sync bilingual deck). It is a *fallback*: a real PythonCourses
+# checkout still wins. On the bundled corpus only the scale-independent no-op
+# *invariant* runs — the population/size floors below are real-corpus-scale and
+# would be vacuous on one pair, so they stay gated to a real corpus. See Phase C
+# of ``docs/claude/sync-corpus-mutation-443-investigation-handover.md``.
+_BUNDLED_CORPUS = Path(__file__).resolve().parents[1] / "data" / "sync_corpus"
 
-    Requires at least one *real* ``.de.py`` / ``.en.py`` pair (not merely a
-    ``.de.py``), so the skip predicate agrees with ``discover_pairs``: a de-only
-    or unpaired tree skips cleanly instead of running an empty harness that would
-    trip ``test_corpus_discovered``'s ``total_pairs >= 100`` floor.
+
+def _has_pair(cand: Path) -> bool:
+    if not cand.is_dir():
+        return False
+    for de_path in cand.rglob("*.de.py"):
+        if de_path.with_name(de_path.name[: -len(".de.py")] + ".en.py").exists():
+            return True
+    return False
+
+
+def _corpus_dir() -> tuple[Path, bool] | None:
+    """Resolve the corpus root and whether it is the bundled synthetic one.
+
+    Order: ``CLM_SYNC_CORPUS_DIR`` env, the maintainer's PythonCourses checkout,
+    then the committed synthetic corpus. Requires at least one real ``.de.py`` /
+    ``.en.py`` pair so the skip predicate agrees with ``discover_pairs``.
+    Returns ``(root, is_bundled)``.
     """
-    candidates: list[Path] = []
+    external: list[Path] = []
     env = os.environ.get("CLM_SYNC_CORPUS_DIR")
     if env:
-        candidates.append(Path(env))
-    candidates.append(Path(r"C:\Users\tc\Programming\Python\Courses\Own\PythonCourses\slides"))
-    for cand in candidates:
-        if not cand.is_dir():
-            continue
-        for de_path in cand.rglob("*.de.py"):
-            en_path = de_path.with_name(de_path.name[: -len(".de.py")] + ".en.py")
-            if en_path.exists():
-                return cand  # at least one real pair -> usable corpus
+        external.append(Path(env))
+    external.append(Path(r"C:\Users\tc\Programming\Python\Courses\Own\PythonCourses\slides"))
+    bundled = _BUNDLED_CORPUS.resolve()
+    for cand in external:
+        if _has_pair(cand):
+            return cand, cand.resolve() == bundled
+    if _has_pair(_BUNDLED_CORPUS):
+        return _BUNDLED_CORPUS, True
     return None
 
 
-_CORPUS = _corpus_dir()
+_resolved = _corpus_dir()
+_CORPUS = _resolved[0] if _resolved else None
+_BUNDLED = _resolved[1] if _resolved else False
 
-pytestmark = [
-    pytest.mark.slow,
-    pytest.mark.integration,
-    pytest.mark.skipif(_CORPUS is None, reason="PythonCourses sync corpus not available"),
-]
+# Real corpus = ``slow`` (≈18 s over 212 pairs) and CI never runs ``slow``; the
+# bundled fallback is one pair (~instant), so drop ``slow`` there and let the
+# ``integration`` CI job run the no-op invariant. No ``skipif``: bundled always present.
+pytestmark = [pytest.mark.integration]
+if not _BUNDLED:
+    pytestmark.append(pytest.mark.slow)
 
 
 @pytest.fixture(scope="module")
@@ -85,6 +105,13 @@ def report():
     return result
 
 
+_real_corpus_only = pytest.mark.skipif(
+    _BUNDLED,
+    reason="scale-dependent floor — meaningful only on the full PythonCourses corpus",
+)
+
+
+@_real_corpus_only
 def test_corpus_discovered(report):
     # Sanity: the harness actually found a substantial corpus (else every other
     # assertion is vacuously true).
@@ -100,6 +127,7 @@ def test_noop_plans_apply_with_zero_bytes_and_zero_llm(report):
     assert report.violations == [], report.render()
 
 
+@_real_corpus_only
 def test_noop_pairs_do_not_catastrophically_regress(report):
     # If a later phase makes already-synced pairs churn, they stop classifying
     # as no-op and this floor trips. (Phase-0 measured 81; floor has headroom for
@@ -110,6 +138,7 @@ def test_noop_pairs_do_not_catastrophically_regress(report):
     )
 
 
+@_real_corpus_only
 def test_churn_baseline_populations_present(report):
     # The measurement half: the item-2 (neutral, silent-drop) and item-3 (id-less
     # localized, re-translated) exposure populations are what Phases 2-3 must


### PR DESCRIPTION
## Summary

Closes the CI-coverage gap behind issue #443 (Phases **B** and **C** of the investigation handover). The #443 engine bug itself was fixed in PR #471; this PR makes the oracles that catch that whole class of bug actually run in CI.

## The gap

The corpus mutation oracle (`test_sync_corpus_mutation.py`) and the no-op backstop (`test_sync_corpus_noop.py`) were **doubly invisible to CI**:

1. They `skipif` the PythonCourses corpus is absent — and CI / fresh clones don't have it.
2. They carry the `slow` marker, and **every CI job excludes `slow`** (`ci.yml`: the fast, integration, and e2e jobs all add `and not slow`).

So the only time they ran was a developer's `-m "not docker"` pre-release run — which is exactly how #443 surfaced as a multi-hour release-gate detour instead of a caught PR regression.

## Phase B — committed synthetic corpus

- New `tests/data/sync_corpus/deck_features.{de,en}.py`: one bilingual deck in post-sync-clean shape carrying all four mutation cell classes (neutral shared code, id-less localized markdown, a **shared-id** voiceover companion, keyed markdown).
- `_corpus_dir()` now returns `(root, is_bundled)` and **falls back** to this corpus when no real PythonCourses checkout is found. Env (`CLM_SYNC_CORPUS_DIR`) and the maintainer path still win, so the release-time run keeps full-scale realism. The `skipif` is removed.
- The `slow` marker is **conditional** — applied on the real corpus (genuinely slow; CI doesn't have it), dropped on the tiny bundled one — so the **`integration` CI job runs all six mutation tests in ~2 s**.

## Phase C — sibling no-op oracle

`test_sync_corpus_noop.py` gets the same fallback, but its assertions split:

- The **scale-independent invariant** (`test_noop_plans_apply_with_zero_bytes_and_zero_llm` — a "nothing to do" plan must write zero bytes / make zero LLM calls) now runs on the bundled corpus in CI.
- The **corpus-scale measurement floors** (`>=100` pairs, population counts tuned to the 212-pair real corpus) stay gated to a real corpus via `@_real_corpus_only` — they'd be vacuous and misleading on one synthetic pair.

Grep confirmed these two files are the only `CLM_SYNC_CORPUS_DIR` / corpus-`skipif` users.

## Other

- `ruff`: `extend-exclude` + `force-exclude` for the percent-format deck fixtures (their markdown bodies aren't valid Python).
- Updated `docs/claude/sync-corpus-mutation-443-investigation-handover.md` with a **RESOLVED** banner and Phase A/B/C outcomes (records that the §2 `vo_anchor` hypothesis was refuted; real cause was the asymmetric id-less↔id'd companion, fixed in PR #471).

## Verification

- **Bundled path (simulates CI):** 6 mutation tests pass + the no-op invariant passes, 3 scale floors skip — **~2 s**.
- **Real corpus (local release gate):** all 10 tests pass (258 s), behavior unchanged (still `slow`+`integration`).
- ruff lint+format clean; mypy `src/clm` green; pre-push fast suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
