### PR TITLE
fix(slides sync): thread the source comment token through reflow hashing (#458)

### DIFF
--- a/changelog.d/458-comment-token-hash.fixed.md
+++ b/changelog.d/458-comment-token-hash.fixed.md
@@ -1,0 +1,12 @@
+- **`//`-comment decks (C++/C#/Java/TS) now get reflow-insensitive markdown
+  hashing.** #429 made a pure soft re-wrap of a markdown prose cell hash identically
+  (so it is not mis-read as an edit), but it hard-coded the `#` comment token, so only
+  Python/Rust decks benefited; a `//` deck's re-wrap still read as drift. The real
+  source comment token is now threaded from `CellMetadata.comment_token` through
+  `cell_content_hash` / `hash_cell` / `anchor_of` (Option A — the ~25 hash call sites
+  are unchanged, so the threading is atomic and can't half-apply). `WATERMARK_HASH_VERSION`
+  is bumped to 3 and the consistency ledger gains a per-entry `hash_version`, so `//`
+  decks re-baseline once automatically (the existing stale-version self-heal); `#`-deck
+  hashes are byte-identical and do not re-baseline. The Studio render path threads the
+  token too, so a future `//`-deck would not false-trip the optimistic-concurrency
+  guard. (#458, follow-up to #429)

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -2,6 +2,25 @@
 
 This guide covers breaking changes across major CLM versions.
 
+## `//`-language decks re-baseline the sync watermark once (issue #458, {version})
+
+`clm slides sync`'s reflow-insensitive markdown hashing (#429) now threads the
+deck's real source comment token, so `//`-comment decks (C++/C#/Java/TS) get the
+same benefit Python/Rust decks already had: a pure soft re-wrap of a markdown
+prose cell no longer reads as an edit. Because that changes every `//`-deck
+markdown hash, `WATERMARK_HASH_VERSION` is bumped to `3`.
+
+**One-time migration — no action required.** The watermark's existing
+stale-version self-heal does the work: on the first `clm slides sync apply` (or
+`autopilot`) after upgrading, a `//` deck's stale-version watermark is treated as
+absent, the pair cold-starts off git `HEAD`, and the new hashes are recorded — no
+manual `clm slides sync baseline clear` and no false "everything edited" drift.
+The committed **consistency ledger** (`--ledger`) self-heals the same way:
+a `//`-deck entry whose hashes the new engine computes differently re-checks and
+re-records on the next `baseline bless --ledger` / `apply --ledger`. **`#`-comment
+decks (Python/Rust) are unaffected** — their hashes are byte-identical (`"#"` was
+the prior default), so neither the watermark nor the ledger re-baselines for them.
+
 ## Cohort calendar event UIDs are now globally unique (issue #436, {version})
 
 `clm calendar generate -f ics` and `clm calendar push` give every event a

--- a/src/clm/infrastructure/llm/cache.py
+++ b/src/clm/infrastructure/llm/cache.py
@@ -748,8 +748,11 @@ def _deserialize_tags(raw: str) -> frozenset[str]:
 # self-heals the migration: the pair cold-starts off git HEAD and the next apply
 # re-records it at the current version, with no manual ``watermark clear`` and no
 # false "everything edited" drift. Issue #429 introduced reflow-insensitive
-# markdown hashing → version 2.
-WATERMARK_HASH_VERSION = 2
+# markdown hashing → version 2. Issue #458 threaded the real source comment token
+# into that hashing so ``//`` languages (C++/C#/Java/TS) get the reflow benefit too,
+# changing every ``//``-deck markdown hash (``#``-deck hashes are byte-identical, since
+# ``"#"`` was the prior default) → version 3. The same gate re-baselines stale pairs.
+WATERMARK_HASH_VERSION = 3
 
 
 class SyncWatermarkCache:

--- a/src/clm/notebooks/slide_parser.py
+++ b/src/clm/notebooks/slide_parser.py
@@ -29,6 +29,12 @@ class CellMetadata:
     raw_header: str = ""
     slide_id: str | None = None
     for_slide: str | None = None
+    # The source language's line-comment token (``"#"`` python/rust, ``"//"``
+    # cpp/csharp/java/typescript), stamped by :func:`parse_cell_header`. Carried here so
+    # the content-hash chokepoints (:func:`~clm.slides.sync_writeback.hash_cell` /
+    # ``anchor_of``) can reflow-normalize ``//`` markdown with the real token (#458)
+    # without threading it through every call site. Defaults to ``"#"``.
+    comment_token: str = "#"
 
     @property
     def is_slide(self) -> bool:
@@ -154,6 +160,7 @@ def parse_cell_header(header: str, comment_token: str = "#") -> CellMetadata:
             cell_type="j2",
             is_j2=True,
             raw_header=header,
+            comment_token=comment_token,
         )
 
     cell_type = "markdown" if "[markdown]" in header else "code"
@@ -183,6 +190,7 @@ def parse_cell_header(header: str, comment_token: str = "#") -> CellMetadata:
         raw_header=header,
         slide_id=slide_id,
         for_slide=for_slide,
+        comment_token=comment_token,
     )
 
 

--- a/src/clm/slides/assign_ids.py
+++ b/src/clm/slides/assign_ids.py
@@ -169,7 +169,7 @@ def _write_slide_id(cell: _Cell, slide_id: str) -> None:
     stripped = _strip_existing_slide_id(existing).rstrip()
     new_header = f'{stripped} slide_id="{slide_id}"'
     cell.lines[0] = new_header
-    cell.metadata = parse_cell_header(new_header)
+    cell.metadata = parse_cell_header(new_header, cell.metadata.comment_token)
 
 
 # ---------------------------------------------------------------------------

--- a/src/clm/slides/reconcile_vo_ids.py
+++ b/src/clm/slides/reconcile_vo_ids.py
@@ -111,7 +111,7 @@ def _strip_slide_id(cell: RawCell) -> None:
     """Remove ``slide_id="…"`` from a cell header in place (byte-preserving)."""
     new_header = _SLIDE_ID_RE.sub("", cell.lines[0]).rstrip()
     cell.lines[0] = new_header
-    cell.metadata = parse_cell_header(new_header)
+    cell.metadata = parse_cell_header(new_header, cell.metadata.comment_token)
 
 
 def _stamp_slide_id(cell: RawCell, slide_id: str) -> None:
@@ -119,7 +119,7 @@ def _stamp_slide_id(cell: RawCell, slide_id: str) -> None:
     stripped = _SLIDE_ID_RE.sub("", cell.lines[0]).rstrip()
     new_header = f'{stripped} slide_id="{slide_id}"'
     cell.lines[0] = new_header
-    cell.metadata = parse_cell_header(new_header)
+    cell.metadata = parse_cell_header(new_header, cell.metadata.comment_token)
 
 
 def reconcile_voiceover_ids(

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -2800,7 +2800,11 @@ def _build_narrative_cell(
         body_lines.pop(0)
     while body_lines and body_lines[-1] == "":
         body_lines.pop()
-    return RawCell(lines=[header, *body_lines], line_number=0, metadata=parse_cell_header(header))
+    return RawCell(
+        lines=[header, *body_lines],
+        line_number=0,
+        metadata=parse_cell_header(header, comment_token),
+    )
 
 
 def _slug_or_default(en_body: str) -> str:
@@ -2859,7 +2863,7 @@ def _stamp_slide_id(cell: RawCell, slide_id: str) -> None:
     stripped = _SLIDE_ID_RE.sub("", cell.lines[0]).rstrip()
     header = f'{stripped} slide_id="{slide_id}"'
     cell.lines[0] = header
-    cell.metadata = parse_cell_header(header)
+    cell.metadata = parse_cell_header(header, cell.metadata.comment_token)
 
 
 def _build_cell(
@@ -2878,7 +2882,11 @@ def _build_cell(
         body_lines.pop(0)
     while body_lines and body_lines[-1] == "":
         body_lines.pop()
-    return RawCell(lines=[header, *body_lines], line_number=0, metadata=parse_cell_header(header))
+    return RawCell(
+        lines=[header, *body_lines],
+        line_number=0,
+        metadata=parse_cell_header(header, comment_token),
+    )
 
 
 def _insert_at_anchor(
@@ -3900,7 +3908,7 @@ def _clear_slide_id(cell: RawCell) -> None:
     """Remove any ``slide_id="…"`` from a cell header (the inverse of stamping)."""
     header = _SLIDE_ID_RE.sub("", cell.lines[0]).rstrip()
     cell.lines[0] = header
-    cell.metadata = parse_cell_header(header)
+    cell.metadata = parse_cell_header(header, cell.metadata.comment_token)
 
 
 def _header_rows(cells: list[Cell]) -> list[tuple[int, str | None, str, str, str | None]]:

--- a/src/clm/slides/sync_ledger.py
+++ b/src/clm/slides/sync_ledger.py
@@ -53,6 +53,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from clm.infrastructure.llm.cache import WATERMARK_HASH_VERSION
 from clm.notebooks.slide_parser import Cell, comment_token_for_path, parse_cells
 from clm.slides.sync_writeback import construct_of, hash_cell, role_of
 
@@ -92,6 +93,14 @@ class LedgerEntry:
     confirmed_commit: str | None
     confirmed_by: str  # "apply" | "bless" | "accept" | "autopilot" | "seed" | "establish"
     confirmed_oracle: str  # "structural" | "assume" | "agent" | "semantic:<model>"
+    # The hash-function version (``cache.WATERMARK_HASH_VERSION``) the de/en hashes were
+    # computed under. ``trusts`` requires it to equal the current version, so a hash-form
+    # change (#458 threaded the comment token into markdown hashing) cleanly invalidates a
+    # stale entry — it re-checks and re-records rather than trusting a hash a newer engine
+    # would compute differently. Defaults to the current version (a pre-#458 entry, which
+    # carries no field, is assumed current — its hashes are unchanged for ``#`` decks and
+    # simply will not match for ``//`` decks, so it re-checks either way).
+    hash_version: int = WATERMARK_HASH_VERSION
 
 
 #: Id-less narrative key ``(owning_slide_id, role, occ)`` — the classifier's own
@@ -128,12 +137,26 @@ class SyncLedger:
         Any drift on either half misses, so the slide falls through to the bundle.
         """
         entry = self.entries.get((slide_id, role))
-        return entry is not None and entry.de_hash == de_hash and entry.en_hash == en_hash
+        return _entry_trusts(entry, de_hash, en_hash)
 
     def trusts_idless(self, key: IdlessKey, de_hash: str, en_hash: str) -> bool:
         """:meth:`trusts` for an id-less narrative keyed by ``(owning_slide_id, role, occ)``."""
-        entry = self.idless.get(key)
-        return entry is not None and entry.de_hash == de_hash and entry.en_hash == en_hash
+        return _entry_trusts(self.idless.get(key), de_hash, en_hash)
+
+
+def _entry_trusts(entry: LedgerEntry | None, de_hash: str, en_hash: str) -> bool:
+    """Whether ``entry`` confirms exactly these hashes under the *current* hash version.
+
+    A stale ``hash_version`` (an entry recorded before a hash-form change) is never
+    trusted — it re-checks and re-records, rather than trusting a hash a newer engine
+    would compute differently (#458).
+    """
+    return (
+        entry is not None
+        and entry.hash_version == WATERMARK_HASH_VERSION
+        and entry.de_hash == de_hash
+        and entry.en_hash == en_hash
+    )
 
 
 def ledger_path_for(de_path: Path) -> Path:
@@ -176,6 +199,7 @@ def load(path: Path) -> SyncLedger:
                     confirmed_commit=rec.get("confirmed_commit"),
                     confirmed_by=rec.get("confirmed_by", "apply"),
                     confirmed_oracle=rec.get("confirmed_oracle", "structural"),
+                    hash_version=rec.get("hash_version", WATERMARK_HASH_VERSION),
                 )
     idless: dict[IdlessKey, LedgerEntry] = {}
     raw_idless = data.get("idless", [])
@@ -196,6 +220,7 @@ def load(path: Path) -> SyncLedger:
                 confirmed_commit=rec.get("confirmed_commit"),
                 confirmed_by=rec.get("confirmed_by", "apply"),
                 confirmed_oracle=rec.get("confirmed_oracle", "structural"),
+                hash_version=rec.get("hash_version", WATERMARK_HASH_VERSION),
             )
     return SyncLedger(schema=SCHEMA_VERSION, entries=entries, idless=idless)
 
@@ -207,7 +232,7 @@ def _to_json(ledger: SyncLedger) -> str:
     branches confirm *different* slides, and turn a genuine same-slide conflict into
     a reviewable line conflict (the design's drop-on-conflict → re-check rule).
     """
-    slides: dict[str, dict[str, dict[str, str | None]]] = {}
+    slides: dict[str, dict[str, dict[str, str | int | None]]] = {}
     for (slide_id, role), e in ledger.entries.items():
         slides.setdefault(slide_id, {})[role] = {
             "de_hash": e.de_hash,
@@ -216,6 +241,7 @@ def _to_json(ledger: SyncLedger) -> str:
             "confirmed_commit": e.confirmed_commit,
             "confirmed_by": e.confirmed_by,
             "confirmed_oracle": e.confirmed_oracle,
+            "hash_version": e.hash_version,
         }
     # Id-less narratives are a *list* (their key has no natural nesting): one object per
     # entry, sorted by the key so the file is canonical and a merge is line-local.
@@ -230,6 +256,7 @@ def _to_json(ledger: SyncLedger) -> str:
             "confirmed_commit": e.confirmed_commit,
             "confirmed_by": e.confirmed_by,
             "confirmed_oracle": e.confirmed_oracle,
+            "hash_version": e.hash_version,
         }
         for (owning, role, occ), e in sorted(
             ledger.idless.items(), key=lambda kv: (str(kv[0][0]), kv[0][1], kv[0][2])

--- a/src/clm/slides/sync_writeback.py
+++ b/src/clm/slides/sync_writeback.py
@@ -174,10 +174,11 @@ def normalize_for_hash(text: str, comment_token: str = "#") -> str:
     (indented code), and structural markdown (headings, list markers, block
     quotes, table rows, thematic breaks). Issue #429.
 
-    ``comment_token`` defaults to ``"#"`` (Python/Rust). Threading the real token
-    for ``//`` languages is a follow-up — until then ``//`` markdown is hashed
-    consistently but without the reflow benefit (still safe: both the baseline
-    write and the compare read use the same default, so no false drift).
+    ``comment_token`` is the source language's line-comment token (``"#"`` python/
+    rust, ``"//"`` cpp/csharp/java/typescript): each line is de-prefixed with it
+    before reflow, so a ``//`` markdown cell gets the same reflow-insensitivity a
+    ``#`` cell does (#458 — the token is threaded from ``CellMetadata.comment_token``
+    via :func:`hash_cell` / :func:`anchor_of`). Defaults to ``"#"``.
     """
     out: list[str] = []
     para: list[str] = []
@@ -237,7 +238,7 @@ def normalize_for_hash(text: str, comment_token: str = "#") -> str:
     return "\n".join(collapsed).strip()
 
 
-def cell_content_hash(text: str, *, markdown: bool = False) -> str:
+def cell_content_hash(text: str, *, markdown: bool = False, comment_token: str = "#") -> str:
     """Hash ``text`` the way ``Cell.content`` is hashed.
 
     ``Cell.content`` operates on the body as the parser produces it: body
@@ -249,12 +250,14 @@ def cell_content_hash(text: str, *, markdown: bool = False) -> str:
     ``markdown=True`` (set only where the text is a markdown cell body — code
     cells and j2 headers must stay byte-exact) routes through
     :func:`normalize_for_hash` so a pure prose re-wrap hashes identically
-    (Issue #429). The default ``markdown=False`` preserves the historical
-    ``.strip()``-only behaviour exactly. **Changing either branch's canonical
-    form invalidates every stored hash — bump
-    ``cache.WATERMARK_HASH_VERSION`` so stale snapshots are re-baselined.**
+    (Issue #429), de-prefixing each line with ``comment_token`` so ``//``
+    languages get the same reflow-insensitivity (Issue #458). The default
+    ``markdown=False`` preserves the historical ``.strip()``-only behaviour
+    exactly (and ignores ``comment_token``). **Changing either branch's canonical
+    form invalidates every stored hash — bump ``cache.WATERMARK_HASH_VERSION`` so
+    stale snapshots are re-baselined.**
     """
-    canonical = normalize_for_hash(text) if markdown else text.strip()
+    canonical = normalize_for_hash(text, comment_token) if markdown else text.strip()
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
@@ -265,7 +268,9 @@ def hash_cell(metadata: CellMetadata, text: str) -> str:
     write/read/compare site keys a given cell identically (mismatched flags would
     read as false drift). Code cells and j2 headers stay byte-exact.
     """
-    return cell_content_hash(text, markdown=metadata.cell_type == "markdown")
+    return cell_content_hash(
+        text, markdown=metadata.cell_type == "markdown", comment_token=metadata.comment_token
+    )
 
 
 def construct_of(metadata: CellMetadata, body: str) -> str | None:
@@ -304,7 +309,9 @@ def anchor_of(metadata: CellMetadata, body: str) -> str:
     construct = construct_of(metadata, body)
     if construct is not None:
         return f"construct:{construct}"
-    return f"hash:{cell_content_hash(body, markdown=metadata.cell_type == 'markdown')}"
+    return "hash:" + cell_content_hash(
+        body, markdown=metadata.cell_type == "markdown", comment_token=metadata.comment_token
+    )
 
 
 def row_anchor(slide_id: str | None, construct: str | None, content_hash: str) -> str:
@@ -421,7 +428,13 @@ def build_twin_cell(source_cell: RawCell, target_lang: str, target_body: str) ->
         body_lines.pop(0)
     while body_lines and body_lines[-1] == "":
         body_lines.pop()
-    return RawCell(lines=[header, *body_lines], line_number=0, metadata=parse_cell_header(header))
+    # Reuse the source cell's comment token so the twin's metadata hashes correctly for
+    # a ``//`` deck if compared in-pass before the disk re-parse (#458).
+    return RawCell(
+        lines=[header, *body_lines],
+        line_number=0,
+        metadata=parse_cell_header(header, source_cell.metadata.comment_token),
+    )
 
 
 @dataclass
@@ -494,7 +507,7 @@ class FileState:
         new_header = set_header_tags(cell.lines[0], new_tags)
         if new_header != cell.lines[0]:
             cell.lines[0] = new_header
-            cell.metadata = parse_cell_header(new_header)
+            cell.metadata = parse_cell_header(new_header, cell.metadata.comment_token)
             self.dirty = True
         return True
 
@@ -530,7 +543,7 @@ class FileState:
             new_header = set_header_tags(cell.lines[0], new_tags)
             if new_header != cell.lines[0]:
                 cell.lines[0] = new_header
-                cell.metadata = parse_cell_header(new_header)
+                cell.metadata = parse_cell_header(new_header, cell.metadata.comment_token)
                 self.dirty = True
             return True
         return False

--- a/src/clm/web/studio/service.py
+++ b/src/clm/web/studio/service.py
@@ -248,10 +248,15 @@ class StudioService:
 
     # ----------------------------------------------------------------- open
 
-    def _cell_views(self, text: str, lang: str | None) -> list[CellView]:
+    def _cell_views(self, text: str, lang: str | None, comment_token: str = "#") -> list[CellView]:
         from collections import Counter
 
-        parsed = parse_cells(text)
+        # Parse with the deck's real comment token so a ``//`` deck's cells carry the
+        # right token in BOTH the render hash (hash_cell below) and the clean-edit
+        # round-trip check (token at line below) — otherwise the markdown reflow hash
+        # (#458) computed here would differ from the write-guard's, false-tripping the
+        # optimistic-concurrency check and making ``//`` markdown cells uneditable.
+        parsed = parse_cells(text, comment_token)
         # A cell is only safely addressable when its (slide_id, role) key is
         # UNIQUE in the file — FileState.find_cell returns the first match and
         # ignores language, so a colliding key (e.g. a genuinely interleaved
@@ -316,7 +321,7 @@ class StudioService:
             deck_id=deck_id,
             deck_version=self._deck_version(path),
             lang=lang,
-            cells=self._cell_views(text, lang),
+            cells=self._cell_views(text, lang, comment_token_for_path(path)),
             lock=self.compute_lock(deck_id, path),
         )
 

--- a/tests/slides/test_reflow_hash.py
+++ b/tests/slides/test_reflow_hash.py
@@ -14,6 +14,11 @@ def _md(text: str) -> str:
     return cell_content_hash(text, markdown=True)
 
 
+def _md_slash(text: str) -> str:
+    """Markdown hash for a ``//``-comment deck (C++/C#/Java/TS), Issue #458."""
+    return cell_content_hash(text, markdown=True, comment_token="//")
+
+
 class TestProseReflow:
     def test_softwrap_hashes_equal(self) -> None:
         a = "# This is a long paragraph that\n# wraps across two lines."
@@ -101,6 +106,59 @@ class TestCodeCellUnchanged:
         a = cell_content_hash("x = 1\ny = 2", markdown=False)
         b = cell_content_hash("x = 1 y = 2", markdown=False)
         assert a != b
+
+
+class TestSlashCommentReflow:
+    """Issue #458: ``//``-comment decks get the same reflow-insensitivity as ``#``."""
+
+    def test_softwrap_hashes_equal(self) -> None:
+        a = "// This is a long paragraph that\n// wraps across two lines."
+        b = "// This is a long paragraph that wraps\n// across two lines."
+        assert _md_slash(a) == _md_slash(b)
+
+    def test_one_long_line_equals_wrapped(self) -> None:
+        words = " ".join(f"word{i}" for i in range(40))
+        one_line = f"// {words}"
+        wrapped = "\n".join(f"// {chunk}" for chunk in _wrap(words, 8))
+        assert _md_slash(one_line) == _md_slash(wrapped)
+
+    def test_genuinely_different_prose_differs(self) -> None:
+        a = "// This is a long paragraph that\n// wraps across two lines."
+        b = "// This is a DIFFERENT paragraph that\n// wraps across two lines."
+        assert _md_slash(a) != _md_slash(b)
+
+    def test_heading_kept_on_own_line(self) -> None:
+        a = "// # Heading\n// Some prose here that is\n// wrapped."
+        b = "// # Heading\n// Some prose here that is wrapped."
+        assert _md_slash(a) == _md_slash(b)
+        assert normalize_for_hash(a, "//").startswith("# Heading\n")
+
+    def test_fenced_code_blank_line_is_significant(self) -> None:
+        a = "// ```cpp\n// int x = 1;\n// int y = 2;\n// ```"
+        b = "// ```cpp\n// int x = 1;\n//\n// int y = 2;\n// ```"
+        assert _md_slash(a) != _md_slash(b)
+
+    def test_without_token_the_slash_prefix_blocks_reflow(self) -> None:
+        # The #458 motivation: hashing a //-cell with the "#" default leaves the "// "
+        # prefix on each line, so a re-wrap moves the embedded // tokens → different hash.
+        a = "// This is a long paragraph that\n// wraps across two lines."
+        b = "// This is a long paragraph that wraps\n// across two lines."
+        assert cell_content_hash(a, markdown=True) != cell_content_hash(b, markdown=True)
+
+
+class TestHashCommentUnchangedByVersionBump:
+    """#458 must not change any ``#``-deck hash (``"#"`` was the prior default)."""
+
+    def test_default_equals_explicit_hash_token(self) -> None:
+        text = "# A paragraph of prose\n# wrapped across lines."
+        assert cell_content_hash(text, markdown=True) == cell_content_hash(
+            text, markdown=True, comment_token="#"
+        )
+
+    def test_hash_reflow_still_works(self) -> None:
+        a = "# A paragraph of prose that\n# wraps across two lines."
+        b = "# A paragraph of prose\n# that wraps across two lines."
+        assert _md(a) == _md(b)
 
 
 def _wrap(words: str, n: int) -> list[str]:

--- a/tests/slides/test_sync_ledger_hash_version.py
+++ b/tests/slides/test_sync_ledger_hash_version.py
@@ -1,0 +1,86 @@
+"""Issue #458: the consistency ledger carries a per-entry ``hash_version``.
+
+A hash-form change (#458 threaded the comment token into markdown hashing) must not
+let a stale entry — whose hashes a newer engine would compute differently — be trusted.
+``trusts`` requires the current version; a pre-#458 entry (no field) defaults to current
+on load, so ``#`` decks (whose hashes are unchanged) keep their trust, while a future
+bump cleanly invalidates.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from clm.infrastructure.llm.cache import WATERMARK_HASH_VERSION
+from clm.slides.sync_ledger import LedgerEntry, SyncLedger, load, save
+
+
+def _entry(**kw) -> LedgerEntry:
+    base = {
+        "de_hash": "aaa",
+        "en_hash": "bbb",
+        "construct": None,
+        "confirmed_commit": "c1",
+        "confirmed_by": "bless",
+        "confirmed_oracle": "structural",
+    }
+    base.update(kw)
+    return LedgerEntry(**base)
+
+
+def test_new_entry_records_current_hash_version(tmp_path: Path) -> None:
+    led = SyncLedger()
+    led.entries[("intro", "slide")] = _entry()
+    path = tmp_path / "sync-ledger.json"
+    save(led, path)
+    rec = json.loads(path.read_text(encoding="utf-8"))["slides"]["intro"]["slide"]
+    assert rec["hash_version"] == WATERMARK_HASH_VERSION
+    back = load(path)
+    assert back.entries[("intro", "slide")].hash_version == WATERMARK_HASH_VERSION
+    assert back.trusts("intro", "slide", "aaa", "bbb")
+
+
+def test_stale_hash_version_is_not_trusted() -> None:
+    led = SyncLedger()
+    led.entries[("old", "slide")] = _entry(hash_version=WATERMARK_HASH_VERSION - 1)
+    assert not led.trusts("old", "slide", "aaa", "bbb")
+
+
+def test_pre_versioned_entry_defaults_to_current_on_load(tmp_path: Path) -> None:
+    # A ledger written before #458 has no hash_version field; it must load as current
+    # (so a # deck, whose hashes did not change, keeps its trust).
+    path = tmp_path / "sync-ledger.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "slides": {
+                    "intro": {
+                        "slide": {
+                            "de_hash": "aaa",
+                            "en_hash": "bbb",
+                            "construct": None,
+                            "confirmed_commit": "c1",
+                            "confirmed_by": "bless",
+                            "confirmed_oracle": "structural",
+                        }
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    back = load(path)
+    assert back.entries[("intro", "slide")].hash_version == WATERMARK_HASH_VERSION
+    assert back.trusts("intro", "slide", "aaa", "bbb")
+
+
+def test_idless_entry_round_trips_hash_version(tmp_path: Path) -> None:
+    led = SyncLedger()
+    led.idless[(None, "voiceover", 0)] = _entry()
+    path = tmp_path / "sync-ledger.json"
+    save(led, path)
+    back = load(path)
+    assert back.idless[(None, "voiceover", 0)].hash_version == WATERMARK_HASH_VERSION
+    assert back.trusts_idless((None, "voiceover", 0), "aaa", "bbb")

--- a/tests/slides/test_sync_reflow_slash.py
+++ b/tests/slides/test_sync_reflow_slash.py
@@ -1,0 +1,85 @@
+"""Issue #458 end-to-end: a pure markdown re-wrap of a ``//`` deck is not an edit.
+
+The ``#`` version (``test_sync_reflow_no_edit``) proved Python/Rust decks; this proves
+the C++/C#/Java/TS (``//``) decks #458 extended the reflow benefit to. The deck files
+use a ``.cpp`` extension so ``comment_token_for_path`` resolves ``"//"``, and the cells
+use the ``// %%`` boundary + ``// ``-prefixed prose.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.notebooks.slide_parser import parse_cells
+from clm.slides.sync_plan import build_sync_plan, ordered_sync_cells
+
+
+def _slide(lang: str, sid: str, body: str) -> str:
+    return f'// %% [markdown] lang="{lang}" tags=["slide"] slide_id="{sid}"\n{body}\n'
+
+
+def _write_pair(tmp_path: Path, de: str, en: str) -> tuple[Path, Path]:
+    de_path = tmp_path / "deck.de.cpp"
+    en_path = tmp_path / "deck.en.cpp"
+    de_path.write_text(de, encoding="utf-8")
+    en_path.write_text(en, encoding="utf-8")
+    return de_path, en_path
+
+
+def _seed_watermark(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> None:
+    for lang, path in (("de", de_path), ("en", en_path)):
+        # Parse with the // token so the watermark seed keys cells the same way the
+        # plan (comment_token_for_path) will — otherwise the seed mis-parses the deck.
+        cells = ordered_sync_cells(parse_cells(path.read_text(encoding="utf-8"), "//"), lang)
+        cache.put_deck(
+            de_path=str(de_path),
+            en_path=str(en_path),
+            lang=lang,
+            cells=[(c.position, c.slide_id, c.role, c.content_hash, c.construct) for c in cells],
+        )
+
+
+_DE_WRAPPED = _slide(
+    "de", "intro", "// Dies ist ein langer Absatz der\n// über mehrere Zeilen umgebrochen ist."
+)
+_EN = _slide("en", "intro", "// This is a long paragraph that\n// wraps across several lines.")
+
+
+def test_slash_reflow_only_produces_no_edit(tmp_path: Path) -> None:
+    de_path, en_path = _write_pair(tmp_path, _DE_WRAPPED, _EN)
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        _seed_watermark(cache, de_path, en_path)
+        # Re-wrap the DE paragraph at a different column — same words, new breaks.
+        de_path.write_text(
+            _slide(
+                "de",
+                "intro",
+                "// Dies ist ein langer Absatz\n// der über mehrere Zeilen umgebrochen ist.",
+            ),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        assert [p for p in plan.proposals if p.kind == "edit"] == []
+    finally:
+        cache.close()
+
+
+def test_slash_real_word_change_still_edits(tmp_path: Path) -> None:
+    de_path, en_path = _write_pair(tmp_path, _DE_WRAPPED, _EN)
+    cache = SyncWatermarkCache(tmp_path / "clm-llm.sqlite")
+    try:
+        _seed_watermark(cache, de_path, en_path)
+        de_path.write_text(
+            _slide(
+                "de",
+                "intro",
+                "// Dies ist ein KURZER Absatz der\n// über mehrere Zeilen umgebrochen ist.",
+            ),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+        assert any(p.kind == "edit" and p.slide_id == "intro" for p in plan.proposals)
+    finally:
+        cache.close()

--- a/tests/web/studio/test_slash_deck_hash.py
+++ b/tests/web/studio/test_slash_deck_hash.py
@@ -1,0 +1,47 @@
+"""Issue #458: Studio renders a ``//``-deck cell's hash with the real comment token.
+
+``_cell_views`` must parse with the deck's comment token so the render hash equals the
+write-guard hash (``hash_cell`` over ``metadata.comment_token``). Token-less parsing
+would leave the ``// `` prefix on each prose line, so the hashed (reflow-normalized)
+text — and thus the optimistic-concurrency check — would diverge for a ``//`` deck.
+
+(Studio's ``open_deck`` is ``.py``-only today, so the divergence is latent rather than
+live; this proves the render path threads the token regardless, future-proofing Studio
+for ``//`` decks and exercising the fix at the unit level.)
+"""
+
+from __future__ import annotations
+
+from clm.notebooks.slide_parser import parse_cells
+from clm.slides.sync_writeback import hash_cell
+
+from .conftest import Course  # noqa: F401  (imported for the `service`/`course` fixtures)
+
+_SLASH_CELL = (
+    '// %% [markdown] lang="de" tags=["slide"] slide_id="x"\n'
+    "// Dies ist ein langer Absatz der\n"
+    "// über mehrere Zeilen umgebrochen ist und genug Text hat.\n"
+)
+
+
+_SLASH_CELL_REWRAPPED = (
+    '// %% [markdown] lang="de" tags=["slide"] slide_id="x"\n'
+    "// Dies ist ein langer Absatz\n"
+    "// der über mehrere Zeilen umgebrochen ist und genug Text hat.\n"
+)
+
+
+def test_cell_views_render_hash_uses_the_deck_comment_token(service) -> None:
+    views = service._cell_views(_SLASH_CELL, None, "//")
+    slide = next(v for v in views if v.role == "slide")
+
+    parsed_slash = parse_cells(_SLASH_CELL, "//")[0]
+    assert slide.content_hash == hash_cell(parsed_slash.metadata, parsed_slash.content)
+
+    # Reflow-insensitivity reaches the Studio render hash: the same // prose re-wrapped
+    # renders the SAME content_hash — it would NOT if the token were not threaded
+    # (the "// " prefix would stay embedded in the hashed prose and move on a re-wrap).
+    rewrapped = next(
+        v for v in service._cell_views(_SLASH_CELL_REWRAPPED, None, "//") if v.role == "slide"
+    )
+    assert rewrapped.content_hash == slide.content_hash


### PR DESCRIPTION
## What

Threads the real source comment token through reflow-insensitive markdown hashing so `//`-comment decks (C++/C#/Java/TS) get the benefit #429 gave Python/Rust. Closes #458 (follow-up to #429).

#429 made a pure soft re-wrap of a markdown prose cell hash identically (so it isn't mis-read as an edit), but hard-coded the `#` comment token — so a `//` deck's re-wrap still read as drift (the `// ` prefix stayed on each prose line, moving the embedded tokens to new word positions).

## How (Option A — atomic by construction)

- The token rides on **`CellMetadata.comment_token`**, stamped at the single `parse_cell_header` chokepoint. `hash_cell` / `anchor_of` forward `metadata.comment_token` into `cell_content_hash` → `normalize_for_hash`. Because every markdown hash call site already passes `metadata`, **the ~25 hash sites change zero lines** — the threading can't half-apply (a partial change would make write and read disagree → false drift, the exact trap the issue warns about). `row_anchor` (formats a *stored* hash) is untouched and stays in lockstep with `anchor_of`.
- **Migration is automatic + one-time.** `WATERMARK_HASH_VERSION` 2→3: the existing stale-version self-heal treats a `//` deck's old watermark as absent → cold-start off git `HEAD` → re-record at v3. `#`-deck hashes are byte-identical (`"#"` was the prior default), so they **don't** re-baseline.
- **Consistency ledger** gains a per-entry `hash_version`; `trusts` requires the current version, so a `//` entry re-checks + re-records while `#` entries (defaulted to current on load) keep their trust. A *future* bump then cleanly invalidates all entries.
- Hardened the in-pass re-header sites (`build_twin_cell`, `FileState.replace_cell_tags`/`replace_idless_localized_tags`, and the `reconcile_vo_ids`/`assign_ids`/`sync_apply` header rewriters) to reuse the cell's own `metadata.comment_token`.
- **Studio**: `_cell_views`/`open_deck` thread `comment_token_for_path` so a future `//` deck's render hash matches the write-guard hash (Studio is `.py`-only today, so this is latent — but it's the right consistency fix the review flagged).

## Tests

- `//` mirror of the #429 reflow-hash unit tests + a `#`-deck **no-churn** regression (default == explicit `#`).
- `//`-deck **sync round-trip**: a re-wrap produces **no** edit proposal; a real word change still does.
- Ledger `hash_version` round-trip + stale-version rejection + pre-versioned-defaults-to-current.
- Studio `//` render-hash unit test (reflow-insensitive through `_cell_views`).
- Broad regression: 2194 slides/studio/cache tests + 269 CLI sync tests pass.

## Docs

- `clm info migration` — a `//`-deck re-baseline note (no action required).
- changelog fragment `changelog.d/458-comment-token-hash.fixed.md`.

Part of the slides-sync improvement arc (design doc in #489).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014RqsUHWEuje4hqVp5FZKkz
