### PR TITLE
fix(sync): carry both DE/EN cells on keyed conflict report items (#451)

### DIFF
--- a/changelog.d/451-conflict-excerpts.fixed.md
+++ b/changelog.d/451-conflict-excerpts.fixed.md
@@ -1,0 +1,10 @@
+- **`clm slides sync report` now carries both current cells on a keyed `conflict`.**
+  A baseline-relative conflict (both halves changed since the baseline) previously
+  reported empty `source_excerpt` / `target_excerpt`, forcing an agent to re-open
+  and re-parse every `.de.py` / `.en.py` to tell a *false* conflict (a consistent
+  bilingual edit) from a genuine one. The conflict's current DE cell (`source_*`)
+  and EN cell (`target_*`) are now populated — resolved by the conflict's
+  `slide_id` (robust to the position-scheme used for id-less cells), with a
+  remove-vs-edit conflict carrying only the surviving side. Flows through `clm
+  slides sync report --json`, the `slides_sync_report` MCP tool, and `task` /
+  `accept` framing. (#451)

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -2212,8 +2212,13 @@ Each `assisted` / `ambiguity` item is enriched with the **cell bytes** the work
 concerns, so a model can act without re-deriving the engine's positions:
 `source_lang` + `source_excerpt` + `source_line` (the side to reconcile *from*)
 and the matching `target_*` triple (the existing counterpart, for an
-edit/conflict; absent for an `add`, whose translation does not exist yet).
-Resolution is **fail-closed** — a position it cannot resolve with certainty
+edit/conflict; absent for an `add`, whose translation does not exist yet). A
+**keyed `conflict`** (both halves changed since baseline) carries *both* current
+cells — DE in `source_*`, EN in `target_*` — resolved by its `slide_id` (since
+CLM {version}, issue #451), so an agent can judge directly whether EN is already
+a faithful translation of DE (most early-baseline conflicts are false — a
+consistent bilingual edit). A remove-vs-edit conflict carries only the surviving
+side. Resolution is **fail-closed** — a cell it cannot resolve with certainty
 yields no excerpt rather than a wrong one. Excerpts are omitted for `mechanical`
 items (you apply those without reading them); the `*_position` indices and
 `slide_id` still locate every cell in the source you hold. A directory run wraps

--- a/src/clm/slides/sync_report.py
+++ b/src/clm/slides/sync_report.py
@@ -210,6 +210,11 @@ class _SourceIndex:
       :func:`sync_plan._localized_lang_cells` assigns. Used by the id-less localized
       membership proposals, whose positions are non-j2 ``lang`` indices.
 
+    It also resolves a cell by its **``(slide_id, role)`` key** (:meth:`resolve_by_key`),
+    the natural address for a *keyed* item: a keyed conflict carries a ``slide_id``
+    but no position, and its ``role`` (e.g. ``"code"``) does not reliably pick the
+    right *positional* scheme, so the id is the sound key.
+
     Built from the working-tree files (each read + parsed once) — sound **only**
     while they still hold the cells the plan's positions index, i.e. a ``--dry-run``
     before any apply. An out-of-range position resolves to ``(None, None)`` rather
@@ -219,6 +224,11 @@ class _SourceIndex:
     def __init__(self, de_path: Path, en_path: Path) -> None:
         self._sync: dict[str, list[Cell]] = {}
         self._localized: dict[str, list[Cell]] = {}
+        # ``(slide_id, role) -> Cell`` per language for keyed lookups (#451). The
+        # engine reconciles per ``(slide_id, role)``, which is unique per half, so
+        # the last write on a (pathological) duplicate is harmless — a real dup-id
+        # is surfaced as an error elsewhere, never as a clean keyed conflict.
+        self._by_key: dict[str, dict[tuple[str, str], Cell]] = {}
         for lang, path in (("de", de_path), ("en", en_path)):
             cells = parse_cells(path.read_text(encoding="utf-8"), comment_token_for_path(path))
             self._sync[lang] = [
@@ -227,6 +237,12 @@ class _SourceIndex:
             self._localized[lang] = [
                 c for c in cells if not c.metadata.is_j2 and c.metadata.lang == lang
             ]
+            keyed: dict[tuple[str, str], Cell] = {}
+            for c in cells:
+                role = role_of(c.metadata)
+                if role is not None and c.metadata.slide_id is not None and c.metadata.lang == lang:
+                    keyed[(c.metadata.slide_id, role)] = c
+            self._by_key[lang] = keyed
 
     def resolve(
         self, lang: str | None, scheme: str, position: int | None
@@ -238,6 +254,17 @@ class _SourceIndex:
         if position >= len(cells):
             return None, None
         cell = cells[position]
+        return cell.content, cell.line_number
+
+    def resolve_by_key(self, lang: str, slide_id: str, role: str) -> tuple[str | None, int | None]:
+        """The ``(body, 1-based line)`` of the ``(slide_id, role)`` cell in ``lang``.
+
+        ``(None, None)`` when the half has no such cell — e.g. the side that
+        *removed* the cell in a remove-vs-edit conflict.
+        """
+        cell = self._by_key.get(lang, {}).get((slide_id, role))
+        if cell is None:
+            return None, None
         return cell.content, cell.line_number
 
 
@@ -276,8 +303,48 @@ def _item_languages(item: ReconciliationItem) -> tuple[str | None, str | None]:
     return None, None
 
 
+def _keyed_item_languages(item: ReconciliationItem) -> tuple[str | None, str | None]:
+    """``(source, target)`` languages for a *keyed* item (one carrying a ``slide_id``).
+
+    A direction names them outright; a directionless **conflict** is DE→EN (DE the
+    source, EN the target — matching the id-less conflict convention and the de-wins
+    default). Anything else has no source/target to resolve.
+    """
+    if item.direction in ("de->en", "en->de"):
+        source, target = item.direction.split("->")
+        return source, target
+    if item.kind == "conflict":
+        return "de", "en"
+    return None, None
+
+
 def _enrich(item: ReconciliationItem, index: _SourceIndex) -> None:
     """Resolve an item's positions to concrete cell bytes (mutates ``item`` in place)."""
+    # A *keyed* item (carries a ``slide_id``) is resolved by its ``(slide_id, role)``
+    # key, not by position. This is both the natural address for a cell identified by
+    # its id and robust against the positional-scheme ambiguity: a localized id'd cell
+    # has role ``"code"`` / ``"markdown"``, which the positional path mis-reads as the
+    # id-less *localized* scheme while the cell's position is a *sync* index — so an
+    # interleaved id-less cell would make a position-based resolve pick the wrong cell.
+    # By-key is identical to the positional result for sync-scheme roles and correct
+    # for localized roles, so it strictly improves keyed resolution. It also fills a
+    # keyed **conflict**, which carries no position at all (issue #451): the both-edited
+    # cell's current DE (source) and EN (target) bytes. A remove-vs-edit conflict
+    # leaves the removed half ``None``. The id-less localized items (``slide_id`` is
+    # ``None``) keep the positional path below.
+    if item.slide_id and item.role:
+        source_lang, target_lang = _keyed_item_languages(item)
+        if source_lang is not None:
+            item.source_lang = source_lang
+            item.source_excerpt, item.source_line = index.resolve_by_key(
+                source_lang, item.slide_id, item.role
+            )
+        if target_lang is not None:
+            item.target_lang = target_lang
+            item.target_excerpt, item.target_line = index.resolve_by_key(
+                target_lang, item.slide_id, item.role
+            )
+        return
     source_lang, target_lang = _item_languages(item)
     scheme = _scheme_for(item.role)
     if source_lang is not None:

--- a/tests/slides/test_sync_report.py
+++ b/tests/slides/test_sync_report.py
@@ -274,6 +274,11 @@ def _idless_code(lang: str, body: str) -> str:
     return f'# %% lang="{lang}" tags=["keep"]\n{body}\n'
 
 
+def _idd_code(lang: str, sid: str, body: str) -> str:
+    # A localized id'd code cell → role_of returns CODE_ROLE ("code").
+    return f'# %% lang="{lang}" tags=["keep"] slide_id="{sid}"\n{body}\n'
+
+
 def _pair(tmp_path: Path, de: str, en: str) -> tuple[Path, Path]:
     de_path = tmp_path / "deck_x.de.py"
     en_path = tmp_path / "deck_x.en.py"
@@ -316,6 +321,40 @@ class TestCellExcerpts:
         assert "zweite Folie" in item.source_excerpt
         assert "second slide" in item.target_excerpt
         assert isinstance(item.source_line, int) and isinstance(item.target_line, int)
+
+    def test_keyed_code_edit_resolves_by_key_not_position(self, tmp_path):
+        # A keyed CODE edit has role "code" (the localized-code role), which the
+        # positional path would resolve under the *localized* (non-j2) scheme while
+        # the cell's position is a *sync* index. An interleaved id-less code cell
+        # makes those indices diverge — by-key resolution stays correct. Same root
+        # cause as the keyed-conflict fix (#451), kept consistent across kinds.
+        de = "\n".join(
+            [_idless_code("de", 'print("vorlauf")'), _idd_code("de", "cc", "def de_f(): ...")]
+        )
+        en = "\n".join(
+            [_idless_code("en", 'print("prelude")'), _idd_code("en", "cc", "def en_f(): ...")]
+        )
+        de_path, en_path = _pair(tmp_path, de, en)
+        plan = _real_plan(
+            de_path,
+            en_path,
+            # `_edit` would set source_position=1 (sync index of the keyed cell); the
+            # positional path under the localized scheme would (wrongly) pick index 1
+            # there = the keyed cell on EN side too, but for the SOURCE it would pick
+            # localized[1]. Either way an interleave can misalign — by-key cannot.
+            Proposal(
+                kind="edit",
+                role="code",
+                direction="de->en",
+                slide_id="cc",
+                source_position=1,
+                target_position=1,
+            ),
+        )
+        item = build_report(plan, with_excerpts=True).assisted[0]
+        assert "def de_f()" in item.source_excerpt
+        assert "def en_f()" in item.target_excerpt
+        assert "vorlauf" not in (item.source_excerpt or "")
 
     def test_idless_localized_edit_uses_nonj2_scheme(self, tmp_path):
         de = "\n".join([_idless_code("de", 'print("eins")'), _idless_code("de", 'print("zwei")')])
@@ -403,17 +442,77 @@ class TestCellExcerpts:
         assert item.source_lang == "de"
         assert item.source_excerpt is None and item.target_excerpt is None
 
-    def test_keyed_conflict_without_positions_stays_unresolved(self, tmp_path):
+    def test_keyed_conflict_resolves_both_sides_by_key(self, tmp_path):
+        # Issue #451: a keyed conflict (both halves changed since baseline) now
+        # carries both current cells, resolved by (slide_id, role), so an agent can
+        # judge whether EN is already a faithful translation of DE.
+        de = "\n".join([_slide("de", "s1", "erste Folie"), _slide("de", "s2", "zweite Folie")])
+        en = "\n".join([_slide("en", "s1", "first slide"), _slide("en", "s2", "second slide")])
+        de_path, en_path = _pair(tmp_path, de, en)
+        plan = _real_plan(
+            de_path,
+            en_path,
+            Proposal(kind="conflict", role="slide", direction=None, slide_id="s2"),
+        )
+        item = build_report(plan, with_excerpts=True).ambiguity[0]
+        assert (item.source_lang, item.target_lang) == ("de", "en")
+        assert "zweite Folie" in item.source_excerpt
+        assert "second slide" in item.target_excerpt
+        assert isinstance(item.source_line, int) and isinstance(item.target_line, int)
+
+    def test_keyed_conflict_code_role_resolves_by_key_not_position(self, tmp_path):
+        # A keyed CODE conflict has role "code", which the positional scheme would
+        # (wrongly) treat as the *localized* (non-j2) scheme — yet the cell's
+        # position is a *sync* index. An interleaved id-less code cell makes those
+        # two indices diverge, so a position-based resolve would pick the wrong
+        # cell. Resolving by (slide_id, role) is immune. Issue #451.
+        de = "\n".join(
+            [_idless_code("de", 'print("vorlauf")'), _idd_code("de", "cc", "def de_f(): ...")]
+        )
+        en = "\n".join(
+            [_idless_code("en", 'print("prelude")'), _idd_code("en", "cc", "def en_f(): ...")]
+        )
+        de_path, en_path = _pair(tmp_path, de, en)
+        plan = _real_plan(
+            de_path,
+            en_path,
+            Proposal(kind="conflict", role="code", direction=None, slide_id="cc"),
+        )
+        item = build_report(plan, with_excerpts=True).ambiguity[0]
+        assert "def de_f()" in item.source_excerpt
+        assert "def en_f()" in item.target_excerpt
+        # The interleaved id-less code must NOT be what we resolved.
+        assert "vorlauf" not in (item.source_excerpt or "")
+        assert "prelude" not in (item.target_excerpt or "")
+
+    def test_keyed_conflict_removed_side_has_no_excerpt(self, tmp_path):
+        # remove-vs-edit: DE removed the cell, EN still has it. Only the surviving
+        # (EN) side carries an excerpt; the removed side stays None.
+        de = "\n".join([_slide("de", "s1", "nur DE")])  # s2 removed on DE
+        en = "\n".join([_slide("en", "s1", "only EN"), _slide("en", "s2", "second slide")])
+        de_path, en_path = _pair(tmp_path, de, en)
+        plan = _real_plan(
+            de_path,
+            en_path,
+            Proposal(kind="conflict", role="slide", direction=None, slide_id="s2"),
+        )
+        item = build_report(plan, with_excerpts=True).ambiguity[0]
+        assert item.source_excerpt is None  # DE removed it
+        assert item.target_lang == "en" and "second slide" in item.target_excerpt
+
+    def test_keyed_conflict_missing_cell_stays_unresolved(self, tmp_path):
+        # A keyed conflict whose slide_id is in neither half (pathological) yields
+        # no excerpt rather than a wrong one.
         de = "\n".join([_slide("de", "s1", "erste Folie")])
         en = "\n".join([_slide("en", "s1", "first slide")])
         de_path, en_path = _pair(tmp_path, de, en)
         plan = _real_plan(
             de_path,
             en_path,
-            Proposal(kind="conflict", role="slide", direction=None, slide_id="s1"),
+            Proposal(kind="conflict", role="slide", direction=None, slide_id="ghost"),
         )
         item = build_report(plan, with_excerpts=True).ambiguity[0]
-        assert item.source_lang is None and item.source_excerpt is None
+        assert item.source_excerpt is None and item.target_excerpt is None
 
     def test_mechanical_items_are_not_enriched(self, tmp_path):
         de = "\n".join([_slide("de", "s1", "erste Folie"), _slide("de", "s2", "zweite Folie")])


### PR DESCRIPTION
## Summary

`clm slides sync report` left `source_excerpt` / `target_excerpt` **empty** on a keyed `conflict` (both halves changed since the baseline), while an `edit`/`add` carried them. But a conflict is exactly where an agent most needs the content: most early-baseline conflicts are **false** (a consistent bilingual edit) and only a few are genuine (EN stale/divergent) — with empty excerpts the agent had to re-open and re-parse every `.de.py`/`.en.py` to tell them apart.

## Fix

`_enrich` now resolves a **keyed** item (one carrying a `slide_id`) by its `(slide_id, role)` key instead of by position:

- A keyed **conflict** gets the current DE cell in `source_*` and EN cell in `target_*` (DE-source/EN-target, matching the id-less conflict convention). A remove-vs-edit conflict carries only the surviving side.
- This also fixes a **latent scheme bug** shared by keyed **edits**: a localized id'd code/markdown cell has role `"code"`/`"markdown"`, which the positional path mis-reads as the id-less *localized* scheme while the cell's position is a *sync* index — so an interleaved id-less cell could resolve the **wrong** cell. By-key is identical to the positional result for sync-scheme roles and correct for localized roles, so it strictly improves keyed resolution and keeps `edit` and `conflict` enrichment **consistent** (the alignment this change was asked to preserve).

Id-less localized items (`slide_id is None`) keep the positional path unchanged.

## Reach
Flows for free through `clm slides sync report --json`, the `slides_sync_report` MCP tool, and `task` / `accept` framing (all call `build_report(with_excerpts=True)`).

## Tests
- `test_keyed_conflict_resolves_both_sides_by_key`, `test_keyed_conflict_code_role_resolves_by_key_not_position` (interleaving guard — the high-value case), `test_keyed_conflict_removed_side_has_no_excerpt`, `test_keyed_conflict_missing_cell_stays_unresolved`.
- `test_keyed_code_edit_resolves_by_key_not_position` (locks in the consistency fix for edits).
- Existing id-less conflict / edit / add tests stay green (positional path unchanged); full `tests/slides/` + sync CLI suites pass (2110).

Closes #451.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
