### PR TITLE
test: split serial xdist groups by resource class + robust e2e fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -263,6 +263,11 @@ clm-faststream-backend-old/
 # Diagnostic output from the voiceover test tool
 tools/diagnostic_output/
 
+# Transient per-test spec files written by the outline-command tests (they must
+# sit one level under tests/test-data so resolve_course_paths finds the shared
+# slides/ sibling). Created and unlinked per test; the dir itself may linger.
+tests/test-data/_volatile_specs/
+
 # CLM build-internal sidecar tree (per topic and at the repo root). The
 # regenerable scratch under .clm/ is ignored — voiceover caches, recordings
 # event/jobs logs, local config.toml. The COMMITTED inputs under .clm/ are

--- a/changelog.d/test-xdist-load-groups.changed.md
+++ b/changelog.d/test-xdist-load-groups.changed.md
@@ -1,0 +1,12 @@
+- **Further reduced pytest-xdist contention in the test suite** (follow-up to the
+  flakiness hardening). The single `serial` xdist load group is now split by
+  resource class — `@pytest.mark.serial("subproc")` / `("workerpool")` /
+  `("port")` — so the subprocess-spawning and worker-pool families run on
+  different workers concurrently instead of stacking one-at-a-time on a single
+  worker (M-1; guarded by `tests/test_serial_xdist_groups.py`). The
+  outline-command tests now write their transient per-test specs into a
+  dedicated, gitignored, copytree-excluded `_volatile_specs/` directory rather
+  than the committed `course-specs/` tree, removing a Windows scandir/unlink
+  race against the e2e data-copy fixture (M-2). The e2e hardlink copy degrades
+  to a per-file byte copy on failure instead of aborting and crashing a retry on
+  a partial directory (M-4). Test-infrastructure only.

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -156,23 +156,35 @@ usual but keeps any tests sharing an `xdist_group` on the **same** worker.
 
 Four levers keep the per-commit fast suite both quick and flake-free:
 
