### PR TITLE
feat(sync): batch auto-heal + --explain baseline side-by-side + machine-readable id-less error (#364 follow-ups)

### DIFF
--- a/changelog.d/364-followups-batch-heal-explain-positions.fixed.md
+++ b/changelog.d/364-followups-batch-heal-explain-positions.fixed.md
@@ -1,0 +1,15 @@
+- **Stale-watermark auto-heal now covers directory (batch) sweeps.** A writing
+  `clm slides sync apply DIR` / `autopilot DIR` re-baselines each pair's
+  stale-but-consistent watermark independently (the same safe git-HEAD-no-op gate as
+  the single-pair path), instead of only the single-pair case. The batch rollup names
+  how many were re-baselined and each `--json` pair entry carries `auto_healed`
+  (#364 follow-up).
+- **`clm slides sync --explain` shows the git-HEAD baseline side by side** with the
+  watermark baseline when the two disagree — so a stale watermark (errors/conflicts
+  vs the watermark, clean vs git HEAD) is visible at a glance rather than a
+  clean-looking anchor diff that nonetheless errors (#364 follow-up).
+- **The "id-less localized cells edited on both decks" error is now machine-readable.**
+  Besides naming the offending cell's owning slide group in prose, the `report --json`
+  issue item carries the offending cells' localized positions and bytes
+  (`source_position` / `source_excerpt` / `source_line` for DE, `target_*` for EN), so
+  an agent reads them straight from the report (#364 follow-up).

--- a/src/clm/cli/commands/slides/sync.py
+++ b/src/clm/cli/commands/slides/sync.py
@@ -289,6 +289,9 @@ class _PairResult:
     # Issue #448 P1: slides this pair banked to the ledger on a fully-clean apply
     # (apply-batch only). ``None`` when --ledger was off or the pass was not clean.
     ledger_recorded: int | None = None
+    # Issue #364: this pair's stale-but-consistent watermark was auto-re-baselined
+    # before reconciling (writing sweeps only). Surfaced in the batch rollup / JSON.
+    healed: bool = False
 
 
 def _run_batch(
@@ -303,6 +306,7 @@ def _run_batch(
     provider_available: bool,
     baseline_ref: str | None = None,
     ledger: bool = False,
+    auto_heal: bool = True,
     make_judge: Callable[[], SyncJudge | None],
     make_translator: Callable[[], SlideTranslator | None],
     make_recoverer: Callable[[], AlignmentRecoverer | None],
@@ -409,6 +413,7 @@ def _run_batch(
                     correspondence_cache=correspondence_cache,
                     baseline_ref=baseline_ref,
                     ledger=ledger,
+                    auto_heal=auto_heal,
                 )
             )
     finally:
@@ -439,6 +444,7 @@ def _sync_one_pair(
     correspondence_cache: SyncCorrespondenceCache | None,
     baseline_ref: str | None = None,
     ledger: bool = False,
+    auto_heal: bool = True,
 ) -> _PairResult:
     """Sync one pair for the batch, catching any failure so the sweep continues."""
     try:
@@ -450,6 +456,27 @@ def _sync_one_pair(
             baseline_ref=baseline_ref,
             ledger=_load_ledger_if(ledger, de_path),
         )
+        # Auto-heal a stale-but-consistent watermark on a WRITING sweep (#364), then
+        # re-plan — mirrors the single-pair autopilot path. Read-only sweeps
+        # (dry-run / explain) never heal. Skipped when --baseline pins the diff.
+        healed = False
+        if mode == "apply" and auto_heal and baseline_ref is None:
+            healed = _auto_heal_stale_watermark(
+                de_path,
+                en_path,
+                plan,
+                watermark_cache=watermark_cache,
+                provider_available=provider_available,
+            )
+            if healed:
+                plan = build_sync_plan(
+                    de_path,
+                    en_path,
+                    watermark_cache=watermark_cache,
+                    provider_available=provider_available,
+                    baseline_ref=None,
+                    ledger=_load_ledger_if(ledger, de_path),
+                )
         apply_result: ApplyResult | None = None
         explain_text: str | None = None
         if mode == "explain":
@@ -482,7 +509,15 @@ def _sync_one_pair(
             _plan_exit_code(plan) if apply_result is None else _apply_exit_code(plan, apply_result)
         )
         return _PairResult(
-            de_path, en_path, plan, apply_result, explain_text, exit_code, None, ledger_recorded
+            de_path,
+            en_path,
+            plan,
+            apply_result,
+            explain_text,
+            exit_code,
+            None,
+            ledger_recorded,
+            healed=healed,
         )
     except Exception as exc:  # continue-on-error: one bad pair must not abort the sweep
         return _PairResult(de_path, en_path, None, None, None, 2, f"{type(exc).__name__}: {exc}")
@@ -552,7 +587,11 @@ def _batch_rollup(results: list[_PairResult]) -> str:
     clean = sum(1 for r in results if r.exit_code == 0)
     review = sum(1 for r in results if r.exit_code == 1)
     errored = sum(1 for r in results if r.exit_code == 2)
-    return f"{len(results)} pair(s): {clean} clean, {review} review, {errored} errored."
+    healed = sum(1 for r in results if r.healed)
+    line = f"{len(results)} pair(s): {clean} clean, {review} review, {errored} errored."
+    if healed:
+        line += f" ({healed} stale watermark(s) auto-re-baselined.)"
+    return line
 
 
 def _ledger_totals(results: list[_PairResult]) -> tuple[int, int]:
@@ -661,7 +700,10 @@ def _batch_pair_dict(r: _PairResult, mode: str) -> dict:
     assert r.plan is not None
     # Each non-errored pair reuses the single-pair object shape verbatim, so a
     # consumer can treat ``pairs[i]`` exactly like one ``clm slides sync --json``.
-    return _to_dict(r.plan, r.apply_result, None, mode, r.exit_code)
+    d = _to_dict(r.plan, r.apply_result, None, mode, r.exit_code)
+    if r.healed:  # #364: surface a per-pair auto-re-baseline on a writing sweep
+        d["auto_healed"] = True
+    return d
 
 
 def _progress_snippet(text: str, limit: int = 44) -> str:
@@ -1753,6 +1795,7 @@ def sync_apply_cmd(
             as_json=as_json,
             baseline_ref=baseline_ref,
             ledger=ledger,
+            auto_heal=auto_heal,
         )
         return  # _run_apply_batch always sys.exit()s; this is just for the type-checker.
 
@@ -1772,34 +1815,15 @@ def sync_apply_cmd(
         watermark_cache = SyncWatermarkCache(cache_root / CACHE_DB_NAME)
     healed = False
     try:
-        plan, result = _apply_deterministic(
+        plan, result, healed = _apply_deterministic_with_heal(
             de_path,
             en_path,
             watermark_cache=watermark_cache,
             baseline_ref=baseline_ref,
             baseline_from=baseline_from,
             ledger=ledger,
+            auto_heal=auto_heal,
         )
-        # Auto-heal a stale-but-consistent watermark (#364): re-baseline and re-plan
-        # to a clean result instead of erroring on a false stale-baseline conflict.
-        # Only when the watermark is the baseline (no --baseline / --baseline-from).
-        if auto_heal and baseline_ref is None and baseline_from is None:
-            healed = _auto_heal_stale_watermark(
-                de_path,
-                en_path,
-                plan,
-                watermark_cache=watermark_cache,
-                provider_available=False,
-            )
-            if healed:
-                plan, result = _apply_deterministic(
-                    de_path,
-                    en_path,
-                    watermark_cache=watermark_cache,
-                    baseline_ref=None,
-                    baseline_from=None,
-                    ledger=ledger,
-                )
     finally:
         if watermark_cache is not None:
             watermark_cache.close()
@@ -1914,6 +1938,51 @@ def _apply_deterministic(
     return plan, result
 
 
+def _apply_deterministic_with_heal(
+    de_path: Path,
+    en_path: Path,
+    *,
+    watermark_cache: SyncWatermarkCache | None,
+    baseline_ref: str | None = None,
+    baseline_from: tuple[Path, Path, str] | None = None,
+    ledger: bool = False,
+    auto_heal: bool = True,
+) -> tuple[SyncPlan, ApplyResult, bool]:
+    """:func:`_apply_deterministic`, auto-healing a stale watermark first (#364).
+
+    Shared by the single-pair apply and the apply **batch** so they heal identically:
+    if the watermark is stale but git HEAD shows the halves consistent, re-baseline it
+    and re-plan to a clean result instead of erroring on a false stale-baseline
+    conflict. Returns ``(plan, result, healed)``. Auto-heal is skipped when an explicit
+    baseline pins the diff (``--baseline`` / ``--baseline-from``) or ``auto_heal`` is off;
+    it is safe by construction (``_auto_heal_stale_watermark`` re-records only against a
+    verified git-HEAD no-op), so a pair that is *not* stale-but-consistent is untouched.
+    """
+    plan, result = _apply_deterministic(
+        de_path,
+        en_path,
+        watermark_cache=watermark_cache,
+        baseline_ref=baseline_ref,
+        baseline_from=baseline_from,
+        ledger=ledger,
+    )
+    if not (auto_heal and baseline_ref is None and baseline_from is None):
+        return plan, result, False
+    if not _auto_heal_stale_watermark(
+        de_path, en_path, plan, watermark_cache=watermark_cache, provider_available=False
+    ):
+        return plan, result, False
+    plan, result = _apply_deterministic(
+        de_path,
+        en_path,
+        watermark_cache=watermark_cache,
+        baseline_ref=None,
+        baseline_from=None,
+        ledger=ledger,
+    )
+    return plan, result, True
+
+
 def _apply_residue(plan: SyncPlan) -> list[ReconciliationItem]:
     """The tier-2/3 report items model-free apply left untouched (the residue)."""
     report = build_report(plan, with_excerpts=False)
@@ -2012,6 +2081,7 @@ def _run_apply_batch(
     as_json: bool,
     baseline_ref: str | None = None,
     ledger: bool = False,
+    auto_heal: bool = True,
 ) -> None:
     """Model-free tier-1 apply over every split pair under ``root`` (no model, epic #440).
 
@@ -2060,17 +2130,28 @@ def _run_apply_batch(
             if not as_json:
                 click.echo(f"[{i}/{len(pairs)}] {_deck_label(de_path, root)} …", err=True)
             try:
-                plan, result = _apply_deterministic(
+                plan, result, healed = _apply_deterministic_with_heal(
                     de_path,
                     en_path,
                     watermark_cache=watermark_cache,
                     baseline_ref=baseline_ref,
                     ledger=ledger,
+                    auto_heal=auto_heal,
                 )
                 recorded = _maybe_record_ledger(ledger, plan, result, de_path, en_path)
                 exit_code = _apply_exit_code(plan, result)
                 results.append(
-                    _PairResult(de_path, en_path, plan, result, None, exit_code, None, recorded)
+                    _PairResult(
+                        de_path,
+                        en_path,
+                        plan,
+                        result,
+                        None,
+                        exit_code,
+                        None,
+                        recorded,
+                        healed=healed,
+                    )
                 )
             except Exception as exc:  # continue-on-error: one bad pair must not abort the sweep
                 results.append(

--- a/src/clm/cli/commands/slides/sync_autopilot.py
+++ b/src/clm/cli/commands/slides/sync_autopilot.py
@@ -649,6 +649,7 @@ def slides_sync_cmd(
             cache_dir=cache_dir,
             provider_available=provider_available,
             ledger=ledger,
+            auto_heal=auto_heal,
             make_judge=lambda: _resolve_judge(provider, llm_model, ollama_url, llm_timeout),
             make_translator=lambda: OpenRouterSlideTranslator(
                 model=translation_model,

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -2038,8 +2038,8 @@ models for those tiers.)
 | `--baseline REF` / `--baseline-from PATH[@REF]` | As for `report`: `--baseline REF` works over a directory (each pair diffed against REF); `--baseline-from` is single-pair. |
 | `--cache-dir PATH` | Directory holding the watermark. |
 | `--ledger` | Use the per-slide consistency ledger (#448): **read** it to skip slides byte-stable since a recorded confirmation (no re-litigation) before applying, **and** — on a fully-clean pass (no deferred residue, the watermark fully advanced) — **record** the now-in-sync localized slides back to it (`confirmed_by=apply`, gated on structural `verify`). A pass with residue records nothing. The `--json` payload gains a `ledger: {skipped, recorded}` block. **Works over a directory** (each pair uses its own topic ledger; the batch reports aggregate `skipped`/`recorded`). |
-| `--auto-heal` / `--no-auto-heal` | (since CLM {version}, #364) Auto-re-baseline a **stale-but-consistent** watermark instead of erroring on a false stale-baseline conflict: when the watermark is stale but git `HEAD` shows the halves consistent (both edited + committed without an intervening sync), clear + re-record it and apply cleanly. **On by default**; safe by construction (heals only when git `HEAD` is a verified no-op, so it can never mask an un-synced edit, and never outside a git repo). The `--json` payload carries `auto_healed: true` when it fires. Ignored with `--baseline` / `--baseline-from` / `--no-watermark`. |
-| `--yes`, `-y` | **Directory (batch) only**: confirm a writing sweep over every pair under the tree. Ignored for a single pair. (Single-pair only: auto-heal runs per-pair.) |
+| `--auto-heal` / `--no-auto-heal` | (since CLM {version}, #364) Auto-re-baseline a **stale-but-consistent** watermark instead of erroring on a false stale-baseline conflict: when the watermark is stale but git `HEAD` shows the halves consistent (both edited + committed without an intervening sync), clear + re-record it and apply cleanly. **On by default**; safe by construction (heals only when git `HEAD` is a verified no-op, so it can never mask an un-synced edit, and never outside a git repo). The `--json` payload carries `auto_healed: true` when it fires. **Works over a directory too** — each pair heals independently; the batch rollup names the count and each `--json` pair entry carries `auto_healed`. Ignored with `--baseline` / `--baseline-from` / `--no-watermark`. |
+| `--yes`, `-y` | **Directory (batch) only**: confirm a writing sweep over every pair under the tree. Ignored for a single pair. |
 | `--json` | Emit the apply result as JSON. |
 
 #### `clm slides sync task`
@@ -2154,7 +2154,7 @@ default; `--dry-run` previews.
 | `--verify-cold-pairs` / `--no-verify-cold-pairs` | Bootstrap/reconcile cold-pair `slide_id`s gated by a cheap correspondence check (default on with a key); `--no-verify-cold-pairs` refuses instead. |
 | `--llm-recover` / `--recovery-model TEXT` | Opt into the bounded Opus recovery tier for an ambiguous drifted `slide_id` (body-free, validated). |
 | `--rebaseline` | Recover from a stale watermark (clears + re-records, only when the halves agree vs git `HEAD`); single-pair, exits after. Prefer `baseline bless`, or just let `--auto-heal` (below) handle it. |
-| `--auto-heal` / `--no-auto-heal` | (since CLM {version}, #364) On a **writing** run, auto-re-baseline a stale-but-consistent watermark before reconciling (the same safe heal as `--rebaseline`, applied automatically). On by default; ignored for `--dry-run` / `--explain` / `--no-cache` / `--baseline` / `--baseline-from` / `--rebaseline`. |
+| `--auto-heal` / `--no-auto-heal` | (since CLM {version}, #364) On a **writing** run, auto-re-baseline a stale-but-consistent watermark before reconciling (the same safe heal as `--rebaseline`, applied automatically). On by default; **per pair over a directory** sweep too. Ignored for `--dry-run` / `--explain` / `--no-cache` / `--baseline` / `--baseline-from` / `--rebaseline`. |
 | `--ledger` | (since CLM {version}) Use the per-slide consistency ledger (#448): **read** it to skip slides byte-stable since a recorded confirmation (no re-litigation), **and** — on a fully clean pass (nothing deferred, the watermark fully advanced) — **record** the now-in-sync slides back to it (`confirmed_by=autopilot`, gated on structural `verify`). Mirrors `apply --ledger` for the model-bearing path; works over a directory. The `--json` payload gains a `ledger: {skipped, recorded}` block (single pair and batch). |
 | `--baseline REF` / `--baseline-from PATH[@REF]` / `--cache-dir PATH` / `--no-cache` / `--no-env-file` / `--yes` | Baseline selection, watermark store, `.env` loading, and batch confirm, as before. |
 
@@ -2178,9 +2178,15 @@ a stale-but-consistent watermark, since CLM {version}, #364) or `baseline bless`
 replacement for the old `--rebaseline`. A **writing** `apply` / `autopilot` run
 heals it automatically by default (`--no-auto-heal` opts out); the heal is safe by
 construction (it fires only when git `HEAD` shows the halves consistent, so it can
-never mask an un-synced edit). This is the recoverable case behind the "id-less
-localized cells edited on both decks" error: the error now steers to `apply`
-(auto-heal) / `baseline bless`, naming the offending cell's owning slide group.
+never mask an un-synced edit), and applies **per pair** over a directory sweep
+(the batch rollup names how many were re-baselined). This is the recoverable case
+behind the "id-less localized cells edited on both decks" error: the error now
+steers to `apply` (auto-heal) / `baseline bless`, names the offending cell's
+owning slide group, and (since CLM {version}) carries the offending cells'
+**localized positions + bytes** in the `report --json` issue item
+(`source_position` / `source_excerpt` / `target_*`). `--explain` additionally
+shows the **git-HEAD baseline side by side** with the watermark baseline whenever
+the two disagree, so a stale watermark is visible rather than a mystery.
 
 **Renaming a deck (folder or stem) is safe (since CLM {version}, epic
 #440).** Deck identity is path-derived (the watermark key and the git

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -268,6 +268,16 @@ class PlanIssue:
     # structural warning (reorder, ambiguous de/en state, shared-cell auto-heal),
     # which must keep holding the whole watermark.
     tag_hold: TagHold | None = None
+    # Issue #364: machine-readable localization of the id-less-localized both-decks
+    # drift error. The localized (non-j2 ``lang``) position + role of the first drifted
+    # cell on each half, so ``report --json`` can resolve the offending cells to bytes
+    # (the human ``reason`` already names them). ``None`` on every other issue, so the
+    # report enriches only the issues that carry a position.
+    source_position: int | None = None
+    target_position: int | None = None
+    source_lang: str | None = None
+    target_lang: str | None = None
+    role: str | None = None
 
 
 #: One membership-widened watermark row: (position, slide_id, role, content_hash, construct).
@@ -792,6 +802,35 @@ def _drifted_idless_cells(
     return owner, snippets
 
 
+def _first_drifted_idless_position(
+    cells: list[Cell], lang: str, baseline: list[str]
+) -> tuple[int | None, str | None]:
+    """The localized position + role of the first id-less localized cell of ``lang``
+    that drifted from ``baseline``, or ``(None, None)``.
+
+    Companion to :func:`_drifted_idless_cells` (same multiset-diff, same order) that
+    yields the **non-j2 ``lang`` index** — the position the report's excerpt resolver
+    targets under the ``localized`` scheme — and the ``localized-code`` / ``localized-
+    markdown`` role, so the both-decks error is machine-localizable, not just named in
+    prose (Issue #364). Walks :func:`_idless_localized_cells` and
+    :func:`_idless_localized_lang_positions` in lock-step (identical predicate/order).
+    """
+    remaining: Counter[str] = Counter(baseline)
+    positions = _idless_localized_lang_positions(cells, lang)
+    for idx, (cell, _group_sid) in enumerate(_idless_localized_cells(cells, lang)):
+        chash = hash_cell(cell.metadata, cell.content)
+        if remaining.get(chash, 0) > 0:
+            remaining[chash] -= 1
+            continue
+        role = (
+            LOCALIZED_CODE_ROLE
+            if _idless_localized_kind(cell) == "code"
+            else LOCALIZED_MARKDOWN_ROLE
+        )
+        return positions[idx], role
+    return None, None
+
+
 def _drift_cells_clause(de_snippets: list[str], en_snippets: list[str]) -> str:
     """A `` (DE 'x'; EN 'y')`` clause naming the drifted cells, or ``""`` if none.
 
@@ -1075,6 +1114,11 @@ def _classify_idless_localized_drift(
                 return
             de_owner, de_snips = _drifted_idless_cells(de_cells, "de", de_baseline)
             en_owner, en_snips = _drifted_idless_cells(en_cells, "en", en_baseline)
+            # Machine-readable localization (#364): the first drifted cell's localized
+            # position + role on each half, so `report --json` resolves the offending
+            # cells to bytes (DE the source side, EN the target — the prose names them).
+            de_pos, de_role = _first_drifted_idless_position(de_cells, "de", de_baseline)
+            en_pos, en_role = _first_drifted_idless_position(en_cells, "en", en_baseline)
             plan.issues.append(
                 PlanIssue(
                     severity="error",
@@ -1088,6 +1132,11 @@ def _classify_idless_localized_drift(
                     "auto-re-baselines it (or `clm slides sync baseline bless`); otherwise "
                     "resolve the divergence manually (or give the cells slide_ids so they "
                     "pair per-cell)",
+                    source_position=de_pos,
+                    target_position=en_pos,
+                    source_lang="de" if de_pos is not None else None,
+                    target_lang="en" if en_pos is not None else None,
+                    role=de_role or en_role,
                 )
             )
         return
@@ -4509,13 +4558,15 @@ def render_explain(
     # Issue #364 item 4: the anchor diff below is computed against the *watermark*
     # baseline. When that baseline is stale (both halves edited + committed without an
     # intervening sync) the diff can look clean yet the plan still carries an error —
-    # the classifier compares against the same stale baseline. Say so up front, and
-    # point at the git-HEAD diff, so a clean-looking diff that errors is not a mystery.
+    # the classifier compares against the same stale baseline. Say so up front; the
+    # git-HEAD baseline is shown side by side at the foot of the report so a
+    # clean-looking diff that errors is not a mystery.
     if plan.has_errors and plan.baseline_source == "watermark":
         lines.append(
             "  note: errors below are against the recorded watermark, which may be stale; "
-            "compare against committed state with `--baseline HEAD` "
-            "(or `--rebaseline` if the halves are already consistent)."
+            "the git-HEAD baseline is shown for comparison below. If the halves are "
+            "consistent against HEAD, `clm slides sync apply` auto-re-baselines it "
+            "(or `clm slides sync baseline bless`)."
         )
     has_baseline = watermark_cache is not None and watermark_cache.has_pair(
         str(de_path), str(en_path)
@@ -4559,4 +4610,41 @@ def render_explain(
 
     lines.append("plan:")
     lines.append(render_plan(plan))
+    lines.extend(_githead_comparison_lines(de_path, en_path, plan))
     return "\n".join(lines)
+
+
+def _githead_comparison_lines(de_path: Path, en_path: Path, plan: SyncPlan) -> list[str]:
+    """A side-by-side git-HEAD plan when the watermark baseline disagrees with it (#364).
+
+    Only when the report above is against the **watermark** baseline: re-classify the
+    pair against git HEAD (no watermark) and, if there is a real git baseline and the
+    two plans disagree, append the git-HEAD plan. This makes a *stale* watermark
+    visible — a plan that errors/conflicts against the recorded watermark while git
+    HEAD shows the halves consistent — instead of leaving a clean-looking anchor diff
+    that nonetheless errors. ``provider_available=False`` is sound here: the divergence
+    that matters (HEAD clean vs watermark not) has no proposals, so the model-gated
+    cold-pair handling cannot change it.
+    """
+    if plan.baseline_source != "watermark":
+        return []
+    githead = build_sync_plan(de_path, en_path, watermark_cache=None, provider_available=False)
+    if githead.baseline_source != "git-head":
+        return []  # no committed baseline to compare against (not in git / un-committed)
+    same = (plan.is_noop, plan.has_errors, len(plan.proposals), len(plan.issues)) == (
+        githead.is_noop,
+        githead.has_errors,
+        len(githead.proposals),
+        len(githead.issues),
+    )
+    if same:
+        return []  # the two baselines agree — nothing to disambiguate
+    lines = ["", "— git-HEAD baseline (for comparison) —"]
+    if githead.is_noop and not plan.is_noop:
+        lines.append(
+            "  the halves are CONSISTENT against git HEAD but NOT against the recorded "
+            "watermark above → the watermark is stale. `clm slides sync apply` "
+            "auto-re-baselines it (or `clm slides sync baseline bless`)."
+        )
+    lines.append(render_plan(githead))
+    return lines

--- a/src/clm/slides/sync_report.py
+++ b/src/clm/slides/sync_report.py
@@ -195,6 +195,14 @@ def _item_from_issue(issue: PlanIssue) -> ReconciliationItem:
         slide_id=issue.slide_id,
         reason=issue.reason,
         severity=issue.severity,
+        # Issue #364: an id-less-localized drift error carries the localized positions
+        # + role of the offending cells, so `_enrich` can resolve them to bytes. None
+        # on every other issue (no position) — those stay text-only.
+        role=issue.role,
+        source_position=issue.source_position,
+        target_position=issue.target_position,
+        source_lang=issue.source_lang,
+        target_lang=issue.target_lang,
     )
 
 
@@ -320,6 +328,25 @@ def _keyed_item_languages(item: ReconciliationItem) -> tuple[str | None, str | N
 
 def _enrich(item: ReconciliationItem, index: _SourceIndex) -> None:
     """Resolve an item's positions to concrete cell bytes (mutates ``item`` in place)."""
+    # An id-less-localized drift *issue* (#364) carries the localized (non-j2) positions
+    # of the offending cells — its ``slide_id`` is the owning slide *group*, not a cell
+    # key — so resolve it positionally under the localized scheme. Must run BEFORE the
+    # keyed branch, which the owner ``slide_id`` + localized ``role`` would otherwise
+    # claim (and fail, since ``role_of`` never returns a ``localized-*`` role).
+    if item.kind == "issue" and (
+        item.source_position is not None or item.target_position is not None
+    ):
+        if item.source_position is not None:
+            item.source_lang = item.source_lang or "de"
+            item.source_excerpt, item.source_line = index.resolve(
+                item.source_lang, "localized", item.source_position
+            )
+        if item.target_position is not None:
+            item.target_lang = item.target_lang or "en"
+            item.target_excerpt, item.target_line = index.resolve(
+                item.target_lang, "localized", item.target_position
+            )
+        return
     # A *keyed* item (carries a ``slide_id``) is resolved by its ``(slide_id, role)``
     # key, not by position. This is both the natural address for a cell identified by
     # its id and robust against the positional-scheme ambiguity: a localized id'd cell

--- a/tests/cli/test_slides_sync_rebaseline.py
+++ b/tests/cli/test_slides_sync_rebaseline.py
@@ -275,3 +275,93 @@ class TestAutoHeal:
         )
         assert "re-baselined a stale watermark" not in res.stderr
         assert "watermark is stale" in res.stderr
+
+
+def _stale_consistent_batch(tmp_path: Path, stems: tuple[str, ...]):
+    """A git repo under tmp_path with several committed, mutually-consistent pairs,
+    each carrying a *stale* watermark. Returns the cache dir."""
+    for stem in stems:
+        (tmp_path / f"{stem}.de.py").write_text(_deck("de", "neu"), encoding="utf-8")
+        (tmp_path / f"{stem}.en.py").write_text(_deck("en", "new"), encoding="utf-8")
+
+    def _git(*args: str) -> None:
+        subprocess.run(
+            ["git", *args], cwd=str(tmp_path), check=True, capture_output=True, text=True
+        )
+
+    _git("init", "-q")
+    _git("config", "user.email", "t@example.com")
+    _git("config", "user.name", "Test")
+    _git("add", "-A")
+    _git("-c", "commit.gpgsign=false", "commit", "-q", "-m", "baseline")
+    cache = tmp_path / "cache"
+    for stem in stems:
+        _seed_watermark(
+            cache,
+            tmp_path / f"{stem}.de.py",
+            tmp_path / f"{stem}.en.py",
+            de_text=_deck("de", "alt"),
+            en_text=_deck("en", "old"),
+        )
+    return cache
+
+
+class TestBatchAutoHeal:
+    """#364 follow-up: the directory (batch) sweeps auto-heal stale-but-consistent
+    watermarks per pair, like the single-pair path."""
+
+    def test_apply_batch_heals_all_pairs(self, cli_runner, tmp_path):
+        cache = _stale_consistent_batch(tmp_path, ("slides_a", "slides_b"))
+        res = cli_runner.invoke(sync_apply_cmd, ["--yes", "--cache-dir", str(cache), str(tmp_path)])
+        assert res.exit_code == 0, res.output + res.stderr
+        # Both stale watermarks were re-baselined; the rollup reports the count.
+        assert "auto-re-baselined" in res.output
+
+    def test_apply_batch_json_marks_healed_pairs(self, cli_runner, tmp_path):
+        cache = _stale_consistent_batch(tmp_path, ("slides_a", "slides_b"))
+        res = cli_runner.invoke(
+            sync_apply_cmd, ["--yes", "--json", "--cache-dir", str(cache), str(tmp_path)]
+        )
+        payload = json.loads(res.output[res.output.find("{") :])
+        assert payload["exit_code"] == 0
+        assert all(p.get("auto_healed") for p in payload["pairs"])
+
+    def test_apply_batch_no_auto_heal_surfaces_conflicts(self, cli_runner, tmp_path):
+        cache = _stale_consistent_batch(tmp_path, ("slides_a",))
+        res = cli_runner.invoke(
+            sync_apply_cmd,
+            ["--yes", "--no-auto-heal", "--cache-dir", str(cache), str(tmp_path)],
+        )
+        assert "auto-re-baselined" not in res.output
+        assert res.exit_code != 0  # the stale conflict surfaces
+
+    def test_autopilot_batch_heals(self, cli_runner, tmp_path):
+        cache = _stale_consistent_batch(tmp_path, ("slides_a", "slides_b"))
+        res = cli_runner.invoke(
+            slides_sync_cmd, ["--yes", "--cache-dir", str(cache), str(tmp_path)]
+        )
+        assert "auto-re-baselined" in res.output
+
+
+class TestExplainSideBySide:
+    """#364 follow-up: --explain shows the git-HEAD baseline next to the (stale)
+    watermark baseline when they disagree."""
+
+    def test_explain_shows_githead_comparison_when_stale(self, cli_runner, tmp_path):
+        de_path, _en, cache = _stale_consistent(tmp_path)
+        res = cli_runner.invoke(
+            slides_sync_cmd, ["--explain", "--cache-dir", str(cache), str(de_path)]
+        )
+        out = res.output + res.stderr
+        assert "git-HEAD baseline (for comparison)" in out
+        assert "CONSISTENT against git HEAD" in out
+
+    def test_explain_no_comparison_when_watermark_fresh(self, cli_runner, tmp_path):
+        # Watermark matches committed content → both baselines agree → no comparison.
+        de_path, en_path = _commit_pair(tmp_path, _deck("de", "x"), _deck("en", "y"))
+        cache = tmp_path / "cache"
+        _seed_watermark(cache, de_path, en_path, de_text=_deck("de", "x"), en_text=_deck("en", "y"))
+        res = cli_runner.invoke(
+            slides_sync_cmd, ["--explain", "--cache-dir", str(cache), str(de_path)]
+        )
+        assert "git-HEAD baseline (for comparison)" not in (res.output + res.stderr)

--- a/tests/slides/test_sync_idless_localized_drift_repro.py
+++ b/tests/slides/test_sync_idless_localized_drift_repro.py
@@ -259,6 +259,39 @@ class TestIdlessDriftErrorIsLocalized:
         assert "baseline bless" in reason
         assert "sync apply" in reason
 
+    @pytest.mark.parametrize("baseline", ["git-head", "watermark"])
+    def test_error_carries_structured_positions(self, tmp_path: Path, baseline: str):
+        # #364 follow-up: the error is machine-localizable — it carries the localized
+        # positions + role of the first drifted cell on each half, not just prose.
+        plan, _result, _de_after, _en_after = _sync(tmp_path, baseline, DE0_U, EN0_U, DE1_U, EN1_U)
+        located = [
+            e
+            for e in _error_issues(plan)
+            if e.source_position is not None or e.target_position is not None
+        ]
+        assert located, "the id-less drift error should carry structured positions"
+        err = located[0]
+        assert err.source_position is not None  # DE side drifted
+        assert err.target_position is not None  # EN side drifted
+        assert err.source_lang == "de" and err.target_lang == "en"
+        assert err.role in ("localized-code", "localized-markdown")
+
+    def test_report_enriches_idless_error_with_cell_bytes(self, tmp_path: Path):
+        # The report (with excerpts) resolves those positions to the offending cells'
+        # bytes, so an agent reads them straight from `report --json`.
+        from clm.slides.sync_report import build_report
+
+        plan, _result, _de_after, _en_after = _sync(
+            tmp_path, "watermark", DE0_U, EN0_U, DE1_U, EN1_U
+        )
+        report = build_report(plan, with_excerpts=True)
+        issues = [i for i in report.ambiguity if i.kind == "issue" and i.source_excerpt]
+        assert issues, "the id-less error item should be enriched with cell bytes"
+        item = issues[0]
+        assert "test_queries" in item.source_excerpt  # the drifted DE cell
+        assert item.target_excerpt is not None
+        assert "comparison_queries" in item.target_excerpt  # the drifted EN cell
+
 
 # ---------------------------------------------------------------------------
 # #365 increment 2 — resolve a side: a per-cell *one-sided* winner inside a

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -1224,7 +1224,9 @@ def test_explain_without_watermark_reads_everything_as_new(tmp_path: Path):
 def test_explain_warns_when_watermark_baseline_errors(tmp_path: Path):
     # Issue #364 item 4: an error against a (possibly stale) watermark baseline can show
     # a clean-looking anchor diff yet still error. --explain must say so up front and
-    # point at the git-HEAD / --rebaseline comparison, so the mismatch is not a mystery.
+    # steer to the live verbs (`apply` auto-heals / `baseline bless`), so the mismatch
+    # is not a mystery. (The git-HEAD side-by-side appears only inside a git repo; this
+    # tmp dir is not one, so just the up-front note is asserted here.)
     # Use an UNPAIRABLE structure (DE has an extra id-less cell EN lacks) so the drift
     # keeps the deck-wide error path rather than degrading to a conflict (Issue #365).
     de = _slide("de", "a", "# ## A") + _code_localized_idless("de", "for q in test_queries:\n    p")
@@ -1254,7 +1256,7 @@ def test_explain_warns_when_watermark_baseline_errors(tmp_path: Path):
 
     assert plan.has_errors
     assert "may be stale" in text
-    assert "--rebaseline" in text
+    assert "baseline bless" in text  # steers to the live verb, not the retired --rebaseline
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The three deferred items noted in the #364 PR (#480).

### 1. Batch / directory auto-heal
The single-pair stale-watermark auto-heal now also runs over a **directory** sweep, per pair. Extracted a shared `_apply_deterministic_with_heal` used by both the single-pair `apply` and `_run_apply_batch`, and threaded `auto_heal` through `_run_batch` → `_sync_one_pair` for the autopilot batch (writing mode only). `_PairResult` carries `healed`; the human rollup names how many were re-baselined and each `--json` pair entry gets `auto_healed`. Same safe gate — heals only against a verified git-HEAD no-op, never outside a git repo, skipped under `--baseline` / `--no-watermark` / `--no-auto-heal`.

### 2. `--explain` watermark-vs-git-HEAD side-by-side
When the report is against the **watermark** baseline and it disagrees with git HEAD (the stale-but-consistent signature), `render_explain` appends the git-HEAD plan with a callout (`— git-HEAD baseline (for comparison) —` + "CONSISTENT against git HEAD …"). So a clean-looking anchor diff that nonetheless errors is no longer a mystery. Only inside a git repo, only when the two disagree.

### 3. Machine-readable id-less error
The "id-less localized cells edited on both decks" `PlanIssue` now carries the offending cells' **localized positions + role** (`_first_drifted_idless_position`). `_item_from_issue` forwards them, and a dedicated `issue` branch in `_enrich` (positional, localized scheme — placed *before* the keyed branch so the owner `slide_id` doesn't mis-route it) resolves them to bytes. `report --json` now localizes the error machine-readably (`source_position`/`source_excerpt`/`target_*`), not just in prose.

## Consistency
All three steer messaging to the live verbs (`sync apply` auto-heals / `baseline bless`), never the retired `--rebaseline`. The single-pair and batch apply paths now share one heal helper so they can't drift.

## Tests
- `TestBatchAutoHeal` (apply + autopilot batch heal all pairs; `--json` per-pair `auto_healed`; `--no-auto-heal` surfaces conflicts).
- `TestExplainSideBySide` (git-HEAD comparison shown when stale, absent when fresh).
- `test_error_carries_structured_positions` + `test_report_enriches_idless_error_with_cell_bytes` (parametrized git-head/watermark).
- Updated the existing `--explain` note + id-less-error wording tests. Full `tests/slides/` + sync CLI suites green (2140+).

Follow-ups to #364 (no issue of their own).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
