### PR TITLE
fix: globally-unique cohort-calendar event UIDs (#436)

### DIFF
--- a/changelog.d/436-calendar-uid-collision.fixed.md
+++ b/changelog.d/436-calendar-uid-collision.fixed.md
@@ -1,0 +1,14 @@
+- **Cohort calendar: fix UID collisions that silently dropped events (#436).**
+  `clm calendar generate -f ics` and `clm calendar push` seeded each event's
+  stable UID from the bare slide-file **stem**, which is unique only within a
+  topic — so two distinct decks that share a stem (a common pattern: many topics
+  name their lead deck `slides_010_*`) produced the **same** UID and collided.
+  One event was silently dropped from the `.ics` feed and from a pushed Google
+  calendar (`duplicate event UID … keeping the later assignment`). The UID is now
+  seeded from each deck's globally-unique **`module/topic/stem`** identity, which
+  eliminates the entire collision class. **One-time migration:** because every
+  video/merged event's UID changes (date-keyed review/exam inserts keep theirs),
+  the first `clm calendar push` after upgrading re-creates those events once
+  (read-only `.ics`/Google subscribers see a one-time refresh — no emails, since
+  the events have no attendees, and no manual step). Preview it with
+  `clm calendar push … --dry-run`. See `clm info migration`.

--- a/docs/claude/design/cohort-viewing-calendar.md
+++ b/docs/claude/design/cohort-viewing-calendar.md
@@ -394,10 +394,12 @@ into their own calendar app automatically.
   exclusive-end semantics).
 - `SUMMARY` = localized video/deck titles for that assignment (`-L` controls
   language); `DESCRIPTION` lists deck files / topic ids for traceability.
-- `UID` is stable across re-exports — derived from `(channel, bucket-ref)` —
-  so re-issuing the feed *updates* events in place instead of duplicating them.
-  This is what lets holidays/catch-up edits propagate cleanly to a subscribed
-  student.
+- `UID` is stable across re-exports — derived from `(channel, bucket-ref)`,
+  where the bucket-ref is each deck's globally-unique `module/topic/stem`
+  identity (issue #436; *not* the bare slide-file stem, which collided when two
+  decks shared it and silently dropped an event) — so re-issuing the feed
+  *updates* events in place instead of duplicating them. This is what lets
+  holidays/catch-up edits propagate cleanly to a subscribed student.
 - `insert` entries (review/exam days) become events with no deck list.
 
 ## 9. Relationship to release (kept independent)

--- a/src/clm/cli/commands/export/schedule.py
+++ b/src/clm/cli/commands/export/schedule.py
@@ -80,6 +80,15 @@ class ScheduleDeck:
     # filename ("02 Linear Regression.html"); 0 when unknown (e.g. a disabled
     # deck read from the filesystem, which is never built/numbered).
     number_in_section: int = 0
+    # Parent module directory name (e.g. "module_550_ml_azav"). With topic_id and
+    # deck_file this forms the deck's globally-unique identity: the stem alone is
+    # unique only *within* a topic, so two decks sharing a stem once collided to a
+    # single cohort-calendar UID and silently dropped an event (issue #436). Empty
+    # only for a deck read from disk for a topic that does not resolve (a
+    # disabled-export edge that never reaches the calendar's UID path). Appended
+    # last so the established positional field order (disabled, number_in_section)
+    # is unchanged.
+    module: str = ""
 
 
 @dataclass
@@ -187,6 +196,10 @@ def _topic_decks(topic, language: str) -> list[ScheduleDeck]:
     language so a split pair is listed once (and with the correct title),
     mirroring the build's per-language routing.
     """
+    # A topic lives at slides/<module>/<topic>, so the topic path's parent is the
+    # module directory regardless of whether the topic is a directory or a single
+    # file; this completes each deck's globally-unique module/topic/stem identity.
+    module = topic.path.parent.name
     decks: list[ScheduleDeck] = []
     for notebook in topic.notebooks:
         if not notebook_in_language(notebook, language):
@@ -202,6 +215,7 @@ def _topic_decks(topic, language: str) -> list[ScheduleDeck]:
                 video_title=title,
                 topic_id=topic.id,
                 deck_file=notebook.path.stem,
+                module=module,
                 number_in_section=getattr(notebook, "number_in_section", 0) or 0,
             )
         )
@@ -239,6 +253,11 @@ def _decks_for_subsection(
         if not disabled and topic_spec.id in topic_decks:
             decks.extend(topic_decks[topic_spec.id])
         else:
+            # Resolve the deck's module from the filesystem topic map (same source
+            # disabled_topic_slides reads), so a disabled deck still carries its
+            # globally-unique module/topic/stem identity.
+            topic_path = course._topic_path_map.get(topic_spec.id)
+            module = topic_path.parent.name if topic_path is not None else ""
             slides = disabled_topic_slides(course, topic_spec, language) or []
             for file_name, title in slides:
                 decks.append(
@@ -246,6 +265,7 @@ def _decks_for_subsection(
                         video_title=title,
                         topic_id=topic_spec.id,
                         deck_file=Path(file_name).stem,
+                        module=module,
                         disabled=disabled,
                     )
                 )

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -2,6 +2,37 @@
 
 This guide covers breaking changes across major CLM versions.
 
+## Cohort calendar event UIDs are now globally unique (issue #436, {version})
+
+`clm calendar generate -f ics` and `clm calendar push` give every event a
+**stable UID** so re-exporting / re-pushing updates events in place instead of
+duplicating them. That UID was seeded from the bare **slide-file stem**, which is
+unique only *within* a topic — so two distinct decks sharing a stem (a common
+pattern: many topics name their lead deck `slides_010_*`) produced the **same**
+UID and collided. One event was silently dropped from the `.ics` feed and from a
+pushed Google calendar (`duplicate event UID … keeping the later assignment`).
+
+The UID is now seeded from each deck's globally-unique **`module/topic/stem`**
+identity, eliminating the entire collision class.
+
+**One-time migration — no action required.** Because every **video / merged**
+event's UID changes (date-keyed review/exam *inserts* keep theirs and are left
+in place), the **first `clm calendar push` after upgrading re-creates those
+events once**: it deletes the old-UID events and inserts the new ones in a single
+sync. Students subscribed to the shared Google calendar (read-only "See all event
+details", with no event guests) and `.ics` subscribers see a one-time refresh of
+the entries — **no notification emails are sent** (the events have no attendees)
+and no manual step is needed. Preview the churn first:
+
+```bash
+clm calendar push course.xml --channel <name> --dry-run
+```
+
+The `.ics` feed re-keys the same way on its next export. After this single
+re-creation the calendar is stable again. (There is no opt-out / versioned scheme:
+the old stem-only UID was buggy, so keeping it alive was deliberately rejected in
+favour of one clean re-key.)
+
 ## `clm slides sync` is now a verb group; the bare command reads (epic #440, {version})
 
 `clm slides sync` was a single leaf command that **wrote to the working tree by

--- a/src/clm/cohort_calendar/projection.py
+++ b/src/clm/cohort_calendar/projection.py
@@ -68,7 +68,7 @@ class Assignment:
     decks: tuple[ScheduleDeck, ...]  # empty for an `insert`
     label: str | None  # set for inserts; else None
     kind: str  # "video" | "merged" | "insert"
-    bucket_refs: tuple[str, ...]  # stable id seeds (deck-file stems) for .ics UIDs
+    bucket_refs: tuple[str, ...]  # globally-unique id seeds (module/topic/stem) for .ics UIDs
     plan_label: str = ""  # plan-relative coordinate, e.g. "W4 Tuesday" (drift/status)
     section_title: str = ""  # localized section name of the (first) bucket; "" for inserts
     activity_labels: tuple[str, ...] = ()  # non-deck day items (project work, exam, …)
@@ -164,8 +164,22 @@ def _resolve_ref(ref: str, buckets) -> tuple[int | None, str | None]:
     return matches[0], None
 
 
+def _deck_ref(deck: ScheduleDeck) -> str:
+    """A deck's globally-unique, stable id seed: ``module/topic/stem``.
+
+    The bare deck-file stem is unique only *within* a topic, so two distinct
+    decks that share a stem (a common pattern — many topics name their lead deck
+    ``slides_010_*``) once produced the same ``.ics`` / Google Calendar UID and
+    silently dropped one event (issue #436). Qualifying the stem with the topic
+    id and the parent module name makes the seed unique across the whole course
+    while staying stable across re-projection — none of the three parts depends
+    on dates. Empty parts (an unresolved disabled-export deck) are skipped.
+    """
+    return "/".join(part for part in (deck.module, deck.topic_id, deck.deck_file) if part)
+
+
 def _bucket_refs(decks: tuple[ScheduleDeck, ...]) -> tuple[str, ...]:
-    return tuple(d.deck_file for d in decks)
+    return tuple(_deck_ref(d) for d in decks)
 
 
 def _activity_labels(buckets_slice) -> tuple[str, ...]:

--- a/src/clm/cohort_calendar/render.py
+++ b/src/clm/cohort_calendar/render.py
@@ -178,9 +178,10 @@ def _ics_escape(text: str) -> str:
 def assignment_uid(a: Assignment, namespace: str) -> str:
     """A stable UID per assignment so re-exports update rather than duplicate.
 
-    Seeded by the assignment's bucket refs (deck-file stems) for video/merged
-    rows, or the date for an insert — both stable across re-projection of the
-    same content, even as dates shift. Shared with the Google Calendar push
+    Seeded by the assignment's bucket refs — each deck's globally-unique
+    ``module/topic/stem`` identity (issue #436) — for video/merged rows, or the
+    date for an insert; both are stable across re-projection of the same content,
+    even as dates shift. Shared with the Google Calendar push
     (:mod:`clm.cohort_calendar.google_sync`) so the ``.ics`` feed and a pushed
     calendar agree on event identity.
     """

--- a/src/clm/cohort_calendar/status.py
+++ b/src/clm/cohort_calendar/status.py
@@ -7,8 +7,9 @@ it takes the reference date explicitly (the CLI passes the system date, or
 Drift is measured against the *ideal* calendar — the same buckets, start, and
 pattern but with **no holidays and no adjustments** — i.e. the as-planned
 schedule. The reference assignment (the one active today, else the next one) is
-matched to its ideal twin by its first bucket ref (a deck-file stem, stable even
-across merges), and the gap in calendar days is the drift.
+matched to its ideal twin by its first bucket ref (the deck's globally-unique
+``module/topic/stem`` identity, issue #436, stable even across merges), and the
+gap in calendar days is the drift.
 """
 
 from __future__ import annotations

--- a/tests/cli/test_schedule.py
+++ b/tests/cli/test_schedule.py
@@ -75,6 +75,25 @@ class TestBuildSchedule:
         ]
         assert monday.decks[0].video_title == "Some Topic from Test 1"
 
+    def test_deck_carries_real_module_for_uid_identity(self, course):
+        # Issue #436: each deck's globally-unique cohort-calendar UID seed is
+        # module/topic/stem, and `module` is derived from the topic's parent dir
+        # on disk (topic.path.parent.name). Lock that real derivation here — every
+        # cohort_calendar unit test injects `module=` by hand, so without this a
+        # regression in the derivation (e.g. reading the topic dir instead of the
+        # module) would pass all tests yet still let real calendars collide. Monday
+        # draws two topics from two different modules, the exact collision shape.
+        weeks = build_schedule(course, "en")
+        monday = weeks[0].days[0]
+        assert [(d.module, d.topic_id) for d in monday.decks] == [
+            ("module_000_test_1", "some_topic_from_test_1"),
+            ("module_010_test_2", "a_topic_from_test_2"),
+        ]
+        wednesday = weeks[1].days[0]
+        assert [(d.module, d.topic_id) for d in wednesday.decks] == [
+            ("module_030_single_notebook", "simple_notebook"),
+        ]
+
     def test_label_uses_name_override(self, course):
         weeks = build_schedule(course, "en")
         tuesday = weeks[0].days[1]

--- a/tests/cohort_calendar/test_google_sync.py
+++ b/tests/cohort_calendar/test_google_sync.py
@@ -140,6 +140,37 @@ class TestBuildDesiredEvents:
         assert body["summary"] == "Review & Q&A"
         assert "description" not in body
 
+    def test_same_stem_decks_yield_two_events_not_one(self):
+        # Issue #436: two distinct decks sharing the slide-file stem
+        # "slides_010_review.de" must produce two events, not collide into one.
+        proj = Projection(
+            (
+                Assignment(
+                    dt.date(2026, 3, 2),
+                    dt.date(2026, 3, 2),
+                    (deck("Review W1-6", "review_w01_w06", "slides_010_review.de"),),
+                    None,
+                    "video",
+                    ("module_545_foundations/review_w01_w06/slides_010_review.de",),
+                    section_title="W01",
+                ),
+                Assignment(
+                    dt.date(2026, 3, 9),
+                    dt.date(2026, 3, 9),
+                    (deck("Review W5-9", "review_w05_w09", "slides_010_review.de"),),
+                    None,
+                    "video",
+                    ("module_550_ml_azav/review_w05_w09/slides_010_review.de",),
+                    section_title="W06",
+                ),
+            ),
+            (),
+        )
+        desired = gs.build_desired_events(proj, namespace="jan")
+        assert len(desired) == 2
+        # Both survive into a sync plan (neither silently dropped).
+        assert len(gs.plan_sync(desired, []).inserts) == 2
+
     def test_span_covers_all_dates(self):
         body = gs.build_desired_events(sample(), namespace="jan")[UID_SPAN]
         assert body["start"] == {"date": "2026-03-04"}

--- a/tests/cohort_calendar/test_projection.py
+++ b/tests/cohort_calendar/test_projection.py
@@ -268,3 +268,41 @@ class TestActivityDays:
         (a,) = proj.assignments
         assert a.kind == "merged"
         assert a.activity_labels == ("Projekt A", "Projekt B")
+
+
+class TestBucketRefIdentity:
+    """Issue #436: the UID seed must be globally unique, not the bare stem."""
+
+    @staticmethod
+    def _qualified_deck(module: str, topic: str, stem: str) -> ScheduleDeck:
+        return ScheduleDeck(video_title=stem, topic_id=topic, deck_file=stem, module=module)
+
+    @staticmethod
+    def _solo_bucket(deck_: ScheduleDeck, *, week: int) -> Bucket:
+        return Bucket(decks=[deck_], span=1, week=week, weekday_label="Mon", weekdays=("mon",))
+
+    def test_same_stem_different_topic_and_module_do_not_collide(self):
+        # Two distinct review decks both named slides_010_review.de — the exact
+        # ML-AZAV collision from #436. Their bucket refs (and thus UIDs) must differ.
+        d1 = self._qualified_deck(
+            "module_545_foundations", "review_w01_w06", "slides_010_review.de"
+        )
+        d2 = self._qualified_deck("module_550_ml_azav", "review_w05_w09", "slides_010_review.de")
+        proj = project([self._solo_bucket(d1, week=1), self._solo_bucket(d2, week=2)], cfg())
+        assert proj.ok
+        refs = [a.bucket_refs for a in proj.assignments]
+        assert refs == [
+            ("module_545_foundations/review_w01_w06/slides_010_review.de",),
+            ("module_550_ml_azav/review_w05_w09/slides_010_review.de",),
+        ]
+        # The derived UIDs are what actually collided in the calendar / push.
+        from clm.cohort_calendar.render import assignment_uid
+
+        uids = {assignment_uid(a, "jan") for a in proj.assignments}
+        assert len(uids) == 2
+
+    def test_ref_skips_empty_parts(self):
+        # A deck with no resolvable module degrades gracefully to topic/stem.
+        d = self._qualified_deck("", "intro", "slides_010_intro")
+        (a,) = project([self._solo_bucket(d, week=1)], cfg()).assignments
+        assert a.bucket_refs == ("intro/slides_010_intro",)


### PR DESCRIPTION
## Problem (#436)

Cohort-calendar event UIDs (`clm calendar generate -f ics` and `clm calendar push`) were seeded from the bare **slide-file stem** (`projection._bucket_refs` → `tuple(d.deck_file for d in decks)`). Stems are unique only *within* a topic, so two distinct decks sharing a stem — a common pattern, since many topics name their lead deck `slides_010_*` — produced the **same** UID and collided. One event was silently dropped from the `.ics` feed and from a pushed Google calendar (`build_desired_events` does `desired[uid] = body`, last-wins). This bit the real ML-AZAV 2026-04 cohort: two review decks both named `slides_010_review.de` merged into one event, dropping the W1–6 review.

## Fix

Seed the UID from each deck's globally-unique **`module/topic/stem`** identity instead, eliminating the entire collision class (topic IDs alone aren't globally unique either — `build_topic_map` returns a *list* per ID across modules).

- `ScheduleDeck` gains a `module` field (appended last to keep the positional field order), derived from `topic.path.parent.name` on the enabled path and the topic-path map on the disabled path. Topics are always direct children of a module dir, so the parent is reliably the module.
- `projection._bucket_refs` joins `module/topic/stem` via a new `_deck_ref` helper (empty parts skipped).
- Date-keyed `insert` (review/exam) events are untouched — they key on the date, not the stem.

## Migration decision: accept the one-time re-key (no tooling, no dual scheme)

Discussed the three options from the issue against the deployment reality (one live cohort, shared **read-only** with students who are **not event guests**):

- **Versioned dual scheme** — rejected: permanently maintains two schemes *and* keeps the v1 collision bug alive.
- **Zero-churn in-place UID rewrite** — rejected: `clm_uid` is a CLM-private property, not the Google event ID; a rewrite keeps event IDs stable (no flicker) but the `.ics` feed re-keys regardless, so it only solves half the churn while adding throwaway, collision-aware code. `plan_sync` already makes permanent duplicates structurally impossible, so the churn path is safe.
- **Accept one-time churn** — chosen: simplest, single clean scheme, lowest long-term maintenance. The events are CLM-owned/disposable by design, and **no notification emails fire** (no attendees, and read-only subscribers can't enable change-emails). The only effect is a one-time visual refresh.

The first push after upgrading re-creates each **video/merged** event once. Documented in `clm info migration` and a changelog fragment; preview with `clm calendar push … --dry-run`.

## Verification

- Adversarial 3-lens review (correctness / completeness / migration accuracy): no blockers. Confirmed the `module` derivation is right for every topic kind, the `.ics` and Google paths consume the same seed, `status.py` drift matching is transparent to the change, and `plan_sync`/`apply_plan` can't leave permanent duplicates. Its findings (a missing real-derivation test, two stale docstrings, an over-broad "every event" claim, a positional-arg footgun) are all addressed in this PR.
- Tests (all green): projection- and push-level regressions for the same-stem collision, plus a **fixture-driven** test that locks the real `topic.path.parent.name` derivation across two modules (every other test injected `module=` by hand). `ruff` + `mypy` clean; fast suite green on push.

Closes #436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGRj5teMpcTKrmGcNQyZVS
