### PR TITLE
perf: cache topic map for module-bound resolution + parallelize manifest hashing

### DIFF
--- a/changelog.d/jobs-db-env-var.added.md
+++ b/changelog.d/jobs-db-env-var.added.md
@@ -1,0 +1,10 @@
+- **`CLM_JOBS_DB_PATH` / `CLM_CACHE_DB_PATH` / `CLM_TELEMETRY_DB_PATH` env vars.**
+  The global `--jobs-db-path` / `--cache-db-path` / `--telemetry-db-path` options
+  now also read these environment variables, so the databases can be relocated
+  once instead of per-invocation. An explicit env path is honored verbatim (not
+  re-anchored to the project root). The jobs DB is ephemeral — pointing
+  `CLM_JOBS_DB_PATH` at a RAM disk (e.g. `Z:\clm_jobs.db`, Direct worker mode)
+  spares the SSD without affecting the persistent cache or telemetry databases.
+  (Note: the pre-existing `CLM_PATHS__*` variables only feed `clm config`
+  display; these new `CLM_*_DB_PATH` forms are what a build/status/monitor run
+  actually opens.)

--- a/changelog.d/perf-spec-load-and-manifest.fixed.md
+++ b/changelog.d/perf-spec-load-and-manifest.fixed.md
@@ -1,0 +1,14 @@
+- **Course loading no longer re-scans `slides/` once per module-bound topic.**
+  A spec that binds topics to a module (`<topic module="…">` or a section-level
+  `module=` default) resolved each bound topic by re-walking the entire
+  `slides/` tree from scratch, so "Loading course specification…" scaled with
+  *(bound topics × total slide files)*. The full topic map is now built once and
+  cached (`Course._full_topic_map`) and reused for module-bound resolution. On a
+  real 124-topic / 54-module-bound course over ~2,150 slide files this cut
+  `Course.from_spec` from ~32 s to ~1 s.
+- **Provenance-manifest hashing now runs in parallel.** Writing
+  `.clm-manifest.json` re-reads and SHA-256-hashes every output file; the reads
+  were serial, so the step took several seconds on a large output tree. Hashing
+  is now done with a bounded thread pool (order-preserving, so the manifest is
+  still deterministic), a ~4–7× speedup per target on a multi-core machine
+  (~6 s → ~1.2 s across three targets in local testing).

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -152,10 +152,21 @@ Environment variables override configuration files.
 
 ### Paths
 
+These are the env-var forms of the global `--cache-db-path` / `--jobs-db-path` /
+`--telemetry-db-path` options, honored by every command (an explicit path is
+respected verbatim — it is not re-anchored to the project root the way the bare
+default is):
+
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `CLM_PATHS__CACHE_DB_PATH` | Cache database path | `clm_cache.db` |
-| `CLM_PATHS__JOBS_DB_PATH` | Job queue database path | `clm_jobs.db` |
+| `CLM_CACHE_DB_PATH` | Cache database path (persistent — processed-file results) | `clm_cache.db` |
+| `CLM_JOBS_DB_PATH` | Job-queue database path (jobs, workers, events). Ephemeral: only needs to survive a single `clm` run, so it can live on a RAM disk (e.g. `Z:\clm_jobs.db`) to spare the SSD. **Direct worker mode only** — a host RAM-disk path is not visible inside Docker workers. | `clm_jobs.db` |
+| `CLM_TELEMETRY_DB_PATH` | Execution-telemetry database (per-deck kernel crash/flake history). Kept separate from the cache DB so clearing the cache never erases the history. | `clm_telemetry.db` next to the cache DB |
+
+> The older `CLM_PATHS__CACHE_DB_PATH` / `CLM_PATHS__JOBS_DB_PATH` variables feed
+> the `[paths]` config model surfaced by `clm config`, **not** the database a
+> command actually opens. Use the `CLM_*_DB_PATH` forms above to relocate the
+> databases a build/status/monitor run uses.
 
 ### External Tools
 

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -9,9 +9,9 @@ clm [OPTIONS] COMMAND [ARGS]...
 | Option | Description |
 |--------|-------------|
 | `--version` | Show version and exit |
