### PR TITLE
refactor(sync): document + enforce the keyed-vs-id-less scheme invariant in the report (#451 follow-up)

### DIFF
--- a/src/clm/slides/sync_report.py
+++ b/src/clm/slides/sync_report.py
@@ -78,9 +78,19 @@ _ASSISTED_KINDS = frozenset({"add", "edit", "rename", "mint", "adopt", "reconcil
 
 #: Proposal roles whose ``source_position`` / ``target_position`` index a language's
 #: **non-j2 cells** (the engine's "localized" scheme) rather than its sync-relevant
-#: cells (the default "sync" scheme). These four roles appear *only* on the id-less
-#: localized membership proposals (edit / conflict / retag), so the role alone is a
-#: sound discriminator between the two schemes.
+#: cells (the default "sync" scheme), used by :func:`_scheme_for` for the *positional*
+#: enrichment path.
+#:
+#: IMPORTANT — the role alone is NOT a keyed-vs-id-less discriminator: ``role_of``
+#: returns ``"code"`` / ``"markdown"`` for *keyed* (id'd) localized cells too, and a
+#: keyed cell's position is a *sync* index, not a localized one. So this set is only
+#: sound *because* :func:`_enrich` routes every **keyed** item (one carrying a
+#: ``slide_id``) through :meth:`_SourceIndex.resolve_by_key` and returns **before**
+#: the positional path runs (issue #451). By the time ``_scheme_for`` is consulted the
+#: item is therefore guaranteed id-less, and a localized role correctly names the
+#: non-j2 scheme. Keep that ordering: consulting ``_scheme_for`` on a keyed item would
+#: resolve a sync-index position against the localized cell list (a wrong/empty
+#: excerpt when id-less cells are interleaved).
 _LOCALIZED_POSITION_ROLES = frozenset(
     {LOCALIZED_CODE_ROLE, LOCALIZED_MARKDOWN_ROLE, "code", "markdown"}
 )
@@ -289,12 +299,19 @@ def _item_languages(item: ReconciliationItem) -> tuple[str | None, str | None]:
     index in ``source_position`` and the EN index in ``target_position`` — so it
     resolves as DE→EN. Every other directionless item (a keyed conflict / mint /
     issue) has no positional source/target and stays unresolved.
+
+    This is the **positional** path; :func:`_enrich` only reaches it for id-less items
+    (keyed items resolve by ``(slide_id, role)`` first). The explicit
+    ``item.slide_id is None`` guard on the conflict branch enforces that invariant
+    locally: a keyed conflict must never be read positionally, because its ``role``
+    (e.g. ``"code"``) would mis-select the localized scheme for a sync-index position.
     """
     if item.direction in ("de->en", "en->de"):
         source, target = item.direction.split("->")
         return source, target
     if (
         item.kind == "conflict"
+        and item.slide_id is None
         and _scheme_for(item.role) == "localized"
         and item.source_position is not None
         and item.target_position is not None

--- a/tests/slides/test_sync_report.py
+++ b/tests/slides/test_sync_report.py
@@ -485,6 +485,61 @@ class TestCellExcerpts:
         assert "vorlauf" not in (item.source_excerpt or "")
         assert "prelude" not in (item.target_excerpt or "")
 
+    def test_keyed_conflict_with_positions_still_resolves_by_key(self, tmp_path):
+        # Invariant guard: even if a (future / erroneous) producer set positions on a
+        # keyed conflict, the keyed branch must win — never the position+scheme path,
+        # which would mis-select the localized scheme for role "code". The bad
+        # positions below point at the interleaved id-less cell under the localized
+        # scheme; by-key must ignore them and resolve the id'd cell.
+        de = "\n".join(
+            [_idless_code("de", 'print("vorlauf")'), _idd_code("de", "cc", "def de_f(): ...")]
+        )
+        en = "\n".join(
+            [_idless_code("en", 'print("prelude")'), _idd_code("en", "cc", "def en_f(): ...")]
+        )
+        de_path, en_path = _pair(tmp_path, de, en)
+        plan = _real_plan(
+            de_path,
+            en_path,
+            Proposal(
+                kind="conflict",
+                role="code",
+                direction=None,
+                slide_id="cc",
+                source_position=0,  # localized index 0 = the id-less "vorlauf" cell
+                target_position=0,  # localized index 0 = the id-less "prelude" cell
+            ),
+        )
+        item = build_report(plan, with_excerpts=True).ambiguity[0]
+        assert "def de_f()" in item.source_excerpt  # resolved by (slide_id, role), not pos
+        assert "vorlauf" not in (item.source_excerpt or "")
+
+    def test_item_languages_skips_keyed_conflict(self):
+        # The positional path is id-less-only: a keyed conflict (slide_id set), even
+        # with positions, must not be claimed by `_item_languages` (it is handled by
+        # the by-key branch in `_enrich`). Guards the `_scheme_for("code")` footgun.
+        from clm.slides.sync_report import ReconciliationItem, _item_languages
+
+        keyed = ReconciliationItem(
+            tier="ambiguity",
+            kind="conflict",
+            role="code",
+            slide_id="cc",
+            source_position=0,
+            target_position=0,
+        )
+        assert _item_languages(keyed) == (None, None)
+        # The id-less twin (slide_id None) is still resolved positionally.
+        idless = ReconciliationItem(
+            tier="ambiguity",
+            kind="conflict",
+            role="code",
+            slide_id=None,
+            source_position=0,
+            target_position=0,
+        )
+        assert _item_languages(idless) == ("de", "en")
+
     def test_keyed_conflict_removed_side_has_no_excerpt(self, tmp_path):
         # remove-vs-edit: DE removed the cell, EN still has it. Only the surviving
         # (EN) side carries an excerpt; the removed side stays None.


### PR DESCRIPTION
## Background

While fixing #451 I found that `_scheme_for("code")` returns the **localized** scheme, but `role_of` returns `"code"`/`"markdown"` for *keyed* (id'd) localized cells too — whose `position` is a **sync** index. So the `_LOCALIZED_POSITION_ROLES` comment claiming *"the role alone is a sound discriminator between the two schemes"* is false.

## Consequences (already neutralized)

`_scheme_for` is used **only** by `sync_report.py`'s excerpt enrichment — never by the engine that classifies/writes/syncs. So the worst it could ever do is produce a wrong/empty `source_excerpt`/`target_excerpt` in the agent-facing report (`report --json` / `task` / `accept`), on a `--dry-run`. It never affected an actual sync.

And **#451 already eliminated it**: `_enrich` now routes every keyed item (slide_id present) through `resolve_by_key` and `return`s **before** the positional `_scheme_for` path. Since a sync-index `"code"`/`"markdown"` position only exists on a cell that *has* a slide_id, such items always take the keyed branch — so `_scheme_for` is now reached only by **id-less** items, for which `"localized"` is correct.

## What this PR does (hygiene, no behavior change)

The residue was a **misleading comment + a latent footgun** (reorder `_enrich` and the bug returns silently). This PR makes the invariant explicit and enforced:

- Corrects the `_LOCALIZED_POSITION_ROLES` comment to state the real invariant: the role is *not* the discriminator — the `slide_id` gate in `_enrich` is, and the positional path is reached only for id-less items.
- Adds an explicit `item.slide_id is None` guard to `_item_languages`'s conflict branch, so the positional path is **provably** id-less-only. `_item_languages` is called only from `_enrich`'s positional path (after the keyed branch returns), so this is a no-op in the real flow — purely a regression guard.
- Tests: a keyed conflict carrying (bad) positions still resolves by key; a unit test of `_item_languages` skipping a keyed conflict while still resolving the id-less twin.

No user-facing change → no changelog fragment / info-topic update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
