### PR TITLE
perf(build): offload job submission off the event loop so the progress bar tracks workers

### DIFF
--- a/changelog.d/build-progress-eventloop-offload.fixed.md
+++ b/changelog.d/build-progress-eventloop-offload.fixed.md
@@ -1,0 +1,18 @@
+- **Build progress bar no longer freezes for minutes behind job submission.**
+  When many topics needed rebuilding, the `clm build` progress bar could sit
+  frozen at a few dozen completed jobs for one to two minutes — while
+  `clm monitor` showed hundreds of jobs finishing — and then jump far ahead. The
+  bar advances only from the completion poll loop, and that loop shares one
+  asyncio event loop with job *submission*, whose synchronous body (the SQLite
+  job-cache probe, the worker-availability wait, the payload JSON serialization,
+  and the jobs-DB INSERT) ran inline with no `await` and starved the poll loop
+  during a submission burst. The previous attempt only moved the result-cache
+  *write* off the poll loop, which was never what blocked the bar. The submission
+  body now runs on a dedicated single-thread executor, a per-operation semaphore
+  bounds how much work (notably the on-loop cache-hit replay) lands in one
+  event-loop turn, the end-of-stage result-cache drain no longer blocks the loop,
+  and the jobs-DB runtime connection now uses `synchronous=NORMAL` (it had been
+  reverting to the fsync-on-every-commit default). On a 1,440-job synthetic
+  rebuild this cut the worst progress-loop stall from ~19 s to ~1 s and reduced
+  total build time. A new opt-in `CLM_PROFILE_BUILD=1` build diagnostic and the
+  `scripts/profile_build_stall.py` harness make the poll-loop health measurable.

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -176,6 +176,16 @@ export DRAWIO_EXECUTABLE="/Applications/draw.io.app/Contents/MacOS/draw.io"
 set DRAWIO_EXECUTABLE="C:\Program Files\draw.io\draw.io.exe"
 ```
 
+### Diagnostics
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `CLM_PROFILE_BUILD` | Set to `1` to make `clm build` emit `[build-profile]` lines (to stderr) measuring the completion poll loop's health: per-cycle gaps, the worst stall and how many completions it hid, and the on-loop vs offloaded submission cost. Use when the progress bar appears to stall behind the workers. Zero overhead when unset. | (unset) |
+
+The `scripts/profile_build_stall.py` harness drives a throwaway synthetic course
+with this enabled (against isolated temp databases) to reproduce and measure the
+build's submission / poll-loop behavior.
+
 ### Slide Authoring
 
 | Variable | Description | Default |

--- a/scripts/profile_build_stall.py
+++ b/scripts/profile_build_stall.py
@@ -1,0 +1,200 @@
+"""Reproduce and measure the ``clm build`` progress-bar / event-loop behavior.
+
+Generates a throwaway SYNTHETIC course (many trivial topics) in a temp dir and
+runs ``clm build`` against it with ``CLM_PROFILE_BUILD=1`` so the build emits the
+``[build-profile]`` summary from :mod:`clm.infrastructure.build_profiling`
+(poll-loop inter-iteration gaps, on-loop submission cost, payload-build cost).
+
+It is a guard against performance regressions in the build's submission /
+completion-poll machinery — in particular the "progress bar freezes for a long
+time at ~30 jobs while ``clm monitor`` shows hundreds finishing, then jumps"
+stall caused by synchronous job submission starving the completion poll loop.
+
+Safety:
+* uses ISOLATED temp cache/jobs DBs and a temp output dir, so it never touches a
+  real course's databases or output;
+* ``--no-html`` produces notebook/code worker jobs via jupytext WITHOUT running
+  any Jupyter kernel, so the run is fast but still exercises the real submission
+  + poll loop with real worker subprocesses.
+
+Usage (from the repo root, in the project venv)::
+
+    python scripts/profile_build_stall.py --topics 60 --siblings 3 --sibling-kb 30
+
+Read the ``worst stall`` and ``max gap`` lines: a healthy build keeps the gap
+near the poll interval (~0.5 s). A multi-second ``worst stall`` is the freeze.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SLIDE_TEMPLATE = """\
+# j2 from 'macros.j2' import header
+# {{{{ header("Synthetisches Thema {k}", "Synthetic Topic {k}") }}}}
+
+# %% [markdown]
+# ## Synthetic Topic {k}
+#
+# Generated content so the payload builder has something to read, base64-encode
+# (siblings) and hash.
+{filler}
+
+# %%
+def compute_{k}(n):
+    total = 0
+    for i in range(n):
+        total += i * {k}
+    return total
+
+
+print(compute_{k}(10))
+
+# %%
+print("synthetic slide {k} done")
+"""
+
+
+def make_course(root: Path, topics: int, siblings: int, sibling_kb: int) -> Path:
+    """Create a synthetic course under ``root`` and return the spec path."""
+    slides = root / "data" / "slides" / "module_000_synth"
+    slides.mkdir(parents=True, exist_ok=True)
+
+    filler = "\n".join(f"# context line {i} for the synthetic deck" for i in range(20))
+    sibling_blob = ("synthetic sibling payload data; " * 64 + "\n") * max(
+        1, (sibling_kb * 1024) // 2048
+    )
+
+    topic_ids: list[str] = []
+    for k in range(1, topics + 1):
+        topic_id = f"synth_{k:03d}"
+        topic_ids.append(topic_id)
+        if siblings > 0:
+            tdir = slides / f"topic_{k:03d}_{topic_id}"
+            (tdir / "data").mkdir(parents=True, exist_ok=True)
+            (tdir / f"slides_{topic_id}.py").write_text(
+                SLIDE_TEMPLATE.format(k=k, filler=filler), encoding="utf-8"
+            )
+            for s in range(siblings):
+                (tdir / "data" / f"sibling_{s}.txt").write_text(sibling_blob, encoding="utf-8")
+        else:
+            (slides / f"topic_{k:03d}_{topic_id}.py").write_text(
+                SLIDE_TEMPLATE.format(k=k, filler=filler), encoding="utf-8"
+            )
+
+    per_section = max(1, topics // 4)
+    sections_xml = []
+    for s_idx, start in enumerate(range(0, topics, per_section), start=1):
+        chunk = topic_ids[start : start + per_section]
+        topics_xml = "\n".join(f"                <topic>{tid}</topic>" for tid in chunk)
+        sections_xml.append(
+            f"""        <section>
+            <name>
+                <de>Woche {s_idx}</de>
+                <en>Week {s_idx}</en>
+            </name>
+            <topics>
+{topics_xml}
+            </topics>
+        </section>"""
+        )
+
+    spec = root / "course.xml"
+    spec.write_text(
+        f"""<course>
+    <name>
+        <de>Synthetischer Lastkurs</de>
+        <en>Synthetic Load Course</en>
+    </name>
+    <prog-lang>python</prog-lang>
+    <description>
+        <de>Lasttest</de>
+        <en>Load test</en>
+    </description>
+    <sections>
+{chr(10).join(sections_xml)}
+    </sections>
+</course>
+""",
+        encoding="utf-8",
+    )
+    return spec
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--topics", type=int, default=60, help="number of synthetic topics")
+    ap.add_argument(
+        "--siblings",
+        type=int,
+        default=3,
+        help="sibling files per topic (0 = single-file topics; >0 exercises the payload base64 cost)",
+    )
+    ap.add_argument("--sibling-kb", type=int, default=30, help="size of each sibling file in KiB")
+    ap.add_argument("--keep", action="store_true", help="keep the temp dir for inspection")
+    args = ap.parse_args()
+
+    workdir = Path(tempfile.mkdtemp(prefix="clm_profile_build_"))
+    spec = make_course(workdir, args.topics, args.siblings, args.sibling_kb)
+
+    env = dict(os.environ)
+    env["CLM_PROFILE_BUILD"] = "1"
+
+    cmd = [
+        sys.executable,
+        "-m",
+        "clm",
+        "--cache-db-path",
+        str(workdir / "cache.db"),  # isolated; never the real cache
+        "--jobs-db-path",
+        str(workdir / "jobs.db"),
+        "build",
+        str(spec),
+        "--data-dir",
+        str(workdir / "data"),
+        "--output-dir",
+        str(workdir / "out"),
+        "--no-html",  # notebook/code jobs via jupytext, no Jupyter kernel
+        "--no-diagrams",
+        "--no-progress",  # measure via the profiler, not the live bar
+        "--log-level",
+        "WARNING",
+    ]
+    print(
+        f"[profile] topics={args.topics} siblings={args.siblings} "
+        f"sibling_kb={args.sibling_kb}\n[profile] workdir={workdir}",
+        flush=True,
+    )
+
+    t0 = time.perf_counter()
+    proc = subprocess.run(cmd, cwd=str(REPO_ROOT), env=env, capture_output=True, text=True)
+    wall = time.perf_counter() - t0
+
+    prof_lines = [ln for ln in (proc.stdout + proc.stderr).splitlines() if "[build-profile]" in ln]
+    print(f"\n[profile] build wall time: {wall:.1f}s, exit={proc.returncode}")
+    if prof_lines:
+        for ln in prof_lines:
+            print("   " + ln.split("] ", 1)[-1] if "] " in ln else ln)
+    else:
+        print("   (no [build-profile] lines captured — last 25 stderr lines:)")
+        for ln in proc.stderr.splitlines()[-25:]:
+            print("   ! " + ln)
+
+    if args.keep:
+        print(f"[profile] kept {workdir}")
+    else:
+        shutil.rmtree(workdir, ignore_errors=True)
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/clm/core/operations/process_notebook.py
+++ b/src/clm/core/operations/process_notebook.py
@@ -9,6 +9,8 @@ from typing import Any
 from attrs import frozen
 
 from clm.core.course_files.notebook_file import NotebookFile
+from clm.infrastructure.build_profiling import now as profiler_now
+from clm.infrastructure.build_profiling import profiler
 from clm.infrastructure.messaging.correlation_ids import (
     new_correlation_id,
     note_correlation_id_dependency,
@@ -415,6 +417,10 @@ class ProcessNotebookOperation(Operation):
         return stems
 
     async def payload(self, build_reporter: Any = None) -> NotebookPayload:
+        # Profiling: time the synchronous payload build (slide read + base64 of
+        # every topic sibling + content hashing) which runs on the event loop
+        # and contributes to submission starving the completion poll loop.
+        _payload_t0 = profiler_now() if profiler.enabled else 0.0
         course = self.input_file.course
         correlation_id = await new_correlation_id()
 
@@ -483,6 +489,8 @@ class ProcessNotebookOperation(Operation):
             cross_references=self.compute_cross_references(data),
         )
         await note_correlation_id_dependency(correlation_id, payload)
+        if profiler.enabled:
+            profiler.record_payload_build(profiler_now() - _payload_t0)
         return payload
 
     @property

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -10,6 +10,7 @@ import logging
 import queue
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -21,6 +22,8 @@ from clm.core.output_write_registry import (
 )
 from clm.infrastructure.backend import JobsPendingTimeoutError
 from clm.infrastructure.backends.local_ops_backend import LocalOpsBackend
+from clm.infrastructure.build_profiling import now as profiler_now
+from clm.infrastructure.build_profiling import profiler
 from clm.infrastructure.database.db_operations import DatabaseManager
 from clm.infrastructure.database.job_queue import JobQueue
 from clm.infrastructure.database.schema import init_database
@@ -37,6 +40,12 @@ if TYPE_CHECKING:
     from clm.infrastructure.utils.copy_file_data import CopyFileData
 
 logger = logging.getLogger(__name__)
+
+
+# Max concurrent ``execute_operation`` calls (see ``_ensure_submission_semaphore``).
+# Small on purpose: the submit thread is single, and a tighter cap keeps any
+# on-loop cache-hit-replay burst short so the progress bar stays responsive.
+SUBMISSION_CONCURRENCY = 8
 
 
 @define
@@ -79,6 +88,24 @@ class SqliteBackend(LocalOpsBackend):
     _result_cache_queue: Any = field(init=False, default=None)
     _result_cache_thread: Any = field(init=False, default=None)
 
+    # Bounded thread pool for the synchronous job-submission tail (job-cache
+    # probe, worker-availability wait, payload JSON serialization, jobs-DB
+    # INSERT). That work has no await and used to run inline on the event loop,
+    # so a submission burst starved the completion poll loop and froze the
+    # progress bar (the bar only advances from that poll loop). Offloading it
+    # keeps the loop free to poll. Small + bounded because the jobs DB
+    # serializes writers anyway, so more threads only add lock contention.
+    _submit_executor: "ThreadPoolExecutor | None" = field(init=False, default=None)
+
+    # Caps how many operations are processed concurrently, bounding the on-loop
+    # work that runs per event-loop turn. The cache-HIT replay path still runs
+    # on the loop (it reads the result cache and mutates the non-thread-safe
+    # output registry), so without a cap a burst of cache hits blocks the poll
+    # loop for the whole batch. The gate keeps any such burst small, and adds
+    # backpressure so submission does not build the whole course's payloads
+    # in memory at once. Created lazily on the event loop.
+    _submission_semaphore: "asyncio.Semaphore | None" = field(init=False, default=None)
+
     def __attrs_post_init__(self):
         """Initialize SQLite database and job queue."""
         # Database should already be initialized, but ensure it exists
@@ -115,7 +142,52 @@ class SqliteBackend(LocalOpsBackend):
         self._perform_session_start_cleanup()
 
     async def execute_operation(self, operation: Operation, payload: Payload) -> None:
+        """Submit a job to the SQLite queue (timing wrapper).
+
+        The real work lives in :meth:`_execute_operation_impl`. This thin
+        wrapper only measures the call under ``CLM_PROFILE_BUILD`` — this is
+        the awaitless submission body whose synchronous cost (payload
+        serialization, cache lookup, INSERT, or cache-hit unpickle+write)
+        starves the completion poll loop and freezes the progress bar.
+        """
+        async with self._ensure_submission_semaphore():
+            # Time inside the gate so the (off-loop) semaphore wait is not
+            # counted as on-loop blocking.
+            if not profiler.enabled:
+                await self._execute_operation_impl(operation, payload)
+                return
+            start = profiler_now()
+            cache_hit = False
+            try:
+                cache_hit = await self._execute_operation_impl(operation, payload)
+            finally:
+                profiler.record_execute_op(profiler_now() - start, cache_hit)
+
+    def _ensure_submission_semaphore(self) -> asyncio.Semaphore:
+        """Lazily create the per-operation concurrency gate on the event loop.
+
+        Bounds how many ``execute_operation`` calls run concurrently. The
+        cache-HIT replay path runs on the loop (result-cache read + non-thread-
+        safe registry mutation), so this cap limits how much of it can pile into
+        a single event-loop turn and stall the completion poll loop, and it
+        backpressures submission so the whole course's payloads are not built in
+        memory at once. Misses spend their time awaiting the single submit
+        thread, so a handful of permits keeps that thread saturated without
+        bloating its queue.
+        """
+        sem = self._submission_semaphore
+        if sem is None:
+            sem = asyncio.Semaphore(SUBMISSION_CONCURRENCY)
+            self._submission_semaphore = sem
+        return sem
+
+    async def _execute_operation_impl(self, operation: Operation, payload: Payload) -> bool:
         """Submit a job to the SQLite queue.
+
+        Returns ``True`` when the operation was satisfied from a cache (DB
+        result cache or SQLite job cache) without submitting a worker job,
+        ``False`` when a new job was enqueued. The boolean is only consumed by
+        the profiling wrapper.
 
         Args:
             operation: Operation to execute
@@ -225,86 +297,60 @@ class SqliteBackend(LocalOpsBackend):
                         detail="stored result replayed, no execution",
                     )
 
-                return
-
-        # Check SQLite job cache
-        # Same gate as the database cache above — --ignore-cache (ignore_db)
-        # must bypass *both* caches, otherwise workers get silently skipped
-        # for output paths whose content_hash matches a prior run.
-        if not self.ignore_db and self.job_queue:
-            cached = self.job_queue.check_cache(str(payload.output_file), payload.content_hash())
-            if cached:
-                logger.debug(f"SQLite cache hit for {payload.output_file}")
-                # Output file should already exist from previous run
-                output_path = Path(payload.output_file)
-                # Make path absolute relative to workspace if not already absolute
-                if not output_path.is_absolute():
-                    output_path = self.workspace_path / output_path
-                if output_path.exists():
-                    # Replay stored errors/warnings for this result, exactly
-                    # like the database-cache path above. Without this, a
-                    # results_cache hit (e.g. after retention pruned the
-                    # processed_files entry) silently dropped the issues a
-                    # worker recorded for this content — the build went
-                    # green while the output still contained the flagged
-                    # content (issue #321: replay must be observationally
-                    # equivalent to execution).
-                    self._report_cached_issues(
-                        payload.input_file,
-                        payload.content_hash(),
-                        payload.output_metadata(),
-                    )
-                    # Report cache hit to build reporter for progress tracking
-                    if self.build_reporter:
-                        self.build_reporter.report_cache_hit(
-                            str(payload.input_file),
-                            job_type,
-                            detail="output already on disk, no execution",
-                        )
-                    return
-                else:
-                    logger.warning(f"Cache indicated file exists but not found: {output_path}")
+                return True
 
         if service_name not in service_to_job_type:
             raise ValueError(f"Unknown service: {service_name}")
 
-        # Check if workers are available for this job type (unless check is skipped for testing)
-        if not self.skip_worker_check:
-            available_workers = self._get_available_workers(job_type)
-            if available_workers == 0:
-                raise RuntimeError(
-                    f"No workers available to process '{job_type}' jobs. "
-                    f"Please start {job_type} workers before submitting jobs. "
-                    f"Workers should register in the database within 10 seconds of starting."
-                )
-
-            logger.debug(f"Found {available_workers} available worker(s) for job type '{job_type}'")
-
-        # Prepare payload dict using Pydantic's model_dump() with mode='json'
-        # This ensures bytes are serialized to base64 strings for JSON compatibility
-        payload_dict = payload.model_dump(mode="json")
-
-        # Extract correlation_id from payload
-        correlation_id = getattr(payload, "correlation_id", None)
-
-        # Add job to queue (job_queue is always initialized in __attrs_post_init__)
-        assert self.job_queue is not None
-
-        # Note: Job cancellation for watch mode is handled by the file_event_handler
-        # when a file change is detected, not here. The same source file can produce
-        # multiple output files (HTML, .ipynb, .py in multiple languages), so we
-        # cannot cancel by input file alone during normal operation submission.
-
-        job_id = self.job_queue.add_job(
-            job_type=job_type,
-            input_file=str(payload.input_file),
-            output_file=str(payload.output_file),
-            content_hash=payload.content_hash(),
-            payload=payload_dict,
-            correlation_id=correlation_id,
+        # The remaining submission work — the SQLite job-cache probe, the
+        # worker-availability wait (which can ``time.sleep`` for seconds while
+        # workers activate), the payload JSON serialization (which re-encodes
+        # the base64 sibling blobs), and the jobs-DB INSERT — is fully
+        # synchronous. Run inline on the event loop it was the dominant cost
+        # that starved the completion poll loop, so a submission burst froze
+        # the progress bar (which only advances from that poll loop) while the
+        # workers raced ahead. It touches only thread-safe resources (JobQueue
+        # keeps a per-thread SQLite connection; model_dump is pure), so we run
+        # it on a bounded thread pool and the event loop stays free to poll.
+        #
+        # Everything AFTER the offload — the registries, the build reporter,
+        # the active_jobs dict, and the db_manager-backed cached-issue replay —
+        # is confined to the event-loop thread because none of it is
+        # thread-safe (the DB result-cache replay above, db_manager.get_result,
+        # stays on the loop for the same reason).
+        _offload_t0 = profiler_now() if profiler.enabled else 0.0
+        outcome, job_id = await asyncio.get_running_loop().run_in_executor(
+            self._ensure_submit_executor(),
+            self._submit_job_blocking,
+            payload,
+            job_type,
         )
+        if profiler.enabled:
+            profiler.record_submit_offload(profiler_now() - _offload_t0)
 
-        # Track active job
+        if outcome == "jobcache_hit":
+            # Stored output is already on disk (results_cache hit). Replay its
+            # issues and report the hit here on the loop thread — db_manager
+            # reads and the build reporter are loop-confined. Mirrors the
+            # database-cache replay above (issue #321: a cache replay must be
+            # observationally equivalent to execution).
+            self._report_cached_issues(
+                payload.input_file,
+                payload.content_hash(),
+                payload.output_metadata(),
+            )
+            if self.build_reporter:
+                self.build_reporter.report_cache_hit(
+                    str(payload.input_file),
+                    job_type,
+                    detail="output already on disk, no execution",
+                )
+            return True
+
+        # outcome == "submitted": the job is in the jobs DB. Register it for the
+        # poll loop and report it — all loop-confined state.
+        assert job_id is not None
+        correlation_id = getattr(payload, "correlation_id", None)
         self.active_jobs[job_id] = {
             "job_type": job_type,
             "input_file": str(payload.input_file),
@@ -328,6 +374,83 @@ class SqliteBackend(LocalOpsBackend):
         logger.debug(
             f"Added job {job_id} ({job_type}): {payload.input_file} -> {payload.output_file}"
         )
+        return False
+
+    def _submit_job_blocking(self, payload: Payload, job_type: str) -> tuple[str, int | None]:
+        """Synchronous job-submission tail, run off the event loop.
+
+        Performs the SQLite job-cache probe, the worker-availability wait, the
+        payload JSON serialization, and the jobs-DB INSERT. Returns
+        ``("jobcache_hit", None)`` when a stored output already satisfies the
+        request, or ``("submitted", job_id)`` when a new job was enqueued.
+
+        Runs on a :attr:`_submit_executor` thread, so it must touch ONLY
+        thread-safe resources: ``JobQueue`` keeps a per-thread SQLite connection
+        (so ``check_cache`` / ``_get_available_workers`` / ``add_job`` are safe
+        here) and ``model_dump`` is pure. It must NOT touch ``db_manager``, the
+        registries, or the build reporter — the caller does the cache-issue
+        replay, reporting, and ``active_jobs`` bookkeeping on the event-loop
+        thread after this returns.
+        """
+        assert self.job_queue is not None
+
+        # SQLite job cache: a stored result whose output is already on disk
+        # needs no worker run. Same --ignore-cache gate as the DB cache above.
+        if not self.ignore_db:
+            cached = self.job_queue.check_cache(str(payload.output_file), payload.content_hash())
+            if cached:
+                logger.debug(f"SQLite cache hit for {payload.output_file}")
+                output_path = Path(payload.output_file)
+                if not output_path.is_absolute():
+                    output_path = self.workspace_path / output_path
+                if output_path.exists():
+                    return ("jobcache_hit", None)
+                logger.warning(f"Cache indicated file exists but not found: {output_path}")
+
+        # Worker availability (may briefly block waiting for workers to activate).
+        if not self.skip_worker_check:
+            available_workers = self._get_available_workers(job_type)
+            if available_workers == 0:
+                raise RuntimeError(
+                    f"No workers available to process '{job_type}' jobs. "
+                    f"Please start {job_type} workers before submitting jobs. "
+                    f"Workers should register in the database within 10 seconds of starting."
+                )
+            logger.debug(f"Found {available_workers} available worker(s) for job type '{job_type}'")
+
+        # Prepare payload dict (model_dump mode='json' base64-encodes bytes) and
+        # enqueue the job. Job cancellation for watch mode is handled elsewhere
+        # (the file_event_handler), not here.
+        payload_dict = payload.model_dump(mode="json")
+        correlation_id = getattr(payload, "correlation_id", None)
+        job_id = self.job_queue.add_job(
+            job_type=job_type,
+            input_file=str(payload.input_file),
+            output_file=str(payload.output_file),
+            content_hash=payload.content_hash(),
+            payload=payload_dict,
+            correlation_id=correlation_id,
+        )
+        return ("submitted", job_id)
+
+    def _ensure_submit_executor(self) -> ThreadPoolExecutor:
+        """Lazily create the single-thread job-submission executor.
+
+        Deliberately ONE worker. The goal is only to move the synchronous
+        submission tail OFF the event loop, not to submit concurrently:
+        ``check_cache`` (``BEGIN IMMEDIATE``) and ``add_job`` (INSERT) take the
+        jobs-DB write lock, which SQLite serializes anyway, so multiple
+        submission threads just pile onto that lock and starve the workers'
+        ``get_next_job`` and the poll loop's own writes (measured: an 8-thread
+        pool nearly doubled total build time). A single dedicated thread
+        reproduces the original serial submission throughput with zero added
+        lock contention, while the event loop stays free to poll.
+        """
+        executor = self._submit_executor
+        if executor is None:
+            executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="clm-submit")
+            self._submit_executor = executor
+        return executor
 
     def _can_replay_from_cache(self, payload: Payload) -> bool:
         """Gate the ``processed_files`` short-circuit on the execution cache.
@@ -474,7 +597,18 @@ class SqliteBackend(LocalOpsBackend):
         failed_jobs: list[dict[str, Any]] = []
         last_cleanup_time = start_time
 
+        # Profiling: the inter-iteration gap of this poll loop. A healthy gap is
+        # ~poll_interval; a multi-second gap means the loop was starved of the
+        # event loop (submission monopolizing it) and the progress bar was
+        # frozen for that long. Recorded per cycle under CLM_PROFILE_BUILD.
+        last_cycle_t = profiler_now() if profiler.enabled else 0.0
+        cycle_gap = 0.0
+
         while True:
+            if profiler.enabled:
+                _cycle_now = profiler_now()
+                cycle_gap = _cycle_now - last_cycle_t
+                last_cycle_t = _cycle_now
             # If no active jobs, check whether we can exit
             if not self.active_jobs:
                 if all_submitted is None or all_submitted.is_set():
@@ -667,6 +801,11 @@ class SqliteBackend(LocalOpsBackend):
             for job_id in completed_jobs:
                 del self.active_jobs[job_id]
 
+            if profiler.enabled:
+                profiler.record_poll_cycle(
+                    cycle_gap, len(completed_jobs), len(self.active_jobs), self.poll_interval
+                )
+
             # Check timeout
             elapsed = asyncio.get_event_loop().time() - start_time
             if elapsed > self.max_wait_for_completion_duration:
@@ -688,7 +827,7 @@ class SqliteBackend(LocalOpsBackend):
         # shutdown. This is where any backlog the writer could not keep up with
         # during the stage is absorbed, with a progress line so it is not a
         # silent pause.
-        self._drain_result_cache_writes()
+        await self._drain_result_cache_writes()
 
         # Stop progress tracking and log summary
         if self.progress_tracker:
@@ -755,6 +894,8 @@ class SqliteBackend(LocalOpsBackend):
     async def shutdown(self):
         """Shutdown the backend and perform build-end cleanup if configured."""
         logger.debug("Shutting down SQLite backend")
+        # Emit the build profiling summary (no-op unless CLM_PROFILE_BUILD is set).
+        profiler.dump_summary()
         # Wait for remaining jobs with shorter timeout
         if self.active_jobs:
             logger.warning(f"Shutdown called with {len(self.active_jobs)} job(s) still pending")
@@ -766,6 +907,13 @@ class SqliteBackend(LocalOpsBackend):
         # Stop the background result-cache writer before any cleanup/VACUUM so
         # all pending blob writes land first and nothing races the compaction.
         self._stop_result_cache_writer()
+
+        # Shut down the job-submission thread pool (all submission is done by
+        # the time we reach shutdown). wait=True so its jobs-DB connections are
+        # closed before any end-of-build cleanup/VACUUM.
+        if self._submit_executor is not None:
+            self._submit_executor.shutdown(wait=True)
+            self._submit_executor = None
 
         # Perform build-end cleanup if configured
         self._perform_build_end_cleanup()
@@ -1147,12 +1295,17 @@ class SqliteBackend(LocalOpsBackend):
                 except Exception:  # pragma: no cover - best-effort close
                     logger.debug("Error closing result-cache writer DB", exc_info=True)
 
-    def _drain_result_cache_writes(self) -> None:
-        """Block until every queued result-cache write has been committed.
+    async def _drain_result_cache_writes(self) -> None:
+        """Wait until every queued result-cache write has been committed.
 
         Called at the end of each ``wait_for_completion`` so the cache DB is
         fully populated for callers that read it immediately afterwards. The
         writer thread keeps running for the next stage.
+
+        The blocking ``queue.join()`` runs off the event loop (``to_thread``):
+        if the background writer fell behind, joining inline here would freeze
+        the loop — and therefore the progress bar — at the end of every stage
+        (three times per stage with the default shared/trainer/speaker targets).
         """
         q = self._result_cache_queue
         if q is None:
@@ -1160,7 +1313,7 @@ class SqliteBackend(LocalOpsBackend):
         pending = q.qsize()
         if pending:
             self._show_progress(f"Finishing {pending} result-cache write(s)...")
-        q.join()
+        await asyncio.to_thread(q.join)
 
     def _stop_result_cache_writer(self) -> None:
         """Drain remaining writes and stop the writer thread (idempotent)."""

--- a/src/clm/infrastructure/build_profiling.py
+++ b/src/clm/infrastructure/build_profiling.py
@@ -1,0 +1,204 @@
+"""Opt-in build performance profiling (``CLM_PROFILE_BUILD=1``).
+
+This is a lightweight, zero-cost-when-disabled diagnostic for the build's
+*progress-reporting* health — specifically the symptom where the ``clm build``
+progress bar appears frozen mid-stage while ``clm monitor`` shows hundreds of
+jobs finishing, then jumps far ahead.
+
+The bar only advances from inside ``SqliteBackend.wait_for_completion``'s poll
+loop (it calls ``progress_tracker.job_completed`` per retired job). If that
+coroutine is starved of the event loop — because job *submission* runs a burst
+of awaitless, CPU/IO-heavy work (payload build, cache unpickle, disk writes,
+SQLite inserts) on the same loop — the bar freezes even though the worker
+subprocesses keep finishing. This module measures exactly that:
+
+* the inter-iteration **gap** of the poll loop (healthy ≈ ``poll_interval``;
+  a multi-second gap is the freeze), and the number of completions retired when
+  the loop finally runs again (the size of the "jump");
+* the per-call wall time of ``execute_operation`` (the awaitless submission
+  body), split by cache hit/miss, which is the work that starves the loop.
+
+Enable with ``CLM_PROFILE_BUILD=1``. When disabled, the call sites skip all
+timing and this module's methods early-return, so there is no measurable
+overhead on a normal build. A summary is logged at backend shutdown.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import threading
+from time import perf_counter
+
+logger = logging.getLogger(__name__)
+
+
+def _env_enabled() -> bool:
+    return os.environ.get("CLM_PROFILE_BUILD", "").strip().lower() in ("1", "true", "yes")
+
+
+def _configure_stderr_handler() -> None:
+    """Route this module's records straight to stderr, INFO+, regardless of the
+    app's log config.
+
+    The build configures logging to send INFO records to a file (the console
+    only carries the Rich build summary), so profiling lines would otherwise be
+    invisible. Because profiling is explicitly opt-in (``CLM_PROFILE_BUILD``),
+    attaching a dedicated stderr handler with ``propagate=False`` makes the
+    measurements reliably visible/capturable without touching global logging.
+    """
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+
+class BuildProfiler:
+    """Process-wide accumulator for build profiling counters.
+
+    Thread-safe: ``record_execute_op`` may be called from worker threads once
+    the submission work is offloaded off the event loop, while
+    ``record_poll_cycle`` is called from the event-loop thread.
+    """
+
+    def __init__(self, enabled: bool) -> None:
+        self.enabled = enabled
+        self._lock = threading.Lock()
+        if enabled:
+            _configure_stderr_handler()
+
+        # Poll-loop health.
+        self.poll_cycles = 0
+        self.poll_gap_max = 0.0
+        self.poll_gap_sum = 0.0
+        self.poll_starved_cycles = 0  # gap > 2x poll_interval
+        self.poll_completed_total = 0
+        # The single worst stall, with how many jobs it hid (the "jump" size).
+        self.worst_gap = 0.0
+        self.worst_gap_completed = 0
+
+        # Submission body (execute_operation) timing. ``op_time_sum`` is the
+        # total wall time of the call; ``offload_time_sum`` is the part spent
+        # awaiting the off-loop submission executor (which does not block the
+        # event loop). On-loop blocking time = op_time_sum - offload_time_sum.
+        self.op_count = 0
+        self.op_time_sum = 0.0
+        self.op_time_max = 0.0
+        self.op_hits = 0
+        self.op_misses = 0
+        self.offload_count = 0
+        self.offload_time_sum = 0.0
+
+        # Payload build (ProcessNotebookOperation.payload) timing — the slide
+        # read + base64 of every topic sibling + content hashing, also on-loop.
+        self.payload_count = 0
+        self.payload_time_sum = 0.0
+        self.payload_time_max = 0.0
+
+    def record_poll_cycle(
+        self, gap_s: float, completed_count: int, active_count: int, poll_interval: float
+    ) -> None:
+        """Record one poll-loop iteration's gap since the previous iteration."""
+        if not self.enabled:
+            return
+        with self._lock:
+            self.poll_cycles += 1
+            self.poll_gap_sum += gap_s
+            self.poll_completed_total += completed_count
+            if gap_s > self.poll_gap_max:
+                self.poll_gap_max = gap_s
+            if gap_s > 2.0 * poll_interval:
+                self.poll_starved_cycles += 1
+            if gap_s > self.worst_gap:
+                self.worst_gap = gap_s
+                self.worst_gap_completed = completed_count
+        # Surface the bad gaps live so a long run is not silent. A gap beyond
+        # ~3x the poll interval means the loop did not get scheduled on time —
+        # i.e. the bar was frozen for that long.
+        if gap_s > max(2.0, 3.0 * poll_interval):
+            logger.info(
+                "[build-profile] poll-loop stalled %.2fs (then retired %d job(s); %d still active)",
+                gap_s,
+                completed_count,
+                active_count,
+            )
+
+    def record_execute_op(self, elapsed_s: float, cache_hit: bool) -> None:
+        """Record one ``execute_operation`` (submission body) call."""
+        if not self.enabled:
+            return
+        with self._lock:
+            self.op_count += 1
+            self.op_time_sum += elapsed_s
+            if elapsed_s > self.op_time_max:
+                self.op_time_max = elapsed_s
+            if cache_hit:
+                self.op_hits += 1
+            else:
+                self.op_misses += 1
+
+    def record_submit_offload(self, elapsed_s: float) -> None:
+        """Record time spent awaiting the off-loop submission executor.
+
+        This is wall time that does NOT block the event loop (the loop is free
+        to poll while it runs), so it is subtracted from the execute_operation
+        total to report the true on-loop blocking cost.
+        """
+        if not self.enabled:
+            return
+        with self._lock:
+            self.offload_count += 1
+            self.offload_time_sum += elapsed_s
+
+    def record_payload_build(self, elapsed_s: float) -> None:
+        """Record one ``payload()`` build (slide read + sibling base64 + hash)."""
+        if not self.enabled:
+            return
+        with self._lock:
+            self.payload_count += 1
+            self.payload_time_sum += elapsed_s
+            if elapsed_s > self.payload_time_max:
+                self.payload_time_max = elapsed_s
+
+    def summary_lines(self) -> list[str]:
+        with self._lock:
+            avg_gap = self.poll_gap_sum / self.poll_cycles if self.poll_cycles else 0.0
+            avg_payload_ms = (
+                (self.payload_time_sum / self.payload_count * 1000.0) if self.payload_count else 0.0
+            )
+            return [
+                "[build-profile] ===== build profiling summary =====",
+                f"[build-profile] poll loop: {self.poll_cycles} cycle(s), "
+                f"avg gap {avg_gap * 1000:.0f}ms, max gap {self.poll_gap_max:.2f}s, "
+                f"{self.poll_starved_cycles} starved cycle(s) (gap > 2x interval)",
+                f"[build-profile] worst stall: {self.worst_gap:.2f}s, which hid "
+                f"{self.worst_gap_completed} completion(s) (the 'jump' size)",
+                f"[build-profile] submission: {self.op_count} execute_operation call(s) "
+                f"({self.op_hits} hit / {self.op_misses} miss), "
+                f"{self.op_time_sum - self.offload_time_sum:.2f}s ON-LOOP "
+                f"(+ {self.offload_time_sum:.2f}s offloaded to the submit thread, "
+                f"not blocking the loop), max call {self.op_time_max * 1000:.0f}ms",
+                f"[build-profile] payload build: {self.payload_count} call(s), "
+                f"total {self.payload_time_sum:.2f}s on-loop, avg {avg_payload_ms:.1f}ms, "
+                f"max {self.payload_time_max * 1000:.0f}ms",
+                "[build-profile] ===================================",
+            ]
+
+    def dump_summary(self) -> None:
+        if not self.enabled:
+            return
+        for line in self.summary_lines():
+            logger.info(line)
+
+
+# Process-wide singleton. ``enabled`` is read once from the environment, which
+# is set before the build subprocess starts.
+profiler = BuildProfiler(enabled=_env_enabled())
+
+
+def now() -> float:
+    """Monotonic timer for measuring intervals (perf_counter)."""
+    return perf_counter()

--- a/src/clm/infrastructure/database/job_queue.py
+++ b/src/clm/infrastructure/database/job_queue.py
@@ -93,6 +93,15 @@ class JobQueue:
                 timeout=30.0,
                 isolation_level=None,  # Enable autocommit mode for simple operations
             )
+            # The WAL/synchronous=NORMAL pragmas set in init_database run on a
+            # throwaway connection; journal_mode=WAL persists in the DB file but
+            # synchronous is PER-CONNECTION and otherwise reverts to the default
+            # FULL here, fsyncing on every commit. On this hot path (each
+            # add_job INSERT, each worker get_next_job/status UPDATE, every
+            # poll-loop write) that per-commit fsync is pure latency. NORMAL is
+            # safe under WAL: at worst the last committed transaction is lost on
+            # power failure, never corruption — fine for a rebuildable queue.
+            self._local.conn.execute("PRAGMA synchronous=NORMAL")
             self._local.conn.row_factory = sqlite3.Row
         return cast(Connection, self._local.conn)
 

--- a/tests/infrastructure/backends/test_sqlite_backend_submission_offload.py
+++ b/tests/infrastructure/backends/test_sqlite_backend_submission_offload.py
@@ -1,0 +1,154 @@
+"""Regression tests for the build-progress-stall fix.
+
+The ``clm build`` progress bar advances only from
+``SqliteBackend.wait_for_completion``'s poll loop. Before the fix, the
+synchronous job-submission body (job-cache probe, worker-availability wait,
+payload JSON serialization, jobs-DB INSERT) ran inline on the event loop, so a
+submission burst starved that poll loop and the bar froze for a long time while
+the workers raced ahead. The fix moves that body onto a single dedicated thread
+and gates per-operation concurrency with a semaphore.
+
+These tests lock in the two observable properties of that fix:
+
+* the submission body runs OFF the event-loop thread, and
+* a coroutine running concurrently with submission keeps getting scheduled
+  (i.e. the loop is not starved).
+"""
+
+import asyncio
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from clm.infrastructure.backends.sqlite_backend import (
+    SUBMISSION_CONCURRENCY,
+    SqliteBackend,
+)
+from clm.infrastructure.database.job_queue import JobQueue
+from clm.infrastructure.database.schema import init_database
+from clm.infrastructure.messaging.base_classes import Payload
+from clm.infrastructure.operation import Operation
+
+
+class _MockOperation(Operation):
+    """Minimal notebook-service operation."""
+
+    @property
+    def service_name(self) -> str:
+        return "notebook-processor"
+
+    async def execute(self, backend, *args, **kwargs):  # pragma: no cover - unused
+        pass
+
+
+class _MockPayload(Payload):
+    correlation_id: str = "cid"
+    input_file: str = "in.py"
+    input_file_name: str = "in.py"
+    output_file: str = "out.ipynb"
+    data: str = "content"
+
+
+@pytest.fixture
+def backend(tmp_path: Path):
+    db_path = tmp_path / "jobs.db"
+    init_database(db_path)
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    be = SqliteBackend(
+        db_path=db_path,
+        workspace_path=workspace,
+        skip_worker_check=True,  # no workers in a unit test
+    )
+    yield be
+    be.active_jobs.clear()  # avoid the 5s shutdown wait for unprocessed jobs
+
+
+@pytest.mark.asyncio
+async def test_submission_runs_off_the_event_loop_thread(backend):
+    """The synchronous submission tail runs on the dedicated submit thread."""
+    main_thread = threading.current_thread()
+    seen: dict[str, threading.Thread] = {}
+    real = SqliteBackend._submit_job_blocking
+
+    def spy(self, payload, job_type):
+        seen["thread"] = threading.current_thread()
+        return real(self, payload, job_type)
+
+    try:
+        with patch.object(SqliteBackend, "_submit_job_blocking", spy):
+            await backend.execute_operation(_MockOperation(), _MockPayload())
+
+        assert seen["thread"] is not main_thread
+        assert seen["thread"].name.startswith("clm-submit")
+        # The job was still enqueued and tracked for the poll loop.
+        assert len(backend.active_jobs) == 1
+        job_queue = JobQueue(backend.db_path)
+        try:
+            assert job_queue.get_next_job("notebook") is not None
+        finally:
+            job_queue.close()
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_submission_does_not_starve_the_event_loop(backend):
+    """A concurrent coroutine keeps getting scheduled while jobs are submitted.
+
+    With the submission body offloaded, a slow ``add_job`` no longer blocks the
+    loop, so a 5 ms heartbeat ticks many times across ~0.4 s of submission. On
+    the pre-fix inline path the heartbeat would be starved to a few ticks.
+    """
+    real_add_job = JobQueue.add_job
+
+    def slow_add_job(self, *args, **kwargs):
+        time.sleep(0.02)  # simulate a slow synchronous submission step
+        return real_add_job(self, *args, **kwargs)
+
+    ticks = 0
+    stop = asyncio.Event()
+
+    async def heartbeat():
+        nonlocal ticks
+        while not stop.is_set():
+            ticks += 1
+            await asyncio.sleep(0.005)
+
+    try:
+        with patch.object(JobQueue, "add_job", slow_add_job):
+            hb = asyncio.ensure_future(heartbeat())
+            await asyncio.gather(
+                *(
+                    backend.execute_operation(
+                        _MockOperation(),
+                        _MockPayload(input_file=f"in{i}.py", output_file=f"out{i}.ipynb"),
+                    )
+                    for i in range(20)
+                )
+            )
+            stop.set()
+            await hb
+
+        # 20 jobs * 20 ms serialized on the single submit thread ~= 0.4 s; a
+        # non-starved 5 ms heartbeat ticks dozens of times in that window.
+        assert ticks > 10, f"event loop appears starved during submission (ticks={ticks})"
+        assert len(backend.active_jobs) == 20
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_submission_semaphore_gate_is_installed(backend):
+    """execute_operation is gated by a bounded concurrency semaphore."""
+    await backend.execute_operation(_MockOperation(), _MockPayload())
+    try:
+        sem = backend._submission_semaphore
+        assert isinstance(sem, asyncio.Semaphore)
+        # All permits released after the single call completes.
+        assert sem._value == SUBMISSION_CONCURRENCY
+    finally:
+        await backend.shutdown()


### PR DESCRIPTION
## Problem

When many topics need rebuilding, the `clm build` progress bar freezes for 1–2 minutes at a few dozen completed jobs — while `clm monitor` shows hundreds of jobs finishing — then suddenly jumps far ahead.

**Root cause (re-investigated):** the bar advances *only* from `SqliteBackend.wait_for_completion`'s completion poll loop, which shares one asyncio event loop with job **submission**. Submission's body — the SQLite job-cache probe, the worker-availability wait (which can `time.sleep` for seconds), the payload JSON serialization, and the jobs-DB `INSERT` — ran inline with **no `await`**, so a submission burst monopolized the loop and the poll task never got scheduled. The workers (separate processes) and `monitor` (a separate reader) kept going; only the build's own bar was starved. When submission drained, the poll loop ran once and retired everything at once → the jump.

The earlier fix (`9f7dfd18`) only moved the result-cache **write** off the poll loop, but that already ran *after* the bar advanced — it was never on the bar's critical path, which is why the stall persisted.

## Fix

- **Offload the synchronous submission tail** (`_submit_job_blocking`) onto a **dedicated single-thread executor**. One thread, not a pool: the jobs DB serializes writers, so parallel submission only piles onto the write lock and starves the workers (an 8-thread pool nearly *doubled* build time in testing).
- **Per-operation semaphore** (`SUBMISSION_CONCURRENCY = 8`) bounds how much on-loop work — notably the cache-**hit** replay, which keeps the result-cache read + the non-thread-safe output registry on the loop — lands in a single event-loop turn, and adds backpressure so a course's payloads aren't all built in memory at once.
- **Non-blocking end-of-stage drain:** `_drain_result_cache_writes` now joins the writer queue off the loop (it ran 3× per stage with the default shared/trainer/speaker targets).
- **`synchronous=NORMAL` on the jobs-DB runtime connection:** the WAL pragmas in `init_database` run on a throwaway connection, so the per-thread runtime connection had been reverting to the fsync-on-every-commit default.

Thread-safety is respected: only thread-safe resources run on the submit thread (`JobQueue` keeps a per-thread connection; `model_dump` is pure). The `db_manager` result-cache read, the output registries, the build reporter, and `active_jobs` stay confined to the event-loop thread.

## Measured impact

Synthetic 60-topic / 1,440-job rebuild (`scripts/profile_build_stall.py`, isolated temp DBs, no kernels):

| metric | before | after |
|---|---|---|
| worst poll-loop stall (the freeze) | **19.4 s** | **~1.0 s** |
| on-loop submission cost | 31.7 s | ~1.0 s |
| total build wall time | 84 s | 65–76 s |

## Diagnostics (kept for future regressions)

- `CLM_PROFILE_BUILD=1` makes the build emit `[build-profile]` poll-loop/submission timings (`src/clm/infrastructure/build_profiling.py`), zero-overhead when unset.
- `scripts/profile_build_stall.py` reproduces and measures the behavior safely against throwaway synthetic courses + isolated temp databases.

## Tests

- New `tests/infrastructure/backends/test_sqlite_backend_submission_offload.py`: submission runs off the event-loop thread; a concurrent coroutine keeps getting scheduled during submission (would be starved on the inline path); the concurrency gate is installed.
- Existing backend (106), job-queue, worker-base, build-output, and e2e course-conversion (12, real workers) suites pass; ruff + mypy + the pre-push fast suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFuHisaRBkQCPWzXQ9CzCZ
