### PR TITLE
feat(build): explain why decks miss the cache via --explain-rebuilds

### DIFF
--- a/changelog.d/explain-rebuilds.added.md
+++ b/changelog.d/explain-rebuilds.added.md
@@ -1,0 +1,12 @@
+- **`clm build --explain-rebuilds` logs why each deck missed the build cache
+  and is being rebuilt.** When many decks rebuild whose sources should not have
+  changed, this names the cause per deck: `no cache entry` (never built with
+  this cache, or the cache was cleared), `content hash changed` (the source
+  text or one of its dependencies differs — with the cached vs. current hash),
+  or `no cache entry for this output target` (a new kind/format/language). Off
+  by default so a normal build pays nothing — the extra read-only probe runs
+  only on a miss and only when the flag is set. Reasons always go to the log
+  file and, under `-O verbose`, to the console. Also settable via
+  `CLM_EXPLAIN_REBUILDS={1,true,yes,0,false,no}`. Complements
+  `clm cache explain FILE --spec SPEC`, which gives a full per-artifact,
+  per-cache-layer breakdown for a single deck.

--- a/src/clm/cli/build_reporter.py
+++ b/src/clm/cli/build_reporter.py
@@ -211,6 +211,22 @@ class BuildReporter:
             cached=self._stage_cached_count,
         )
 
+    def report_rebuild_reason(self, file_path: str, job_type: str, reason: str) -> None:
+        """Explain why a file is being rebuilt instead of served from cache.
+
+        Only called under ``clm build --explain-rebuilds``. Purely
+        informational: it does not touch the progress/cache counters (the
+        normal :meth:`report_file_started` path still tracks the submitted
+        job). The reason is also written to the log file by the backend; this
+        surfaces it on the console in verbose output modes.
+
+        Args:
+            file_path: Path to the source file being rebuilt
+            job_type: Type of job (notebook, plantuml, drawio)
+            reason: Human-readable explanation of the cache miss
+        """
+        self.formatter.show_rebuild_reason(file_path, job_type, reason)
+
     def report_file_started(self, file_path: str, job_type: str, job_id: int | None = None) -> None:
         """Report that a file has started processing.
 

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -157,6 +157,30 @@ def _resolve_fail_on_missing_xref(cli_value: bool | None, resolved_http_replay_m
     return resolved_http_replay_mode == "replay"
 
 
+def _resolve_explain_rebuilds(cli_flag: bool) -> bool:
+    """Resolve whether ``clm build`` logs why each deck missed the cache.
+
+    Off by default: the extra per-miss probe only runs when explicitly
+    requested, so a normal build pays nothing. Enabled by the
+    ``--explain-rebuilds`` flag or ``CLM_EXPLAIN_REBUILDS={1,true,yes}``.
+    """
+    import os
+
+    if cli_flag:
+        return True
+    env_value = os.environ.get("CLM_EXPLAIN_REBUILDS")
+    if env_value is not None:
+        normalized = env_value.strip().lower()
+        if normalized in ("1", "true", "yes"):
+            return True
+        if normalized in ("0", "false", "no"):
+            return False
+        raise click.UsageError(
+            f"Invalid CLM_EXPLAIN_REBUILDS={env_value!r}. Valid values: 1/true/yes/0/false/no."
+        )
+    return False
+
+
 def _resolve_write_provenance_manifest(
     *, requested: bool, is_snapshot: bool, verify_against_dir: Path | None
 ) -> bool:
@@ -480,6 +504,14 @@ class BuildConfig:
     # builds at the entry point — it embeds a build timestamp and source commit,
     # so it must never enter a byte-reproducibility baseline.
     write_provenance_manifest: bool = True
+
+    # Log why each deck missed the cache and is being rebuilt (issue: many
+    # decks rebuilding whose sources should not change). Resolved from
+    # ``--explain-rebuilds`` / ``CLM_EXPLAIN_REBUILDS`` by
+    # ``_resolve_explain_rebuilds``. Off by default so the per-miss diagnostic
+    # probe never runs on a normal build; the reasons go to the log file and,
+    # under ``--output-mode verbose``, to the console.
+    explain_rebuilds: bool = False
 
 
 def _should_emit_provenance_manifest(summary: BuildSummary | None, config: BuildConfig) -> bool:
@@ -1638,6 +1670,7 @@ async def main_build(
     telemetry_db_path: Path | None = None,
     no_html: bool = False,
     no_diagrams: bool = False,
+    explain_rebuilds: bool = False,
 ) -> BuildSummary | None:
     """Main orchestration function for course building.
 
