### PR TITLE
docs: surface the section → source-deck mapping in decks/outline help

### DIFF
--- a/changelog.d/decks-outline-section-mapping-docs.changed.md
+++ b/changelog.d/decks-outline-section-mapping-docs.changed.md
@@ -1,0 +1,11 @@
+- **`clm course decks --json`, `clm export outline --format json`, and the
+  `course_outline` MCP tool now document that their JSON *is* the
+  section → source-`.py`-deck mapping.** The capability was always present (a
+  per-topic array carrying each topic's `section` / `resolved_module` /
+  `slide_files`, or sections whose topics carry `slides: [{file, title}]`), but
+  the help text and tool descriptions only said "List the deck files" / "Output
+  as JSON" / "Generate a structured JSON outline", so agents reconstructed the
+  mapping by parsing the spec XML or grepping `slides/`. The command help,
+  docstrings, `clm info commands`, and the two MCP `course_outline` docstrings
+  now state the mapping explicitly and cross-reference each other. Docs only —
+  no behavior change.

--- a/src/clm/cli/commands/course/decks.py
+++ b/src/clm/cli/commands/course/decks.py
@@ -75,7 +75,15 @@ def _rel(path: Path, base: Path) -> str:
     help="Course data directory (contains slides/). Default: inferred from the "
     "spec file (its grandparent).",
 )
