### PR TITLE
fix: consistent DB-path resolution; remove vestigial [paths] config

### DIFF
--- a/changelog.d/db-path-resolution-consistency.fixed.md
+++ b/changelog.d/db-path-resolution-consistency.fixed.md
@@ -1,0 +1,13 @@
+- **Build-end cache cleanup now follows `--cache-db-path`.** The end-of-build
+  "prune stale executed-notebook hashes" step located the cache DB via a
+  separate, CLI-disconnected config field (`get_config().paths.cache_db_path`)
+  instead of the path the build actually opened. When `--cache-db-path` /
+  `CLM_CACHE_DB_PATH` was overridden — or a build ran from a topic
+  subdirectory — it pruned the wrong file (or created a stray `clm_cache.db`
+  in the cwd) and never pruned the real cache. It now uses the backend's own
+  cache DB path.
+- **`clm status` / `clm monitor` honor `CLM_JOBS_DB_PATH`.** They previously
+  auto-detected the jobs DB via the legacy `CLM_DB_PATH` only, so a build
+  redirected with `CLM_JOBS_DB_PATH` (e.g. onto a RAM disk) left them opening a
+  different, idle database. `CLM_JOBS_DB_PATH` now takes precedence, with
+  `CLM_DB_PATH` kept as a fallback.

--- a/changelog.d/remove-vestigial-paths-config.removed.md
+++ b/changelog.d/remove-vestigial-paths-config.removed.md
@@ -1,0 +1,10 @@
+- **Removed the vestigial `[paths]` config section and its `CLM_PATHS__*`
+  environment variables.** `CLM_PATHS__CACHE_DB_PATH` / `CLM_PATHS__JOBS_DB_PATH`
+  / `CLM_PATHS__WORKSPACE_PATH` (and the `[paths]` block in `clm.toml` /
+  `.clm/config.toml`) never actually relocated the databases a command opened —
+  those paths come from the global `--cache-db-path` / `--jobs-db-path` /
+  `--telemetry-db-path` options (and their `CLM_*_DB_PATH` env vars). The config
+  section only surfaced in `clm config show`, misleadingly displaying hardcoded
+  defaults rather than the effective paths. `clm config show` now reports the
+  actual resolved database paths under a `[Databases]` heading. Old config files
+  with a leftover `[paths]` section keep loading (the section is ignored).

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -160,13 +160,13 @@ default is):
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `CLM_CACHE_DB_PATH` | Cache database path (persistent — processed-file results) | `clm_cache.db` |
-| `CLM_JOBS_DB_PATH` | Job-queue database path (jobs, workers, events). Ephemeral: only needs to survive a single `clm` run, so it can live on a RAM disk (e.g. `Z:\clm_jobs.db`) to spare the SSD. **Direct worker mode only** — a host RAM-disk path is not visible inside Docker workers. | `clm_jobs.db` |
+| `CLM_JOBS_DB_PATH` | Job-queue database path (jobs, workers, events). Ephemeral: only needs to survive a single `clm` run, so it can live on a RAM disk (e.g. `Z:\clm_jobs.db`) to spare the SSD. `clm status` / `clm monitor` honor it too, so they inspect the same DB a redirected build wrote. **Direct worker mode only** — a host RAM-disk path is not visible inside Docker workers. | `clm_jobs.db` |
 | `CLM_TELEMETRY_DB_PATH` | Execution-telemetry database (per-deck kernel crash/flake history). Kept separate from the cache DB so clearing the cache never erases the history. | `clm_telemetry.db` next to the cache DB |
 
-> The older `CLM_PATHS__CACHE_DB_PATH` / `CLM_PATHS__JOBS_DB_PATH` variables feed
-> the `[paths]` config model surfaced by `clm config`, **not** the database a
-> command actually opens. Use the `CLM_*_DB_PATH` forms above to relocate the
-> databases a build/status/monitor run uses.
+> The database paths are **not** part of the `[…]` config-file model. They are
+> resolved from the global CLI options / the `CLM_*_DB_PATH` env vars above. (The
+> pre-1.19 `[paths]` config section and its `CLM_PATHS__*` variables never
+> actually relocated the databases a command opened and have been removed.)
 
 ### External Tools
 

--- a/src/clm/cli/commands/config.py
+++ b/src/clm/cli/commands/config.py
@@ -67,7 +67,8 @@ def config_init(location, force):
 
 
 @config.command(name="show")