@@ -1763,6 +1796,7 @@ async def main_build(
         fail_on_missing_xref=fail_on_missing_xref,
         write_provenance_manifest=provenance_manifest,
         telemetry_db_path=telemetry_db_path,
+        explain_rebuilds=explain_rebuilds,
     )
 
     # Create output formatter early to show startup messages
@@ -1850,6 +1884,7 @@ async def main_build(
                 ignore_db=config.ignore_cache,
                 build_reporter=build_reporter,
                 incremental=config.incremental,
+                explain_rebuilds=config.explain_rebuilds,
                 image_registry=course.image_registry,
                 telemetry_store=telemetry_store,
             )
@@ -2247,6 +2282,18 @@ async def main_build(
     ),
 )
 @click.option(
+    "--explain-rebuilds",
+    is_flag=True,
+    default=False,
+    help=(
+        "Log why each deck missed the build cache and is being rebuilt "
+        "(no cache entry / content hash changed / new output target). Off "
+        "by default so a normal build pays nothing; reasons go to the log "
+        "file, and to the console under --output-mode verbose. Also "
+        "settable via CLM_EXPLAIN_REBUILDS={1,true,yes,0,false,no}."
+    ),
+)
+@click.option(
     "--image-mode",
     type=click.Choice(["duplicated", "shared"], case_sensitive=False),
     default="duplicated",
@@ -2326,6 +2373,7 @@ def build(
     http_replay,
     fail_on_error,
     fail_on_missing_xref,
+    explain_rebuilds,
     image_mode,
     image_format,
     inline_images,
@@ -2422,6 +2470,7 @@ def build(
     resolved_fail_on_missing_xref = _resolve_fail_on_missing_xref(
         fail_on_missing_xref, resolved_http_replay_mode
     )
+    resolved_explain_rebuilds = _resolve_explain_rebuilds(explain_rebuilds)
 
     effective_provenance_manifest = _resolve_write_provenance_manifest(
         requested=provenance_manifest,
@@ -2471,6 +2520,7 @@ def build(
             telemetry_db_path=ctx.obj.get("TELEMETRY_DB_PATH") if ctx.obj else None,
             no_html=no_html,
             no_diagrams=no_diagrams,
+            explain_rebuilds=resolved_explain_rebuilds,
         )
     )
 

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -49,6 +49,7 @@ Key options:
 | `--watch-mode [fast\|normal]` | `fast` = notebooks only; `normal` = all formats |
 | `--ignore-cache` | Reprocess all files (still updates cache) |
 | `--clear-cache` | Clear cache before building |
+| `--explain-rebuilds` | Log **why** each deck missed the build cache and is being rebuilt: `no cache entry`, `content hash changed` (source text or a dependency differs, with the cached vs. current hash), or `no cache entry for this output target` (new kind/format/language). Off by default so a normal build pays nothing — the reason probe runs only on a miss when this is set. Reasons go to the log file always, and to the console under `-O verbose`. Also settable via `CLM_EXPLAIN_REBUILDS={1,true,yes,0,false,no}`. Use `clm cache explain FILE --spec SPEC` for a full per-artifact, per-cache-layer breakdown of a single deck (CLM {version}). |
 | `--clean` | Wipe each output root and regenerate from scratch (legacy flow; preserves nested `.git/`). Use for emergency recovery from a corrupted output tree. The default no longer wipes — see "Git-friendly output writes" below. |
 | `--no-sweep` | Disable the post-build stray-file sweep. Useful when iterating on a single section and you don't want orphans from other sections deleted. |
 | `--incremental` | Keep directories, only write newly processed files (skip cached ones). Implies `--no-sweep`. |
@@ -4543,6 +4544,7 @@ Create and manage ZIP archives of course output.
 | `CLM_HTTP_REPLAY_TRACE_MAX_BODY_BYTES` | Cap on bytes recorded for the head/tail body excerpts in trace events (default: implementation-defined). |
 | `CLM_FAIL_ON_ERROR` | Override the default exit-on-cell-error policy for `clm build`. Accepts `1`/`true`/`yes` or `0`/`false`/`no`. Overridden by `--fail-on-error` / `--no-fail-on-error`. See `clm build` → "Exit codes". |
 | `CLM_FAIL_ON_MISSING_XREF` | Override the default exit-on-missing-cross-reference policy for `clm build` (issue #17). Accepts `1`/`true`/`yes` or `0`/`false`/`no`. Overridden by `--fail-on-missing-xref` / `--no-fail-on-missing-xref`. See `clm info spec-files` → "Cross-references". |
+| `CLM_EXPLAIN_REBUILDS` | Log why each deck missed the build cache and is being rebuilt (`clm build`). Accepts `1`/`true`/`yes` or `0`/`false`/`no`. Overridden by `--explain-rebuilds`. See `clm build` → the `--explain-rebuilds` option. |
 | `LANGFUSE_HOST` | Langfuse server URL (or `LANGFUSE_BASE_URL`); enables LLM call tracing when set with keys below |
 | `LANGFUSE_PUBLIC_KEY` | Langfuse public key for LLM tracing |
 | `LANGFUSE_SECRET_KEY` | Langfuse secret key for LLM tracing |

--- a/src/clm/cli/output_formatter.py
+++ b/src/clm/cli/output_formatter.py
@@ -198,6 +198,25 @@ class OutputFormatter(ABC):
             detail: Optional human-readable cache-layer description
         """
 
+    def show_rebuild_reason(  # noqa: B027
+        self, file_path: str, job_type: str, reason: str
+    ) -> None:
+        """Show why a file is being rebuilt instead of replayed (optional).
+
+        Emitted only under ``clm build --explain-rebuilds``. Complements
+        :meth:`show_cache_hit`: where that explains a replay, this explains a
+        miss (no cache entry, content hash changed, new output target).
+
+        This method is intentionally not abstract - it's an optional hook that
+        subclasses may override for verbose output. The default implementation
+        is a no-op (the reason still reaches the log file via the backend).
+
+        Args:
+            file_path: Path to the source file being rebuilt
+            job_type: Type of job (notebook, plantuml, drawio)
+            reason: Human-readable explanation of the cache miss
+        """
+
     def show_startup_message(self, message: str) -> None:  # noqa: B027
         """Show a startup progress message (optional).
 
@@ -601,6 +620,19 @@ class VerboseOutputFormatter(DefaultOutputFormatter):
         detail_info = f" ({detail})" if detail else ""
         self.console.print(
             f"  [cyan]↻[/cyan] [dim]Replayed from cache {job_type}: {display_path}{detail_info}[/dim]"
+        )
+
+    def show_rebuild_reason(self, file_path: str, job_type: str, reason: str) -> None:
+        """Show why a file is being rebuilt instead of replayed.
+
+        Args:
+            file_path: Path to the source file being rebuilt
+            job_type: Type of job (notebook, plantuml, drawio)
+            reason: Human-readable explanation of the cache miss
+        """
+        display_path = format_error_path(file_path)
+        self.console.print(
+            f"  [yellow]⟳[/yellow] [dim]Rebuilding {job_type}: {display_path} — {reason}[/dim]"
         )
 
     def show_file_completed(

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -70,6 +70,12 @@ class SqliteBackend(LocalOpsBackend):
     skip_worker_check: bool = False  # Skip worker availability check (for unit tests only)
     build_reporter: Optional["BuildReporter"] = None  # Optional build reporter for improved output
     incremental: bool = False  # Incremental mode: skip writing cached results
+    # When True (``clm build --explain-rebuilds`` / ``CLM_EXPLAIN_REBUILDS``),
+    # a ``processed_files`` cache MISS runs one extra read-only probe to log
+    # *why* the deck is being rebuilt (no cache entry / content-hash changed /
+    # new output target). Off by default so a normal build pays nothing — the
+    # miss path stays a single boolean check.
+    explain_rebuilds: bool = False
     # Persistent per-deck execution telemetry (issue #330). When set, the
     # backend records retry/crash telemetry the notebook worker attached to
     # its results (completed jobs: ``execution_telemetry`` warnings; failed
@@ -299,6 +305,14 @@ class SqliteBackend(LocalOpsBackend):
 
                 return True
 
+            # Cache MISS on the stored result. When rebuild explanation is
+            # enabled, run one extra read-only probe to log why. Only for a
+            # genuine ``result is None`` miss — the ``result`` truthy but
+            # replay-gated case (Recording HTML producer) already logs its
+            # own reason in ``_can_replay_from_cache``.
+            if self.explain_rebuilds and result is None:
+                self._explain_rebuild(payload, job_type)
+
         if service_name not in service_to_job_type:
             raise ValueError(f"Unknown service: {service_name}")
 
@@ -503,6 +517,50 @@ class SqliteBackend(LocalOpsBackend):
             )
             return False
         return True
+
+    def _explain_rebuild(self, payload: Payload, job_type: str) -> None:
+        """Log *why* a ``processed_files`` cache miss forces a rebuild.
+
+        Only invoked when :attr:`explain_rebuilds` is set, so the extra
+        read-only probe never runs on a normal build. Touches ``db_manager``,
+        so — like the cache-hit replay path above — it must stay on the
+        event-loop thread (``db_manager`` is not thread-safe). Purely
+        informational: it never changes the rebuild decision, and a probe
+        failure degrades to a debug line rather than disturbing the build.
+        """
+        if self.db_manager is None:
+            return
+        try:
+            reason_code, detail = self.db_manager.diagnose_cache_miss(
+                payload.input_file, payload.content_hash(), payload.output_metadata()
+            )
+        except Exception as e:  # never let a diagnostic break the build
+            logger.debug(f"Could not diagnose rebuild reason for {payload.input_file}: {e}")
+            return
+
+        reason = self._format_rebuild_reason(reason_code, detail, payload)
+        logger.info(f"Rebuilding {payload.input_file} -> {payload.output_file}: {reason}")
+        if self.build_reporter:
+            self.build_reporter.report_rebuild_reason(str(payload.input_file), job_type, reason)
+
+    @staticmethod
+    def _format_rebuild_reason(reason_code: str, detail: str | None, payload: Payload) -> str:
+        """Turn a ``diagnose_cache_miss`` verdict into a human-readable reason."""
+        if reason_code == "no_entry":
+            return "no cache entry for this file (never built with this cache, or cache cleared)"
+        if reason_code == "hash_mismatch":
+            stored = (detail or "")[:12]
+            current = payload.content_hash()[:12]
+            return (
+                f"content hash changed — source text or a dependency differs "
+                f"(cached {stored}…, now {current}…)"
+            )
+        if reason_code == "metadata_mismatch":
+            return (
+                f"no cache entry for this output target "
+                f"({payload.output_metadata()}) — new kind/format/language"
+            )
+        return "cache miss"
 
     def _cleanup_dead_worker_jobs(self) -> int:
         """Check for jobs stuck in 'processing' with dead workers and reset them.

--- a/src/clm/infrastructure/database/db_operations.py
+++ b/src/clm/infrastructure/database/db_operations.py
@@ -173,6 +173,50 @@ class DatabaseManager:
         db_result = cursor.fetchone()
         return pickle.loads(db_result[0]) if db_result else None
 
+    def diagnose_cache_miss(
+        self, file_path: str, content_hash: str, output_metadata: str
+    ) -> tuple[str, str | None]:
+        """Explain why :meth:`get_result` missed for this exact key.
+
+        Read-only diagnostic used only by ``clm build --explain-rebuilds`` —
+        it runs one extra indexed ``SELECT`` and is never called on a normal
+        build, so the default hot path pays nothing. Returns a
+        ``(reason, detail)`` pair:
+
+        - ``("no_entry", None)`` — no ``processed_files`` row exists for this
+          file at all (never built against this cache, or the cache was
+          cleared).
+        - ``("hash_mismatch", stored_hash)`` — a row exists for this file and
+          this same output target, but its content hash differs (the source
+          text or one of its dependencies changed). ``stored_hash`` is the
+          newest stored hash for that target.
+        - ``("metadata_mismatch", None)`` — rows exist for this file but none
+          for this output target (a new kind/format/language, or the
+          output-metadata key drifted).
+
+        The caller only reaches this when ``get_result(file_path,
+        content_hash, output_metadata)`` returned ``None``, so a row matching
+        all three cannot exist; the ``hash_mismatch`` branch therefore always
+        reports a genuinely different stored hash.
+        """
+        assert self.conn is not None, "Database connection not initialized"
+        cursor = self.conn.cursor()
+        cursor.execute(
+            """
+            SELECT content_hash, output_metadata FROM processed_files
+            WHERE file_path = ?
+            ORDER BY created_at DESC
+            """,
+            (str(file_path),),
+        )
+        rows = cursor.fetchall()
+        if not rows:
+            return ("no_entry", None)
+        for row_hash, row_meta in rows:
+            if row_meta == output_metadata:
+                return ("hash_mismatch", row_hash)
+        return ("metadata_mismatch", None)
+
     def remove_old_entries(self, file_path: str) -> None:
         assert self.conn is not None, "Database connection not initialized"
         cursor = self.conn.cursor()

--- a/tests/infrastructure/backends/test_sqlite_backend.py
+++ b/tests/infrastructure/backends/test_sqlite_backend.py
@@ -1361,3 +1361,112 @@ async def test_speaker_alias_triggers_executed_notebooks_check(
     finally:
         backend.active_jobs.clear()
         await backend.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# --explain-rebuilds: log WHY a deck missed the cache and is being rebuilt
+# ---------------------------------------------------------------------------
+
+
+def test_format_rebuild_reason_no_entry():
+    reason = SqliteBackend._format_rebuild_reason("no_entry", None, MockPayload())
+    assert "no cache entry" in reason
+
+
+def test_format_rebuild_reason_hash_mismatch():
+    payload = MockPayload(data="abc")
+    reason = SqliteBackend._format_rebuild_reason("hash_mismatch", "deadbeefcafe0000", payload)
+    assert "content hash changed" in reason
+    assert "deadbeefcafe" in reason  # cached short hash
+    assert payload.content_hash()[:12] in reason  # current short hash
+
+
+def test_format_rebuild_reason_metadata_mismatch():
+    payload = MockPayload()
+    reason = SqliteBackend._format_rebuild_reason("metadata_mismatch", None, payload)
+    assert "output target" in reason
+    assert payload.output_metadata() in reason  # "default"
+
+
+@pytest.mark.asyncio
+async def test_explain_rebuild_reports_formatted_reason(temp_db, temp_workspace, temp_cache_db):
+    """_explain_rebuild turns a diagnose verdict into a reason and reports it."""
+    reporter = Mock()
+    db_manager = _make_mock_db_manager(temp_cache_db, None)
+    db_manager.diagnose_cache_miss.return_value = ("hash_mismatch", "0123456789abcdef")
+
+    backend = SqliteBackend(
+        db_path=temp_db,
+        workspace_path=temp_workspace,
+        db_manager=db_manager,
+        build_reporter=reporter,
+        explain_rebuilds=True,
+        skip_worker_check=True,
+    )
+    try:
+        payload = MockPayload(data="content")
+        backend._explain_rebuild(payload, "notebook")
+
+        db_manager.diagnose_cache_miss.assert_called_once()
+        reporter.report_rebuild_reason.assert_called_once()
+        file_arg, job_arg, reason_arg = reporter.report_rebuild_reason.call_args.args
+        assert file_arg == payload.input_file
+        assert job_arg == "notebook"
+        assert "content hash changed" in reason_arg
+        assert "0123456789ab" in reason_arg
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_explain_rebuilds_triggers_on_cache_miss(temp_db, temp_workspace, temp_cache_db):
+    """A processed_files miss under --explain-rebuilds probes for a reason and still submits."""
+    reporter = Mock()
+    db_manager = _make_mock_db_manager(temp_cache_db, None)  # get_result -> None (miss)
+    db_manager.diagnose_cache_miss.return_value = ("no_entry", None)
+
+    backend = SqliteBackend(
+        db_path=temp_db,
+        workspace_path=temp_workspace,
+        db_manager=db_manager,
+        build_reporter=reporter,
+        explain_rebuilds=True,
+        skip_worker_check=True,
+    )
+    try:
+        operation = MockOperation(service_name_value="notebook-processor")
+        payload = MockPayload(data="fresh content")
+        await backend.execute_operation(operation, payload)
+
+        db_manager.diagnose_cache_miss.assert_called_once()
+        reporter.report_rebuild_reason.assert_called_once()
+        assert "no cache entry" in reporter.report_rebuild_reason.call_args.args[2]
+        # The reason is diagnostic only — the job is still submitted.
+        assert len(backend.active_jobs) == 1
+    finally:
+        backend.active_jobs.clear()
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_explain_rebuilds_off_runs_no_probe(temp_db, temp_workspace, temp_cache_db):
+    """Default build: a cache miss must NOT run the diagnostic probe (no slowdown)."""
+    db_manager = _make_mock_db_manager(temp_cache_db, None)  # get_result -> None (miss)
+
+    backend = SqliteBackend(
+        db_path=temp_db,
+        workspace_path=temp_workspace,
+        db_manager=db_manager,
+        skip_worker_check=True,
+        # explain_rebuilds defaults to False
+    )
+    try:
+        operation = MockOperation(service_name_value="notebook-processor")
+        payload = MockPayload(data="fresh content")
+        await backend.execute_operation(operation, payload)
+
+        db_manager.diagnose_cache_miss.assert_not_called()
+        assert len(backend.active_jobs) == 1
+    finally:
+        backend.active_jobs.clear()
+        await backend.shutdown()

--- a/tests/infrastructure/database/db_operations_test.py
+++ b/tests/infrastructure/database/db_operations_test.py
@@ -87,6 +87,47 @@ def test_get_result(db_manager):
     assert non_existent is None
 
 
+def test_diagnose_cache_miss_no_entry(db_manager):
+    """No row for the file at all -> ('no_entry', None)."""
+    reason, detail = db_manager.diagnose_cache_miss("never_built.py", "hash", "test_metadata")
+    assert reason == "no_entry"
+    assert detail is None
+
+
+def test_diagnose_cache_miss_hash_mismatch(db_manager):
+    """A row for the same file+target but a different hash -> ('hash_mismatch', stored)."""
+    result = create_result(metadata="html-de")
+    db_manager.store_result("test.py", "old_hash", "corr", result)
+
+    # Same file + same output target, different content hash (the get_result
+    # exact-key lookup would have missed).
+    reason, detail = db_manager.diagnose_cache_miss("test.py", "new_hash", "html-de")
+    assert reason == "hash_mismatch"
+    assert detail == "old_hash"
+
+
+def test_diagnose_cache_miss_hash_mismatch_reports_newest(db_manager):
+    """When several hashes are stored for a target, report the newest one."""
+    result = create_result(metadata="html-de")
+    db_manager.store_result("test.py", "hash_old", "corr", result)
+    db_manager.store_result("test.py", "hash_new", "corr", result)
+
+    reason, detail = db_manager.diagnose_cache_miss("test.py", "requested", "html-de")
+    assert reason == "hash_mismatch"
+    assert detail == "hash_new"
+
+
+def test_diagnose_cache_miss_metadata_mismatch(db_manager):
+    """Rows exist for the file but not for this output target -> metadata_mismatch."""
+    result = create_result(metadata="html-de")
+    db_manager.store_result("test.py", "hash", "corr", result)
+
+    # Same content hash, but a target (kind/format/language) never built before.
+    reason, detail = db_manager.diagnose_cache_miss("test.py", "hash", "notebook-en")
+    assert reason == "metadata_mismatch"
+    assert detail is None
+
+
 def test_remove_old_entries(db_manager):
     result = create_result()
     # Store multiple results


### PR DESCRIPTION
## Why

Recently many `clm build` runs rebuild decks whose sources shouldn't have changed. Diagnosing this required `clm cache explain` on one file at a time, out of band — a build gave no per-deck signal for *why* it re-executed a deck. Cache **hits** log at INFO; cache **misses** just enqueued the job silently.

## What

`clm build --explain-rebuilds` (or `CLM_EXPLAIN_REBUILDS={1,true,yes}`) logs, per deck, why a `processed_files` cache **miss** forced a rebuild:

- **no cache entry** — never built with this cache, or the cache was cleared
- **content hash changed** — the source text or one of its dependencies differs (with the cached vs. current short hash)
- **no cache entry for this output target** — a new kind/format/language, or output-metadata drift

Reasons always go to the log file and, under `-O verbose`, to the console. Complements `clm cache explain FILE --spec SPEC`, which gives the full per-artifact, per-cache-layer breakdown for a single deck.

## Gating (no slowdown in the normal case)

The extra work — one read-only `DatabaseManager.diagnose_cache_miss` probe — runs **only on a miss AND only when the flag is set**. With the flag off (the default), the miss path is a single boolean check; the default hot path is untouched. Verified by `test_explain_rebuilds_off_runs_no_probe`, which asserts the probe is never called on a default build.

## Changes

- `DatabaseManager.diagnose_cache_miss` — read-only classifier (`no_entry` / `hash_mismatch` / `metadata_mismatch`).
- `SqliteBackend` — `explain_rebuilds` field + `_explain_rebuild` / `_format_rebuild_reason`; invoked in the `result is None` miss branch (the replay-gated Recording-HTML producer case already logs its own reason, so it's excluded).
- `--explain-rebuilds` flag + `CLM_EXPLAIN_REBUILDS` env resolution wired through `BuildConfig`.
- `BuildReporter.report_rebuild_reason` → `OutputFormatter.show_rebuild_reason` (verbose renders it, others no-op).
- Updated `clm info commands` (flag + env-var tables) and a changelog fragment.

## Tests

8 new tests (all green): 4 for `diagnose_cache_miss` (each branch + newest-hash reporting), the reason formatter, the reporter integration, the miss-branch trigger, and the gating negative test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
