### PR TITLE
feat(slides sync): `sync diagnose` — classify a verify symptom into its root cause

### DIFF
--- a/changelog.d/sync-diagnose.added.md
+++ b/changelog.d/sync-diagnose.added.md
@@ -1,0 +1,17 @@
+- **New `clm slides sync diagnose` verb — classify a `verify` symptom into its root
+  cause.** A `verify` failure (`id-asymmetry`, `duplicate-id`) has several unrelated
+  root causes, each needing a different fix; renaming ids until `verify` passes hides
+  the real defect. `diagnose` is a read-only superset of `verify` **and**
+  `reconcile-vo-ids`: for every finding — plus the verify-invisible narrative
+  id-disagreements (a narration cell id'd on one half, id-less on the other) — it
+  names the root cause (`MIS-TAG` / `ID-LESS-TWIN` / `CONTENT-GAP` / `WHOLE-DECK-GAP`
+  / `DUPLICATE-NARRATION-OVERSTAMP` / `NARRATIVE-ID-DISAGREEMENT` / …), the evidence
+  (content-language vs `lang=` tag, who carries the id, whether a twin exists), and
+  whether the fix is mechanical or authoring. `--apply` performs **only** the
+  identity-preserving narrative fixes (strip a duplicated/asymmetric narration id to
+  the canonical id-less form), re-gated by structure; it **never** renames an id to
+  silence a symptom. Content language is judged by a tiny built-in DE/EN heuristic
+  that abstains on short/title-only text. Read-only by default, `--json` for agents;
+  the root-cause catalog ships in `clm info sync-agents`. Also adds
+  `reconcile_vo_ids.collapse_intra_half_duplicates` for the symmetric narration
+  over-stamp the existing reconciler left alone.

--- a/src/clm/cli/commands/slides/sync.py
+++ b/src/clm/cli/commands/slides/sync.py
@@ -102,6 +102,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from clm.infrastructure.llm.ollama_client import SyncJudge, SyncProposal
+    from clm.slides.sync_diagnose import ApplyDiagnoseResult, DiagnoseResult
     from clm.slides.sync_plan_walker import PlanWalkResult
     from clm.slides.sync_recover import AlignmentRecoverer, CorrespondenceVerifier
     from clm.slides.sync_report import ReconciliationItem
@@ -1078,6 +1079,162 @@ def _print_verify_human(results: list[VerifyResult], root: Path | None) -> None:
 
 
 # ---------------------------------------------------------------------------
+# diagnose — classify a verify symptom into its root cause (Issue: sync diagnose)
+# ---------------------------------------------------------------------------
+
+
+def _run_diagnose(de_path: Path, en_path: Path | None, *, as_json: bool, apply_fixes: bool) -> None:
+    """Classify ``verify`` symptoms for a pair / tree into root causes, then ``sys.exit``.
+
+    A read-only superset of ``verify`` (same producer; never alters verify's exit
+    semantics): each violation — plus the verify-invisible narrative id-disagreements —
+    is labelled with its root cause and prescribed fix. ``--apply`` performs ONLY the
+    mechanical narrative fixes (strip duplicated/asymmetric narration ids to id-less),
+    re-gated by structure; everything else stays advisory. Lazy-imports the classifier
+    inside the body to preserve the LazyGroup startup cost. Always ``sys.exit``s.
+    """
+    from clm.slides.sync_diagnose import apply_mechanical_fixes, diagnose_pair
+
+    root: Path | None
+    if de_path.is_dir():
+        if en_path is not None:
+            raise click.UsageError(
+                f"{de_path} is a directory (batch diagnose), which takes a single "
+                "directory argument; do not pass a second path."
+            )
+        pairs, solos = iter_split_pairs(find_split_slide_files_recursive(de_path))
+        for solo in solos:
+            tag = split_lang_tag(solo)
+            other = "EN" if tag == "de" else "DE"
+            click.echo(
+                f"warning: skipping {solo.name} — no {other} twin found under {de_path}.",
+                err=True,
+            )
+        pair_list = [(de_p.resolve(), en_p.resolve()) for de_p, en_p in pairs]
+        root = de_path
+    else:
+        de_resolved, en_resolved = _resolve_single_path(de_path, en_path)
+        de_resolved, en_resolved = _resolve_sync_pair(de_resolved, en_resolved)
+        de_resolved, en_resolved = de_resolved.resolve(), en_resolved.resolve()
+        pair_list = [(de_resolved, en_resolved)]
+        root = None
+
+    applied: list[ApplyDiagnoseResult] | None = [] if apply_fixes else None
+    results: list[DiagnoseResult] = []
+    for de_p, en_p in pair_list:
+        if apply_fixes:
+            ar = apply_mechanical_fixes(de_p, en_p)
+            assert applied is not None
+            applied.append(ar)
+            results.append(ar.residual if ar.residual is not None else diagnose_pair(de_p, en_p))
+        else:
+            results.append(diagnose_pair(de_p, en_p))
+
+    exit_code = 2 if any(not r.ok for r in results) else 0
+    if as_json:
+        click.echo(json.dumps(_diagnose_to_dict(results, applied, root, exit_code), indent=2))
+    else:
+        _print_diagnose_human(results, applied, root)
+    sys.exit(exit_code)
+
+
+def _diagnose_to_dict(
+    results: list[DiagnoseResult],
+    applied: list[ApplyDiagnoseResult] | None,
+    root: Path | None,
+    exit_code: int,
+) -> dict[str, object]:
+    payload: dict[str, object] = {"mode": "diagnose", "exit_code": exit_code}
+    if root is not None:
+        payload["root"] = str(root)
+    applied_by_path = (
+        {(str(a.de_path), str(a.en_path)): a for a in applied} if applied is not None else {}
+    )
+    pairs: list[dict] = []
+    for r in results:
+        entry: dict = {
+            "de_path": str(r.de_path),
+            "en_path": str(r.en_path),
+            "ok": r.ok,
+            "git_baseline": r.git_baseline,
+            "diagnoses": [
+                {
+                    "root_cause": d.root_cause,
+                    "fix_class": d.fix_class,
+                    "severity": d.severity,
+                    "slide_id": d.slide_id,
+                    "role": d.role,
+                    "prescribed_fix": d.prescribed_fix,
+                    "evidence": d.evidence,
+                }
+                for d in r.diagnoses
+            ],
+        }
+        ar = applied_by_path.get((str(r.de_path), str(r.en_path)))
+        if ar is not None:
+            entry["applied"] = {
+                "written": ar.written,
+                "refused": ar.refused,
+                "reconcile_changes": ar.reconcile_changes,
+                "collapsed_duplicates": ar.collapsed_duplicates,
+                "new_errors": ar.new_errors,
+            }
+        pairs.append(entry)
+    payload["pairs"] = pairs
+    return payload
+
+
+def _print_diagnose_human(
+    results: list[DiagnoseResult], applied: list[ApplyDiagnoseResult] | None, root: Path | None
+) -> None:
+    if not results:
+        click.echo(
+            f"no split-format deck pairs found under {root}."
+            if root is not None
+            else "nothing to diagnose."
+        )
+        return
+    applied_by_path = (
+        {(str(a.de_path), str(a.en_path)): a for a in applied} if applied is not None else {}
+    )
+    for r in results:
+        mark = "PASS" if r.ok else "FAIL"
+        errs = [d for d in r.diagnoses if d.severity == "error"]
+        warns = [d for d in r.diagnoses if d.severity == "warning"]
+        bits = []
+        if errs:
+            bits.append(f"{len(errs)} finding{'s' if len(errs) != 1 else ''}")
+        if warns:
+            bits.append(f"{len(warns)} warning{'s' if len(warns) != 1 else ''}")
+        if not r.git_baseline:
+            bits.append("dropped-id check skipped (untracked)")
+        summary = f" ({', '.join(bits)})" if bits else " (no issues)"
+        click.echo(f"{mark} {r.de_path.name}{summary}")
+        ar = applied_by_path.get((str(r.de_path), str(r.en_path)))
+        if ar is not None:
+            if ar.refused:
+                click.echo(f"    --apply REFUSED (would introduce: {', '.join(ar.new_errors)})")
+            elif ar.written:
+                click.echo(
+                    f"    --apply: stripped {ar.reconcile_changes} asymmetric + "
+                    f"{ar.collapsed_duplicates} duplicate narration id(s) to id-less."
+                )
+            else:
+                click.echo("    --apply: no mechanical narrative fix needed.")
+        for d in r.diagnoses:
+            sid = f" slide_id={d.slide_id!r}" if d.slide_id else ""
+            role = f" role={d.role!r}" if d.role else ""
+            click.echo(f"    [{d.root_cause} / {d.fix_class}]{sid}{role}")
+            click.echo(f"        → {d.prescribed_fix}")
+    if len(results) > 1:
+        clean = sum(1 for r in results if r.ok)
+        click.echo(
+            f"\ndiagnosed {len(results)} pair(s): {clean} clean, "
+            f"{len(results) - clean} with findings."
+        )
+
+
+# ---------------------------------------------------------------------------
 # Exit codes
 # ---------------------------------------------------------------------------
 
@@ -1685,6 +1842,43 @@ def sync_verify_cmd(de_path: Path, en_path: Path | None, as_json: bool) -> None:
     corrupt. Answers "did this edit corrupt the pair?", not "is it in sync?".
     """
     _run_verify(de_path, en_path, as_json=as_json)
+
+
+@slides_sync_group.command("diagnose")
+@_DECK_ARG
+@_EN_ARG
+@click.option("--json", "as_json", is_flag=True, help="Emit the diagnosis as JSON.")
+@click.option(
+    "--apply",
+    "apply_fixes",
+    is_flag=True,
+    help=(
+        "Apply ONLY the mechanical narrative fixes — strip duplicated / asymmetric "
+        "narration ids to the canonical id-less form, re-gated by structure. Mis-tags, "
+        "content gaps, and whole-deck gaps stay advisory. Dry-run when omitted."
+    ),
+)
+def sync_diagnose_cmd(
+    de_path: Path, en_path: Path | None, as_json: bool, apply_fixes: bool
+) -> None:
+    """Classify each ``verify`` symptom into its root cause + fix (read-only by default).
+
+    A ``verify`` failure is a *symptom*, not a diagnosis: ``id-asymmetry`` /
+    ``duplicate-id`` each have several unrelated root causes needing different fixes.
+    ``diagnose`` is a read-only superset of ``verify`` **and** ``reconcile-vo-ids``: for
+    every finding — plus the verify-invisible narrative id-disagreements — it names the
+    root cause (mis-tag / id-less-twin / content-gap / whole-deck-gap / narration
+    over-stamp / …), the evidence (content-language vs ``lang=`` tag, who carries the
+    id), and whether the fix is **mechanical** (auto-fixable) or **authoring**.
+
+    \b
+    It **never** suggests renaming an id to make verify pass (that buries a real gap —
+    the ``array-limitations`` trap). ``--apply`` performs only the identity-preserving
+    narrative fixes, re-gated so a write never introduces a new structural error;
+    everything else is a worklist entry. Exit ``0`` = no error-severity finding, ``2`` =
+    findings remain. Works on a single pair or a directory.
+    """
+    _run_diagnose(de_path, en_path, as_json=as_json, apply_fixes=apply_fixes)
 
 
 @slides_sync_group.command("apply")

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -2018,6 +2018,39 @@ dropped vs git `HEAD`. **No model, no watermark, writes nothing.** Answers *"did
 this edit break the pair?"*, not *"is it in sync?"* (`report`) or *"is the
 translation good?"*. Exit `0` = sound (warnings allowed), `2` = corrupt. CI-safe.
 
+#### `clm slides sync diagnose`
+
+```
+clm slides sync diagnose DECK [EN_PATH] [OPTIONS]
+```
+
+A `verify` failure is a *symptom*, not a diagnosis: the same code (`id-asymmetry`,
+`duplicate-id`) has several unrelated root causes, each needing a **different**
+fix. `diagnose` is a **read-only superset of `verify` and `reconcile-vo-ids`**: for
+every finding — *plus* the verify-invisible narrative id-disagreements (a narration
+cell id'd on one half, id-less on the other, which `verify` cannot see because the
+slide's id is still carried by the slide cell in both halves) — it names the root
+cause, the evidence behind it (content-language vs `lang=` tag, who carries the id,
+whether a twin exists), and whether the fix is **mechanical** (auto-fixable) or
+**authoring** (needs a human / translation).
+
+Root-cause vocabulary: `DUPLICATE-NARRATION-OVERSTAMP`, `NARRATIVE-ID-DISAGREEMENT`
+(mechanical); `MIS-TAG`, `ID-LESS-TWIN`, `CONTENT-GAP`, `WHOLE-DECK-GAP`,
+`DUPLICATE-ID-NON-NARRATIVE`, `UNIFY-ALIGNMENT`, `DROPPED-ID` (authoring/advisory).
+
+It **never** suggests renaming an id to make `verify` pass — that buries a real gap
+(the `array-limitations` trap). Content language is judged by a tiny built-in DE/EN
+heuristic that **abstains** on short/title-only text, so a mis-tag is asserted only
+on confident evidence.
+
+| Option | Description |
+|--------|-------------|
+| `--apply` | Perform **only** the identity-preserving narrative fixes (strip a duplicated / asymmetric narration id to the canonical id-less form, via `reconcile-vo-ids`), re-gated by structure so a write never introduces a new error. Mis-tags, content gaps, mis-pairings, and whole-deck gaps stay advisory (never auto-rewritten). Dry-run when omitted. |
+| `--json` | Emit the diagnosis as JSON: per pair, `ok` + a `diagnoses[]` of `{root_cause, fix_class, severity, slide_id, role, prescribed_fix, evidence}`, plus an `applied` block under `--apply`. |
+
+Read-only by default (no model, no key). Exit `0` = no error-severity finding,
+`2` = findings remain. Works on a single pair or a directory.
+
 #### `clm slides sync apply`
 
 ```

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -162,6 +162,41 @@ makes). Exit `0` = structurally valid (warnings allowed), `2` = corruption. Run
 it after every hand edit and after every `accept`. It is CI-safe because it
 needs no model, and works on a single pair or a directory.
 
+## Diagnosing a `verify` failure — `clm slides sync diagnose DECK`
+
+A `verify` failure is a **symptom, not a diagnosis**: the same code —
+`id-asymmetry`, `duplicate-id` — is produced by several *unrelated* root causes,
+each needing a *different* fix. **The anti-pattern is to rename / re-slug ids until
+`verify` passes** — that hides the real defect (it can point an id at the wrong
+content while the truly-missing slide stays absent — the `array-limitations`
+trap). So: **diagnose each failing pair before touching it.**
+
+`clm slides sync diagnose DECK` does that mechanically. It is a **read-only
+superset of `verify` and `reconcile-vo-ids`** — it runs the same structural checks
+*and* the occurrence-pairing detection that catches the most common case `verify`
+cannot see (a narration cell id'd on one half, id-less on the other: no
+`id-asymmetry` fires, because the slide's id is still on the slide cell in both
+halves). For each finding it emits a **root cause**, the **evidence** (the cell's
+*content language* vs its `lang=` tag, who carries the id, whether a twin exists),
+the **prescribed fix**, and whether that fix is **mechanical** or **authoring**:
+
+| Root cause | Meaning | Fix |
+|---|---|---|
+| `DUPLICATE-NARRATION-OVERSTAMP` | several `voiceover`/`notes` cells under one slide all id'd (`assign-ids` over-stamp) | **mechanical** — strip to id-less (`--apply`) |
+| `NARRATIVE-ID-DISAGREEMENT` | a narration cell id'd on one half, id-less on its twin | **mechanical** — strip to id-less (`--apply`) |
+| `MIS-TAG` | a cell's content language ≠ its `lang=` tag → routed into the wrong half | authoring — move it to the right half with the twin's id |
+| `ID-LESS-TWIN` | the twin exists but was never tagged | authoring — add `tags=[…]` + `slide_id` (no translation) |
+| `CONTENT-GAP` | the slide exists in only one language | authoring — translate the missing twin (same id) |
+| `WHOLE-DECK-GAP` | one half is empty | authoring — a translation project; track it |
+| `DUPLICATE-ID-NON-NARRATIVE`, `UNIFY-ALIGNMENT`, `DROPPED-ID` | a real structural problem | authoring — resolve by hand |
+
+`diagnose --apply` performs **only** the two mechanical narrative fixes (re-gated
+by structure so a write never introduces a new error); everything else is a
+worklist entry it **never** auto-rewrites — and it never renames an id to silence a
+symptom. Read-only by default, `--json` for the structured form. Use it as step 1
+when `verify` (or a sweep) reports `id-asymmetry` / `duplicate-id`, then act on the
+labelled findings instead of guessing.
+
 ## Baselines (you rarely touch these)
 
 `report` / `verify` default to git `HEAD`; you do not need the watermark for the

--- a/src/clm/slides/content_lang.py
+++ b/src/clm/slides/content_lang.py
@@ -1,0 +1,190 @@
+"""Lightweight DE/EN content-language detection for sync diagnostics (no ML dep).
+
+The ``clm slides sync diagnose`` classifier needs to tell a cell's *content
+language* from its declared ``lang=`` tag, to separate a **mis-tag** (a German
+paragraph routed into the EN half) from a genuine **content gap**. No
+language-detection dependency exists in CLM, and the ``[ml]`` extra is blocked, so
+this is a deliberately tiny heuristic, not a dependency: a German signal
+(umlaut/eszett presence + German stop-word hits) versus an English signal (English
+stop-word hits).
+
+It **abstains** (``label == "unknown"``) on short / code-heavy / stop-word-free
+text — exactly the title-only cells where any statistical detector is least
+reliable — so the classifier never asserts a mis-tag on a guess (it treats
+``unknown`` as "cannot assert mis-tag" and downgrades to advisory).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# High-frequency English function words (a superset of slug._STOP_WORDS plus a few
+# discriminators). These appear densely in English prose and rarely in German.
+_EN_WORDS = frozenset(
+    {
+        "the",
+        "a",
+        "an",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "of",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "and",
+        "or",
+        "but",
+        "with",
+        "by",
+        "as",
+        "this",
+        "that",
+        "these",
+        "those",
+        "it",
+        "we",
+        "you",
+        "they",
+        "he",
+        "she",
+        "not",
+        "do",
+        "does",
+        "can",
+        "will",
+        "which",
+        "from",
+        "have",
+        "has",
+        "there",
+        "their",
+        "our",
+        "its",
+        "if",
+        "then",
+        "than",
+        "when",
+        "while",
+        "into",
+        "about",
+    }
+)
+# High-frequency German function words — the DE counterparts. Short, common, and
+# essentially absent from English prose.
+_DE_WORDS = frozenset(
+    {
+        "der",
+        "die",
+        "das",
+        "und",
+        "ist",
+        "sind",
+        "war",
+        "waren",
+        "nicht",
+        "mit",
+        "für",
+        "auf",
+        "ein",
+        "eine",
+        "einen",
+        "einem",
+        "einer",
+        "zu",
+        "von",
+        "im",
+        "den",
+        "dem",
+        "des",
+        "sich",
+        "wir",
+        "sie",
+        "ihr",
+        "auch",
+        "oder",
+        "aber",
+        "wird",
+        "werden",
+        "kann",
+        "durch",
+        "bei",
+        "als",
+        "dass",
+        "wenn",
+        "man",
+        "es",
+        "noch",
+        "nur",
+        "hier",
+        "diese",
+        "dieser",
+        "dieses",
+        "so",
+        "wie",
+        "um",
+    }
+)
+_UMLAUT_RE = re.compile(r"[äöüÄÖÜß]")
+_WORD_RE = re.compile(r"[a-zA-ZäöüÄÖÜß]+")
+
+# An umlaut/eszett is a near-certain German marker (English prose essentially never
+# carries one), so it is weighted like several stop-word hits.
+_UMLAUT_WEIGHT = 3.0
+# Below this confidence the guess is reported as ``unknown`` — the classifier must
+# not assert a mis-tag on weak evidence.
+_MIN_CONFIDENCE = 0.34
+# Below this many prose words there is too little signal to judge (title-only/code).
+_MIN_WORDS = 5
+
+
+@dataclass(frozen=True)
+class LangGuess:
+    """A content-language guess. ``label`` is ``"de"`` / ``"en"`` / ``"unknown"``."""
+
+    label: str
+    confidence: float  # 0.0–1.0; 0.0 when abstaining
+
+    @property
+    def confident(self) -> bool:
+        """Whether the guess is strong enough to act on (assert a mis-tag)."""
+        return self.label != "unknown" and self.confidence >= _MIN_CONFIDENCE
+
+
+def detect(text: str) -> LangGuess:
+    """Guess whether ``text`` is German or English prose, or abstain.
+
+    Returns ``LangGuess("unknown", 0.0)`` when there is too little prose, or the DE
+    and EN signals are too close to call — the safe default for the classifier.
+    """
+    words = [w.lower() for w in _WORD_RE.findall(text)]
+    has_umlaut = bool(_UMLAUT_RE.search(text))
+    if len(words) < _MIN_WORDS:
+        # Too little prose to judge. An umlaut is still a strong DE marker even in a
+        # short string, but report modest confidence so a title cell rarely drives a
+        # mis-tag assertion on its own.
+        return LangGuess("de", 0.6) if has_umlaut else LangGuess("unknown", 0.0)
+
+    de_hits = sum(1 for w in words if w in _DE_WORDS)
+    en_hits = sum(1 for w in words if w in _EN_WORDS)
+    de_signal = de_hits + (_UMLAUT_WEIGHT if has_umlaut else 0.0)
+    en_signal = float(en_hits)
+    total = de_signal + en_signal
+    if total == 0:
+        return LangGuess("unknown", 0.0)
+
+    label = "de" if de_signal > en_signal else "en"
+    margin = abs(de_signal - en_signal) / total
+    # Scale the margin down when the absolute evidence is thin (few stop-word hits),
+    # so a single stray hit in otherwise-neutral text does not read as confident.
+    evidence = min(total, 5.0) / 5.0
+    confidence = round(margin * evidence, 3)
+    if confidence < _MIN_CONFIDENCE:
+        return LangGuess("unknown", confidence)
+    return LangGuess(label, confidence)

--- a/src/clm/slides/reconcile_vo_ids.py
+++ b/src/clm/slides/reconcile_vo_ids.py
@@ -188,3 +188,56 @@ def reconcile_voiceover_ids(
     de_out = reconstruct(de_pre, de_cells) if result.de_changed else de_text
     en_out = reconstruct(en_pre, en_cells) if result.en_changed else en_text
     return de_out, en_out, result
+
+
+def _collapse_one_half(cells: list[RawCell]) -> int:
+    """Strip the id from every narrative cell in a duplicated ``(slide_id, role)`` group.
+
+    Returns the number of cells stripped. Mutates ``cells`` in place.
+    """
+    groups: dict[tuple[str, str], list[RawCell]] = {}
+    for cell in cells:
+        meta = cell.metadata
+        if meta.is_j2 or not meta.is_narrative or meta.slide_id is None:
+            continue
+        role = role_of(meta)
+        if role is None:
+            continue
+        groups.setdefault((meta.slide_id, role), []).append(cell)
+    stripped = 0
+    for group in groups.values():
+        if len(group) <= 1:
+            continue
+        for cell in group:
+            _strip_slide_id(cell)
+            stripped += 1
+    return stripped
+
+
+def collapse_intra_half_duplicates(
+    de_text: str,
+    en_text: str,
+    de_token: str,
+    en_token: str,
+) -> tuple[str, str, int]:
+    """Strip ``slide_id`` from narrative cells that duplicate a ``(slide_id, role)`` key
+    within a half — the **symmetric** over-stamp :func:`reconcile_voiceover_ids` leaves
+    alone.
+
+    A slide with several ``voiceover`` / ``notes`` cells all stamped with the slide's id
+    (``assign-ids`` ``source=voiceover-inherit``) collides on ``(slide_id, role)`` within
+    each half. When *both* halves are over-stamped the same way, the occurrence pairing
+    sees them *agree* (both id'd), so ``reconcile_voiceover_ids`` does not touch them —
+    yet ``verify`` flags a ``duplicate-id`` on each half. This strips the id from
+    **every** narrative cell in a duplicated ``(slide_id, role)`` group → the engine's
+    canonical id-less narration form (collision-proof). It never mints or derives an id
+    (#162). Returns ``(de_text', en_text', stripped_count)``; a half is returned
+    byte-identical when nothing changed.
+    """
+    de_pre, de_cells = split_cells(de_text, de_token)
+    en_pre, en_cells = split_cells(en_text, en_token)
+    de_stripped = _collapse_one_half(de_cells)
+    en_stripped = _collapse_one_half(en_cells)
+    de_out = reconstruct(de_pre, de_cells) if de_stripped else de_text
+    en_out = reconstruct(en_pre, en_cells) if en_stripped else en_text
+    return de_out, en_out, de_stripped + en_stripped

--- a/src/clm/slides/sync_diagnose.py
+++ b/src/clm/slides/sync_diagnose.py
@@ -1,0 +1,370 @@
+"""Classify a ``clm slides sync verify`` symptom into its root cause (the catalog).
+
+A ``verify`` failure is a *symptom*, not a diagnosis: the same code — ``id-asymmetry``,
+``duplicate-id`` — is produced by several unrelated root causes, each needing a
+*different* fix. This module turns each finding into a labelled diagnosis with the
+evidence behind it (content-language vs ``lang=`` tag, who carries the id, whether a
+twin exists) and whether the fix is **mechanical** (auto-fixable, identity-preserving)
+or **authoring** (needs a human / translation).
+
+It is a **read-only superset of both** ``sync verify`` **and** ``reconcile-vo-ids``:
+the canonical id-less-twin case (a narrative cell id'd on one half, id-less on the
+other) produces *no* ``verify`` violation — the owning slide's id is still carried by
+the slide cell in both halves — so the classifier runs ``reconcile``'s own
+occurrence-pairing detection independently, not only off a ``VerifyViolation``.
+
+**The anti-pattern guard.** The recommended fix is *never* "rename slide_id X to Y to
+make verify pass" — that buries a real gap (the ``array-limitations`` trap). Auto-fix is
+permitted *only* for identity-preserving narrative operations (strip a duplicated /
+asymmetric narration id to the canonical id-less form). A mis-tag, mis-pairing, content
+gap, or whole-deck gap is **advisory** — a worklist entry, never an auto-rewrite.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from clm.notebooks.slide_parser import comment_token_for_path
+from clm.slides.content_lang import detect
+from clm.slides.lang_coverage import CoverageStatus, classify_counts, count_languages
+from clm.slides.raw_cells import RawCell, split_cells
+from clm.slides.reconcile_vo_ids import (
+    TO_IDLESS,
+    collapse_intra_half_duplicates,
+    reconcile_voiceover_ids,
+)
+from clm.slides.sync_verify import VerifyResult, structural_gate, verify_pair
+
+_NARRATIVE_ROLES = frozenset({"voiceover", "notes"})
+
+# Root-cause labels (the catalog).
+DUPLICATE_NARRATION_OVERSTAMP = "DUPLICATE-NARRATION-OVERSTAMP"
+DUPLICATE_ID_NON_NARRATIVE = "DUPLICATE-ID-NON-NARRATIVE"
+NARRATIVE_ID_DISAGREEMENT = "NARRATIVE-ID-DISAGREEMENT"
+MIS_TAG = "MIS-TAG"
+ID_LESS_TWIN = "ID-LESS-TWIN"
+CONTENT_GAP = "CONTENT-GAP"
+WHOLE_DECK_GAP = "WHOLE-DECK-GAP"
+UNIFY_ALIGNMENT = "UNIFY-ALIGNMENT"
+DROPPED_ID = "DROPPED-ID"
+
+MECHANICAL = "MECHANICAL"
+AUTHORING = "AUTHORING"
+
+
+@dataclass(frozen=True)
+class Diagnosis:
+    """One classified finding: its root cause, the prescribed fix, and the evidence."""
+
+    root_cause: str
+    fix_class: str  # MECHANICAL | AUTHORING
+    severity: str  # "error" | "warning"
+    prescribed_fix: str
+    evidence: dict
+    slide_id: str | None = None
+    role: str | None = None
+
+
+@dataclass
+class DiagnoseResult:
+    """The classified verdict for one pair."""
+
+    de_path: Path
+    en_path: Path
+    diagnoses: list[Diagnosis] = field(default_factory=list)
+    git_baseline: bool = True
+
+    @property
+    def ok(self) -> bool:
+        """True iff no *error*-severity diagnosis — warnings do not fail the gate."""
+        return not any(d.severity == "error" for d in self.diagnoses)
+
+    @property
+    def mechanical(self) -> list[Diagnosis]:
+        return [d for d in self.diagnoses if d.fix_class == MECHANICAL]
+
+
+@dataclass
+class ApplyDiagnoseResult:
+    """The outcome of ``diagnose --apply`` (the mechanical narrative fixes only)."""
+
+    de_path: Path
+    en_path: Path
+    written: bool = False
+    refused: bool = False
+    reconcile_changes: int = 0
+    collapsed_duplicates: int = 0
+    new_errors: list[str] = field(default_factory=list)
+    residual: DiagnoseResult | None = None
+
+
+def _id_cells(cells: list[RawCell]) -> dict[str, RawCell]:
+    """First cell per ``slide_id`` (document order); id-less cells excluded."""
+    out: dict[str, RawCell] = {}
+    for cell in cells:
+        sid = cell.metadata.slide_id
+        if sid is not None and sid not in out:
+            out[sid] = cell
+    return out
+
+
+def _idless_slide_count(cells: list[RawCell]) -> int:
+    """Count of slide-start cells in a half that carry no ``slide_id`` (twin candidates)."""
+    return sum(1 for c in cells if c.metadata.is_slide_start and c.metadata.slide_id is None)
+
+
+def _classify_id_asymmetry(
+    sid: str,
+    de_cells: list[RawCell],
+    en_cells: list[RawCell],
+    de_ids: set[str],
+) -> Diagnosis:
+    """Disambiguate an ``id-asymmetry`` for ``sid`` into mis-tag / id-less-twin / gap.
+
+    The affected half is recomputed from the id sets (the side is NOT a field on the
+    violation), then the orphan cell's *content language* is compared against its
+    ``lang=`` tag. The result is **always advisory** (never an auto-rewrite) and never
+    suggests renaming an id — a content gap stays a gap.
+    """
+    orphan_half = "de" if sid in de_ids else "en"
+    orphan_cells = de_cells if orphan_half == "de" else en_cells
+    other_cells = en_cells if orphan_half == "de" else de_cells
+    orphan = next((c for c in orphan_cells if c.metadata.slide_id == sid), None)
+    base_evidence: dict = {"orphan_half": orphan_half}
+
+    if orphan is None:  # pragma: no cover - defensive; the id came from these cells
+        return Diagnosis(
+            CONTENT_GAP,
+            AUTHORING,
+            "error",
+            f"slide_id {sid!r} has no twin in the other half — author the missing twin.",
+            base_evidence,
+            slide_id=sid,
+        )
+
+    lang_tag = orphan.metadata.lang
+    guess = detect(orphan.body)
+    base_evidence |= {
+        "lang_tag": lang_tag,
+        "content_lang": guess.label,
+        "content_lang_confidence": guess.confidence,
+    }
+
+    if guess.confident and lang_tag is not None and guess.label != lang_tag:
+        return Diagnosis(
+            MIS_TAG,
+            AUTHORING,
+            "error",
+            f"the cell's content reads as {guess.label!r} but it is tagged lang={lang_tag!r}, "
+            f"so the split routed it into the wrong half. Move it to the {guess.label!r} "
+            f"half with the twin's slide_id and remove the stray copy (a routing bug). "
+            "Confirm with `clm slides language-view`.",
+            base_evidence,
+            slide_id=sid,
+        )
+
+    idless = _idless_slide_count(other_cells)
+    if idless > 0:
+        ev = base_evidence | {"idless_slide_cells_in_other_half": idless}
+        return Diagnosis(
+            ID_LESS_TWIN,
+            AUTHORING,
+            "error",
+            f"slide_id {sid!r} is missing from the other half, which has {idless} id-less "
+            "slide cell(s) — one may be the un-tagged twin. If so, ADD "
+            f'tags=[...] slide_id="{sid}" to that cell (no translation needed). Verify it '
+            "is the right cell first — do NOT rename an unrelated slide to match.",
+            ev,
+            slide_id=sid,
+        )
+
+    return Diagnosis(
+        CONTENT_GAP,
+        AUTHORING,
+        "error",
+        f"slide_id {sid!r} exists only in the {orphan_half!r} half (no id-less twin "
+        f"candidate in the other) — author the missing twin in the other language with "
+        f"the same slide_id. This is a translation gap, not a mechanical fix; never "
+        "rename an unrelated slide to silence it.",
+        base_evidence,
+        slide_id=sid,
+    )
+
+
+def _classify(de_text: str, en_text: str, token: str, vresult: VerifyResult) -> list[Diagnosis]:
+    """Classify every verify violation plus the verify-invisible narrative disagreements."""
+    _de_pre, de_cells = split_cells(de_text, token)
+    _en_pre, en_cells = split_cells(en_text, token)
+    de_ids = set(_id_cells(de_cells))
+
+    # Whole-deck gap: combine the DE count from the DE half with the EN count from the
+    # EN half (as scan_coverage does) — counting one half alone always reads as N/0.
+    de_count = count_languages(de_text, token)[0]
+    en_count = count_languages(en_text, token)[1]
+    coverage = classify_counts(de_count, en_count)
+    whole_deck_gap = coverage in (CoverageStatus.DE_ONLY, CoverageStatus.EN_ONLY)
+
+    diagnoses: list[Diagnosis] = []
+    if whole_deck_gap:
+        present = "de" if coverage is CoverageStatus.DE_ONLY else "en"
+        diagnoses.append(
+            Diagnosis(
+                WHOLE_DECK_GAP,
+                AUTHORING,
+                "error",
+                f"the {present!r} half has slides ({de_count} de / {en_count} en) but the "
+                "other half is empty — this is a whole-deck translation project, not a "
+                "mechanical fix. Track it (e.g. a course-planning entry); per-slide "
+                "id-asymmetries are suppressed here so they do not masquerade as N gaps.",
+                {"de_slides": de_count, "en_slides": en_count, "coverage": coverage.value},
+            )
+        )
+
+    # The verify-invisible flagship case: a narrative id'd on one half, id-less on the
+    # other. Run reconcile's own occurrence pairing INDEPENDENTLY of any violation.
+    _de2, _en2, rec = reconcile_voiceover_ids(de_text, en_text, token, token, direction=TO_IDLESS)
+    reconcile_keys = {(c.owning_slide_id, c.role) for c in rec.changes}
+    for change in rec.changes:
+        diagnoses.append(
+            Diagnosis(
+                NARRATIVE_ID_DISAGREEMENT,
+                MECHANICAL,
+                "error",
+                "a narrative cell is id'd on one half and id-less on the other; strip the "
+                "id to the canonical id-less narration form (`clm slides sync diagnose "
+                "--apply`, or `clm slides reconcile-vo-ids`).",
+                {
+                    "edited_half": change.lang,
+                    "owning_slide_id": change.owning_slide_id,
+                    "occurrence": change.occurrence,
+                    "current_id": change.old_id,
+                },
+                slide_id=change.owning_slide_id,
+                role=change.role,
+            )
+        )
+
+    for v in vresult.violations:
+        if v.kind == "unify":
+            diagnoses.append(
+                Diagnosis(
+                    UNIFY_ALIGNMENT,
+                    AUTHORING,
+                    "error",
+                    "the halves do not unify back into one bilingual source (a byte-diff in "
+                    "a shared cell, a header/preamble mismatch, or a broken alignment). Read "
+                    "the message, fix the offending cell, re-run.",
+                    {"message": v.message},
+                )
+            )
+        elif v.kind == "duplicate-id":
+            if v.role in _NARRATIVE_ROLES:
+                if (v.slide_id, v.role) in reconcile_keys:
+                    continue  # the asymmetric case — already reported as a disagreement
+                diagnoses.append(
+                    Diagnosis(
+                        DUPLICATE_NARRATION_OVERSTAMP,
+                        MECHANICAL,
+                        "error",
+                        f"a slide has several {v.role!r} cells all keyed (slide_id={v.slide_id!r}, "
+                        f"role={v.role!r}) — assign-ids over-stamped each. Strip them to the "
+                        "canonical id-less narration form (`clm slides sync diagnose --apply`).",
+                        {"message": v.message},
+                        slide_id=v.slide_id,
+                        role=v.role,
+                    )
+                )
+            else:
+                diagnoses.append(
+                    Diagnosis(
+                        DUPLICATE_ID_NON_NARRATIVE,
+                        AUTHORING,
+                        "error",
+                        f"a non-narrative (slide_id={v.slide_id!r}, role={v.role!r}) key is "
+                        "duplicated within a half — a real structural problem. Resolve it by "
+                        "hand (a stray copy, or a mis-keyed cell); never auto-strip a slide id.",
+                        {"message": v.message},
+                        slide_id=v.slide_id,
+                        role=v.role,
+                    )
+                )
+        elif v.kind == "id-asymmetry":
+            if whole_deck_gap:
+                continue  # one whole-deck finding, not N per-slide gaps
+            diagnoses.append(_classify_id_asymmetry(v.slide_id or "", de_cells, en_cells, de_ids))
+        elif v.kind == "dropped-id":
+            diagnoses.append(
+                Diagnosis(
+                    DROPPED_ID,
+                    AUTHORING,
+                    "warning",
+                    "an id'd cell present at git HEAD is gone now — confirm the removal was "
+                    "intentional (a deliberate removal is fine; an accidental drop is not).",
+                    {"message": v.message},
+                    slide_id=v.slide_id,
+                )
+            )
+    return diagnoses
+
+
+def diagnose_pair(de_path: Path, en_path: Path) -> DiagnoseResult:
+    """Diagnose a resolved DE/EN split pair (reads the files + git HEAD, no model)."""
+    token = comment_token_for_path(de_path)
+    de_text = de_path.read_text(encoding="utf-8")
+    en_text = en_path.read_text(encoding="utf-8")
+    vresult = verify_pair(de_path, en_path)
+    diagnoses = _classify(de_text, en_text, token, vresult)
+    return DiagnoseResult(de_path, en_path, diagnoses, git_baseline=vresult.git_baseline)
+
+
+def apply_mechanical_fixes(de_path: Path, en_path: Path) -> ApplyDiagnoseResult:
+    """Apply ONLY the identity-preserving narrative fixes, re-gated by structure (#455).
+
+    Two passes, both narrative-only and collision-proof: (1) ``reconcile_voiceover_ids``
+    (``TO_IDLESS``) strips an *asymmetric* narration id so the halves agree id-less;
+    (2) ``collapse_intra_half_duplicates`` strips a *symmetric* over-stamp. The write is
+    refused only if it would introduce a NEW structural error (it never should — strip
+    is identity-preserving — but the gate is the fail-safe). Unrelated authoring findings
+    (a content gap, a slide mis-tag) are left untouched and surface in ``residual``; the
+    fix is best-effort, not a guarantee the whole pair becomes clean.
+    """
+    token = comment_token_for_path(de_path)
+    de_text = de_path.read_text(encoding="utf-8")
+    en_text = en_path.read_text(encoding="utf-8")
+
+    before = {(v.kind, v.slide_id, v.role) for v in structural_gate(de_text, en_text, token)}
+
+    de1, en1, rec = reconcile_voiceover_ids(de_text, en_text, token, token, direction=TO_IDLESS)
+    de2, en2, collapsed = collapse_intra_half_duplicates(de1, en1, token, token)
+
+    after = {(v.kind, v.slide_id, v.role) for v in structural_gate(de2, en2, token)}
+    new_errors = sorted(f"{kind} {sid}/{role}" for (kind, sid, role) in (after - before))
+    if new_errors:
+        return ApplyDiagnoseResult(
+            de_path,
+            en_path,
+            written=False,
+            refused=True,
+            reconcile_changes=len(rec.changes),
+            collapsed_duplicates=collapsed,
+            new_errors=new_errors,
+        )
+
+    written = False
+    if de2 != de_text:
+        de_path.write_text(de2, encoding="utf-8")
+        written = True
+    if en2 != en_text:
+        en_path.write_text(en2, encoding="utf-8")
+        written = True
+
+    return ApplyDiagnoseResult(
+        de_path,
+        en_path,
+        written=written,
+        refused=False,
+        reconcile_changes=len(rec.changes),
+        collapsed_duplicates=collapsed,
+        residual=diagnose_pair(de_path, en_path),
+    )

--- a/tests/cli/test_slides_sync_diagnose.py
+++ b/tests/cli/test_slides_sync_diagnose.py
@@ -1,0 +1,100 @@
+"""CLI tests for ``clm slides sync diagnose`` (read-only by default; --apply; --json)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands.slides.sync import sync_diagnose_cmd
+
+
+@pytest.fixture
+def cli_runner():
+    try:
+        return CliRunner(mix_stderr=False)
+    except TypeError:  # pragma: no cover - older click
+        return CliRunner()
+
+
+def _deck(lang: str, cells: list[tuple[list[str], str | None, str]]) -> str:
+    head = f"# j2 from 'macros.j2' import header_{lang}\n# {{{{ header_{lang}(\"T\") }}}}\n"
+    out = [head]
+    for tags, sid, body in cells:
+        tagstr = "[" + ", ".join(f'"{t}"' for t in tags) + "]"
+        idstr = f' slide_id="{sid}"' if sid else ""
+        out.append(f'# %% [markdown] lang="{lang}" tags={tagstr}{idstr}\n# {body}\n')
+    return "".join(out)
+
+
+def _dup_pair(tmp_path: Path) -> tuple[Path, Path]:
+    de = _deck(
+        "de",
+        [
+            (["slide"], "intro", "Hallo"),
+            (["voiceover"], "intro", "Eins"),
+            (["voiceover"], "intro", "Zwei"),
+        ],
+    )
+    en = _deck(
+        "en",
+        [
+            (["slide"], "intro", "Hello"),
+            (["voiceover"], "intro", "One"),
+            (["voiceover"], "intro", "Two"),
+        ],
+    )
+    dp, ep = tmp_path / "x.de.py", tmp_path / "x.en.py"
+    dp.write_text(de, encoding="utf-8")
+    ep.write_text(en, encoding="utf-8")
+    return dp, ep
+
+
+def test_clean_pair_passes(cli_runner, tmp_path):
+    dp = tmp_path / "x.de.py"
+    ep = tmp_path / "x.en.py"
+    dp.write_text(_deck("de", [(["slide"], "intro", "Hallo")]), encoding="utf-8")
+    ep.write_text(_deck("en", [(["slide"], "intro", "Hello")]), encoding="utf-8")
+    res = cli_runner.invoke(sync_diagnose_cmd, [str(dp)])
+    assert res.exit_code == 0, res.output + res.stderr
+    assert "PASS" in res.output
+
+
+def test_dup_narration_fails_and_json_carries_root_cause(cli_runner, tmp_path):
+    dp, _ep = _dup_pair(tmp_path)
+    res = cli_runner.invoke(sync_diagnose_cmd, ["--json", str(dp)])
+    assert res.exit_code == 2, res.output + res.stderr
+    payload = json.loads(res.output[res.output.find("{") :])
+    causes = [d["root_cause"] for d in payload["pairs"][0]["diagnoses"]]
+    assert "DUPLICATE-NARRATION-OVERSTAMP" in causes
+    assert payload["mode"] == "diagnose"
+
+
+def test_apply_fixes_the_mechanical_case(cli_runner, tmp_path):
+    dp, _ep = _dup_pair(tmp_path)
+    res = cli_runner.invoke(sync_diagnose_cmd, ["--apply", str(dp)])
+    # After stripping the over-stamped narration ids the pair is clean → exit 0.
+    assert res.exit_code == 0, res.output + res.stderr
+    assert "--apply" in res.output
+    # A second dry-run diagnose now passes.
+    res2 = cli_runner.invoke(sync_diagnose_cmd, [str(dp)])
+    assert res2.exit_code == 0, res2.output + res2.stderr
+
+
+def test_apply_is_dry_run_by_default(cli_runner, tmp_path):
+    dp, ep = _dup_pair(tmp_path)
+    before = dp.read_text(encoding="utf-8")
+    res = cli_runner.invoke(sync_diagnose_cmd, [str(dp)])
+    assert res.exit_code == 2
+    assert dp.read_text(encoding="utf-8") == before  # no write without --apply
+
+
+def test_directory_mode(cli_runner, tmp_path):
+    _dup_pair(tmp_path)
+    res = cli_runner.invoke(sync_diagnose_cmd, ["--json", str(tmp_path)])
+    assert res.exit_code == 2, res.output + res.stderr
+    payload = json.loads(res.output[res.output.find("{") :])
+    assert payload["root"] == str(tmp_path)
+    assert len(payload["pairs"]) == 1

--- a/tests/slides/test_content_lang.py
+++ b/tests/slides/test_content_lang.py
@@ -1,0 +1,37 @@
+"""Unit tests for the lightweight DE/EN content-language detector (content_lang)."""
+
+from __future__ import annotations
+
+from clm.slides.content_lang import detect
+
+
+def test_clear_german_prose_is_confident_de():
+    g = detect("Dies ist ein deutscher Absatz mit vielen Woertern und Umlauten wie schoen und gut")
+    assert g.label == "de"
+    assert g.confident
+
+
+def test_clear_english_prose_is_confident_en():
+    g = detect("This is an english paragraph with many words and it is clearly english here")
+    assert g.label == "en"
+    assert g.confident
+
+
+def test_umlaut_is_a_strong_german_marker():
+    g = detect("Wir möchten die Schlüssel über die Brücke führen und prüfen")
+    assert g.label == "de"
+    assert g.confident
+
+
+def test_title_only_text_abstains():
+    # The exact case the classifier must not guess on (drives the duplicate-id row).
+    assert detect("Introduction").label == "unknown"
+    assert detect("Array Limitations").label == "unknown"
+
+
+def test_code_heavy_or_neutral_text_abstains():
+    assert detect("x = foo(bar) + baz(qux)").label == "unknown"
+
+
+def test_unknown_is_not_confident():
+    assert not detect("Introduction").confident

--- a/tests/slides/test_sync_diagnose.py
+++ b/tests/slides/test_sync_diagnose.py
@@ -1,0 +1,175 @@
+"""Tests for the ``sync diagnose`` classifier (sync_diagnose).
+
+Covers each root-cause catalog row, the verify-invisible narrative cases the
+classifier must surface independently of ``verify``, the mechanical ``--apply``
+fixes (re-gated by structure), and the anti-rename invariant.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.slides.sync_diagnose import (
+    AUTHORING,
+    CONTENT_GAP,
+    DUPLICATE_NARRATION_OVERSTAMP,
+    ID_LESS_TWIN,
+    MECHANICAL,
+    MIS_TAG,
+    NARRATIVE_ID_DISAGREEMENT,
+    WHOLE_DECK_GAP,
+    apply_mechanical_fixes,
+    diagnose_pair,
+)
+
+# German prose long enough for the detector to be confident.
+_DE_PROSE = "Dies ist ein deutscher Absatz mit vielen Woertern und Umlauten wie schoen"
+_EN_PROSE = "This is an english paragraph with many common words and it is clearly english"
+
+
+def _deck(lang: str, cells: list[tuple[list[str], str | None, str]]) -> str:
+    head = f"# j2 from 'macros.j2' import header_{lang}\n# {{{{ header_{lang}(\"T\") }}}}\n"
+    out = [head]
+    for tags, sid, body in cells:
+        tagstr = "[" + ", ".join(f'"{t}"' for t in tags) + "]"
+        idstr = f' slide_id="{sid}"' if sid else ""
+        out.append(f'# %% [markdown] lang="{lang}" tags={tagstr}{idstr}\n# {body}\n')
+    return "".join(out)
+
+
+def _write(tmp_path: Path, de: str, en: str) -> tuple[Path, Path]:
+    dp, ep = tmp_path / "x.de.py", tmp_path / "x.en.py"
+    dp.write_text(de, encoding="utf-8")
+    ep.write_text(en, encoding="utf-8")
+    return dp, ep
+
+
+def _causes(result) -> list[str]:
+    return [d.root_cause for d in result.diagnoses]
+
+
+def test_clean_pair_has_no_findings(tmp_path):
+    dp, ep = _write(
+        tmp_path,
+        _deck("de", [(["slide"], "intro", "Hallo Welt")]),
+        _deck("en", [(["slide"], "intro", "Hello world")]),
+    )
+    result = diagnose_pair(dp, ep)
+    assert result.ok
+    assert result.diagnoses == []
+
+
+def test_symmetric_narration_overstamp_is_mechanical_and_autofixable(tmp_path):
+    de = _deck(
+        "de",
+        [
+            (["slide"], "intro", "Hallo"),
+            (["voiceover"], "intro", "Eins"),
+            (["voiceover"], "intro", "Zwei"),
+        ],
+    )
+    en = _deck(
+        "en",
+        [
+            (["slide"], "intro", "Hello"),
+            (["voiceover"], "intro", "One"),
+            (["voiceover"], "intro", "Two"),
+        ],
+    )
+    dp, ep = _write(tmp_path, de, en)
+    result = diagnose_pair(dp, ep)
+    assert DUPLICATE_NARRATION_OVERSTAMP in _causes(result)
+    assert all(
+        d.fix_class == MECHANICAL
+        for d in result.diagnoses
+        if d.root_cause == DUPLICATE_NARRATION_OVERSTAMP
+    )
+    ar = apply_mechanical_fixes(dp, ep)
+    assert ar.written and not ar.refused
+    assert ar.collapsed_duplicates == 4  # both halves, 2 cells each
+    assert ar.residual is not None and ar.residual.ok
+
+
+def test_asymmetric_narration_disagreement_is_verify_invisible_but_diagnosed(tmp_path):
+    # DE voiceover id'd, EN voiceover id-less → NO verify violation (the slide id is on
+    # the slide cell in both halves), but reconcile-pairing surfaces it.
+    de = _deck("de", [(["slide"], "intro", "Hallo"), (["voiceover"], "intro", "Notiz")])
+    en = _deck("en", [(["slide"], "intro", "Hello"), (["voiceover"], None, "Note")])
+    dp, ep = _write(tmp_path, de, en)
+    result = diagnose_pair(dp, ep)
+    assert NARRATIVE_ID_DISAGREEMENT in _causes(result)
+    ar = apply_mechanical_fixes(dp, ep)
+    assert ar.written and ar.reconcile_changes == 1
+    assert ar.residual is not None and ar.residual.ok
+
+
+def test_mis_tag_detected_by_content_language(tmp_path):
+    # EN half carries a slide whose content is German but tagged lang="en".
+    de = _deck("de", [(["slide"], "intro", "Hallo Welt")])
+    en = _deck("en", [(["slide"], "intro", "Hello world"), (["slide"], "misT", _DE_PROSE)])
+    dp, ep = _write(tmp_path, de, en)
+    result = diagnose_pair(dp, ep)
+    mis = [d for d in result.diagnoses if d.root_cause == MIS_TAG]
+    assert mis, _causes(result)
+    assert mis[0].fix_class == AUTHORING
+    assert mis[0].evidence["content_lang"] == "de"
+    assert mis[0].evidence["lang_tag"] == "en"
+
+
+def test_content_gap_is_authoring_and_warns_against_rename(tmp_path):
+    de = _deck("de", [(["slide"], "intro", "Hallo"), (["slide"], "gap", _DE_PROSE)])
+    en = _deck("en", [(["slide"], "intro", "Hello")])
+    dp, ep = _write(tmp_path, de, en)
+    result = diagnose_pair(dp, ep)
+    gap = [d for d in result.diagnoses if d.root_cause == CONTENT_GAP]
+    assert gap, _causes(result)
+    assert gap[0].fix_class == AUTHORING
+    assert "rename" in gap[0].prescribed_fix.lower()  # mentioned only to forbid it
+    assert "never rename" in gap[0].prescribed_fix.lower()
+
+
+def test_id_less_twin_when_other_half_has_an_idless_slide(tmp_path):
+    de = _deck("de", [(["slide"], "intro", "Hallo"), (["slide"], "ztwin", _DE_PROSE)])
+    en = _deck("en", [(["slide"], "intro", "Hello"), (["slide"], None, _EN_PROSE)])
+    dp, ep = _write(tmp_path, de, en)
+    result = diagnose_pair(dp, ep)
+    twin = [d for d in result.diagnoses if d.root_cause == ID_LESS_TWIN]
+    assert twin, _causes(result)
+    assert twin[0].fix_class == AUTHORING
+    assert "do not rename" in twin[0].prescribed_fix.lower()
+
+
+def test_whole_deck_gap_suppresses_per_slide_asymmetries(tmp_path):
+    de = _deck("de", [(["slide"], "intro", "Hallo"), (["slide"], "two", "Zwei Inhalt")])
+    en = "# j2 from 'macros.j2' import header_en\n# {{ header_en(\"T\") }}\n"
+    dp, ep = _write(tmp_path, de, en)
+    result = diagnose_pair(dp, ep)
+    causes = _causes(result)
+    assert WHOLE_DECK_GAP in causes
+    # The two id-asymmetries are folded into the one whole-deck finding, not N gaps.
+    assert CONTENT_GAP not in causes
+
+
+def test_apply_never_touches_a_content_gap(tmp_path):
+    # A content gap is authoring-only: --apply must not write or resolve it.
+    de = _deck("de", [(["slide"], "intro", "Hallo"), (["slide"], "gap", _DE_PROSE)])
+    en = _deck("en", [(["slide"], "intro", "Hello")])
+    dp, ep = _write(tmp_path, de, en)
+    de_before, en_before = dp.read_text(encoding="utf-8"), ep.read_text(encoding="utf-8")
+    ar = apply_mechanical_fixes(dp, ep)
+    assert not ar.written  # nothing mechanical to do
+    assert dp.read_text(encoding="utf-8") == de_before
+    assert ep.read_text(encoding="utf-8") == en_before
+    assert ar.residual is not None and CONTENT_GAP in _causes(ar.residual)
+
+
+def test_no_diagnosis_ever_prescribes_a_bare_rename(tmp_path):
+    # The anti-pattern guard: no fix says "rename X to Y" without forbidding it.
+    de = _deck("de", [(["slide"], "intro", "Hallo"), (["slide"], "gap", _DE_PROSE)])
+    en = _deck("en", [(["slide"], "intro", "Hello"), (["slide"], None, _EN_PROSE)])
+    dp, ep = _write(tmp_path, de, en)
+    result = diagnose_pair(dp, ep)
+    for d in result.diagnoses:
+        fix = d.prescribed_fix.lower()
+        if "rename" in fix:
+            assert "never rename" in fix or "do not rename" in fix


### PR DESCRIPTION
## What

Adds `clm slides sync diagnose DECK [--json] [--apply]` — a read-only verb that turns the **manual** `verify`-failure diagnostic procedure (the `diagnosing-sync-id-asymmetry.md` analysis) into tooling. A `verify` failure is a *symptom*, not a diagnosis: `id-asymmetry` / `duplicate-id` each have several unrelated root causes needing different fixes, and "rename ids until verify passes" is the anti-pattern that buries real gaps (the `array-limitations` trap).

## How

- **Read-only superset of `verify` AND `reconcile-vo-ids`.** Critically, it runs `reconcile`'s occurrence-pairing detection *independently* of `verify`, so it catches the most common case `verify` cannot see: a narration cell id'd on one half and id-less on the other (no `id-asymmetry` fires — the slide's id is still on the slide cell in both halves).
- Each finding gets a **root cause**, **evidence** (content-language vs `lang=` tag, who carries the id, whether a twin exists), the **prescribed fix**, and a **MECHANICAL/AUTHORING** class.
- **`content_lang.detect`** — a tiny built-in DE/EN heuristic (umlaut/eszett + stop-word contrast) that **abstains** on short/title-only text, so a mis-tag is only asserted on confident evidence. No ML dependency (the `[ml]` extra is blocked).
- **`--apply`** performs **only** the identity-preserving narrative fixes (strip a duplicated/asymmetric narration id to the canonical id-less form), re-gated by `structural_gate` so a write never introduces a new error. It **never renames an id** to silence a symptom; mis-tags / content gaps / whole-deck gaps stay advisory.
- Adds `reconcile_vo_ids.collapse_intra_half_duplicates` for the *symmetric* narration over-stamp the existing reconciler (which only touches pairs that *disagree* on id-ness) left alone.
- The `diagnose` verb is registered beside `verify` and lazy-imports the classifier inside the body (preserves the LazyGroup startup win).

## Catalog

`DUPLICATE-NARRATION-OVERSTAMP`, `NARRATIVE-ID-DISAGREEMENT` (mechanical); `MIS-TAG`, `ID-LESS-TWIN`, `CONTENT-GAP`, `WHOLE-DECK-GAP`, `DUPLICATE-ID-NON-NARRATIVE`, `UNIFY-ALIGNMENT`, `DROPPED-ID` (authoring).

## Tests

`tests/slides/test_content_lang.py` (detector confidence + abstention), `tests/slides/test_sync_diagnose.py` (every catalog row, the verify-invisible narrative cases, `--apply` re-gating, the anti-rename guard), `tests/cli/test_slides_sync_diagnose.py` (dry-run default, `--apply`, `--json`, directory mode). Existing `verify` / `reconcile-vo-ids` tests pass unchanged (97 in regression).

## Docs

- `clm info commands` — a `clm slides sync diagnose` section.
- `clm info sync-agents` — a "Diagnosing a verify failure" section + the root-cause catalog table, so course-repo agents get it **version-accurately** (replacing the hand-copied `diagnosing-sync-id-asymmetry.md`).
- changelog fragment `changelog.d/sync-diagnose.added.md`.

Part of the slides-sync improvement arc (design doc lands in #489).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RqsUHWEuje4hqVp5FZKkz