-@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Output as JSON. Adds a per-topic ``topics`` array — each entry "
+    "carries its ``section``, ``resolved_module`` and ``slide_files`` (the "
+    "source ``.py`` decks), plus first-occurrence-shadowed duplicates and "
+    "unresolved topics. This is the section -> source-file mapping in one call.",
+)
 def spec_decks_cmd(
     spec_file: Path | None,
     all_specs: Path | None,
@@ -90,6 +98,12 @@ def spec_decks_cmd(
     references pick their module; unbound duplicates are first-occurrence-wins).
     This is the reliable way to compute a spec's "shipping set" — do not guess
     from deck filenames.
+
+    Plain output is one deck path per line. ``--json`` additionally emits a
+    per-topic ``topics`` array keyed by ``section`` with each topic's
+    ``slide_files`` — i.e. the **section -> source-``.py``-deck mapping**, with
+    no need to parse the spec XML by hand. (``clm export outline --format json``
+    gives the same mapping grouped by section and annotated with deck titles.)
 
     \b
     Examples:

--- a/src/clm/cli/commands/export/outline.py
+++ b/src/clm/cli/commands/export/outline.py
@@ -1,8 +1,10 @@
 """Outline command for generating course outlines in Markdown and JSON format.
 
 This module provides a command to export a course structure as a Markdown
-outline or structured JSON, with section names as headings and topic titles
-as entries.
+outline (section headings + topic/deck titles) or structured JSON. The JSON
+form additionally carries each topic's directory and its slide ``{file,
+title}`` entries, so it doubles as the section -> source-``.py`` deck-file
+mapping.
 """
 
 import json
@@ -620,6 +622,10 @@ def generate_outline_json(
 ) -> dict:
     """Generate a structured JSON outline for a course.
 
+    Each section entry carries a ``topics`` list; every topic carries its
+    ``directory`` and a ``slides`` list of ``{file, title}`` — the
+    section -> source-``.py`` deck-file mapping, annotated with titles.
+
     Args:
         course: The course to generate an outline for
         language: Language code ('en' or 'de')
@@ -781,8 +787,14 @@ def outline(
 ):
     """Generate an outline of a course in Markdown or JSON format.
 
-    Creates a document with section names as headings and topic titles
-    as entries. Use --format json for structured output.
+    Markdown (the default) uses section names as headings and topic/deck
+    titles as bullet entries — titles only, no file paths. Pass
+    ``--format json`` for structured output: each section then carries a
+    ``topics`` array whose entries include the topic ``directory`` and a
+    ``slides`` list of ``{file, title}`` — i.e. the **section -> source-``.py``
+    deck-file mapping**, annotated with titles, without parsing the spec XML.
+    (``clm course decks <spec> --json`` gives the same mapping as a flat,
+    build-resolution-accurate ``topics`` array.)
 
     \b
     Examples:

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -546,7 +546,13 @@ single entry — the same per-language routing the build applies.
 
 #### `clm export outline`
 
-Generate a Markdown (or JSON) outline of a course.
+Generate a Markdown (or JSON) outline of a course. Markdown is section
+headings + topic/deck titles (titles only). `--format json` additionally gives
+each topic a `directory` and a `slides` list of `{file, title}` — the
+**section → source-`.py`-deck mapping**, annotated with titles, so you never
+have to parse the spec XML to learn which files back a section. (`clm course
+decks <spec> --json` returns the same mapping as a flat, build-resolution-
+accurate `topics` array.)
 
 ```
 clm export outline [OPTIONS] SPEC_FILE
@@ -848,12 +854,19 @@ decks. Module-bound `<topic>`/`<section>` references resolve in their module;
 unbound topic IDs that match multiple modules are first-occurrence-wins (matching
 the build), and the shadowed matches are reported in `--json` output.
 
+Plain output is one deck path per line. `--json` adds a per-topic `topics`
+array that pairs each topic's `section` with its `slide_files` — the
+**section → source-`.py`-deck mapping** in one call, so there is no need to
+parse the spec XML or grep `slides/` to learn which files back each section.
+(`clm export outline <spec> --format json` returns the same mapping grouped by
+section and annotated with deck titles.)
+
 | Option | Description |
 |--------|-------------|
 | `--all-specs DIR` | Resolve the union shipping set across every `*.xml` spec in `DIR`, annotating each deck with the spec(s) that reference it. Mutually exclusive with `SPEC_FILE`. |
 | `--lang de\|en\|both` | Keep only decks serving this language. Bilingual decks (no `.de`/`.en` tag) serve both, so they always survive the filter; split halves are kept only for their own language. Default: `both`. |
 | `--data-dir DIR` | Course data directory (contains `slides/`). Default: inferred from the spec file (its grandparent). |
-| `--json` | Output as JSON (includes per-topic resolution, unresolved topics, and first-occurrence-shadowed duplicates). |
+| `--json` | Output as JSON: a per-topic `topics` array (each with `section`, `resolved_module`, `slide_files`), plus unresolved topics and first-occurrence-shadowed duplicates. |
 
 Topic references that resolve to no directory on disk are reported as a warning
 (stderr) but do not fail the command.

--- a/src/clm/mcp/server.py
+++ b/src/clm/mcp/server.py
@@ -107,6 +107,14 @@ def create_server(data_dir: Path) -> FastMCP:
     ) -> str:
         """Generate a structured JSON outline for a course.
 
+        The outline is the **section -> source-deck mapping**: a list of
+        sections, each with a ``topics`` array whose entries carry the topic
+        ``directory`` and a ``slides`` list of ``{file, title}`` (the source
+        ``.py`` deck files). Use this instead of parsing the spec XML or
+        grepping ``slides/`` to learn which files back each section. (The CLI
+        ``clm course decks <spec> --json`` returns the same mapping as a flat,
+        build-resolution-accurate ``topics`` array.)
+
         Args:
             spec_file: Path to the course spec file (absolute, or
                 relative to the data directory).

--- a/src/clm/mcp/tools.py
+++ b/src/clm/mcp/tools.py
@@ -246,6 +246,10 @@ async def handle_course_outline(
 ) -> str:
     """Generate a structured JSON outline for a course.
 
+    The outline doubles as the section -> source-deck mapping: each section's
+    ``topics`` array carries the topic ``directory`` and a ``slides`` list of
+    ``{file, title}`` (the source ``.py`` deck files).
+
     Args:
         spec_file: Path to the course spec file (absolute or relative to data_dir).
         data_dir: Root data directory.


### PR DESCRIPTION
## Problem

Agents repeatedly reconstruct the **section → source-`.py`-deck mapping** for a course by parsing the spec XML by hand or grepping `slides/` — even though CLM already computes it. Three surfaces return exactly this data today:

- `clm course decks <spec> --json` → a per-topic `topics[]` array, each entry carrying `section`, `resolved_module`, `path`, and `slide_files[]` (build-resolution-accurate).
- `clm export outline <spec> --format json` → `sections[] → topics[] → slides[]` with both `file` and `title`.
- The `course_outline` MCP tool → the same outline JSON, in one call (no LLM, no build).

The capability isn't missing — it's **undiscoverable**. Each surface understates what it returns, and the *default* (non-JSON) output hides exactly the half an agent needs:

- `clm course decks` plain output is a flat file list with **no section labels**; `--help` says only *"List the deck files a course spec pulls in"* and `--json` says only *"Output as JSON."*
- `clm export outline` plain markdown is section headings + **titles only, no files**; the docstring says *"section names as headings and topic titles as entries"* — signalling "titles only" and never mentioning that `--format json` adds per-slide `file`/`directory`.
- MCP `course_outline` is described as *"Generate a structured JSON outline for a course"* — no hint it contains source filenames.

Because `clm info commands` and the agent guide are generated from these docstrings, the understatement is mirrored into every surface an agent reads.

## Change (docs only — no behavior change)

Make the mapping discoverable where agents look:

- **`course decks`** — `--json` option help + command docstring now name the `topics[].section` + `slide_files` mapping and cross-reference `export outline`.
- **`export outline`** — command, module, and `generate_outline_json` docstrings now state that `--format json` adds per-topic `directory` + `slides: [{file, title}]` (markdown stays titles-only by design), and cross-reference `course decks --json`.
- **MCP `course_outline`** — both the exposed `server.py` description and the `tools.py` handler docstring now describe the JSON as the section → source-deck mapping.
- **`clm info commands`** (`commands.md`) — updated for both commands.
- Added a `changelog.d/` fragment (`changed`).

## Verification

- All four edited Python files AST-parse.
- No added Python line exceeds the 100-char limit (the one >100 line is a markdown table row in `commands.md`, consistent with the existing rows there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)