-def config_show():
+@click.pass_context
+def config_show(ctx):
     """Show current configuration values.
 
     This command displays the current configuration, including values
@@ -80,10 +81,17 @@ def config_show():
     click.echo("Current CLM Configuration:")
     click.echo("=" * 60)
 
-    click.echo("\n[Paths]")
-    click.echo(f"  cache_db_path: {cfg.paths.cache_db_path}")
-    click.echo(f"  jobs_db_path: {cfg.paths.jobs_db_path}")
-    click.echo(f"  workspace_path: {cfg.paths.workspace_path or '(not set)'}")
+    # Effective database paths — the ones a build/status/monitor run actually
+    # opens. These come from the global CLI options (resolved in clm.cli.main,
+    # honoring --cache-db-path / CLM_CACHE_DB_PATH and project-root anchoring),
+    # not from the config file / ClmConfig, so show what was resolved here.
+    obj = ctx.obj or {}
+    click.echo("\n[Databases]  (effective paths for this invocation)")
+    click.echo(f"  cache_db_path: {obj.get('CACHE_DB_PATH', '(default: clm_cache.db)')}")
+    click.echo(f"  jobs_db_path: {obj.get('JOBS_DB_PATH', '(default: clm_jobs.db)')}")
+    click.echo(
+        f"  telemetry_db_path: {obj.get('TELEMETRY_DB_PATH', '(default: next to cache DB)')}"
+    )
 
     from clm.infrastructure.llm.cache import CACHE_DB_NAME, describe_cache_dir
 

--- a/src/clm/cli/status/collector.py
+++ b/src/clm/cli/status/collector.py
@@ -58,8 +58,11 @@ class StatusCollector:
 
     def _get_default_db_path(self) -> Path:
         """Get default database path from environment or config."""
-        # Check environment variable
-        db_path = os.getenv("CLM_DB_PATH")
+        # Prefer CLM_JOBS_DB_PATH — the env var for the global ``--jobs-db-path``
+        # that ``clm build`` honors — so ``clm status`` / ``clm monitor`` open the
+        # same jobs DB a redirected build wrote (e.g. a RAM-disk path). Fall back
+        # to the legacy CLM_DB_PATH for compatibility.
+        db_path = os.getenv("CLM_JOBS_DB_PATH") or os.getenv("CLM_DB_PATH")
         if db_path:
             return Path(db_path)
 

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -1060,17 +1060,24 @@ class SqliteBackend(LocalOpsBackend):
                         f"Build end: Cleaned up {total_cache_cleaned} cache database entries"
                     )
 
-            # Clean up executed notebook cache (shares clm_cache.db)
-            cache_db_path = get_config().paths.cache_db_path
-            try:
-                with ExecutedNotebookCache(cache_db_path) as nb_cache:
-                    nb_cleaned = nb_cache.prune_stale_hashes()
-                    if nb_cleaned > 0:
-                        logger.info(
-                            f"Build end: Cleaned up {nb_cleaned} stale executed notebook cache entries"
-                        )
-            except Exception as e:
-                logger.debug(f"Could not clean executed notebook cache: {e}")
+                # Clean up executed notebook cache (shares the cache DB file).
+                # Use the path this backend actually opened — the same file
+                # ``db_manager`` manages — not ``get_config().paths.cache_db_path``,
+                # a separate, CLI-disconnected setting. That config field ignores
+                # ``--cache-db-path`` / ``CLM_CACHE_DB_PATH`` and the project-root
+                # anchoring, so it pointed at the wrong DB (or created a stray
+                # ``clm_cache.db`` in the cwd) whenever the cache path was
+                # overridden or the build ran from a subdirectory.
+                try:
+                    with ExecutedNotebookCache(self.db_manager.db_path) as nb_cache:
+                        nb_cleaned = nb_cache.prune_stale_hashes()
+                        if nb_cleaned > 0:
+                            logger.info(
+                                f"Build end: Cleaned up {nb_cleaned} stale executed "
+                                f"notebook cache entries"
+                            )
+                except Exception as e:
+                    logger.debug(f"Could not clean executed notebook cache: {e}")
 
             # Vacuum if configured (can be slow for large DBs)
             if retention_config.auto_vacuum_after_cleanup:

--- a/src/clm/infrastructure/config.py
+++ b/src/clm/infrastructure/config.py
@@ -170,25 +170,6 @@ class RetentionConfig(BaseModel):
     )
 
 
-class PathsConfig(BaseModel):
-    """Path-related configuration."""
-
-    cache_db_path: str = Field(
-        default="clm_cache.db",
-        description="Path to the cache database (stores processed file results)",
-    )
-
-    jobs_db_path: str = Field(
-        default="clm_jobs.db",
-        description="Path to the job queue database (stores jobs, workers, events)",
-    )
-
-    workspace_path: str = Field(
-        default="",
-        description="Workspace path for workers (usually derived from output directory)",
-    )
-
-
 class ExternalToolsConfig(BaseModel):
     """External tool paths configuration."""
 
@@ -763,11 +744,16 @@ class ClmConfig(BaseSettings):
     system config > defaults.
 
     Environment Variables:
-        - CLM_PATHS__DB_PATH: Database path
         - CLM_LOGGING__LOG_LEVEL: Logging level
         - PLANTUML_JAR: PlantUML JAR path (no CLM_ prefix)
         - DRAWIO_EXECUTABLE: Draw.io executable path (no CLM_ prefix)
         - And many more (see nested config classes)
+
+    Note: the database paths (cache/jobs/telemetry) are NOT configured here.
+    They are global CLI options (``--cache-db-path`` etc.) with matching
+    ``CLM_CACHE_DB_PATH`` / ``CLM_JOBS_DB_PATH`` / ``CLM_TELEMETRY_DB_PATH``
+    environment variables, resolved in ``clm.cli.main`` so a run from a topic
+    subdirectory opens the same DB as one from the repo root.
     """
 
     model_config = SettingsConfigDict(
@@ -775,11 +761,6 @@ class ClmConfig(BaseSettings):
         env_nested_delimiter="__",
         extra="ignore",
         case_sensitive=False,
-    )
-
-    paths: PathsConfig = Field(
-        default_factory=PathsConfig,
-        description="Path-related configuration",
     )
 
     retention: RetentionConfig = Field(
@@ -1021,21 +1002,13 @@ def create_example_config() -> str:
 # Nested settings use double underscores: CLM_<SECTION>__<KEY>
 #
 # Examples:
-#   CLM_PATHS__CACHE_DB_PATH=/tmp/cache.db
-#   CLM_PATHS__JOBS_DB_PATH=/tmp/jobs.db
 #   CLM_LOGGING__LOG_LEVEL=DEBUG
 #   PLANTUML_JAR=/usr/local/share/plantuml.jar
 #   DRAWIO_EXECUTABLE=/usr/local/bin/drawio
-
-[paths]
-# Path to the cache database (stores processed file results)
-cache_db_path = "clm_cache.db"
-
-# Path to the job queue database (stores jobs, workers, events)
-jobs_db_path = "clm_jobs.db"
-
-# Workspace path for workers (optional, usually derived from output directory)
-workspace_path = ""
+#
+# The database paths are NOT set here — they are global CLI options
+# (--cache-db-path / --jobs-db-path / --telemetry-db-path) with matching
+# CLM_CACHE_DB_PATH / CLM_JOBS_DB_PATH / CLM_TELEMETRY_DB_PATH env vars.
 
 [retention]
 # Database retention and cleanup configuration

--- a/tests/cli/test_config_command.py
+++ b/tests/cli/test_config_command.py
@@ -54,7 +54,7 @@ class TestConfigInit:
         assert "Created configuration file" in result.output
         content = isolated_config_dirs["user"].read_text()
         # Example config must document a handful of expected sections.
-        assert "[paths]" in content
+        assert "[retention]" in content
         assert "[logging]" in content
         assert "[worker_management]" in content
 
@@ -90,7 +90,7 @@ class TestConfigInit:
         assert "Created configuration file" in result.output
         # Now contains the templated content, not the sentinel.
         assert cfg.read_text() != "# existing\n"
-        assert "[paths]" in cfg.read_text()
+        assert "[retention]" in cfg.read_text()
 
     def test_init_reports_permission_error(self, isolated_config_dirs):
         runner = CliRunner()
@@ -119,7 +119,7 @@ class TestConfigShow:
         assert result.exit_code == 0, result.output
         assert "Current CLM Configuration" in result.output
         for header in (
-            "[Paths]",
+            "[Databases]",
             "[External Tools]",
             "[Logging]",
             "[Jupyter]",
@@ -130,14 +130,11 @@ class TestConfigShow:
     def test_show_reflects_project_config_values(self, isolated_config_dirs):
         project_cfg = isolated_config_dirs["project"]
         project_cfg.parent.mkdir(parents=True, exist_ok=True)
-        project_cfg.write_text(
-            '[logging]\nlog_level = "DEBUG"\n[paths]\ncache_db_path = "custom_cache.db"\n'
-        )
+        project_cfg.write_text('[logging]\nlog_level = "DEBUG"\n')
         runner = CliRunner()
         result = runner.invoke(cli, ["config", "show"])
         assert result.exit_code == 0, result.output
         assert "DEBUG" in result.output
-        assert "custom_cache.db" in result.output
 
     def test_show_includes_llm_cache_section(self, isolated_config_dirs):
         runner = CliRunner()

--- a/tests/cli/test_status_collector.py
+++ b/tests/cli/test_status_collector.py
@@ -365,6 +365,32 @@ class TestStatusCollector:
         collector = StatusCollector()
         assert collector.db_path == db_path
 
+    def test_default_db_path_prefers_jobs_db_env(self, tmp_path, monkeypatch):
+        """CLM_JOBS_DB_PATH (the build's jobs-DB env var) wins over the anchored default.
+
+        Without this, a build redirected via CLM_JOBS_DB_PATH (e.g. a RAM disk)
+        would leave `clm status` / `clm monitor` opening a different, idle DB.
+        """
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("CLM_DB_PATH", raising=False)
+        # The anchored default exists, but the env var must take precedence.
+        (tmp_path / "clm_jobs.db").touch()
+        target = tmp_path / "ram" / "jobs.db"
+        monkeypatch.setenv("CLM_JOBS_DB_PATH", str(target))
+
+        collector = StatusCollector()
+        assert collector.db_path == target
+
+    def test_default_db_path_legacy_env_still_works(self, tmp_path, monkeypatch):
+        """The legacy CLM_DB_PATH still works when CLM_JOBS_DB_PATH is unset."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("CLM_JOBS_DB_PATH", raising=False)
+        target = tmp_path / "legacy.db"
+        monkeypatch.setenv("CLM_DB_PATH", str(target))
+
+        collector = StatusCollector()
+        assert collector.db_path == target
+
     def test_collect_queue_stats_uses_correct_timestamp_comparison(self, db_path, job_queue):
         """Test that queue stats correctly compare timestamps.
 

--- a/tests/infrastructure/backends/test_sqlite_backend_resilience.py
+++ b/tests/infrastructure/backends/test_sqlite_backend_resilience.py
@@ -444,16 +444,17 @@ async def test_session_start_cleanup_handles_exception(temp_db, temp_workspace):
 
 @pytest.mark.asyncio
 async def test_build_end_cleanup_prunes_and_vacuums(temp_db, temp_workspace, tmp_path, monkeypatch):
-    # Point config cache_db_path at tmp_path so ExecutedNotebookCache works.
+    # Regression: the build-end executed-notebook prune must target the cache DB
+    # the backend actually opened (``db_manager.db_path``), NOT a path re-derived
+    # from config/env. A decoy ``CLM_CACHE_DB_PATH`` must be left untouched — the
+    # old code opened (and would create) ``get_config().paths.cache_db_path``
+    # here, pruning the wrong file whenever the cache path was overridden.
     from clm.infrastructure import config as config_mod
 
-    monkeypatch.setattr(
-        config_mod,
-        "_config",
-        None,
-    )
+    monkeypatch.setattr(config_mod, "_config", None)
     monkeypatch.setenv("CLM_RETENTION__AUTO_VACUUM_AFTER_CLEANUP", "true")
-    monkeypatch.setenv("CLM_PATHS__CACHE_DB_PATH", str(tmp_path / "cache.db"))
+    decoy = tmp_path / "decoy_cache.db"
+    monkeypatch.setenv("CLM_CACHE_DB_PATH", str(decoy))
 
     cache_db = tmp_path / "cache.db"
     backend = _backend(temp_db, temp_workspace)
@@ -468,6 +469,10 @@ async def test_build_end_cleanup_prunes_and_vacuums(temp_db, temp_workspace, tmp
         await backend.shutdown()
         # Reset the cached config.
         config_mod._config = None
+
+    # The backend's real cache DB was used; the env/config decoy was never opened.
+    assert cache_db.exists()
+    assert not decoy.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/infrastructure/test_config.py
+++ b/tests/infrastructure/test_config.py
@@ -19,21 +19,6 @@ from clm.infrastructure.config import (
 class TestConfigDefaults:
     """Test default configuration values."""
 
-    def test_default_paths(self, monkeypatch):
-        """Test default path configuration."""
-        # Clear any environment variables that might interfere
-        for var in [
-            "CLM_PATHS__CACHE_DB_PATH",
-            "CLM_PATHS__JOBS_DB_PATH",
-            "CLM_PATHS__WORKSPACE_PATH",
-        ]:
-            monkeypatch.delenv(var, raising=False)
-
-        config = ClmConfig()
-        assert config.paths.cache_db_path == "clm_cache.db"
-        assert config.paths.jobs_db_path == "clm_jobs.db"
-        assert config.paths.workspace_path == ""
-
     def test_default_logging(self, monkeypatch):
         """Test default logging configuration."""
         # Clear any environment variables that might interfere
@@ -85,16 +70,14 @@ class TestEnvironmentVariables:
 
     def test_clm_prefixed_env_vars(self, monkeypatch):
         """Test CLM_ prefixed environment variables."""
-        monkeypatch.setenv("CLM_PATHS__CACHE_DB_PATH", "/tmp/cache.db")
-        monkeypatch.setenv("CLM_PATHS__JOBS_DB_PATH", "/tmp/jobs.db")
         monkeypatch.setenv("CLM_LOGGING__LOG_LEVEL", "DEBUG")
         monkeypatch.setenv("CLM_LOGGING__ENABLE_TEST_LOGGING", "true")
+        monkeypatch.setenv("CLM_RETENTION__CACHE_VERSIONS_TO_KEEP", "5")
 
         config = ClmConfig()
-        assert config.paths.cache_db_path == "/tmp/cache.db"
-        assert config.paths.jobs_db_path == "/tmp/jobs.db"
         assert config.logging.log_level == "DEBUG"
         assert config.logging.enable_test_logging is True
+        assert config.retention.cache_versions_to_keep == 5
 
     def test_nested_env_vars(self, monkeypatch):
         """Test nested environment variables with double underscores."""
@@ -162,10 +145,6 @@ class TestConfigurationFiles:
         # Create a temporary config file
         config_file = tmp_path / "clm.toml"
         config_file.write_text("""
-[paths]
-cache_db_path = "/tmp/cache.db"
-jobs_db_path = "/tmp/jobs.db"
-
 [logging]
 log_level = "WARNING"
 
@@ -177,8 +156,6 @@ plantuml_jar = "/custom/plantuml.jar"
         monkeypatch.chdir(tmp_path)
 
         config = ClmConfig()
-        assert config.paths.cache_db_path == "/tmp/cache.db"
-        assert config.paths.jobs_db_path == "/tmp/jobs.db"
         assert config.logging.log_level == "WARNING"
         assert config.external_tools.plantuml_jar == "/custom/plantuml.jar"
 
@@ -189,62 +166,53 @@ plantuml_jar = "/custom/plantuml.jar"
         clm_dir.mkdir()
         config_file = clm_dir / "config.toml"
         config_file.write_text("""
-[paths]
-cache_db_path = "/tmp/dotclm_cache.db"
-jobs_db_path = "/tmp/dotclm_jobs.db"
+[logging]
+log_level = "WARNING"
+
+[retention]
+cache_versions_to_keep = 3
 """)
 
         monkeypatch.chdir(tmp_path)
 
         config = ClmConfig()
-        assert config.paths.cache_db_path == "/tmp/dotclm_cache.db"
-        assert config.paths.jobs_db_path == "/tmp/dotclm_jobs.db"
+        assert config.logging.log_level == "WARNING"
+        assert config.retention.cache_versions_to_keep == 3
 
     def test_config_file_priority(self, tmp_path, monkeypatch):
         """Test that .clm/config.toml has priority over clm.toml."""
         # Create both config files
         (tmp_path / "clm.toml").write_text("""
-[paths]
-cache_db_path = "/tmp/clm_cache.db"
-jobs_db_path = "/tmp/clm_jobs.db"
+[logging]
+log_level = "INFO"
 """)
 
         clm_dir = tmp_path / ".clm"
         clm_dir.mkdir()
         (clm_dir / "config.toml").write_text("""
-[paths]
-cache_db_path = "/tmp/dotclm_cache.db"
-jobs_db_path = "/tmp/dotclm_jobs.db"
+[logging]
+log_level = "ERROR"
 """)
 
         monkeypatch.chdir(tmp_path)
 
         config = ClmConfig()
         # .clm/config.toml should take priority
-        assert config.paths.cache_db_path == "/tmp/dotclm_cache.db"
-        assert config.paths.jobs_db_path == "/tmp/dotclm_jobs.db"
+        assert config.logging.log_level == "ERROR"
 
     def test_env_overrides_config_file(self, tmp_path, monkeypatch):
         """Test that environment variables override config files."""
         config_file = tmp_path / "clm.toml"
         config_file.write_text("""
-[paths]
-cache_db_path = "/tmp/config_cache.db"
-jobs_db_path = "/tmp/config_jobs.db"
-
 [logging]
 log_level = "INFO"
 """)
 
         monkeypatch.chdir(tmp_path)
-        monkeypatch.setenv("CLM_PATHS__CACHE_DB_PATH", "/tmp/env_cache.db")
-        monkeypatch.setenv("CLM_PATHS__JOBS_DB_PATH", "/tmp/env_jobs.db")
         monkeypatch.setenv("CLM_LOGGING__LOG_LEVEL", "ERROR")
 
         config = ClmConfig()
         # Environment variables should override config file
-        assert config.paths.cache_db_path == "/tmp/env_cache.db"
-        assert config.paths.jobs_db_path == "/tmp/env_jobs.db"
         assert config.logging.log_level == "ERROR"
 
     def test_legacy_env_overrides_config_file(self, tmp_path, monkeypatch):
@@ -318,7 +286,7 @@ class TestConfigHelpers:
         assert len(example) > 0
 
         # Should contain expected sections
-        assert "[paths]" in example
+        assert "[retention]" in example
         assert "[logging]" in example
         assert "[external_tools]" in example
         assert "[jupyter]" in example
@@ -349,7 +317,7 @@ class TestConfigHelpers:
 
         # Check content is valid
         content = config_path.read_text()
-        assert "[paths]" in content
+        assert "[retention]" in content
         assert "[logging]" in content
 
     def test_write_example_config_project(self, tmp_path, monkeypatch):
@@ -381,18 +349,18 @@ class TestGetConfig:
         """Test that get_config reload parameter works."""
         # Get initial config
         config1 = get_config()
-        initial_cache_db_path = config1.paths.cache_db_path
+        initial_log_level = config1.logging.log_level
 
         # Set environment variable
-        monkeypatch.setenv("CLM_PATHS__CACHE_DB_PATH", "/tmp/reloaded.db")
+        monkeypatch.setenv("CLM_LOGGING__LOG_LEVEL", "ERROR")
 
         # Get config again without reload - should be same instance
         config2 = get_config(reload=False)
-        assert config2.paths.cache_db_path == initial_cache_db_path
+        assert config2.logging.log_level == initial_log_level
 
         # Get config with reload - should have new value
         config3 = get_config(reload=True)
-        assert config3.paths.cache_db_path == "/tmp/reloaded.db"
+        assert config3.logging.log_level == "ERROR"
 
 
 class TestConfigIntegration:
@@ -402,9 +370,8 @@ class TestConfigIntegration:
         """Test complete priority chain: env > project > user > system > defaults."""
         # Create project config
         (tmp_path / "clm.toml").write_text("""
-[paths]
-cache_db_path = "/project/cache.db"
-jobs_db_path = "/project/jobs.db"
+[retention]
+cache_versions_to_keep = 9
 
 [logging]
 log_level = "WARNING"
@@ -422,8 +389,7 @@ plantuml_jar = "/project/plantuml.jar"
         config = ClmConfig()
 
         # From project config (no env var override)
-        assert config.paths.cache_db_path == "/project/cache.db"
-        assert config.paths.jobs_db_path == "/project/jobs.db"
+        assert config.retention.cache_versions_to_keep == 9
 
         # From environment variable (overrides project config)
         assert config.logging.log_level == "ERROR"
@@ -450,11 +416,6 @@ plantuml_jar = "/project/plantuml.jar"
 
         config_file = tmp_path / "clm.toml"
         config_file.write_text("""
-[paths]
-cache_db_path = "/test/cache.db"
-jobs_db_path = "/test/jobs.db"
-workspace_path = "/test/workspace"
-
 [external_tools]
 plantuml_jar = "/test/plantuml.jar"
 drawio_executable = "/test/drawio"
@@ -484,9 +445,6 @@ use_sqlite_queue = false
         config = ClmConfig()
 
         # Verify all settings were loaded
-        assert config.paths.cache_db_path == "/test/cache.db"
-        assert config.paths.jobs_db_path == "/test/jobs.db"
-        assert config.paths.workspace_path == "/test/workspace"
         assert config.external_tools.plantuml_jar == "/test/plantuml.jar"
         assert config.external_tools.drawio_executable == "/test/drawio"
         assert config.logging.log_level == "DEBUG"


### PR DESCRIPTION
## Summary

Follow-up to #498. While documenting the new `CLM_JOBS_DB_PATH` env var, we found that CLM has **two parallel, disconnected systems** for resolving database paths:

- **The authoritative one:** the global CLI options `--cache-db-path` / `--jobs-db-path` / `--telemetry-db-path` (and their `CLM_*_DB_PATH` env vars), resolved in `clm.cli.main` and threaded through `ctx.obj` → `BuildConfig` → `DatabaseManager`/`JobQueue`. This is what a build actually opens.
- **A dead shadow:** a pydantic `[paths]` config (`ClmConfig.paths`, env `CLM_PATHS__*`). Almost nothing reads it — only `clm config show` and one build-end cleanup line — so it silently diverged from the real paths.

That split caused two real (low-severity) bugs, and the config itself was misleading. This PR fixes both and removes the dead config.

### 1. Build-end cache cleanup followed the wrong path

The end-of-build "prune stale executed-notebook hashes" step located the cache DB via `get_config().paths.cache_db_path` instead of the DB the backend actually opened. With `--cache-db-path` / `CLM_CACHE_DB_PATH` overridden — or a build run from a topic subdirectory (the `[paths]` value isn't project-root-anchored) — it pruned the wrong file, or created a stray `clm_cache.db` in the cwd, and never pruned the real cache. Now uses `self.db_manager.db_path`.

### 2. `clm status` / `clm monitor` ignored `CLM_JOBS_DB_PATH`

They auto-detected the jobs DB via the legacy `CLM_DB_PATH` only. So a build redirected with `CLM_JOBS_DB_PATH` (e.g. onto a RAM disk — the feature added in #498) left `status`/`monitor` opening a *different, idle* database and reporting a misleadingly empty system. `CLM_JOBS_DB_PATH` now takes precedence; `CLM_DB_PATH` remains a fallback.

### 3. Removed the vestigial `[paths]` config

`CLM_PATHS__CACHE_DB_PATH` / `CLM_PATHS__JOBS_DB_PATH` / `CLM_PATHS__WORKSPACE_PATH` and the `[paths]` block in `clm.toml` never relocated the DB a command opened (`jobs_db_path` and `workspace_path` had **zero** runtime consumers; `cache_db_path` had only the buggy line above). `clm config show` now reports the **effective** resolved paths under a `[Databases]` heading instead of hardcoded defaults. Old config files with a leftover `[paths]` section still load — the section is ignored.

## Testing

Re-pointed the config-precedence tests off the removed `paths` field onto surviving fields (`logging` / `retention`), so the file/env/default precedence chain stays fully covered. Added regression tests: the build-end prune targets `db_manager.db_path` (a decoy `CLM_CACHE_DB_PATH` is left untouched), and `StatusCollector` prefers `CLM_JOBS_DB_PATH` over the anchored default while still honoring legacy `CLM_DB_PATH`. `ruff`/`mypy` clean; pre-push fast suite green; ran the backend/config/status/monitor/db suites locally (268 passed).

## Note — this is one instance of a wider pattern

An audit found the `[paths]` disconnect is **systemic**: the CLI does not participate in `ClmConfig`'s precedence chain at all, and roughly half of `ClmConfig`'s surface (`logging`, `jupyter`, `external_tools`, `workers`, and `paths`) is inert — those TOML/`CLM_*__*` channels do nothing because the real consumers read raw env vars directly. E.g. `[external_tools] plantuml_jar` and `[logging] log_level` in a config file are silently ignored even though `clm config show` displays them. This PR fixes the highest-impact case (DB paths); a broader unification is proposed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