-**1. `serial` — pin contention-prone tests to one worker.** A mock worker pool
-(`tests/infrastructure/workers/test_lifecycle_mock.py`) polls committed SQLite
-registration state; under many concurrent xdist workers its threads get starved
-and registration appears to stall (issue #163). The `serial` marker puts every
-such test on a single shared `xdist_group` so they run one-at-a-time on one
-dedicated worker while the rest of the suite stays fully parallel:
+**1. `serial` — pin contention-prone tests to one worker, by resource class.**
+A mock worker pool (`tests/infrastructure/workers/test_lifecycle_mock.py`) polls
+committed SQLite registration state; under many concurrent xdist workers its
+threads get starved and registration appears to stall (issue #163). The `serial`
+marker pins such tests onto a single `xdist_group` so they run one-at-a-time on
+one worker while the rest of the suite stays fully parallel.
+
+An optional argument names the **resource class** so that *different* heavy
+families don't serialize behind each other: same-class tests share one group
+(one worker, one-at-a-time); different classes get different groups that run on
+*different* workers concurrently. Current classes: `workerpool` (worker-thread /
+registration tests), `subproc` (CPython/mitmdump subprocess spawns), `port`
+(real socket binds). Bare `serial` (no arg) is a default catch-all group.
 
 ```python
 import pytest
 
-pytestmark = pytest.mark.serial  # whole module, or @pytest.mark.serial per-test
+pytestmark = pytest.mark.serial("subproc")   # whole module
+# or per-test:  @pytest.mark.serial("port")
+# or unclassified default group:  @pytest.mark.serial
 ```
 
-`tests/conftest.py` maps `serial` onto the `xdist_group`. **Reach for `serial`
-when a test contends for a global resource** (a fixed port, a shared daemon, a
-registration table) — it is the cheap, surgical alternative to widening
-timeouts, and a no-op under `-n0`.
+`tests/conftest.py` maps the marker (and its optional class arg) onto the
+`xdist_group` via `tests/xdist_group_helpers.serial_group_name`;
+`tests/test_serial_xdist_groups.py` is the meta-test that guards the mapping and
+the split. **Reach for `serial` when a test contends for a global resource** (a
+fixed port, a shared daemon, a registration table) — it is the cheap, surgical
+alternative to widening timeouts, and a no-op under `-n0`. Give it a resource
+class so it only serializes against tests that share the *same* resource.
 
 **2. `integration` — keep real-subprocess long-poles off every commit.** A test
 that spawns a real OS subprocess (a Jupyter kernel, a mitmdump proxy) is slow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,11 +298,16 @@ markers = [
     # external processes — a mitmdump proxy, a Jupyter kernel, a worker pool —
     # whose simultaneous startup across many xdist workers oversubscribes the
     # box and produces contention flakes (readiness ceilings expiring, worker
-    # registration starvation, port races). All ``serial`` tests share one
-    # group, so xdist runs them one-at-a-time on a dedicated worker while the
-    # rest of the suite stays fully parallel. The mapping marker -> xdist_group
-    # lives in ``tests/conftest.py`` (``pytest_collection_modifyitems``).
-    "serial: pin a heavy/contention-prone test to a single xdist worker",
+    # registration starvation, port races). An optional argument names the
+    # RESOURCE CLASS: ``@pytest.mark.serial`` (default group) vs
+    # ``@pytest.mark.serial("subproc")`` / ``("workerpool")`` / ``("port")``.
+    # Same-class tests share one group (run one-at-a-time on one worker);
+    # DIFFERENT classes get different groups that run on different workers
+    # concurrently — so e.g. the subprocess-spawning family doesn't serialize
+    # behind the worker-pool family. The marker -> xdist_group mapping lives in
+    # ``tests/conftest.py`` (``pytest_collection_modifyitems``) via
+    # ``tests/xdist_group_helpers.serial_group_name``.
+    "serial: pin a heavy/contention-prone test to a single xdist worker (optional resource-class arg)",
     # ``flaky`` opts a test into pytest-rerunfailures' SCOPED rerun: there is
     # deliberately NO global ``--reruns`` in addopts (that would rerun every
     # test and mask real regressions), so only tests carrying

--- a/tests/cli/test_outline.py
+++ b/tests/cli/test_outline.py
@@ -27,6 +27,23 @@ from clm.cli.main import cli
 from clm.core.course import Course
 from clm.core.course_spec import CourseSpec
 
+# Per-test spec files for the resolution-dependent outline tests live in a
+# dedicated ``_volatile_specs/`` subdirectory of the shared test-data root. The
+# spec must sit one level under ``tests/test-data`` so ``resolve_course_paths``'
+# grandparent rule still finds the shared ``slides/`` sibling — but writing and
+# unlinking it there (rather than in the committed ``course-specs/``) keeps it
+# clear of the session ``e2e_test_data_template`` copytree, which excludes
+# ``_volatile_specs`` wholesale (see tests/conftest.py), so concurrent xdist
+# workers never race that scan. The directory is gitignored. Keyed by
+# ``request.node.name`` so two workers never collide on the same path.
+_VOLATILE_SPECS_DIR = Path("tests/test-data/_volatile_specs")
+
+
+def _volatile_spec_path(request, slug: str) -> Path:
+    """Return a per-test spec path under the ignored ``_volatile_specs/`` dir."""
+    _VOLATILE_SPECS_DIR.mkdir(parents=True, exist_ok=True)
+    return _VOLATILE_SPECS_DIR / f"{slug}-{request.node.name}.xml"
+
 
 class TestOutlineCommandHelp:
     """Test outline command help and basic structure."""
@@ -334,11 +351,7 @@ class TestOutlineIncludeDisabled:
         File name is per-test (request.node.name) so concurrent xdist workers
         do not race the same shared path.
         """
-        data_dir = Path("tests/test-data")
-        specs_dir = data_dir / "course-specs"
-        spec_file = specs_dir / f"test-spec-with-disabled-{request.node.name}.xml"
-        # Keep spec file inside tests/test-data/course-specs so
-        # resolve_course_paths can locate the shared slides/ sibling.
+        spec_file = _volatile_spec_path(request, "with-disabled")
         spec_file.write_text(
             dedent("""\
                 <course>
@@ -445,9 +458,7 @@ class TestOutlineDisabledShowsRealTitles:
     @pytest.fixture
     def spec_with_resolvable_disabled_section(self, request):
         """Spec whose disabled section references a topic that exists on disk."""
-        data_dir = Path("tests/test-data")
-        specs_dir = data_dir / "course-specs"
-        spec_file = specs_dir / f"test-spec-disabled-resolvable-{request.node.name}.xml"
+        spec_file = _volatile_spec_path(request, "disabled-resolvable")
         spec_file.write_text(
             dedent("""\
                 <course>
@@ -587,9 +598,7 @@ class TestOutlineSectionsOnly:
 
     def test_sections_only_with_include_disabled_markdown(self, request):
         """--sections-only also suppresses topic bullets for disabled sections."""
-        data_dir = Path("tests/test-data")
-        specs_dir = data_dir / "course-specs"
-        spec_file = specs_dir / f"test-spec-sections-only-disabled-{request.node.name}.xml"
+        spec_file = _volatile_spec_path(request, "sections-only-disabled")
         spec_file.write_text(
             dedent("""\
                 <course>
@@ -637,9 +646,7 @@ class TestOutlineSectionsOnly:
 
     def test_sections_only_with_include_disabled_json(self, request):
         """JSON sections-only output keeps disabled flag but drops topics."""
-        data_dir = Path("tests/test-data")
-        specs_dir = data_dir / "course-specs"
-        spec_file = specs_dir / f"test-spec-sections-only-disabled-json-{request.node.name}.xml"
+        spec_file = _volatile_spec_path(request, "sections-only-disabled-json")
         spec_file.write_text(
             dedent("""\
                 <course>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -563,7 +563,16 @@ def pytest_configure(config):
 @pytest.hookimpl(tryfirst=True)
 def pytest_collection_modifyitems(config, items):
     """Auto-skip tests based on tool availability; map ``serial`` to a group."""
+    from tests.xdist_group_helpers import serial_group_name
+
     tool_status = get_tool_availability()
+
+    # Tally serial-marked items per resulting load group so the meta-test
+    # (``tests/test_serial_xdist_groups.py``) can confirm the heavy families
+    # land in DISTINCT groups. This hook sees the FULL collected item list on
+    # every xdist worker (collection runs per-worker before distribution), so
+    # the counts are complete wherever the meta-test happens to execute.
+    serial_group_counts: dict[str, int] = {}
 
     # Count tests by marker for reporting
     docker_tests = []
@@ -650,15 +659,26 @@ def pytest_collection_modifyitems(config, items):
             if not tool_status["docker"]:
                 item.add_marker(skip_docker)
 
-        # Map the project's ``serial`` marker onto an xdist load group so the
-        # ``--dist loadgroup`` scheduler (see pyproject ``addopts``) pins every
-        # serial-marked test onto a single worker. Contention-prone tests that
-        # spawn heavyweight external processes (a mitmdump proxy, a worker
-        # pool) thereby run one-at-a-time instead of racing each other across
-        # workers and oversubscribing the box. A no-op when xdist is disabled
-        # (``-n0``), since there is then only one worker anyway.
-        if "serial" in markers:
-            item.add_marker(pytest.mark.xdist_group("serial"))
+        # Map the project's ``serial`` marker onto a PER-RESOURCE xdist load
+        # group so the ``--dist loadgroup`` scheduler (see pyproject ``addopts``)
+        # pins each contention-prone family onto ONE worker. The optional marker
+        # argument names the resource class: ``@pytest.mark.serial`` -> the
+        # default ``"serial"`` group; ``@pytest.mark.serial("subproc")`` ->
+        # ``"serial-subproc"``. Distinct classes get distinct groups, so e.g. the
+        # subprocess-spawning tests and the worker-pool tests each run
+        # one-at-a-time *within* their class while the two classes run on
+        # DIFFERENT workers concurrently — instead of all serial tests stacking
+        # onto one worker (the single-bucket bottleneck). A no-op under ``-n0``
+        # (one worker anyway).
+        serial_marker = item.get_closest_marker("serial")
+        if serial_marker is not None:
+            resource_class = serial_marker.args[0] if serial_marker.args else None
+            group = serial_group_name(resource_class)
+            item.add_marker(pytest.mark.xdist_group(group))
+            serial_group_counts[group] = serial_group_counts.get(group, 0) + 1
+
+    # Expose the per-group tally for the split-invariant meta-test.
+    setattr(config, "_clm_serial_group_counts", serial_group_counts)
 
 
 @pytest.fixture(scope="function")
@@ -969,30 +989,52 @@ def e2e_test_data_template(tmp_path_factory):
         Path: Path to the template directory containing test-data
     """
     template_dir = tmp_path_factory.mktemp("test-data-template")
-    # Other tests in the suite write transient spec files into the shared
-    # ``tests/test-data/course-specs/`` tree (see e.g. the outline-command
-    # fixtures in ``tests/cli/test_outline.py``). Under xdist that creates a
-    # race against this copytree on Windows: ``os.scandir`` sees the file
-    # but it has been unlinked by the time ``copytree`` tries to read it,
-    # which raises ``[WinError 2]``. The volatile names all follow the
-    # pattern ``test-spec-<slug>-test_<funcname>.xml`` because they use
-    # ``request.node.name``; the committed specs use bare names like
-    # ``test-spec-1.xml`` and don't contain ``-test_``. Skip the volatile
-    # ones at scan time so the e2e setup is robust to concurrent writers.
+    # Some tests write transient, per-test spec files under the shared
+    # ``tests/test-data`` tree (the outline-command fixtures in
+    # ``tests/cli/test_outline.py`` — a spec must live one level under
+    # test-data so ``resolve_course_paths``' grandparent rule finds the shared
+    # ``slides/`` sibling). Under xdist that races this copytree on Windows:
+    # ``os.scandir`` sees a file that has been unlinked by the time copytree
+    # opens it (``[WinError 2]``). Those fixtures write into a dedicated
+    # ``_volatile_specs/`` subdirectory (M-2); excluding that ONE directory
+    # wholesale is robust to whatever filename a future fixture chooses — unlike
+    # the previous ``test-spec-*-test_*.xml`` filename-substring glob, which a
+    # differently-named volatile spec would silently defeat. The old pattern is
+    # kept too, as a belt-and-suspenders for any stray writer outside that dir.
     shutil.copytree(
         DATA_DIR,
         template_dir / "test-data",
-        ignore=shutil.ignore_patterns("test-spec-*-test_*.xml"),
+        ignore=shutil.ignore_patterns("_volatile_specs", "test-spec-*-test_*.xml"),
     )
     return template_dir / "test-data"
+
+
+def _link_or_copy(src, dst, *, follow_symlinks=True):
+    """``copytree`` copy_function: hardlink for speed, byte-copy per file on failure.
+
+    The old approach tried ``copytree(copy_function=os.link)`` wholesale and, on
+    ``OSError``, retried with a plain ``copytree`` — but the first attempt may
+    have already created ``dst`` and linked some files before failing on one,
+    so the retry hit ``FileExistsError`` against the now-partial directory (and
+    the trigger scales with worker count: Windows handle pressure under parallel
+    load makes a mid-copy ``os.link`` failure load-correlated). Degrading only
+    the *single* failing file to ``shutil.copy2`` keeps the hardlink speed win
+    for every other file and can never leave a partial tree for a retry to trip
+    on. ``copy2`` preserves metadata, so the fallback is faithful.
+    """
+    try:
+        os.link(src, dst)
+    except OSError:
+        shutil.copy2(src, dst, follow_symlinks=follow_symlinks)
 
 
 @pytest.fixture
 def e2e_test_data_copy(tmp_path, e2e_test_data_template):
     """Copy test-data to temp directory for E2E testing.
 
-    Uses hardlinks from session-scoped template for fast per-test copies.
-    Falls back to regular copy on platforms that don't support hardlinks.
+    Uses hardlinks from the session-scoped template for fast per-test copies,
+    falling back to a byte copy per file (see :func:`_link_or_copy`) when a
+    hardlink can't be made.
 
     Returns:
         tuple: (data_dir, output_dir) where data_dir is the copied test-data
@@ -1001,13 +1043,9 @@ def e2e_test_data_copy(tmp_path, e2e_test_data_template):
     data_dir = tmp_path / "test-data"
     output_dir = tmp_path / "output"
 
-    # Try to use hardlinks for fast copy from template (O(n) files, not O(n) bytes)
-    # Falls back to regular copy on Windows or cross-filesystem scenarios
-    try:
-        shutil.copytree(e2e_test_data_template, data_dir, copy_function=os.link)
-    except OSError:
-        # Fallback to regular copy if hardlinks not supported
-        shutil.copytree(e2e_test_data_template, data_dir)
+    # Hardlink each file (O(n) files, not O(n) bytes); a file that can't be
+    # linked degrades to a byte copy without aborting the whole tree.
+    shutil.copytree(e2e_test_data_template, data_dir, copy_function=_link_or_copy)
 
     # Create output directory
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/infrastructure/api/test_server.py
+++ b/tests/infrastructure/api/test_server.py
@@ -332,7 +332,7 @@ class TestGlobalSingleton:
 
 
 @pytest.mark.integration
-@pytest.mark.serial
+@pytest.mark.serial("port")
 class TestRealUvicornStartup:
     """Bind an actual uvicorn server; hit /health; ensure clean shutdown.
 

--- a/tests/infrastructure/test_http_replay_mitm.py
+++ b/tests/infrastructure/test_http_replay_mitm.py
@@ -46,10 +46,12 @@ from clm.infrastructure.http_replay_mitm.proxy_manager import (
 #     explicit (run on demand via ``pytest -m integration`` or directly by
 #     path), and the #184 mitmdump contention/flakiness surface leaves the
 #     commit path entirely.
-#   * ``serial`` still pins them onto one xdist worker whenever they ARE run in
-#     parallel, so the mitmdump spawns don't race each other. See the ``serial``
-#     marker in pyproject and its xdist_group mapping in ``tests/conftest.py``.
-pytestmark = [pytest.mark.serial, pytest.mark.integration]
+#   * ``serial("subproc")`` still pins them onto one xdist worker whenever they
+#     ARE run in parallel, so the mitmdump spawns don't race each other (they
+#     share the ``subproc`` load group with the other subprocess-spawning
+#     tests). See the ``serial`` marker in pyproject and its xdist_group mapping
+#     in ``tests/conftest.py``.
+pytestmark = [pytest.mark.serial("subproc"), pytest.mark.integration]
 
 # Skip the whole module if mitmdump isn't reachable — the [mitmproxy]
 # extra installs the Python package but the executable lookup may still

--- a/tests/infrastructure/test_http_replay_mitm_manager.py
+++ b/tests/infrastructure/test_http_replay_mitm_manager.py
@@ -27,8 +27,10 @@ from clm.infrastructure.http_replay_mitm.proxy_manager import MitmproxyManager
 # threads) and amplifying contention flakes. ``serial`` pins the whole module to
 # the single shared serial xdist_group so the spawns run one-at-a-time on one
 # worker while the rest of the suite stays parallel (same mechanism as the #163
-# lifecycle_mock fix). See docs/developer-guide/testing.md ("serial" lever).
-pytestmark = pytest.mark.serial
+# lifecycle_mock fix). The ``"subproc"`` resource class puts these on their own
+# load group, distinct from the worker-pool family, so the two run on different
+# workers concurrently. See docs/developer-guide/testing.md ("serial" lever).
+pytestmark = pytest.mark.serial("subproc")
 
 
 def _manager() -> MitmproxyManager:

--- a/tests/infrastructure/workers/test_lifecycle_mock.py
+++ b/tests/infrastructure/workers/test_lifecycle_mock.py
@@ -34,7 +34,7 @@ from tests.fixtures.mock_workers import MockWorker, MockWorkerConfig, MockWorker
 # addopts makes any retry visible; a test that reruns often wants a root-cause
 # fix, not more retries.
 pytestmark = [
-    pytest.mark.serial,
+    pytest.mark.serial("workerpool"),
     pytest.mark.flaky(
         reruns=2,
         reruns_delay=1,

--- a/tests/test_serial_xdist_groups.py
+++ b/tests/test_serial_xdist_groups.py
@@ -1,0 +1,65 @@
+"""Meta-tests for the ``serial`` -> per-resource xdist load-group mapping (M-1).
+
+Two layers:
+
+1. Pure unit tests of :func:`serial_group_name` — the deterministic mapping a
+   regression (a typo, a collision, dropping the default) would break.
+2. A collection-level invariant read off the tally the conftest hook stashes on
+   ``config`` (``_clm_serial_group_counts``): under the default fast collection
+   the two heavy serial families land in DISTINCT, non-empty groups, so they run
+   on different workers concurrently rather than stacking on one. This is the
+   whole point of splitting the single ``serial`` bucket.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.xdist_group_helpers import serial_group_name
+
+
+class TestSerialGroupName:
+    def test_default_class_is_the_bare_serial_group(self) -> None:
+        assert serial_group_name(None) == "serial"
+
+    def test_named_class_is_prefixed(self) -> None:
+        assert serial_group_name("subproc") == "serial-subproc"
+        assert serial_group_name("workerpool") == "serial-workerpool"
+        assert serial_group_name("port") == "serial-port"
+
+    def test_distinct_classes_map_to_distinct_groups(self) -> None:
+        classes = ["subproc", "workerpool", "port"]
+        groups = [serial_group_name(c) for c in classes]
+        assert len(set(groups)) == len(groups), groups
+        # A named class never collides with the bare default group.
+        assert all(g != serial_group_name(None) for g in groups)
+
+    def test_every_group_is_namespaced_under_serial(self) -> None:
+        for cls in (None, "subproc", "workerpool", "port", "anything"):
+            g = serial_group_name(cls)
+            assert g == "serial" or g.startswith("serial-")
+
+
+def test_heavy_serial_families_are_split_into_distinct_groups(request) -> None:
+    """The two heavy fast-suite serial families must land in DISTINCT groups.
+
+    ``tests/infrastructure/workers/test_lifecycle_mock.py`` (``workerpool``) and
+    ``tests/infrastructure/test_http_replay_mitm_manager.py`` (``subproc``) are
+    the contention-prone families in the fast suite. M-1 puts them in different
+    xdist load groups so they run on different workers concurrently instead of
+    one global serial bottleneck. Skipped when a narrowed ``-m`` filter
+    deselects them (their counts are then absent).
+    """
+    counts = getattr(request.config, "_clm_serial_group_counts", None)
+    assert counts is not None, "the serial -> xdist_group mapping hook did not run"
+
+    # Whatever serial groups exist this run must all be well-formed names.
+    assert all(g == "serial" or g.startswith("serial-") for g in counts), counts
+
+    if not (counts.get("serial-subproc") and counts.get("serial-workerpool")):
+        pytest.skip("the heavy serial families are not both collected under this filter")
+
+    # Both present => they are in distinct, non-empty load groups (distinct keys
+    # each with members), i.e. the single bucket was actually split.
+    assert counts["serial-subproc"] > 0
+    assert counts["serial-workerpool"] > 0

--- a/tests/xdist_group_helpers.py
+++ b/tests/xdist_group_helpers.py
@@ -1,0 +1,25 @@
+"""Helpers for mapping the ``serial`` marker to per-resource xdist load groups.
+
+Kept out of ``conftest.py`` so both the collection hook (which imports it) and
+the meta-test (``tests/test_serial_xdist_groups.py``) import the same pure
+function unambiguously.
+"""
+
+from __future__ import annotations
+
+
+def serial_group_name(resource_class: str | None) -> str:
+    """Map a ``serial`` marker's resource class to its xdist load-group name.
+
+    ``@pytest.mark.serial`` (no arg) maps to the default ``"serial"`` group;
+    ``@pytest.mark.serial("subproc")`` maps to ``"serial-subproc"``. Distinct
+    classes get distinct, stable group names, so under ``--dist loadgroup`` each
+    heavy resource family is serialized *within itself* while the families run
+    on DIFFERENT workers concurrently — instead of every serial test funnelling
+    onto one worker (the single-bucket bottleneck that M-1 removes).
+
+    The group name is deterministic and prefixed with ``serial`` so it never
+    collides with an unrelated ``xdist_group`` a test might set for its own
+    reasons.
+    """
+    return "serial" if resource_class is None else f"serial-{resource_class}"


### PR DESCRIPTION
Medium-term follow-ups (**M-1 / M-2 / M-4**) from `docs/claude/test-flakiness-investigation.md`, building on the flakiness hardening in #483. Test-infrastructure only — no `src/` changes.

## M-1 — split the single `serial` xdist bucket by resource class
The `serial` marker now takes an optional resource-class argument that `tests/conftest.py` maps to a distinct `xdist_group` (via `tests/xdist_group_helpers.serial_group_name`):

| marker | group |
|---|---|
| `@pytest.mark.serial` | `serial` (default catch-all) |
| `@pytest.mark.serial("subproc")` | `serial-subproc` (CPython/mitmdump spawns) |
| `@pytest.mark.serial("workerpool")` | `serial-workerpool` (worker threads / registration) |
| `@pytest.mark.serial("port")` | `serial-port` (real socket binds) |

Same-class tests still run one-at-a-time on one worker, but **different classes run on different workers concurrently** — so the subprocess-spawning family (`http_replay_mitm[_manager]`) no longer serializes behind the worker-pool family (`lifecycle_mock`). Under `--dist loadgroup` this shortens the serial critical path as the bucket grows. The mapping hook stays `@pytest.hookimpl(tryfirst=True)` (the #163 ordering gotcha).

`tests/test_serial_xdist_groups.py` is the meta-test: it unit-tests the pure mapping (default / distinctness / namespacing) and asserts the two heavy fast-suite families land in distinct, non-empty groups — read off a per-group tally the collection hook stashes on `config` (so it's correct on whatever xdist worker the meta-test runs).

## M-2 — move volatile test specs off the committed tree
The outline-command fixtures wrote transient per-test specs into the committed `tests/test-data/course-specs/` tree (so `resolve_course_paths`' grandparent rule finds the sibling `slides/`), relying on a fragile `test-spec-*-test_*.xml` filename-substring `copytree` ignore. They now write into a dedicated **`tests/test-data/_volatile_specs/`** (still one level under `test-data`, so resolution is unchanged), which the `e2e_test_data_template` copytree excludes **wholesale** — robust to any filename a future fixture chooses. The directory is gitignored.

## M-4 — idempotent e2e hardlink-copy fallback
`e2e_test_data_copy` used `copytree(copy_function=os.link)` and, on `OSError`, retried with a plain `copytree` — but the first attempt could leave a **partial** directory, so the retry hit `FileExistsError`. It now uses a per-file `_link_or_copy` (`os.link`, falling back to `shutil.copy2` for just the failing file), so the hardlink speed win is kept and no partial tree can crash a retry. `copy2` preserves metadata.

## Verification
- Full fast suite green at 16 workers (8739 passed; the +5 is the new meta-test).
- The split meta-test **fires** (not skips) and passes when both heavy families are collected.
- e2e structure tests green (exercise `_link_or_copy`); `_volatile_specs/` stays empty + git-ignored after runs.
- ruff clean; pre-push gate green. (mypy hook is `src/`-only; no `src/` changes here.)

## Docs
- Updated the "serial" lever in `docs/developer-guide/testing.md` (resource classes) and the `serial` marker description in `pyproject.toml`.
- (M-3 — tighter global timeout — deliberately deferred; it needs `--durations` measured on a CI-class box first.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