-| `--cache-db-path PATH` | Path to cache database (default: `clm_cache.db`) |
-| `--jobs-db-path PATH` | Path to job queue database (default: `clm_jobs.db`) |
-| `--telemetry-db-path PATH` | Path to the execution-telemetry database recording per-deck kernel crash/flake history across builds (default: `clm_telemetry.db` next to the cache database). Deliberately a separate file: clearing the cache never erases the flake history. (CLM {version}+) |
+| `--cache-db-path PATH` | Path to cache database (default: `clm_cache.db`). Env: `CLM_CACHE_DB_PATH`. |
+| `--jobs-db-path PATH` | Path to job queue database (default: `clm_jobs.db`). The jobs DB is ephemeral (it only needs to outlive a single `clm` run), so it may be placed on a RAM disk to spare the SSD — e.g. `CLM_JOBS_DB_PATH=Z:\clm_jobs.db`. Direct worker mode only; a host RAM-disk path is not visible inside Docker workers. Env: `CLM_JOBS_DB_PATH`. (CLM {version}+) |
+| `--telemetry-db-path PATH` | Path to the execution-telemetry database recording per-deck kernel crash/flake history across builds (default: `clm_telemetry.db` next to the cache database). Deliberately a separate file: clearing the cache never erases the flake history. Env: `CLM_TELEMETRY_DB_PATH`. (CLM {version}+) |
 
 ## Commands
 

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -93,22 +93,29 @@ _COMMANDS = "clm.cli.commands"
     "--cache-db-path",
     type=click.Path(),
     default="clm_cache.db",
-    help="Path to the cache database (stores processed file results)",
+    envvar="CLM_CACHE_DB_PATH",
+    help=("Path to the cache database (stores processed file results). Env: CLM_CACHE_DB_PATH."),
 )
 @click.option(
     "--jobs-db-path",
     type=click.Path(),
     default="clm_jobs.db",
-    help="Path to the job queue database (stores jobs, workers, events)",
+    envvar="CLM_JOBS_DB_PATH",
+    help=(
+        "Path to the job queue database (stores jobs, workers, events). "
+        "Ephemeral — safe to place on a RAM disk (e.g. CLM_JOBS_DB_PATH=Z:\\clm_jobs.db) "
+        "in Direct worker mode. Env: CLM_JOBS_DB_PATH."
+    ),
 )
 @click.option(
     "--telemetry-db-path",
     type=click.Path(),
     default=None,
+    envvar="CLM_TELEMETRY_DB_PATH",
     help=(
         "Path to the execution-telemetry database (per-deck kernel "
         "crash/flake history; issue #330). Default: clm_telemetry.db "
-        "next to the cache database."
+        "next to the cache database. Env: CLM_TELEMETRY_DB_PATH."
     ),
 )
 @click.pass_context

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -60,6 +60,7 @@ from clm.infrastructure.utils.path_utils import (
 
 if TYPE_CHECKING:
     from clm.core.cross_references import CrossReferenceResolver
+    from clm.core.topic_resolver import TopicMatch
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +74,12 @@ class Course(NotebookMixin):
     sections: list[Section] = Factory(list)
     dir_groups: list[DirGroup] = Factory(list)
     _topic_path_map: dict[str, Path] = Factory(dict)
+    # Full filesystem topic map (every occurrence per topic ID), cached from
+    # the single ``build_topic_map`` scan in ``_build_topic_map``. Reused by
+    # module-bound resolution so a spec that binds many topics to a module
+    # does not re-walk the whole ``slides/`` tree once per bound topic — that
+    # rescan dominated "Loading course specification" on large courses.
+    _full_topic_map: "dict[str, list[TopicMatch]]" = field(factory=dict, init=False, repr=False)
     output_languages: list[str] | None = None
     output_kinds: list[str] | None = None
     fallback_execute: bool = False
@@ -1007,12 +1014,18 @@ class Course(NotebookMixin):
 
         # Module-bound resolution. Use the full topic map (includes every
         # occurrence) so we can pick the one in the requested module even
-        # when other modules share the topic ID.
+        # when other modules share the topic ID. The map is scanned once in
+        # ``_build_topic_map`` (called at the start of ``_build_sections``,
+        # before any topic is resolved) and cached here; re-walking the
+        # ``slides/`` tree per bound topic used to dominate course loading.
         from clm.core.topic_resolver import build_topic_map, matches_for_binding
 
-        slides_dir = self.course_root / "slides"
-        full_map = build_topic_map(slides_dir)
-        candidates = matches_for_binding(full_map, topic_id, module)
+        if not self._full_topic_map:
+            # Defensive: only when resolution is driven without the normal
+            # ``_build_topic_map`` priming (e.g. a direct unit-test call).
+            slides_dir = self.course_root / "slides"
+            self._full_topic_map = build_topic_map(slides_dir)
+        candidates = matches_for_binding(self._full_topic_map, topic_id, module)
 
         if not candidates:
             logger.error(f"Topic not found: {topic_id} in module {module}")
@@ -1093,6 +1106,10 @@ class Course(NotebookMixin):
                     (first_path, str(dup.path)) for dup in matches[1:]
                 ]
             self._topic_path_map[topic_id] = matches[0].path
