### PR TITLE
fix(sync): auto-heal a stale watermark + steer the stale message to live verbs (#364)

### DIFF
--- a/changelog.d/364-stale-watermark-autoheal.fixed.md
+++ b/changelog.d/364-stale-watermark-autoheal.fixed.md
@@ -1,0 +1,16 @@
+- **`clm slides sync apply` / `autopilot` auto-heal a stale watermark.** When both
+  halves of a split deck were edited and committed without an intervening sync, the
+  watermark falls behind and a watermark-baselined run errored on a *false*
+  stale-baseline conflict (the "id-less localized cells edited on both decks" error,
+  or a keyed conflict) even though the halves are already mutually consistent. A
+  **writing** run now detects that case and re-baselines the watermark automatically
+  before reconciling, so the sync just proceeds (#364). On by default and safe by
+  construction — it heals only when git `HEAD` shows the halves consistent (a
+  verified no-op), so it can never mask an un-synced edit, and never fires outside a
+  git repo. Pass `--no-auto-heal` to surface the conflict instead; the `apply
+  --json` payload carries `auto_healed: true` when it fires.
+- **Stale-watermark messaging now points at the live verbs.** The stale-watermark
+  hint and the id-less-localized error steered to the retired `clm slides sync
+  --rebaseline` flag; they now point at `clm slides sync apply` (which auto-heals)
+  and `clm slides sync baseline bless` (#364). The id-less error already names the
+  offending cell's owning slide group and echoes the drifted cells.

--- a/src/clm/cli/commands/slides/sync.py
+++ b/src/clm/cli/commands/slides/sync.py
@@ -768,21 +768,64 @@ def _is_stale_but_consistent(
     """
     if plan.baseline_source != "watermark" or plan.is_noop:
         return False
-    return _githead_plan(de_path, en_path, provider_available=provider_available).is_noop
+    githead = _githead_plan(de_path, en_path, provider_available=provider_available)
+    # Require a REAL git baseline: outside a git repo (or for an un-committed deck)
+    # the git-head plan has no baseline to diff against (``baseline_source == "none"``)
+    # and is vacuously a no-op — that must NOT read as "halves consistent at HEAD".
+    return githead.baseline_source == "git-head" and githead.is_noop
+
+
+def _auto_heal_stale_watermark(
+    de_path: Path,
+    en_path: Path,
+    plan: SyncPlan,
+    *,
+    watermark_cache: SyncWatermarkCache | None,
+    provider_available: bool,
+) -> bool:
+    """Re-baseline a *stale-but-consistent* watermark in place; return whether it healed.
+
+    The recoverable case behind #364: both halves were edited and committed without
+    an intervening sync, so the watermark fell behind and a watermark-baselined run
+    now errors/conflicts against a *false* baseline — even though git HEAD shows the
+    halves already mutually consistent. Re-record the watermark from that consistent
+    HEAD state so the caller can re-plan to a clean result, instead of surfacing a
+    cryptic stale-baseline conflict.
+
+    Safe by construction (the same gate as ``baseline bless`` / the old
+    ``--rebaseline``): heals **only** when the git-HEAD plan is a no-op, so nothing
+    that still needs syncing is ever masked. A no-op for a non-watermark run (already
+    git-HEAD baselined, or ``--baseline`` pinned) — the caller gates on those.
+    """
+    if watermark_cache is None or plan.baseline_source != "watermark" or plan.is_noop:
+        return False
+    githead = _githead_plan(de_path, en_path, provider_available=provider_available)
+    # Heal ONLY against a real git baseline (``baseline_source == "git-head"``).
+    # Outside a git repo / for an un-committed deck the git-head plan has no baseline
+    # and is vacuously a no-op — healing then would wipe a legitimate watermark-diffed
+    # edit (it has no committed state to prove the halves are actually consistent).
+    if githead.baseline_source != "git-head" or not githead.is_noop:
+        return False  # no real baseline, or genuine pending changes — never mask them
+    if watermark_cache.has_pair(str(de_path), str(en_path)):
+        watermark_cache.clear_pair(str(de_path), str(en_path))
+    # A no-op plan has no proposals, so no judge/translator is needed; apply still
+    # writes the fresh whole-deck watermark at the current (consistent) state.
+    apply_plan(githead, judge=None, watermark_cache=watermark_cache)
+    return True
 
 
 def _rebaseline_hint_text(de_path: Path, recorded_commit: str | None = None) -> str:
     # When we know the commit the watermark was recorded at, name it as a precise
-    # --baseline target (diff against the last synced point) alongside --rebaseline.
+    # --baseline target (diff against the last synced point).
     baseline_ref = recorded_commit[:12] if recorded_commit else "<last-synced-commit>"
     return (
         "note: this deck's halves are consistent against git HEAD, but its recorded "
         "watermark is stale (the usual cause: both halves edited + committed without an "
-        "intervening sync). Reset it with "
-        f"`clm slides sync --rebaseline {de_path.name}` (refuses if HEAD shows real "
-        "changes), diff against the last sync with "
-        f"`clm slides sync --baseline {baseline_ref} {de_path.name}`, "
-        "or `clm slides watermark clear`."
+        f"intervening sync). `clm slides sync apply {de_path.name}` auto-re-baselines it "
+        "(it heals a stale-but-consistent watermark by default; pass --no-auto-heal to "
+        f"opt out), or reset it now with `clm slides sync baseline bless {de_path.name}`. "
+        f"Diff against the last sync with `clm slides sync --baseline {baseline_ref} "
+        f"{de_path.name}`."
     )
 
 
@@ -1644,6 +1687,17 @@ def sync_verify_cmd(de_path: Path, en_path: Path | None, as_json: bool) -> None:
         "directory (each pair uses its own ledger)."
     ),
 )
+@click.option(
+    "--auto-heal/--no-auto-heal",
+    "auto_heal",
+    default=True,
+    help=(
+        "Auto-re-baseline a stale-but-consistent watermark instead of erroring (#364): "
+        "when the watermark is stale but git HEAD shows the halves consistent, reset it "
+        "and apply cleanly. Safe (only when HEAD is a verified no-op); on by default. "
+        "Ignored with --baseline / --baseline-from / --no-watermark."
+    ),
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit the apply result as JSON.")
 def sync_apply_cmd(
     de_path: Path,
@@ -1654,6 +1708,7 @@ def sync_apply_cmd(
     baseline_from_spec: str | None,
     cache_dir: Path | None,
     ledger: bool,
+    auto_heal: bool,
     as_json: bool,
 ) -> None:
     """Apply the deterministic tier-1 reconciliation — writes, but never calls a model.
@@ -1715,6 +1770,7 @@ def sync_apply_cmd(
     if use_watermark:
         cache_root = resolve_cache_dir(cli_override=cache_dir)
         watermark_cache = SyncWatermarkCache(cache_root / CACHE_DB_NAME)
+    healed = False
     try:
         plan, result = _apply_deterministic(
             de_path,
@@ -1724,10 +1780,36 @@ def sync_apply_cmd(
             baseline_from=baseline_from,
             ledger=ledger,
         )
+        # Auto-heal a stale-but-consistent watermark (#364): re-baseline and re-plan
+        # to a clean result instead of erroring on a false stale-baseline conflict.
+        # Only when the watermark is the baseline (no --baseline / --baseline-from).
+        if auto_heal and baseline_ref is None and baseline_from is None:
+            healed = _auto_heal_stale_watermark(
+                de_path,
+                en_path,
+                plan,
+                watermark_cache=watermark_cache,
+                provider_available=False,
+            )
+            if healed:
+                plan, result = _apply_deterministic(
+                    de_path,
+                    en_path,
+                    watermark_cache=watermark_cache,
+                    baseline_ref=None,
+                    baseline_from=None,
+                    ledger=ledger,
+                )
     finally:
         if watermark_cache is not None:
             watermark_cache.close()
 
+    if healed and not as_json:
+        click.echo(
+            f"note: re-baselined a stale watermark for {de_path.name} automatically "
+            "(its halves are consistent against git HEAD). Pass --no-auto-heal to opt out.",
+            err=True,
+        )
     if ledger and plan.ledger_skipped:
         click.echo(
             f"ledger: skipped {plan.ledger_skipped} slide(s) trusted in-sync "
@@ -1736,7 +1818,14 @@ def sync_apply_cmd(
         )
     ledger_recorded = _maybe_record_ledger(ledger, plan, result, de_path, en_path)
     exit_code = _apply_exit_code(plan, result)
-    _emit_apply(plan, result, de_path, as_json=as_json, ledger_recorded=ledger_recorded)
+    _emit_apply(
+        plan,
+        result,
+        de_path,
+        as_json=as_json,
+        ledger_recorded=ledger_recorded,
+        auto_healed=healed,
+    )
     sys.exit(exit_code)
 
 
@@ -1862,6 +1951,7 @@ def _emit_apply(
     *,
     as_json: bool,
     ledger_recorded: int | None = None,
+    auto_healed: bool = False,
 ) -> None:
     """Print what a single-pair model-free apply wrote and what residue remains."""
     residue = _apply_residue(plan)
@@ -1871,6 +1961,7 @@ def _emit_apply(
             "en_path": str(plan.en_path),
             "mode": "apply",
             "exit_code": _apply_exit_code(plan, result),
+            "auto_healed": auto_healed,
             "apply": _apply_dict(result),
             "residue": [
                 {

--- a/src/clm/cli/commands/slides/sync_autopilot.py
+++ b/src/clm/cli/commands/slides/sync_autopilot.py
@@ -30,6 +30,7 @@ import click
 from clm.cli.commands.slides.sync import (
     CACHE_DB_NAME,
     _apply_exit_code,
+    _auto_heal_stale_watermark,
     _cold_baseline_hint_text,
     _is_stale_but_consistent,
     _issue_line,
@@ -392,6 +393,18 @@ def _resolve_verifier(verify_enabled: bool) -> CorrespondenceVerifier | None:
     ),
 )
 @click.option(
+    "--auto-heal/--no-auto-heal",
+    "auto_heal",
+    default=True,
+    help=(
+        "Auto-re-baseline a stale-but-consistent watermark on a WRITING run instead of "
+        "erroring (#364): the same safe heal as --rebaseline (only when git HEAD shows "
+        "the halves consistent), applied automatically before reconciling. On by "
+        "default; ignored for --dry-run / --explain / --no-cache / --baseline / "
+        "--baseline-from / --rebaseline."
+    ),
+)
+@click.option(
     "--baseline",
     "baseline_ref",
     default=None,
@@ -477,6 +490,7 @@ def slides_sync_cmd(
     cache_dir: Path | None,
     no_cache: bool,
     rebaseline: bool,
+    auto_heal: bool,
     baseline_ref: str | None,
     baseline_from_spec: str | None,
     no_env_file: bool,
@@ -742,6 +756,42 @@ def slides_sync_cmd(
         # still open, so the stale-watermark hint can name the exact --baseline ref.
         if watermark_cache is not None:
             recorded_commit = watermark_cache.get_synced_commit(str(de_path), str(en_path))
+
+        # Auto-heal a stale-but-consistent watermark on a WRITING run (#364): re-baseline
+        # and re-plan so the reconcile proceeds cleanly instead of erroring on a false
+        # stale-baseline conflict. Read-only modes (dry-run/explain) keep the hint
+        # below; --rebaseline / --baseline / --no-cache opt out, as does --no-auto-heal.
+        if (
+            auto_heal
+            and not dry_run
+            and not explain
+            and not no_cache
+            and not rebaseline
+            and baseline_ref is None
+            and baseline_from is None
+            and _auto_heal_stale_watermark(
+                de_path,
+                en_path,
+                plan,
+                watermark_cache=watermark_cache,
+                provider_available=provider_available,
+            )
+        ):
+            click.echo(
+                f"note: re-baselined a stale watermark for {de_path.name} automatically "
+                "(halves consistent against git HEAD). Pass --no-auto-heal to opt out.",
+                err=True,
+            )
+            plan = build_sync_plan(
+                de_path,
+                en_path,
+                watermark_cache=watermark_cache,
+                provider_available=provider_available,
+                baseline_ref=None,
+                baseline_from=None,
+                detect_rename=True,
+                ledger=_load_ledger_if(ledger, de_path),
+            )
 
         if explain:
             mode = "explain"

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -2038,7 +2038,8 @@ models for those tiers.)
 | `--baseline REF` / `--baseline-from PATH[@REF]` | As for `report`: `--baseline REF` works over a directory (each pair diffed against REF); `--baseline-from` is single-pair. |
 | `--cache-dir PATH` | Directory holding the watermark. |
 | `--ledger` | Use the per-slide consistency ledger (#448): **read** it to skip slides byte-stable since a recorded confirmation (no re-litigation) before applying, **and** — on a fully-clean pass (no deferred residue, the watermark fully advanced) — **record** the now-in-sync localized slides back to it (`confirmed_by=apply`, gated on structural `verify`). A pass with residue records nothing. The `--json` payload gains a `ledger: {skipped, recorded}` block. **Works over a directory** (each pair uses its own topic ledger; the batch reports aggregate `skipped`/`recorded`). |
-| `--yes`, `-y` | **Directory (batch) only**: confirm a writing sweep over every pair under the tree. Ignored for a single pair. |
+| `--auto-heal` / `--no-auto-heal` | (since CLM {version}, #364) Auto-re-baseline a **stale-but-consistent** watermark instead of erroring on a false stale-baseline conflict: when the watermark is stale but git `HEAD` shows the halves consistent (both edited + committed without an intervening sync), clear + re-record it and apply cleanly. **On by default**; safe by construction (heals only when git `HEAD` is a verified no-op, so it can never mask an un-synced edit, and never outside a git repo). The `--json` payload carries `auto_healed: true` when it fires. Ignored with `--baseline` / `--baseline-from` / `--no-watermark`. |
+| `--yes`, `-y` | **Directory (batch) only**: confirm a writing sweep over every pair under the tree. Ignored for a single pair. (Single-pair only: auto-heal runs per-pair.) |
 | `--json` | Emit the apply result as JSON. |
 
 #### `clm slides sync task`
@@ -2152,7 +2153,8 @@ default; `--dry-run` previews.
 | `--glossary-de PATH` / `--glossary-en PATH` | Per-target-language translation conventions; default auto-discover `clm-glossary.<lang>.md` above the deck. |
 | `--verify-cold-pairs` / `--no-verify-cold-pairs` | Bootstrap/reconcile cold-pair `slide_id`s gated by a cheap correspondence check (default on with a key); `--no-verify-cold-pairs` refuses instead. |
 | `--llm-recover` / `--recovery-model TEXT` | Opt into the bounded Opus recovery tier for an ambiguous drifted `slide_id` (body-free, validated). |
-| `--rebaseline` | Recover from a stale watermark (clears + re-records, only when the halves agree vs git `HEAD`). Prefer `baseline bless`. |
+| `--rebaseline` | Recover from a stale watermark (clears + re-records, only when the halves agree vs git `HEAD`); single-pair, exits after. Prefer `baseline bless`, or just let `--auto-heal` (below) handle it. |
+| `--auto-heal` / `--no-auto-heal` | (since CLM {version}, #364) On a **writing** run, auto-re-baseline a stale-but-consistent watermark before reconciling (the same safe heal as `--rebaseline`, applied automatically). On by default; ignored for `--dry-run` / `--explain` / `--no-cache` / `--baseline` / `--baseline-from` / `--rebaseline`. |
 | `--ledger` | (since CLM {version}) Use the per-slide consistency ledger (#448): **read** it to skip slides byte-stable since a recorded confirmation (no re-litigation), **and** — on a fully clean pass (nothing deferred, the watermark fully advanced) — **record** the now-in-sync slides back to it (`confirmed_by=autopilot`, gated on structural `verify`). Mirrors `apply --ledger` for the model-bearing path; works over a directory. The `--json` payload gains a `ledger: {skipped, recorded}` block (single pair and batch). |
 | `--baseline REF` / `--baseline-from PATH[@REF]` / `--cache-dir PATH` / `--no-cache` / `--no-env-file` / `--yes` | Baseline selection, watermark store, `.env` loading, and batch confirm, as before. |
 
@@ -2170,9 +2172,15 @@ watermark so the signal is never silently baselined.
 
 A read that is non-trivial against the **watermark** but clean against git
 `HEAD` (the stale-watermark case) sets `rebaseline_hint` in the `report --json`
-output and prints a hint pointing at `clm slides sync baseline bless` — which
-re-records the baseline from the current state (gated on `verify`), the
-commit-free replacement for the old `--rebaseline`.
+output and prints a hint pointing at `clm slides sync apply` (which **auto-heals**
+a stale-but-consistent watermark, since CLM {version}, #364) or `baseline bless`
+— either re-records the baseline from the current state, the commit-free
+replacement for the old `--rebaseline`. A **writing** `apply` / `autopilot` run
+heals it automatically by default (`--no-auto-heal` opts out); the heal is safe by
+construction (it fires only when git `HEAD` shows the halves consistent, so it can
+never mask an un-synced edit). This is the recoverable case behind the "id-less
+localized cells edited on both decks" error: the error now steers to `apply`
+(auto-heal) / `baseline bless`, naming the offending cell's owning slide group.
 
 **Renaming a deck (folder or stem) is safe (since CLM {version}, epic
 #440).** Deck identity is path-derived (the watermark key and the git

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -182,6 +182,14 @@ normal loop. A few cases:
   by hand): `clm slides sync baseline bless DECK` — no throwaway commit needed
   (it replaces the old `--rebaseline`). It is gated on `verify`, so a structurally
   corrupt pair is refused rather than blessed.
+- **Stale watermark? Just `apply`.** If both halves were edited + committed without
+  an intervening sync, the watermark falls behind and a watermarked run would error
+  on a *false* stale-baseline conflict ("id-less localized cells edited on both
+  decks", or a keyed conflict). A writing `clm slides sync apply DECK` (or
+  `autopilot`) now **auto-re-baselines** that stale-but-consistent watermark by
+  default (#364) — safe by construction (only when git `HEAD` shows the halves
+  consistent), so the reconcile just proceeds. Pass `--no-auto-heal` to surface the
+  conflict instead.
 - **Inspect / maintain**: `clm slides sync baseline show`; drop orphans with
   `clm slides sync baseline prune`; `clm slides sync baseline clear DECK` re-derives
   off git `HEAD` next time.

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -1084,9 +1084,10 @@ def _classify_idless_localized_drift(
                     reason="id-less localized cells (lang= cells with no slide_id) were "
                     f"edited on both decks{_drift_cells_clause(de_snips, en_snips)}; sync "
                     "cannot determine a single direction. If the halves are already "
-                    "consistent the watermark is likely stale — reset it with "
-                    "`clm slides sync --rebaseline`; otherwise resolve the divergence "
-                    "manually (or give the cells slide_ids so they pair per-cell)",
+                    "consistent the watermark is likely stale — `clm slides sync apply` "
+                    "auto-re-baselines it (or `clm slides sync baseline bless`); otherwise "
+                    "resolve the divergence manually (or give the cells slide_ids so they "
+                    "pair per-cell)",
                 )
             )
         return

--- a/tests/cli/test_slides_sync_rebaseline.py
+++ b/tests/cli/test_slides_sync_rebaseline.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
-from clm.cli.commands.slides.sync import CACHE_DB_NAME, slides_sync_cmd
+from clm.cli.commands.slides.sync import CACHE_DB_NAME, slides_sync_cmd, sync_apply_cmd
 from clm.infrastructure.llm.cache import SyncWatermarkCache
 from clm.notebooks.slide_parser import parse_cells
 from clm.slides.sync_plan import ordered_sync_cells
@@ -114,7 +114,10 @@ class TestStaleHint:
         # A two-sided conflict against the stale watermark — not clean.
         assert res.exit_code != 0
         assert "watermark is stale" in res.stderr
-        assert "--rebaseline" in res.stderr
+        # The hint steers to the live verbs (the old `--rebaseline` flag was replaced
+        # by `baseline bless`, and `apply` now auto-heals).
+        assert "baseline bless" in res.stderr
+        assert "sync apply" in res.stderr
 
     def test_hint_in_json(self, cli_runner, tmp_path):
         de_path, _en, cache = _stale_consistent(tmp_path)
@@ -201,3 +204,74 @@ class TestRebaseline:
         )
         assert res.exit_code != 0
         assert "single deck pair" in (res.stderr + res.output)
+
+
+class TestAutoHeal:
+    """#364: a writing run auto-re-baselines a stale-but-consistent watermark by
+    default, instead of surfacing a false stale-baseline conflict."""
+
+    def test_apply_auto_heals(self, cli_runner, tmp_path):
+        de_path, _en, cache = _stale_consistent(tmp_path)
+        res = cli_runner.invoke(sync_apply_cmd, ["--cache-dir", str(cache), str(de_path)])
+        assert res.exit_code == 0, res.output + res.stderr
+        assert "re-baselined a stale watermark" in res.stderr
+        # The watermark now matches current → a follow-up apply is clean, no heal.
+        follow = cli_runner.invoke(sync_apply_cmd, ["--cache-dir", str(cache), str(de_path)])
+        assert follow.exit_code == 0
+        assert "re-baselined a stale watermark" not in follow.stderr
+
+    def test_apply_json_reports_auto_healed(self, cli_runner, tmp_path):
+        de_path, _en, cache = _stale_consistent(tmp_path)
+        res = cli_runner.invoke(sync_apply_cmd, ["--json", "--cache-dir", str(cache), str(de_path)])
+        payload = json.loads(res.output[res.output.find("{") :])
+        assert payload["auto_healed"] is True
+        assert payload["exit_code"] == 0
+
+    def test_apply_no_auto_heal_surfaces_conflict(self, cli_runner, tmp_path):
+        de_path, _en, cache = _stale_consistent(tmp_path)
+        res = cli_runner.invoke(
+            sync_apply_cmd, ["--no-auto-heal", "--cache-dir", str(cache), str(de_path)]
+        )
+        # The stale-baseline conflict is surfaced, not silently healed.
+        assert res.exit_code != 0
+        assert "re-baselined a stale watermark" not in res.stderr
+
+    def test_apply_does_not_heal_real_divergence(self, cli_runner, tmp_path):
+        # git HEAD shows a genuine pending change (one half edited but uncommitted),
+        # so auto-heal must NOT fire — healing would mask the un-synced edit.
+        de_path, en_path = _commit_pair(tmp_path, _deck("de", "old"), _deck("en", "old"))
+        cache = tmp_path / "cache"
+        _seed_watermark(
+            cache, de_path, en_path, de_text=_deck("de", "older"), en_text=_deck("en", "older")
+        )
+        de_path.write_text(_deck("de", "edited-uncommitted"), encoding="utf-8")
+        res = cli_runner.invoke(sync_apply_cmd, ["--cache-dir", str(cache), str(de_path)])
+        assert "re-baselined a stale watermark" not in res.stderr
+
+    def test_apply_no_heal_outside_git(self, cli_runner, tmp_path):
+        # No git repo → the git-head plan has no baseline (vacuously a no-op); auto-heal
+        # must NOT fire and wipe a legitimate watermark-diffed state.
+        de_path = tmp_path / "slides_intro.de.py"
+        en_path = tmp_path / "slides_intro.en.py"
+        de_path.write_text(_deck("de", "neu"), encoding="utf-8")
+        en_path.write_text(_deck("en", "new"), encoding="utf-8")
+        cache = tmp_path / "cache"
+        _seed_watermark(
+            cache, de_path, en_path, de_text=_deck("de", "alt"), en_text=_deck("en", "old")
+        )
+        res = cli_runner.invoke(sync_apply_cmd, ["--cache-dir", str(cache), str(de_path)])
+        assert "re-baselined a stale watermark" not in res.stderr
+
+    def test_autopilot_auto_heals_on_write(self, cli_runner, tmp_path):
+        de_path, _en, cache = _stale_consistent(tmp_path)
+        res = cli_runner.invoke(slides_sync_cmd, ["--cache-dir", str(cache), str(de_path)])
+        assert "re-baselined a stale watermark" in res.stderr
+
+    def test_autopilot_dry_run_does_not_heal(self, cli_runner, tmp_path):
+        # Read-only mode keeps the hint; it never writes/heals.
+        de_path, _en, cache = _stale_consistent(tmp_path)
+        res = cli_runner.invoke(
+            slides_sync_cmd, ["--dry-run", "--cache-dir", str(cache), str(de_path)]
+        )
+        assert "re-baselined a stale watermark" not in res.stderr
+        assert "watermark is stale" in res.stderr

--- a/tests/slides/test_sync_idless_localized_drift_repro.py
+++ b/tests/slides/test_sync_idless_localized_drift_repro.py
@@ -249,12 +249,15 @@ class TestIdlessDriftErrorIsLocalized:
 
     def test_error_steers_to_rebaseline_not_just_assign_ids(self, tmp_path: Path):
         # #364 item 3: the old message only said "assign slide_ids" (which does not help
-        # the stale-watermark case). The new message leads with the actual common fix.
+        # the stale-watermark case). The new message leads with the actual common fix,
+        # steering to the live verbs (`sync apply` auto-heals; `baseline bless`), not the
+        # retired `--rebaseline` flag.
         plan, _result, _de_after, _en_after = _sync(
             tmp_path, "watermark", DE0_U, EN0_U, DE1_U, EN1_U
         )
         reason = "\n".join(e.reason for e in _error_issues(plan))
-        assert "--rebaseline" in reason
+        assert "baseline bless" in reason
+        assert "sync apply" in reason
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

A stale watermark (both halves edited + committed without an intervening sync) made a watermark-baselined run error on a **false** stale-baseline conflict — the "id-less localized cells edited on both decks" error, or a keyed conflict — even though the halves are already mutually consistent. clm 1.16 already localized that error (names the owning slide group + echoes the drifted cells) and surfaced a stale hint; this PR adds the missing **recovery** the issue asked for.

## What changed

- **Default-on auto-heal** for the writing verbs: `clm slides sync apply` and `autopilot` detect the stale-but-consistent case and **re-baseline the watermark before reconciling**, so the sync proceeds cleanly instead of erroring. `--no-auto-heal` opts out; `apply --json` carries `auto_healed: true` when it fires.
- **Safe by construction.** `_auto_heal_stale_watermark` re-records only when the git-HEAD plan is a verified no-op **and** used a real git baseline (`baseline_source == "git-head"`). So it never masks an un-synced edit, and never fires outside a git repo / for an un-committed deck (where a "no-op" is vacuous). The same git-baseline guard is added to `_is_stale_but_consistent` (the report hint) so the read-hint and the writing-heal stay consistent and neither false-positives outside a repo.
- **Messaging steers to the live verbs.** The stale hint and the id-less-localized error pointed at the **retired** `clm slides sync --rebaseline` flag (replaced by `baseline bless` in #430, and not a flag on the read/apply verbs at all). They now point at `clm slides sync apply` (auto-heals) / `baseline bless`.

This is the decision recorded on the issue + #366: take **(D) auto-heal** + git-as-baseline. The bulk of #364 (error localization, staleness detection, git-HEAD default baseline) already shipped in 1.16; this closes the loop.

## Tests
`TestAutoHeal` (real git fixture): apply auto-heals → exit 0 + `auto_healed`; `--no-auto-heal` surfaces the conflict; does **not** heal a real divergence (uncommitted edit at HEAD); does **not** heal outside a git repo (the regression guard — a vacuous no-op must not wipe a legitimate watermark-diffed edit); autopilot heals on write but not on `--dry-run`. Existing rebaseline/hint/id-less-error tests updated for the new verb wording. Full `tests/slides/` + sync CLI suites green.

## Deferred (noted)
Batch (directory) auto-heal and an `--explain` watermark-vs-git-HEAD side-by-side — follow-ups; single-pair is the dominant reconcile workflow.

Closes #364.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
