### PR TITLE
fix(sync): walk up to project root for cache/config + key watermark by main checkout (#477, #435)

### DIFF
--- a/changelog.d/477-435-project-root-and-worktree-cache.fixed.md
+++ b/changelog.d/477-435-project-root-and-worktree-cache.fixed.md
@@ -1,0 +1,18 @@
+- **Cache & config discovery now walk up to the project root.** `clm` resolves
+  the LLM/sync cache directory, project config, and the build/jobs databases
+  relative to the **project root** — discovered by walking up from the current
+  directory to the nearest `pyproject.toml` / `.clm/config.toml` / `.git`, like
+  `git` / `uv` / `ruff`. Running a command from a subdirectory (e.g. a topic dir)
+  no longer treats the subdirectory as the root: it stops ignoring
+  `[tool.clm] cache_dir`, stops creating a stray `<subdir>/.clm-cache/`, and so a
+  watermark/`baseline bless` written from a subdir is visible from the repo root
+  (#477). `clm config locate` now also reports the discovered project root. An
+  explicitly supplied `--cache-db-path` / `--jobs-db-path` is still honored
+  verbatim.
+- **`clm slides sync` watermarks now work from a git worktree.** The watermark is
+  keyed by the **main-checkout** path even when the command runs inside a linked
+  git worktree, so a watermark recorded from the main checkout is found from any
+  worktree (and writes land on the one canonical key instead of accumulating
+  orphaned worktree-path rows). Previously every pair silently missed its
+  watermark from a worktree and cold-started off git `HEAD` (#435). The committed
+  per-slide sync ledger (#448) was already worktree-portable and is unaffected.

--- a/src/clm/cli/commands/config.py
+++ b/src/clm/cli/commands/config.py
@@ -3,6 +3,8 @@
 This module provides commands for managing CLM configuration files.
 """
 
+from pathlib import Path
+
 import click
 
 
@@ -120,12 +122,23 @@ def config_locate():
     and which files currently exist.
     """
     from clm.infrastructure.config import find_config_files, get_config_file_locations
+    from clm.infrastructure.utils.path_utils import find_project_root
 
     locations = get_config_file_locations()
     existing = find_config_files()
 
     click.echo("Configuration File Locations:")
     click.echo("=" * 60)
+
+    # The project root every cwd-independent lookup below is anchored to. Showing
+    # it makes clear WHY a given config / cache file was chosen — and surfaces the
+    # case (issue #477) where a command run from a subdirectory resolves to a
+    # project root above it rather than the cwd.
+    root = find_project_root()
+    click.echo("\nProject root (discovered by walking up for pyproject.toml/.clm/.git):")
+    click.echo(f"  Path: {root}")
+    if root != Path.cwd().resolve():
+        click.echo(f"  Note: differs from the current directory ({Path.cwd()})")
 
     click.echo("\nSystem config (lowest priority):")
     click.echo(f"  Path: {locations['system']}")

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1518,7 +1518,7 @@ clm slides assign-ids [OPTIONS] PATH
 | `--llm-model TEXT` | Ollama model name (default: `qwen3:30b`). |
 | `--ollama-url TEXT` | Base URL of the Ollama daemon (default: `$OLLAMA_URL` or `http://localhost:11434`). |
 | `--llm-timeout SECONDS` | Per-call timeout (default: 120s — cold-load on a 30B model can exceed 60s). |
-| `--cache-dir PATH` | Directory for the LLM cache. Lookup order: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` → `<cwd>/.clm-cache/`. |
+| `--cache-dir PATH` | Directory for the LLM cache. Lookup order: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` → `<project-root>/.clm-cache/`. |
 | `--only bilingual\|split` | (since CLM {version}) Scope a **directory** run to only bilingual decks (no `.de`/`.en` tag) or only split halves — e.g. `--only bilingual` mints bilingual decks while leaving `.de`/`.en` pairs for `clm slides sync`. |
 | `--exclude GLOB` | (since CLM {version}) Skip decks matching `GLOB`, matched against the full path **and** each path component (so `--exclude old_decks` skips an `old_decks/` dir). Repeatable. Underscore-prefixed dirs (`_archive/`, …) are skipped automatically (issue #318). |
 | `--shipping-only` | (since CLM {version}) Scope a directory run to decks reachable from course specs (the shipping set). |
@@ -1972,6 +1972,18 @@ directory; `--json` emits the structured form; `--baseline REF` /
 opt into the watermark accelerator (default off for the read verbs, **on** for
 `apply`).
 
+**Project root & worktrees (since CLM {version}).** The cache directory is
+resolved relative to the **project root**, discovered by walking up from the
+current directory to the nearest `pyproject.toml` / `.clm/config.toml` / `.git`
+(like `git` / `uv` / `ruff`). So every `clm` invocation resolves the same cache
+no matter which subdirectory (e.g. a topic dir) it runs from — earlier releases
+treated the current directory as the root, so a command run from a topic
+silently created a stray `<topic>/.clm-cache/` and missed the configured one
+(#477). The watermark is additionally keyed by the **main-checkout** path even
+when run from a linked git **worktree**, so a watermark recorded from the main
+checkout is found from any worktree and vice-versa (#435) — no `--cache-dir`
+gymnastics needed.
+
 #### `clm slides sync report` (the default verb)
 
 ```
@@ -1985,7 +1997,7 @@ clm slides sync report DECK [EN_PATH] [OPTIONS]   # bare `sync DECK` is the same
 | `--baseline REF` | Diff against an explicit git ref (`HEAD~1`, a SHA) instead of git `HEAD`. Use after you committed single-language edits before syncing — `--baseline HEAD~1` diffs the pre-edit commit. **Works over a directory too**: every pair under the tree is diffed against REF, so a whole topic/module of committed single-language edits is reconciled in one sweep (a plain git-HEAD batch reads those edits as already-consistent). |
 | `--baseline-from PATH[@REF]` | Diff a **renamed** deck against its pre-rename half `PATH` (`@REF` defaults to `HEAD`) when auto rename-detection can't recover it. Single-pair only (it names one deck's old path). |
 | `--use-watermark` | Opt back into the structural watermark as the baseline (default: git `HEAD`). |
-| `--cache-dir PATH` | Directory holding the watermark (only with `--use-watermark`). Lookup: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` → `<cwd>/.clm-cache/`. |
+| `--cache-dir PATH` | Directory holding the watermark (only with `--use-watermark`). Lookup: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` → `<project-root>/.clm-cache/`. |
 | `--ledger` | Consult the per-slide consistency ledger (`<topic>/.clm/sync-ledger.json`, #448): skip any slide whose two current halves are byte-identical to a recorded confirmation, so a sync paid for last round is not re-litigated against an older `--baseline`. A trust *overlay* (the classification is unchanged; it only removes redundant proposals). **Works over a directory** (each pair uses its own topic ledger; the batch JSON/summary reports the aggregate `skipped`). Record confirmations with `baseline bless --ledger` or `apply --ledger`. |
 
 Read-only, no model, no key. Exit code mirrors the plan: `0` clean (in sync),
@@ -2411,7 +2423,7 @@ clm slides bootstrap [OPTIONS] SOURCE   # alias
 | `--glossary PATH` | Translation conventions file (Markdown: a style note + term glossary) appended to the translation prompt. Default: auto-discover `clm-glossary.<target-lang>.md` walking up from SOURCE's directory. |
 | `--provider [openrouter\|local]` | Edit-judge backend for the *delegated-sync* path (when the twin already exists); unused on the bootstrap path. Overridable with `$CLM_SYNC_PROVIDER`. |
 | `--llm-model TEXT` | Model for the delegated-sync edit judge (default `anthropic/claude-sonnet-4-6` for openrouter). |
-| `--cache-dir PATH` | Directory holding the translation + watermark caches. Lookup: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` → `<cwd>/.clm-cache/`. |
+| `--cache-dir PATH` | Directory holding the translation + watermark caches. Lookup: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` → `<project-root>/.clm-cache/`. |
 | `--no-cache` | Do not read or write the translation / watermark caches. |
 | `--no-env-file` | Do not auto-load a `.env` file. |
 | `--json` | Emit a JSON report instead of human-readable lines. |
@@ -2480,7 +2492,7 @@ clm slides coverage [OPTIONS] PATH
 | `--llm-model TEXT` | Ollama model name (default: `qwen3:30b`). |
 | `--ollama-url TEXT` | Base URL of the Ollama daemon (default: `$OLLAMA_URL` or `http://localhost:11434`). |
 | `--llm-timeout SECONDS` | Per-call timeout (default: 120s — cold-load on a 30B local model can exceed 60s). |
-| `--cache-dir PATH` | Directory for the LLM cache. Lookup order: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` → `<cwd>/.clm-cache/`. |
+| `--cache-dir PATH` | Directory for the LLM cache. Lookup order: flag → `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` → `<project-root>/.clm-cache/`. |
 | `--report-only` | Skip cache writes; reads still happen. Useful for measuring the current cache hit rate without persisting fresh verdicts. |
 | `--dump` | Print a readable text dump of cached verdicts instead of running a coverage check. PATH is ignored. Combine with `--json` for machine output. |
 | `--json` | Emit a JSON report. |
@@ -2535,7 +2547,7 @@ clm slides split [OPTIONS] SOURCE
 |--------|-------------|
 | `--force` | Overwrite existing `.de.py` / `.en.py` companions if present |
 | `--report-only`, `--dry-run` | Compute the split and report what would be written without modifying files |
-| `--cache-dir PATH` | Directory for the sync watermark recorded for the split pair (default: `--cache-dir` > `$CLM_CACHE_DIR` > `tool.clm.cache_dir` in pyproject > `<cwd>/.clm-cache/`). Must match what `clm slides sync` resolves so the watermark is found. |
+| `--cache-dir PATH` | Directory for the sync watermark recorded for the split pair (default: `--cache-dir` > `$CLM_CACHE_DIR` > `tool.clm.cache_dir` in pyproject > `<project-root>/.clm-cache/`). Must match what `clm slides sync` resolves so the watermark is found. |
 | `--no-watermark` | Do not record a sync watermark for the freshly-split pair |
 | `--json` | Emit a JSON report |
 
@@ -2580,7 +2592,7 @@ in-sync **by construction**, so this is safe — and it means the next default
 `clm slides sync` (no `--baseline`) sees a single-language edit as an *edit* to
 propagate, rather than reading the whole deck as new (no baseline). The watermark
 is keyed by the same cache directory `sync` resolves (`--cache-dir` >
-`$CLM_CACHE_DIR` > `tool.clm.cache_dir` > `<cwd>/.clm-cache/`), so pass the same
+`$CLM_CACHE_DIR` > `tool.clm.cache_dir` > `<project-root>/.clm-cache/`), so pass the same
 `--cache-dir` to both if you override it. Recording is best-effort: if the cache
 cannot be opened the split still succeeds and emits a `warning:`. Pass
 `--no-watermark` to skip it; a `--report-only` run records nothing.

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -1049,7 +1049,7 @@ or as a CI step.
 
 Verdicts are stored in `clm-llm.sqlite` in the LLM cache directory
 resolved from `--cache-dir` → `$CLM_CACHE_DIR` →
-`tool.clm.cache_dir` → `<cwd>/.clm-cache/`. For AZAV-scale courses
+`tool.clm.cache_dir` → `<project-root>/.clm-cache/`. For AZAV-scale courses
 where the cache is worth sharing across machines, point
 `tool.clm.cache_dir` in the course repo's `pyproject.toml` at a
 sibling git repo (e.g. `../PythonCoursesClmLlmCache`) and commit

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -118,15 +118,36 @@ def cli(ctx, cache_db_path, jobs_db_path, telemetry_db_path):
     Build and manage educational course materials with support for
     Jupyter notebooks, PlantUML diagrams, and Draw.io diagrams.
     """
+    from click.core import ParameterSource
+
     from clm.infrastructure.database.execution_telemetry import default_telemetry_db_path
+    from clm.infrastructure.utils.path_utils import find_project_root
+
+    def _anchor_default(name: str, value: str) -> Path:
+        """Anchor a DB-path *default* to the discovered project root (issue #477).
+
+        A build/status run from a topic subdirectory must open the SAME database
+        as one run from the repo root — otherwise the relative default
+        ``clm_cache.db`` / ``clm_jobs.db`` resolves under the subdir and silently
+        diverges. Only the untouched default is re-anchored; an explicitly
+        supplied path (absolute or relative) is respected verbatim so a caller who
+        passes ``--cache-db-path foo.db`` still gets a cwd-relative file.
+        """
+        path = Path(value)
+        if ctx.get_parameter_source(name) == ParameterSource.DEFAULT and not path.is_absolute():
+            return find_project_root() / path
+        return path
+
+    cache_db = _anchor_default("cache_db_path", cache_db_path)
+    jobs_db = _anchor_default("jobs_db_path", jobs_db_path)
 
     ctx.ensure_object(dict)
-    ctx.obj["CACHE_DB_PATH"] = Path(cache_db_path)
-    ctx.obj["JOBS_DB_PATH"] = Path(jobs_db_path)
+    ctx.obj["CACHE_DB_PATH"] = cache_db
+    ctx.obj["JOBS_DB_PATH"] = jobs_db
     ctx.obj["TELEMETRY_DB_PATH"] = (
         Path(telemetry_db_path)
         if telemetry_db_path is not None
-        else default_telemetry_db_path(Path(cache_db_path))
+        else default_telemetry_db_path(cache_db)
     )
 
 

--- a/src/clm/cli/status/collector.py
+++ b/src/clm/cli/status/collector.py
@@ -63,10 +63,16 @@ class StatusCollector:
         if db_path:
             return Path(db_path)
 
-        # Check current directory
+        # Anchor the jobs-DB discovery to the discovered project root (issue #477)
+        # so `clm status` opens the SAME database whether it runs from the repo
+        # root or a topic subdirectory — otherwise a subdir run opens a different
+        # (usually empty) DB and reports a misleadingly idle system.
+        from clm.infrastructure.utils.path_utils import find_project_root
+
+        root = find_project_root()
         default_paths = [
-            Path.cwd() / "clm_jobs.db",
-            Path.cwd() / "jobs.db",
+            root / "clm_jobs.db",
+            root / "jobs.db",
             Path.home() / ".clm" / "clm_jobs.db",
         ]
 
@@ -75,7 +81,7 @@ class StatusCollector:
                 return path
 
         # Return default (may not exist yet)
-        return Path.cwd() / "clm_jobs.db"
+        return root / "clm_jobs.db"
 
     def collect(self) -> StatusInfo:
         """Collect complete system status.

--- a/src/clm/infrastructure/config.py
+++ b/src/clm/infrastructure/config.py
@@ -934,12 +934,16 @@ def find_config_files() -> dict[str, Path | None]:
     if user_config.exists():
         config_files["user"] = user_config
 
-    # Project config (in current working directory or .clm subdirectory)
-    # Check .clm/config.toml first, then clm.toml
-    cwd = Path.cwd()
+    # Project config: discovered by walking up from cwd to the project root
+    # (issue #477), so a command run from a topic subdirectory finds the same
+    # project config as one run from the repo root. Check .clm/config.toml first,
+    # then clm.toml.
+    from clm.infrastructure.utils.path_utils import find_project_root
+
+    root = find_project_root()
     project_configs = [
-        cwd / ".clm" / "config.toml",
-        cwd / "clm.toml",
+        root / ".clm" / "config.toml",
+        root / "clm.toml",
     ]
 
     for project_config in project_configs:
@@ -966,8 +970,12 @@ def get_config_file_locations() -> dict[str, Path]:
     user_config_dir = Path(platformdirs.user_config_dir("clm", appauthor=False))
     locations["user"] = user_config_dir / "config.toml"
 
-    # Project config location (in current working directory)
-    locations["project"] = Path.cwd() / ".clm" / "config.toml"
+    # Project config location: anchored to the discovered project root (issue
+    # #477), so `config locate` / `config init --location=project` agree no matter
+    # which subdirectory the command runs from.
+    from clm.infrastructure.utils.path_utils import find_project_root
+
+    locations["project"] = find_project_root() / ".clm" / "config.toml"
 
     return locations
 

--- a/src/clm/infrastructure/llm/cache.py
+++ b/src/clm/infrastructure/llm/cache.py
@@ -1,5 +1,6 @@
 """SQLite-based cache for LLM summaries."""
 
+import functools
 import logging
 import sqlite3
 from dataclasses import dataclass
@@ -837,6 +838,21 @@ class SyncWatermarkCache:
             self._conn.execute("ALTER TABLE sync_watermark_meta ADD COLUMN hash_version INTEGER")
         self._conn.commit()
 
+    def _key(self, de_path: str, en_path: str) -> tuple[str, str]:
+        """Canonicalize the ``(de_path, en_path)`` watermark key (issue #435).
+
+        Routes the absolute key paths through :func:`to_main_worktree_path` so a
+        path resolved inside a linked git worktree is keyed by its main-checkout
+        equivalent — every read and write therefore agrees on one key regardless
+        of which worktree the command runs from. A no-op in the main checkout, and
+        idempotent (re-keying an already-canonical key returns it unchanged), so
+        internal methods that re-enter another keyed method stay correct.
+        """
+        return (
+            str(to_main_worktree_path(Path(de_path))),
+            str(to_main_worktree_path(Path(en_path))),
+        )
+
     def get_deck(
         self,
         de_path: str,
@@ -853,6 +869,7 @@ class SyncWatermarkCache:
         its stored hashes use an older canonical form and cannot be compared, so the
         pair cold-starts and is re-recorded at the current version on the next apply.
         """
+        de_path, en_path = self._key(de_path, en_path)
         if not self._version_current(de_path, en_path):
             return []
         rows = self._conn.execute(
@@ -903,6 +920,7 @@ class SyncWatermarkCache:
             raise ValueError(
                 f"lang must be 'de', 'en', 'shared', 'de-header', or 'en-header', got {lang!r}"
             )
+        de_path, en_path = self._key(de_path, en_path)
         tag_for = tags or {}
         anchor_for = anchors or {}
         with self._conn:  # single transaction (BEGIN/COMMIT or ROLLBACK)
@@ -949,6 +967,7 @@ class SyncWatermarkCache:
         distinguish a *known* empty tag set (present, ``frozenset()``) from an
         *undeterminable* one (absent — a pre-#198 watermark row). Issue #198.
         """
+        de_path, en_path = self._key(de_path, en_path)
         rows = self._conn.execute(
             "SELECT position, tags FROM sync_watermarks "
             "WHERE de_path=? AND en_path=? AND lang=? AND tags IS NOT NULL ORDER BY position",
@@ -965,6 +984,7 @@ class SyncWatermarkCache:
         narrative classifier reads as "anchor undeterminable" and skips, so an old
         watermark degrades gracefully (no false edit).
         """
+        de_path, en_path = self._key(de_path, en_path)
         rows = self._conn.execute(
             "SELECT position, anchor FROM sync_watermarks "
             "WHERE de_path=? AND en_path=? AND lang=? AND anchor IS NOT NULL ORDER BY position",
@@ -979,6 +999,7 @@ class SyncWatermarkCache:
         (Issue #429) so the caller cold-starts off git HEAD rather than diffing
         against hashes in an incomparable canonical form.
         """
+        de_path, en_path = self._key(de_path, en_path)
         if not self._version_current(de_path, en_path):
             return False
         row = self._conn.execute(
@@ -989,6 +1010,7 @@ class SyncWatermarkCache:
 
     def get_hash_version(self, de_path: str, en_path: str) -> int | None:
         """The canonicalization version the pair's hashes were recorded at, or None."""
+        de_path, en_path = self._key(de_path, en_path)
         row = self._conn.execute(
             "SELECT hash_version FROM sync_watermark_meta WHERE de_path=? AND en_path=?",
             (de_path, en_path),
@@ -1001,6 +1023,7 @@ class SyncWatermarkCache:
 
     def set_synced_commit(self, de_path: str, en_path: str, commit: str | None) -> None:
         """Record the repo HEAD commit the pair was last synced at (pair-level)."""
+        de_path, en_path = self._key(de_path, en_path)
         with self._conn:
             self._conn.execute(
                 "INSERT INTO sync_watermark_meta (de_path, en_path, synced_commit) "
@@ -1012,6 +1035,7 @@ class SyncWatermarkCache:
 
     def get_synced_commit(self, de_path: str, en_path: str) -> str | None:
         """Return the commit recorded by :meth:`set_synced_commit`, or ``None``."""
+        de_path, en_path = self._key(de_path, en_path)
         row = self._conn.execute(
             "SELECT synced_commit FROM sync_watermark_meta WHERE de_path=? AND en_path=?",
             (de_path, en_path),
@@ -1020,6 +1044,7 @@ class SyncWatermarkCache:
 
     def clear_pair(self, de_path: str, en_path: str) -> int:
         """Delete all watermark rows + metadata for the pair; return rows removed."""
+        de_path, en_path = self._key(de_path, en_path)
         cursor = self._conn.execute(
             "DELETE FROM sync_watermarks WHERE de_path=? AND en_path=?",
             (de_path, en_path),
@@ -1084,8 +1109,15 @@ def describe_cache_dir(
     3. ``tool.clm.cache_dir`` in ``<repo_root>/pyproject.toml``
     4. ``<repo_root>/.clm-cache/`` (default, gitignored)
 
-    ``repo_root`` defaults to the current working directory. This function has
-    **no side effects** — it does not create the directory.
+    ``repo_root`` defaults to the **discovered project root** —
+    :func:`clm.infrastructure.utils.path_utils.find_project_root` walks up from
+    the current working directory to the nearest ``pyproject.toml`` /
+    ``.clm/config.toml`` / ``.git`` (like ``git`` / ``uv`` / ``ruff``), so the
+    cache resolves to the same place no matter which subdirectory the command
+    was invoked from (issue #477). Without the walk-up, running from a topic
+    subdir treated the subdir as the root: it missed ``[tool.clm] cache_dir``
+    and created a stray ``<subdir>/.clm-cache``. This function has **no side
+    effects** — it does not create the directory.
 
     Git-worktree anchoring: a *relative* ``[tool.clm] cache_dir`` (e.g.
     ``../shared-cache``) is normally joined to ``repo_root``. But in a git
@@ -1100,6 +1132,8 @@ def describe_cache_dir(
     """
     import os
 
+    from clm.infrastructure.utils.path_utils import find_project_root
+
     if cli_override is not None:
         return CacheDirResolution(path=Path(cli_override), source="cli")
 
@@ -1107,7 +1141,11 @@ def describe_cache_dir(
     if env:
         return CacheDirResolution(path=Path(env), source="env")
 
-    root = repo_root or Path.cwd()
+    # Discover the project root by walking up (issue #477); an explicit
+    # ``repo_root`` opts out and anchors to that root verbatim (library callers /
+    # tests). The worktree re-anchoring of a relative value below then runs with
+    # the correct root (the worktree checkout root, not a subdir).
+    root = repo_root or find_project_root()
     pyproject = root / "pyproject.toml"
     if pyproject.is_file():
         configured = _read_pyproject_cache_dir(pyproject)
@@ -1184,6 +1222,79 @@ def _main_worktree_root(start: Path) -> Path | None:
     if common.name != ".git":
         return None
     return common.parent
+
+
+def _git_show_toplevel(start: Path) -> Path | None:
+    """The working-tree root of the (possibly linked) worktree containing ``start``.
+
+    ``git rev-parse --show-toplevel`` run with ``cwd=start``. Returns ``None`` when
+    git is unavailable or ``start`` is outside a repo. Used together with
+    :func:`_main_worktree_root` to remap a worktree path to its main-checkout twin.
+    """
+    import subprocess
+
+    try:
+        completed = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(start),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+    out = completed.stdout.strip()
+    if not out:
+        return None
+    return Path(out).resolve()
+
+
+@functools.cache
+def _worktree_remap_for_dir(directory: str) -> tuple[str, str] | None:
+    """``(worktree_toplevel, main_root)`` if ``directory`` is in a LINKED worktree.
+
+    ``None`` for the main worktree, outside a repo, or when git is unavailable.
+    Memoized: the answer is constant per worktree, so keying a whole batch of
+    pairs makes at most one git invocation per unique directory.
+    """
+    start = Path(directory)
+    main_root = _main_worktree_root(start)
+    if main_root is None:
+        return None
+    top = _git_show_toplevel(start)
+    if top is None:
+        return None
+    return (str(top), str(main_root))
+
+
+def to_main_worktree_path(p: Path) -> Path:
+    """Remap a path under a linked git worktree to its main-checkout equivalent.
+
+    The sync watermark is keyed by the absolute ``(de_path, en_path)`` strings,
+    but :meth:`Path.resolve` from a linked worktree yields the *worktree* path —
+    which never matches the rows recorded from the main checkout, so every pair
+    misses its watermark and silently cold-starts off git HEAD (issue #435).
+    Canonicalizing the **key** to the main-checkout path lets the worktree and the
+    main checkout share both the cache file (#374) and the keys inside it, and
+    keeps writes on the single canonical key (no orphaned worktree-path rows).
+
+    Returns ``p`` unchanged when it is not under a linked worktree, is outside a
+    repo, or git is unavailable — so the main checkout and non-git callers are
+    unaffected, and the function is idempotent (a main-checkout path remaps to
+    itself). Only the watermark **key** is canonicalized; file reads and the
+    content-keyed, worktree-portable sync ledger keep the real on-disk path.
+    """
+    resolved = p.resolve()
+    directory = resolved if resolved.is_dir() else resolved.parent
+    remap = _worktree_remap_for_dir(str(directory))
+    if remap is None:
+        return p
+    wt_top, main_root = Path(remap[0]), Path(remap[1])
+    try:
+        rel = resolved.relative_to(wt_top)
+    except ValueError:
+        return p
+    return main_root / rel
 
 
 def _ensure_dir(path: Path) -> Path:

--- a/src/clm/infrastructure/utils/path_utils.py
+++ b/src/clm/infrastructure/utils/path_utils.py
@@ -206,6 +206,49 @@ IGNORE_PATH_REGEX = re.compile(
 )
 
 
+#: Markers that identify a CLM/Python project root, in per-directory precedence
+#: order (the FIRST that matches at the nearest ancestor wins). ``pyproject.toml``
+#: is checked first because it is the file that actually carries ``[tool.clm]
+#: cache_dir`` — so a nested project's own ``pyproject.toml`` correctly wins over
+#: an outer one. A bare ``.clm/`` directory is **deliberately NOT a marker**: a
+#: *topic* directory has its own ``.clm/`` (voiceover scratch + the committed sync
+#: ledger — see :data:`SKIP_DIRS_FOR_COURSE`), so treating the bare dir as a root
+#: marker would stop the ascent at a topic and defeat the walk-up. A topic-local
+#: ``.clm/`` has no ``config.toml``, so the ``.clm/config.toml`` marker is safe.
+_PROJECT_ROOT_FILE_MARKERS = ("pyproject.toml", ".clm/config.toml", "clm.toml")
+
+
+def find_project_root(start: Path | None = None) -> Path:
+    """Walk up from ``start`` (default: cwd) to the nearest project root.
+
+    Mirrors how ``git`` / ``uv`` / ``ruff`` resolve a project: ascend the
+    directory tree until a root marker is found, so a CLM command behaves
+    identically no matter which subdirectory it is invoked from. Markers, in
+    per-directory precedence: ``pyproject.toml``, ``.clm/config.toml``,
+    ``clm.toml``, then a ``.git`` entry. Returns the **resolved** marked
+    directory, or — when no marker exists anywhere up to the filesystem root —
+    the resolved ``start`` (preserving today's cwd-as-root behavior for
+    directories that are genuinely outside any project).
+
+    ``.git`` is matched with :meth:`Path.exists` (not ``is_dir``) because a
+    linked git **worktree** records its ``.git`` as a *file*, not a directory;
+    using ``is_dir`` would skip worktrees. This finds the project root only —
+    distinct from :func:`clm.infrastructure.llm.cache._main_worktree_root`,
+    which answers the different question "what root is *shared* across linked
+    worktrees" (git-common-dir based) and re-anchors a relative ``cache_dir``.
+    """
+    base = (start or Path.cwd()).resolve()
+    for directory in (base, *base.parents):
+        for marker in _PROJECT_ROOT_FILE_MARKERS:
+            if (directory / marker).is_file():
+                return directory
+        # ``.git`` is a directory in a normal checkout, a FILE in a linked
+        # worktree — ``.exists()`` covers both.
+        if (directory / ".git").exists():
+            return directory
+    return base
+
+
 def is_image_file(input_path: Path) -> bool:
     is_image_data = IMG_DATA_FOLDERS.intersection(input_path.absolute().parts) != set()
     return input_path.suffix in IMG_FILE_EXTENSIONS and not is_image_data

--- a/tests/cli/test_cli_db_path_anchoring.py
+++ b/tests/cli/test_cli_db_path_anchoring.py
@@ -1,0 +1,69 @@
+"""The root CLI anchors the *default* build/jobs DB paths to the discovered
+project root (issue #477, full sweep), so a build/status from a subdirectory
+opens the same database as one from the repo root. An explicitly supplied path
+is respected verbatim.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.main import cli
+
+
+@pytest.fixture
+def probe():
+    """Attach a throwaway command that echoes the resolved DB paths, then remove
+    it so the real command tree is unaffected."""
+
+    @click.command(name="_probe_db_paths")
+    @click.pass_context
+    def _probe(ctx):
+        click.echo(f"CACHE={ctx.obj['CACHE_DB_PATH']}")
+        click.echo(f"JOBS={ctx.obj['JOBS_DB_PATH']}")
+
+    cli.add_command(_probe, name="_probe_db_paths")
+    try:
+        yield "_probe_db_paths"
+    finally:
+        cli.commands.pop("_probe_db_paths", None)
+
+
+def _make_project(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    sub = repo / "slides" / "topic_031"
+    sub.mkdir(parents=True)
+    (repo / "pyproject.toml").write_text("[tool.clm]\n", encoding="utf-8")
+    return sub
+
+
+def test_default_db_paths_anchor_to_root_from_subdir(tmp_path, monkeypatch, probe):
+    sub = _make_project(tmp_path)
+    root = (tmp_path / "repo").resolve()
+    monkeypatch.chdir(sub)
+    result = CliRunner().invoke(cli, [probe])
+    assert result.exit_code == 0, result.output
+    assert f"CACHE={root / 'clm_cache.db'}" in result.output
+    assert f"JOBS={root / 'clm_jobs.db'}" in result.output
+
+
+def test_explicit_relative_path_respected(tmp_path, monkeypatch, probe):
+    sub = _make_project(tmp_path)
+    monkeypatch.chdir(sub)
+    result = CliRunner().invoke(cli, ["--cache-db-path", "mine.db", probe])
+    assert result.exit_code == 0, result.output
+    # Explicit relative path is NOT re-anchored — stays as given (cwd-relative).
+    assert "CACHE=mine.db" in result.output
+
+
+def test_explicit_absolute_path_respected(tmp_path, monkeypatch, probe):
+    sub = _make_project(tmp_path)
+    monkeypatch.chdir(sub)
+    abs_db = (tmp_path / "elsewhere" / "c.db").resolve()
+    result = CliRunner().invoke(cli, ["--cache-db-path", str(abs_db), probe])
+    assert result.exit_code == 0, result.output
+    assert f"CACHE={abs_db}" in result.output

--- a/tests/cli/test_config_command.py
+++ b/tests/cli/test_config_command.py
@@ -197,6 +197,26 @@ class TestConfigLocate:
         assert "pyproject.toml [tool.clm] cache_dir" in section
         assert "my-llm-cache" in section
 
+    def test_locate_shows_discovered_project_root_from_subdir(self, tmp_path, monkeypatch):
+        # Issue #477: from a subdir, `config locate` reports the discovered root
+        # (walked up) and notes it differs from cwd. (The cache-path anchoring
+        # itself is covered deterministically in test_cache_dir_resolution.py.)
+        monkeypatch.setattr(
+            "clm.infrastructure.config.platformdirs.user_config_dir",
+            lambda *a, **kw: str(tmp_path / "user"),
+        )
+        (tmp_path / "user").mkdir()
+        repo = tmp_path / "repo"
+        sub = repo / "slides" / "topic_031"
+        sub.mkdir(parents=True)
+        (repo / "pyproject.toml").write_text("[tool.clm]\n", encoding="utf-8")
+        monkeypatch.chdir(sub)
+        result = CliRunner().invoke(cli, ["config", "locate"])
+        assert result.exit_code == 0, result.output
+        assert "Project root" in result.output
+        assert str(repo.resolve()) in result.output
+        assert "differs from the current directory" in result.output
+
 
 class TestConfigHelp:
     def test_group_help(self):

--- a/tests/infrastructure/llm/test_cache_dir_resolution.py
+++ b/tests/infrastructure/llm/test_cache_dir_resolution.py
@@ -82,6 +82,46 @@ class TestDescribeCacheDir:
         assert resolved.is_dir()  # wrapper ensures existence
 
 
+class TestSubdirWalkUp:
+    """Issue #477: from a subdir, describe_cache_dir must discover the project
+    root (walk up) rather than treating cwd as root.
+
+    A real git repo is used so the worktree-anchoring git lookup is deterministic
+    (a main worktree → no re-anchor), independent of any ambient repo the temp
+    dir might sit under.
+    """
+
+    def test_relative_cache_dir_found_from_subdir(self, tmp_path: Path, monkeypatch, git_available):
+        monkeypatch.delenv("CLM_CACHE_DIR", raising=False)
+        repo = tmp_path / "repo"
+        _init_repo(repo, cache_dir_value="../shared-cache")
+        sub = repo / "slides" / "module_410" / "topic_031"
+        sub.mkdir(parents=True)
+        monkeypatch.chdir(sub)
+        # repo_root=None → cwd-based; the walk-up finds repo/pyproject.toml.
+        res = describe_cache_dir()
+        assert res.source == "pyproject"
+        assert res.configured_value == "../shared-cache"
+        # Anchored to the discovered root (repo), NOT the subdir → repo's sibling.
+        assert res.path.resolve() == (tmp_path / "shared-cache").resolve()
+
+    def test_default_anchors_to_root_from_subdir(self, tmp_path: Path, monkeypatch, git_available):
+        # No [tool.clm] cache_dir → the default <root>/.clm-cache must anchor to
+        # the discovered root, never creating a stray <subdir>/.clm-cache (#477).
+        monkeypatch.delenv("CLM_CACHE_DIR", raising=False)
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _git("init", cwd=repo)
+        (repo / "pyproject.toml").write_text("[tool.other]\n", encoding="utf-8")
+        sub = repo / "slides" / "topic_031"
+        sub.mkdir(parents=True)
+        monkeypatch.chdir(sub)
+        res = describe_cache_dir()
+        assert res.source == "default"
+        assert res.path.resolve() == (repo / ".clm-cache").resolve()
+        assert res.path.resolve() != (sub / ".clm-cache").resolve()
+
+
 class TestWorktreeAnchoring:
     def test_relative_cache_dir_anchors_to_main_root_from_worktree(
         self, tmp_path: Path, monkeypatch, git_available

--- a/tests/infrastructure/llm/test_sync_cache.py
+++ b/tests/infrastructure/llm/test_sync_cache.py
@@ -421,36 +421,31 @@ class TestSyncWatermarkCache:
         from clm.infrastructure.llm.cache import WATERMARK_HASH_VERSION
 
         path = tmp_path / "clm-llm.sqlite"
+        # Absolute paths outside any git worktree, so the key is stored verbatim:
+        # the watermark canonicalizes a worktree path to its main-checkout twin
+        # (#435), and the raw-SQL UPDATE below must match the stored key. Real
+        # callers always pass ``.resolve()``d (absolute) deck paths.
+        de, en = str(tmp_path / "a.de.py"), str(tmp_path / "a.en.py")
         cache = SyncWatermarkCache(path)
         try:
-            cache.put_deck(
-                de_path="a.de.py",
-                en_path="a.en.py",
-                lang="de",
-                cells=[(0, "x", "slide", "h", None)],
-            )
-            assert cache.get_hash_version("a.de.py", "a.en.py") == WATERMARK_HASH_VERSION
-            assert cache.has_pair("a.de.py", "a.en.py") is True
-            assert cache.get_deck("a.de.py", "a.en.py", "de") == [(0, "x", "slide", "h", None)]
+            cache.put_deck(de_path=de, en_path=en, lang="de", cells=[(0, "x", "slide", "h", None)])
+            assert cache.get_hash_version(de, en) == WATERMARK_HASH_VERSION
+            assert cache.has_pair(de, en) is True
+            assert cache.get_deck(de, en, "de") == [(0, "x", "slide", "h", None)]
 
             # Simulate a stored snapshot from a different (stale) canonicalization.
             cache._conn.execute(
-                "UPDATE sync_watermark_meta SET hash_version=? WHERE de_path='a.de.py'",
-                (WATERMARK_HASH_VERSION - 1,),
+                "UPDATE sync_watermark_meta SET hash_version=? WHERE de_path=?",
+                (WATERMARK_HASH_VERSION - 1, de),
             )
             cache._conn.commit()
-            assert cache.has_pair("a.de.py", "a.en.py") is False
-            assert cache.get_deck("a.de.py", "a.en.py", "de") == []
+            assert cache.has_pair(de, en) is False
+            assert cache.get_deck(de, en, "de") == []
 
             # A fresh write re-stamps the current version → readable again.
-            cache.put_deck(
-                de_path="a.de.py",
-                en_path="a.en.py",
-                lang="de",
-                cells=[(0, "x", "slide", "h2", None)],
-            )
-            assert cache.has_pair("a.de.py", "a.en.py") is True
-            assert cache.get_deck("a.de.py", "a.en.py", "de") == [(0, "x", "slide", "h2", None)]
+            cache.put_deck(de_path=de, en_path=en, lang="de", cells=[(0, "x", "slide", "h2", None)])
+            assert cache.has_pair(de, en) is True
+            assert cache.get_deck(de, en, "de") == [(0, "x", "slide", "h2", None)]
         finally:
             cache.close()
 
@@ -480,14 +475,17 @@ class TestSyncWatermarkCache:
             snap.close()
             wm.close()
 
-    def test_iter_entries(self, watermarks):
-        watermarks.put_deck(
-            de_path="a.de.py", en_path="a.en.py", lang="de", cells=[(0, "x", "slide", "h", "c0")]
-        )
+    def test_iter_entries(self, watermarks, tmp_path):
+        # Absolute paths outside any git worktree → key stored verbatim, so the
+        # exact-key assertion holds even when the suite runs from a linked
+        # worktree (the watermark canonicalizes a worktree key to its main twin,
+        # #435). Real callers pass ``.resolve()``d (absolute) deck paths.
+        de, en = str(tmp_path / "a.de.py"), str(tmp_path / "a.en.py")
+        watermarks.put_deck(de_path=de, en_path=en, lang="de", cells=[(0, "x", "slide", "h", "c0")])
         rows = watermarks.iter_entries()
         assert len(rows) == 1
         # (de_path, en_path, lang, position, slide_id, role, content_hash, construct, synced_at)
-        assert rows[0][:8] == ("a.de.py", "a.en.py", "de", 0, "x", "slide", "h", "c0")
+        assert rows[0][:8] == (de, en, "de", 0, "x", "slide", "h", "c0")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/infrastructure/llm/test_sync_watermark_worktree.py
+++ b/tests/infrastructure/llm/test_sync_watermark_worktree.py
@@ -1,0 +1,142 @@
+"""Tests for sync-watermark key canonicalization across git worktrees (issue #435).
+
+The watermark is keyed by the absolute ``(de_path, en_path)`` strings. From a
+linked git worktree ``Path.resolve()`` yields the worktree path, which used to
+miss the rows recorded from the main checkout (→ silent cold-start to git HEAD).
+``SyncWatermarkCache`` now canonicalizes the key to the main-checkout path via
+:func:`to_main_worktree_path`, so a worktree and the main checkout share both
+the cache file and the keys inside it.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.llm import cache as cache_mod
+from clm.infrastructure.llm.cache import (
+    SyncWatermarkCache,
+    to_main_worktree_path,
+)
+
+
+@pytest.fixture
+def git_available():
+    if shutil.which("git") is None:  # pragma: no cover - CI always has git
+        pytest.skip("git not available")
+
+
+@pytest.fixture(autouse=True)
+def _clear_remap_cache():
+    """The worktree remap is memoized per process; clear it so each test's
+    freshly-created repo/worktree is resolved afresh."""
+    cache_mod._worktree_remap_for_dir.cache_clear()
+    yield
+    cache_mod._worktree_remap_for_dir.cache_clear()
+
+
+def _git(*args: str, cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=str(cwd), check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git("init", cwd=path)
+    _git("config", "user.email", "t@example.com", cwd=path)
+    _git("config", "user.name", "Test", cwd=path)
+    (path / "slides").mkdir()
+    (path / "slides" / "x.de.py").write_text("# de\n", encoding="utf-8")
+    (path / "slides" / "x.en.py").write_text("# en\n", encoding="utf-8")
+    _git("add", "-A", cwd=path)
+    _git("commit", "-m", "init", cwd=path)
+
+
+_CELLS = [(0, "s1", "code", "h0", None), (1, None, "markdown", "h1", None)]
+
+
+class TestToMainWorktreePath:
+    def test_main_checkout_path_unchanged(self, tmp_path: Path, git_available):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        p = repo / "slides" / "x.de.py"
+        assert to_main_worktree_path(p) == p
+
+    def test_worktree_path_remaps_to_main(self, tmp_path: Path, git_available):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        wt = tmp_path / "wts" / "feature"
+        _git("worktree", "add", str(wt), "-b", "feature", cwd=repo)
+        wt_file = wt / "slides" / "x.de.py"
+        main_file = repo / "slides" / "x.de.py"
+        assert to_main_worktree_path(wt_file).resolve() == main_file.resolve()
+
+    def test_outside_repo_unchanged(self, tmp_path: Path):
+        p = tmp_path / "loose" / "x.de.py"
+        p.parent.mkdir(parents=True)
+        p.write_text("# de\n", encoding="utf-8")
+        assert to_main_worktree_path(p) == p
+
+
+class TestWatermarkAcrossWorktree:
+    def _record(self, db_path: Path, de: Path, en: Path) -> None:
+        cache = SyncWatermarkCache(db_path)
+        try:
+            cache.put_deck(de_path=str(de), en_path=str(en), lang="de", cells=_CELLS)
+            cache.put_deck(de_path=str(de), en_path=str(en), lang="en", cells=_CELLS)
+            cache.set_synced_commit(str(de), str(en), "deadbeef")
+        finally:
+            cache.close()
+
+    def test_record_in_main_read_in_worktree(self, tmp_path: Path, git_available):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        wt = tmp_path / "wts" / "feature"
+        _git("worktree", "add", str(wt), "-b", "feature", cwd=repo)
+        db = tmp_path / "shared.sqlite"  # the shared cache file (#374 anchoring)
+
+        main_de = (repo / "slides" / "x.de.py").resolve()
+        main_en = (repo / "slides" / "x.en.py").resolve()
+        self._record(db, main_de, main_en)
+
+        # Read using the WORKTREE-resolved paths — the pre-#435 bug missed here.
+        wt_de = (wt / "slides" / "x.de.py").resolve()
+        wt_en = (wt / "slides" / "x.en.py").resolve()
+        cache = SyncWatermarkCache(db)
+        try:
+            assert cache.has_pair(str(wt_de), str(wt_en)) is True
+            assert cache.get_deck(str(wt_de), str(wt_en), "de") == _CELLS
+            assert cache.get_synced_commit(str(wt_de), str(wt_en)) == "deadbeef"
+        finally:
+            cache.close()
+
+    def test_write_in_worktree_keys_on_main(self, tmp_path: Path, git_available):
+        repo = tmp_path / "repo"
+        _init_repo(repo)
+        wt = tmp_path / "wts" / "feature"
+        _git("worktree", "add", str(wt), "-b", "feature", cwd=repo)
+        db = tmp_path / "shared.sqlite"
+
+        # Write from the WORKTREE; the row must land on the canonical (main) key,
+        # so exactly ONE pair exists and the main checkout finds it.
+        wt_de = (wt / "slides" / "x.de.py").resolve()
+        wt_en = (wt / "slides" / "x.en.py").resolve()
+        self._record(db, wt_de, wt_en)
+
+        cache = SyncWatermarkCache(db)
+        try:
+            main_de = (repo / "slides" / "x.de.py").resolve()
+            main_en = (repo / "slides" / "x.en.py").resolve()
+            assert cache.has_pair(str(main_de), str(main_en)) is True
+            # Exactly one stored pair, keyed by the MAIN path (no worktree dup).
+            keyed = {(de, en) for (de, en, *_rest) in cache.iter_entries()}
+            assert len(keyed) == 1
+            (stored_de, stored_en) = next(iter(keyed))
+            assert "worktrees" not in stored_de
+            assert Path(stored_de).resolve() == main_de
+        finally:
+            cache.close()

--- a/tests/infrastructure/utils/test_find_project_root.py
+++ b/tests/infrastructure/utils/test_find_project_root.py
@@ -1,0 +1,115 @@
+"""Tests for :func:`clm.infrastructure.utils.path_utils.find_project_root` (issue #477).
+
+The walk-up makes config / cache / DB discovery behave identically from any
+subdirectory of a project, the way ``git`` / ``uv`` / ``ruff`` do.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.infrastructure.utils.path_utils import find_project_root
+
+
+def _has_marker_ancestor(path: Path) -> bool:
+    """Whether any ancestor of ``path`` already carries a project-root marker.
+
+    Used to skip the "no marker → fall back to start" assertion when the test's
+    temp dir happens to live under a marked tree (so the test stays deterministic
+    regardless of where the OS puts temp files).
+    """
+    for directory in (path, *path.parents):
+        if (directory / "pyproject.toml").is_file():
+            return True
+        if (directory / ".clm" / "config.toml").is_file():
+            return True
+        if (directory / "clm.toml").is_file():
+            return True
+        if (directory / ".git").exists():
+            return True
+    return False
+
+
+def test_returns_root_with_pyproject(tmp_path: Path):
+    (tmp_path / "pyproject.toml").write_text("[tool.clm]\n", encoding="utf-8")
+    assert find_project_root(tmp_path) == tmp_path.resolve()
+
+
+def test_walks_up_from_nested_subdir(tmp_path: Path):
+    (tmp_path / "pyproject.toml").write_text("[tool.clm]\n", encoding="utf-8")
+    sub = tmp_path / "slides" / "module_410" / "topic_031"
+    sub.mkdir(parents=True)
+    assert find_project_root(sub) == tmp_path.resolve()
+
+
+def test_clm_config_toml_marker(tmp_path: Path):
+    (tmp_path / ".clm").mkdir()
+    (tmp_path / ".clm" / "config.toml").write_text("", encoding="utf-8")
+    sub = tmp_path / "a" / "b"
+    sub.mkdir(parents=True)
+    assert find_project_root(sub) == tmp_path.resolve()
+
+
+def test_clm_toml_marker(tmp_path: Path):
+    (tmp_path / "clm.toml").write_text("", encoding="utf-8")
+    sub = tmp_path / "x"
+    sub.mkdir()
+    assert find_project_root(sub) == tmp_path.resolve()
+
+
+def test_git_dir_marker(tmp_path: Path):
+    (tmp_path / ".git").mkdir()
+    sub = tmp_path / "deep" / "nest"
+    sub.mkdir(parents=True)
+    assert find_project_root(sub) == tmp_path.resolve()
+
+
+def test_git_file_marker_recognizes_worktree(tmp_path: Path):
+    # A linked git worktree records its ``.git`` as a FILE (a gitdir pointer),
+    # not a directory; ``.exists()`` (not ``is_dir``) must still recognize it.
+    (tmp_path / ".git").write_text("gitdir: /somewhere/.git/worktrees/wt\n", encoding="utf-8")
+    sub = tmp_path / "slides" / "topic"
+    sub.mkdir(parents=True)
+    assert find_project_root(sub) == tmp_path.resolve()
+
+
+def test_nearest_pyproject_wins(tmp_path: Path):
+    # An inner project nested under an outer one: the nearest pyproject (the one
+    # that would carry [tool.clm]) must win.
+    (tmp_path / "pyproject.toml").write_text("", encoding="utf-8")
+    inner = tmp_path / "inner"
+    inner.mkdir()
+    (inner / "pyproject.toml").write_text("[tool.clm]\n", encoding="utf-8")
+    sub = inner / "sub"
+    sub.mkdir()
+    assert find_project_root(sub) == inner.resolve()
+
+
+def test_bare_clm_dir_is_not_a_marker(tmp_path: Path):
+    # A *topic* directory has its own ``.clm/`` (voiceover scratch + sync ledger).
+    # A bare ``.clm`` dir (no config.toml) must NOT stop the walk there, or the
+    # ascent halts at the topic and #477 is not fixed. The real root is found via
+    # its pyproject.toml above.
+    (tmp_path / "pyproject.toml").write_text("[tool.clm]\n", encoding="utf-8")
+    topic = tmp_path / "slides" / "topic_031"
+    topic.mkdir(parents=True)
+    (topic / ".clm").mkdir()  # bare, no config.toml — voiceover/ledger scratch
+    assert find_project_root(topic) == tmp_path.resolve()
+
+
+def test_no_marker_falls_back_to_start(tmp_path: Path):
+    lonely = tmp_path / "no" / "markers" / "here"
+    lonely.mkdir(parents=True)
+    if _has_marker_ancestor(tmp_path):  # pragma: no cover - environment-dependent
+        import pytest
+
+        pytest.skip("temp dir lives under a marked project; fallback not isolatable")
+    assert find_project_root(lonely) == lonely.resolve()
+
+
+def test_default_start_is_cwd(tmp_path: Path, monkeypatch):
+    (tmp_path / "pyproject.toml").write_text("[tool.clm]\n", encoding="utf-8")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    monkeypatch.chdir(sub)
+    assert find_project_root() == tmp_path.resolve()


### PR DESCRIPTION
## Summary

Two related path-discovery bugs in the `slides sync` / LLM cache layer, fixed together because they share a root-discovery foundation. (#448 ledger and #366 git-as-baseline already shipped in 1.16; these are the remaining path bugs.)

### #477 — cwd treated as project root (no walk-up)
Running any `clm` command from a **subdirectory** (e.g. a topic dir) treated the cwd as the project root, so it:
- ignored `[tool.clm] cache_dir`,
- created a stray `<subdir>/.clm-cache/` (easy to commit by accident),
- made a watermark / `baseline bless` written from a subdir invisible from the repo root (reads hit a different sqlite).

**Fix:** a single `find_project_root()` in `path_utils.py` that walks up for `pyproject.toml` / `.clm/config.toml` / `.git` (like git/uv/ruff), routed through every cwd-as-root site: `describe_cache_dir`, `find_config_files` / `get_config_file_locations`, the jobs-DB discovery, and the root `--cache-db-path` / `--jobs-db-path` **defaults** (an explicit path is still honored verbatim — full-sweep per maintainer decision). `config locate` now reports the discovered root. A bare `.clm/` dir is deliberately **not** a marker — topic dirs have their own `.clm/` (voiceover scratch + the sync ledger).

### #435 — watermark missed from a git worktree
The watermark was keyed by the `.resolve()`d absolute paths, so from a linked worktree every pair missed its row and silently cold-started off git HEAD (the un-covered other half of #374, which only anchored the cache *dir*).

**Fix:** canonicalize the key **inside** `SyncWatermarkCache` (`_key` → `to_main_worktree_path`), so reads/writes from any worktree agree on the main-checkout key and writes never orphan worktree-path rows. Cache-layer enforcement covers every surface (CLI, batch, MCP, studio) without per-caller changes; **only the key** is canonicalized — file reads and the content-keyed sync ledger keep the real on-disk path. The git lookup is memoized.

## Behavior change
Discovery now matches git/uv/ruff semantics: a command inside a marked project resolves the project's cache/config/DBs regardless of cwd. Directories genuinely outside any project still fall back to cwd. Documented in the changelog fragment + `clm info commands` / `migration`.

## Tests
- `test_find_project_root.py` — walk-up, nearest-wins, `.git`-as-file (worktree), bare-`.clm` non-marker, fallback.
- `test_cache_dir_resolution.py::TestSubdirWalkUp` — the exact #477 repro (subdir → root-anchored cache; no stray `.clm-cache`).
- `test_sync_watermark_worktree.py` — real `git worktree` round-trip: record-in-main/read-in-worktree, write-in-worktree keys-on-main (one canonical row), `to_main_worktree_path` units.
- `test_cli_db_path_anchoring.py` — default DB paths anchor to root from a subdir; explicit paths respected.
- `config locate` from a subdir reports the discovered root.
- Full fast suite green (pre-push).

Closes #477. Closes #435.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