+
+        # Retain the full (all-occurrences) map so module-bound resolution can
+        # filter it in memory instead of re-scanning the filesystem per topic.
+        self._full_topic_map = full_map
 
         logger.debug(f"Built topic map with {len(self._topic_path_map)} topics")
 

--- a/src/clm/core/provenance_manifest.py
+++ b/src/clm/core/provenance_manifest.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 from collections.abc import Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -60,6 +61,13 @@ MANIFEST_FILENAME = ".clm-manifest.json"
 MANIFEST_VERSION = 1
 
 _HASH_CHUNK = 1 << 16
+
+# Below this many files, hash serially — a thread pool's setup cost outweighs
+# the overlap. Above it, parallelize (see :func:`_hash_paths_parallel`).
+_PARALLEL_HASH_THRESHOLD = 64
+# Upper bound on hashing threads regardless of core count, so a many-core box
+# does not saturate the disk with competing reads.
+_MAX_HASH_WORKERS = 16
 
 # Audience routing for shared-mode images, mirroring the ``target`` branch of
 # ``SharedImageFile.get_processing_operation``. ``speaker`` is the deprecated
@@ -259,6 +267,26 @@ def hash_file(path: Path) -> str:
     return f"sha256:{digest.hexdigest()}"
 
 
+def _hash_paths_parallel(paths: list[Path]) -> list[str]:
+    """Hash *paths* concurrently, returning digests in the same order.
+
+    A thread pool overlaps the per-file reads (hashing releases the GIL during
+    I/O and large ``update`` calls), which is a several-fold speedup when a
+    build's output tree spans thousands of files. Falls back to a serial pass
+    for a handful of files, where the pool's setup cost would not pay off. The
+    worker count is capped so a many-core machine does not thrash the disk.
+    """
+    if len(paths) < _PARALLEL_HASH_THRESHOLD:
+        return [hash_file(p) for p in paths]
+
+    from concurrent.futures import ThreadPoolExecutor
+
+    max_workers = min(_MAX_HASH_WORKERS, (os.cpu_count() or 4) * 2)
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        # ``map`` preserves input order, so results line up with ``paths``.
+        return list(pool.map(hash_file, paths))
+
+
 def build_provenance_manifest(
     course: Course,
     target: OutputTarget,
@@ -283,7 +311,11 @@ def build_provenance_manifest(
     every cleanly-built one.
     """
     failed = frozenset(failed_topics or ())
-    files: list[dict[str, Any]] = []
+    # First pass: enumerate + de-dup + existence-check, collecting the (entry,
+    # path) pairs. Hashing — the dominant cost, one full read per output file —
+    # is deferred to a parallel pass below so the disk reads overlap instead of
+    # running back-to-back (thousands of files, gigabytes, on every build).
+    pending: list[tuple[dict[str, Any], Path]] = []
     seen: set[str] = set()
     for out_path, record in enumerate_expected_outputs(course, target):
         try:
@@ -295,17 +327,29 @@ def build_provenance_manifest(
         if record["topic_id"] in failed:
             continue
         seen.add(rel)
-        files.append(
-            {
-                "path": rel,
-                "section_id": record["section_id"],
-                "topic_id": record["topic_id"],
-                "kind": record["kind"],
-                "format": record["format"],
-                "language": record["language"],
-                "content_hash": hash_file(out_path),
-            }
+        pending.append(
+            (
+                {
+                    "path": rel,
+                    "section_id": record["section_id"],
+                    "topic_id": record["topic_id"],
+                    "kind": record["kind"],
+                    "format": record["format"],
+                    "language": record["language"],
+                },
+                out_path,
+            )
         )
+
+    # Second pass: hash every file concurrently. Hashing releases the GIL
+    # during file reads and large ``update`` calls, so a thread pool overlaps
+    # the I/O-bound work across cores. Results are matched back by index, so
+    # the deterministic final sort is unaffected.
+    files: list[dict[str, Any]] = [entry for entry, _ in pending]
+    if pending:
+        hashes = _hash_paths_parallel([path for _, path in pending])
+        for entry, digest in zip(files, hashes, strict=True):
+            entry["content_hash"] = digest
     files.sort(key=lambda r: r["path"])
     return {
         "version": MANIFEST_VERSION,


### PR DESCRIPTION
## Summary

Three build-time improvements, measured on the real `machine-learning-azav.xml`
course (124 topics, 54 module-bound, 42 modules, ~2,150 slide files, ~31k output
files / 5 GB).

### 1. "Loading course specification" — 32× faster (~32 s → ~1 s)

`Course._resolve_topic_path` resolved **every module-bound topic**
(`<topic module="…">`, or a section-level `module=` default) by calling
`build_topic_map()` from scratch — a full walk of `slides/` with a `.resolve()`
per slide file. So the phase scaled with *(bound topics × total slide files)*;
~91 % of the 32 s was 54 redundant rescans of the same tree.

The full topic map is now built **once** in `_build_topic_map` and cached on
`Course._full_topic_map`; module-bound resolution filters that in memory. The
XML parse itself was never the bottleneck (0.009 s).

### 2. "Writing provenance manifests" — ~4–7× faster per target

`build_provenance_manifest` re-reads and SHA-256-hashes every output file
(needed for release-sync / drift compatibility). The reads were serial
(~14.8 k files / 2.8 GB / ~6 s warm). Hashing now runs on a bounded,
order-preserving thread pool (`_hash_paths_parallel`), overlapping the I/O.
The manifest stays byte-for-byte deterministic (final sort unchanged).

Per target in local testing: shared 3.42 s → 0.47 s, trainer 2.36 s → 0.53 s,
speaker 1.07 s → 0.24 s.

### 3. `CLM_*_DB_PATH` env vars (RAM-disk jobs DB)

The global `--cache-db-path` / `--jobs-db-path` / `--telemetry-db-path` options
now also read `CLM_CACHE_DB_PATH` / `CLM_JOBS_DB_PATH` / `CLM_TELEMETRY_DB_PATH`.
The jobs DB is ephemeral, so `CLM_JOBS_DB_PATH=Z:\clm_jobs.db` (Direct worker
mode) puts it on a RAM disk to spare the SSD, without touching the persistent
cache/telemetry DBs. An explicit env path is honored verbatim (not re-anchored
to the project root). Documented in `configuration.md` and the `commands` info
topic; the note clarifies these differ from the pre-existing `CLM_PATHS__*`
vars, which only feed `clm config` display.

## Not changed (already handled)

Rewriting unchanged output files is already avoided: hash-aware writes have been
unconditional since 1.5.0 (`is_destination_identical` at the cache-replay and
file-copy sites skip byte-identical destinations and preserve mtime), so a
warm-cache rebuild with no changes performs ~zero output writes.

## Testing

`ruff check`/`format` and `mypy` clean; pre-push fast suite green. Locally also
ran `tests/core`, `tests/cli/test_build_command.py`, `test_kernel_triage.py`,
`test_provenance_manifest.py`, `test_manifest_suppressed.py`,
`test_cli_startup.py`, `test_cli_db_path_anchoring.py`, `test_cli_unit.py`
(against the worktree code via `PYTHONPATH=src`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
