### PR TITLE
test: tighten fast-suite timeout to 120s, bump heavier suites per CI (M-3)

### DIFF
--- a/changelog.d/test-fast-suite-timeout.changed.md
+++ b/changelog.d/test-fast-suite-timeout.changed.md
@@ -1,0 +1,10 @@
+- **Tightened the fast-suite per-test timeout from 600s to 120s** (matching CI's
+  `--timeout=120`), so a contention *hang* on the pre-push gate fails promptly
+  instead of stalling ~10 minutes (which forced a manual Ctrl-C + re-run). The
+  slowest legitimate fast test measures ~5.5s (16-worker dev box) / ~11s
+  (64-worker contention), so 120s is a >10x backstop, not a performance gate.
+  `tests/conftest.py` bumps the heavier suites' per-test timeout at collection
+  time to match CI — `integration` → 240s, `e2e`/`slow`/`docker` → 600s — so
+  running them locally (a non-default `-m` selection) never false-kills against
+  the fast default; an explicit `@pytest.mark.timeout` still wins.
+  Test-infrastructure only.

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -243,6 +243,20 @@ xdist load, so the suite relaxes it in one place instead of every heartbeat
 test re-patching the constant. Never raise the **production** default — relax it
 only in tests, via this env var.
 
+### Per-test timeout
+
+`[tool.pytest.ini_options] timeout` (pyproject) defaults to **120s** — the same
+ceiling CI enforces on the fast suite (`--timeout=120`). The slowest legitimate
+fast test measures ~5.5s (16-worker dev box) / ~11s (64-worker contention), so
+120s is a generous hang **backstop**, not a performance gate: it converts a
+contention hang on the pre-push gate from a 10-minute stall (the old 600s) into
+a prompt, attributable failure the scoped `flaky` retry can absorb. The heavier
+suites need more, so `tests/conftest.py` bumps their per-test timeout at
+collection time to match CI — `integration` → 240s, `e2e`/`slow`/`docker` →
+600s — so running them **locally** (a non-default `-m` selection, e.g.
+`pytest -m e2e`) never false-kills against the fast default. Override a single
+test with `@pytest.mark.timeout(N)`; it takes precedence over all of the above.
+
 > The HTTP-replay / cassette tests need the `replay` extra (`pyyaml`,
 > `filelock`). It is included in the auto-synced `dev` dependency group, so
 > `uv sync` / `uv run pytest` always has it; without it those tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -329,8 +329,18 @@ markers = [
 # fix the root cause). There is intentionally no ``--reruns`` here — reruns are
 # opt-in per test via ``@pytest.mark.flaky`` only.
 addopts = "-n auto --dist loadgroup -rR -m 'not slow and not db_only and not integration and not e2e and not docker'"
-# Timeout configuration - prevents tests from hanging indefinitely
-timeout = 600  # 10 minutes default timeout for all tests
+# Per-test timeout — converts a hung test into a prompt, attributable failure
+# instead of a 10-minute stall (the old 600s default, which turned a contention
+# hang on the pre-push gate into a Ctrl-C + manual re-run). 120s matches CI's
+# fast-suite ``--timeout=120`` (.github/workflows/ci.yml), the authoritative
+# ceiling on 2-4 vCPU hardware: the slowest legitimate fast test measures ~5.5s
+# (16-worker dev box) / ~11s (64-worker contention), so 120s is a >10x backstop,
+# NOT a performance gate. The heavier non-fast suites need more headroom, so
+# ``tests/conftest.py`` bumps their per-test timeout at collection time —
+# integration -> 240, e2e/slow/docker -> 600, matching CI — so running them
+# locally (a non-default ``-m`` selection) never false-kills against this
+# fast-suite default. (A ``timeout`` marker takes precedence over this value.)
+timeout = 120
 timeout_method = "thread"  # Works better with asyncio tests
 # Filter out deprecation warnings from third-party packages
 filterwarnings = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -677,6 +677,19 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(pytest.mark.xdist_group(group))
             serial_group_counts[group] = serial_group_counts.get(group, 0) + 1
 
+        # Give the heavier non-fast suites the generous per-test timeout CI
+        # grants them (.github/workflows/ci.yml: integration --timeout=240,
+        # e2e/docker --timeout=600), so running them LOCALLY (a non-default
+        # ``-m`` selection) never false-kills against the tight fast-suite
+        # default in ``[tool.pytest.ini_options] timeout`` (120s). A ``timeout``
+        # marker takes precedence over the ini/CLI value; an explicit per-test
+        # ``@pytest.mark.timeout`` is left untouched.
+        if item.get_closest_marker("timeout") is None:
+            if {"e2e", "slow", "docker"} & set(markers):
+                item.add_marker(pytest.mark.timeout(600))
+            elif "integration" in markers:
+                item.add_marker(pytest.mark.timeout(240))
+
     # Expose the per-group tally for the split-invariant meta-test.
     setattr(config, "_clm_serial_group_counts", serial_group_counts)
 


### PR DESCRIPTION
**M-3** from `docs/claude/test-flakiness-investigation.md` — shrink the hang blast radius on the pre-push gate. Test-infrastructure only.

## Problem
The pyproject default `timeout = 600` meant a contention *hang* in the fast suite stalled the pre-push gate for **10 minutes** before pytest-timeout killed it — turning a flake into a manual Ctrl-C + re-run (the exact pain this whole effort targets).

## Measurement (the investigation's open question, resolved)
| Environment | Slowest fast test |
|---|---|
| dev box, 16 workers (gate config) | **5.49s** |
| dev box, 64 workers (max contention) | ~11s |
| **CI (2–4 vCPU)** | **proven < 120s** — `.github/workflows/ci.yml` already runs the fast suite with `--timeout=120` and is green |

So 120s is a **>10× backstop, not a performance gate**, and it's the *authoritative* CI ceiling (no need to guess the dev→CI slowdown).

## Change
- **`pyproject.toml`: `timeout` 600 → 120** — the fast suite *is* the default `pytest` run, so this is the value that matters, and it matches CI.
- **`tests/conftest.py`: per-marker bump at collection time** so the heavier suites keep CI's generous headroom when run **locally** (a non-default `-m` selection): `integration` → 240s, `e2e`/`slow`/`docker` → 600s. A `timeout` marker takes precedence over the ini default; an explicit per-test `@pytest.mark.timeout` is left untouched. **CI is unaffected** — it passes its own `--timeout` per suite, equal to the marker values.

## Verification
- **Precedence proof:** integration tests taking up to **24.9s survived a deliberate CLI `--timeout=1`** — only possible if the conftest `timeout(240)` marker is applied *and* overrides the CLI value. (This also shows why the bump matters: integration tests run ~13–25s on the dev box, so the bare 120s default would be risky for them on slower hardware.)
- Full fast suite green under the new 120s default (pre-push gate); fast subset + ruff clean. (mypy hook is `src/`-only; no `src/` changes.)

## Docs
- New "Per-test timeout" subsection in `docs/developer-guide/testing.md`; rationale comment on the pyproject `timeout`.

This completes the medium-term flakiness items (M-1/M-2 in #486, M-4 in #486, M-3 here); the structural items S-1/S-2/S-3 remain deferred per the investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
