### PR TITLE
feat(config): shared resolver + config show --json; remove USE_SQLITE_QUEUE (Phase 1)

### DIFF
--- a/changelog.d/config-show-json.added.md
+++ b/changelog.d/config-show-json.added.md
@@ -1,0 +1,4 @@
+- **`clm config show --json`** emits the effective configuration as
+  machine-readable JSON — the resolved database paths, the LLM-cache location,
+  and every `ClmConfig` section (with env/file/default already folded in) — for
+  scripting and debugging.

--- a/changelog.d/remove-use-sqlite-queue.removed.md
+++ b/changelog.d/remove-use-sqlite-queue.removed.md
@@ -1,0 +1,5 @@
+- **Removed the `USE_SQLITE_QUEUE` flag and the `workers.use_sqlite_queue`
+  config field.** A leftover from the multi-queue era — SQLite is the only job
+  queue now, so the flag had no consumer (the pool manager set it in the worker
+  environment but nothing read it). Hard cut; see `clm info migration` for the
+  full removed/renamed configuration-variable table.

--- a/docs/developer-guide/direct_worker_execution.md
+++ b/docs/developer-guide/direct_worker_execution.md
@@ -204,7 +204,6 @@ Workers require these environment variables (automatically set by the pool manag
 - `DB_PATH`: Path to SQLite database
 - `WORKSPACE_PATH`: Path to workspace directory
 - `LOG_LEVEL`: Logging verbosity
-- `USE_SQLITE_QUEUE`: Enable SQLite queue mode
 
 ### WorkerConfig Parameters
 

--- a/src/clm/cli/commands/config.py
+++ b/src/clm/cli/commands/config.py
@@ -8,6 +8,17 @@ from pathlib import Path
 import click
 
 
+def _obj_str(obj: dict, key: str) -> str | None:
+    """Stringify a resolved ``ctx.obj`` path, or ``None`` when absent.
+
+    ``ctx.obj`` carries the effective DB paths resolved by the top-level CLI
+    callback; it is populated in normal invocation but may be empty when
+    ``config show`` is driven in isolation (e.g. a unit test).
+    """
+    val = obj.get(key)
+    return str(val) if val is not None else None
+
+
 @click.group()
 def config():
     """Manage CLM configuration files."""
@@ -67,35 +78,69 @@ def config_init(location, force):
 
 
 @config.command(name="show")
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    help="Emit the effective configuration as JSON (machine-readable).",
+)
 @click.pass_context
-def config_show(ctx):
+def config_show(ctx, as_json):
     """Show current configuration values.
 
     This command displays the current configuration, including values
-    from all sources (config files and environment variables).
+    from all sources (config files and environment variables). Pass
+    ``--json`` for a machine-readable dump of the effective configuration.
     """
     from clm.infrastructure.config import get_config
 
     cfg = get_config(reload=True)
-
-    click.echo("Current CLM Configuration:")
-    click.echo("=" * 60)
 
     # Effective database paths — the ones a build/status/monitor run actually
     # opens. These come from the global CLI options (resolved in clm.cli.main,
     # honoring --cache-db-path / CLM_CACHE_DB_PATH and project-root anchoring),
     # not from the config file / ClmConfig, so show what was resolved here.
     obj = ctx.obj or {}
-    click.echo("\n[Databases]  (effective paths for this invocation)")
-    click.echo(f"  cache_db_path: {obj.get('CACHE_DB_PATH', '(default: clm_cache.db)')}")
-    click.echo(f"  jobs_db_path: {obj.get('JOBS_DB_PATH', '(default: clm_jobs.db)')}")
-    click.echo(
-        f"  telemetry_db_path: {obj.get('TELEMETRY_DB_PATH', '(default: next to cache DB)')}"
-    )
+    databases = {
+        "cache_db_path": _obj_str(obj, "CACHE_DB_PATH"),
+        "jobs_db_path": _obj_str(obj, "JOBS_DB_PATH"),
+        "telemetry_db_path": _obj_str(obj, "TELEMETRY_DB_PATH"),
+    }
 
     from clm.infrastructure.llm.cache import CACHE_DB_NAME, describe_cache_dir
 
     llm = describe_cache_dir()
+
+    if as_json:
+        import json
+
+        # ``model_dump`` carries every ClmConfig section (external_tools,
+        # logging, jupyter, workers, retention, worker_management, git, llm,
+        # recordings) as the effective env/file/default-folded values; the
+        # databases and LLM-cache location are resolved outside ClmConfig, so
+        # they are added explicitly.
+        payload = {
+            "databases": databases,
+            "llm_cache": {
+                "dir": str(llm.path),
+                "source": llm.source,
+                "db": str(llm.path / CACHE_DB_NAME),
+            },
+            **cfg.model_dump(mode="json"),
+        }
+        click.echo(json.dumps(payload, indent=2, default=str))
+        return
+
+    click.echo("Current CLM Configuration:")
+    click.echo("=" * 60)
+
+    click.echo("\n[Databases]  (effective paths for this invocation)")
+    click.echo(f"  cache_db_path: {databases['cache_db_path'] or '(default: clm_cache.db)'}")
+    click.echo(f"  jobs_db_path: {databases['jobs_db_path'] or '(default: clm_jobs.db)'}")
+    click.echo(
+        f"  telemetry_db_path: {databases['telemetry_db_path'] or '(default: next to cache DB)'}"
+    )
+
     click.echo("\n[LLM Cache]  (summaries, titles, translations, sync watermarks)")
     click.echo(f"  llm_cache_dir: {llm.path}  (from {llm.source})")
     click.echo(f"  llm_cache_db: {llm.path / CACHE_DB_NAME}")
@@ -119,7 +164,6 @@ def config_show(ctx):
     click.echo("\n[Workers]")
     click.echo(f"  worker_type: {cfg.workers.worker_type or '(not set)'}")
     click.echo(f"  worker_id: {cfg.workers.worker_id or '(not set)'}")
-    click.echo(f"  use_sqlite_queue: {cfg.workers.use_sqlite_queue}")
 
 
 @config.command(name="locate")

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -3229,7 +3229,7 @@ Manage CLM configuration files.
 |------------|-------------|
 | `config init` | Create an example configuration file |
 | `config locate` | Show configuration file locations |
-| `config show` | Show current configuration values |
+| `config show` | Show current configuration values (effective DB paths + config sections). Add `--json` for machine-readable output. |
 
 ### `clm cache` (CLM {version}+)
 

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -2,6 +2,30 @@
 
 This guide covers breaking changes across major CLM versions.
 
+## Removed / renamed configuration variables ({version})
+
+The database paths are configured **only** through the global CLI options and
+their `CLM_*_DB_PATH` environment variables (resolved once in `clm.cli.main`).
+A parallel `[paths]` config section / `CLM_PATHS__*` family used to shadow them
+but never actually relocated the database a command opened — it has been
+removed. The `USE_SQLITE_QUEUE` flag is also gone: SQLite is the only job queue,
+so the switch had no effect. These are **hard cuts** — the old names no longer
+work.
+
+| Removed variable | Replacement | Notes |
+|---|---|---|
+| `CLM_PATHS__CACHE_DB_PATH` | `CLM_CACHE_DB_PATH` (or `--cache-db-path`) | Same meaning; the new form actually takes effect. |
+| `CLM_PATHS__JOBS_DB_PATH` | `CLM_JOBS_DB_PATH` (or `--jobs-db-path`) | Now honored by `clm build`, `status`, and `monitor` alike. |
+| `CLM_PATHS__WORKSPACE_PATH` | *(none)* | Was vestigial; the worker workspace is derived from the output dir. |
+| `[paths]` section in `clm.toml` / `.clm/config.toml` | CLI options / `CLM_*_DB_PATH` | An old `[paths]` block still loads (it is ignored). |
+| `USE_SQLITE_QUEUE` | *(none)* | SQLite is the only queue; the flag had no consumer. |
+
+`CLM_DB_PATH` (the legacy jobs-DB auto-detect used by `clm status` / `monitor`)
+still works but is superseded by `CLM_JOBS_DB_PATH`, which now takes precedence.
+
+Run `clm config show` (or `clm config show --json`) to see the **effective**
+database paths and configuration for the current invocation.
+
 ## `//`-language decks re-baseline the sync watermark once (issue #458, {version})
 
 `clm slides sync`'s reflow-insensitive markdown hashing (#429) now threads the

--- a/src/clm/infrastructure/config.py
+++ b/src/clm/infrastructure/config.py
@@ -67,7 +67,6 @@ class LegacyEnvSettingsSource(PydanticBaseSettingsSource):
         ("jupyter", "log_cell_processing"): "LOG_CELL_PROCESSING",
         ("workers", "worker_type"): "WORKER_TYPE",
         ("workers", "worker_id"): "WORKER_ID",
-        ("workers", "use_sqlite_queue"): "USE_SQLITE_QUEUE",
     }
 
     def get_field_value(self, field: FieldInfo, field_name: str) -> tuple[Any, str, bool]:
@@ -93,7 +92,7 @@ class LegacyEnvSettingsSource(PydanticBaseSettingsSource):
 
                 # Set the value, converting booleans
                 final_key = field_path[-1]
-                if env_var in ("LOG_CELL_PROCESSING", "USE_SQLITE_QUEUE"):
+                if env_var == "LOG_CELL_PROCESSING":
                     # Boolean conversion
                     current[final_key] = env_value.lower() in ("true", "1", "yes")
                 else:
@@ -262,11 +261,6 @@ class WorkersConfig(BaseModel):
     worker_id: str = Field(
         default="",
         description="Worker ID",
-    )
-
-    use_sqlite_queue: bool = Field(
-        default=True,
-        description="Use SQLite queue for job orchestration",
     )
 
 
@@ -983,6 +977,33 @@ def get_config(reload: bool = False) -> ClmConfig:
     return _config
 
 
+def resolve_setting(cli_value: Any, *, config_value: Any, default: Any) -> Any:
+    """Fold the CLI/env/config-file/default channels into one effective value.
+
+    The standard CLM precedence is ``CLI flag > environment variable > config
+    file > built-in default``. ``config_value`` is expected to be
+    ``get_config().<section>.<field>`` — ``ClmConfig`` already folds the
+    environment-variable and config-file tiers internally, so this helper only
+    layers an explicit CLI value on top and falls back to ``default`` when
+    nothing is set.
+
+    A ``cli_value`` of ``None`` means "flag not supplied" (Click options that
+    participate should default to ``None``, not the built-in default, so
+    "unset" is distinguishable). An empty-string ``config_value`` is treated as
+    unset — several ``ClmConfig`` string fields default to ``""`` to mean "not
+    configured".
+
+    This is the shared seam the config-unification work routes every
+    multi-channel setting through (see
+    ``docs/proposals/config-cli-precedence-unification.md``).
+    """
+    if cli_value is not None:
+        return cli_value
+    if config_value is not None and config_value != "":
+        return config_value
+    return default
+
+
 def create_example_config() -> str:
     """Create an example configuration file content.
 
@@ -1102,10 +1123,6 @@ worker_type = ""
 # Environment variable: WORKER_ID (no CLM_ prefix)
 # Usually set automatically, not needed in config file
 worker_id = ""
-
-# Use SQLite queue for job orchestration
-# Environment variable: USE_SQLITE_QUEUE (no CLM_ prefix)
-use_sqlite_queue = true
 
 [worker_management]
 # Worker lifecycle management configuration

--- a/src/clm/infrastructure/workers/worker_executor.py
+++ b/src/clm/infrastructure/workers/worker_executor.py
@@ -634,7 +634,6 @@ class DirectWorkerExecutor(WorkerExecutor):
                     "DB_PATH": str(self.db_path.absolute()),
                     "WORKSPACE_PATH": str(self.workspace_path.absolute()),
                     "LOG_LEVEL": self.log_level,
-                    "USE_SQLITE_QUEUE": "true",
                 }
             )
 

--- a/tests/cli/test_config_command.py
+++ b/tests/cli/test_config_command.py
@@ -144,6 +144,22 @@ class TestConfigShow:
         assert "llm_cache_dir:" in result.output
         assert "clm-llm.sqlite" in result.output
 
+    def test_show_json_is_machine_readable(self, isolated_config_dirs):
+        import json
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["config", "show", "--json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        # Effective DB paths + LLM cache are resolved outside ClmConfig.
+        assert set(data["databases"]) == {"cache_db_path", "jobs_db_path", "telemetry_db_path"}
+        assert "dir" in data["llm_cache"]
+        # Every ClmConfig section is dumped (retention is a live one).
+        assert "retention" in data
+        assert "logging" in data
+        # use_sqlite_queue was removed — it must not resurface anywhere.
+        assert "use_sqlite_queue" not in data.get("workers", {})
+
 
 class TestConfigLocate:
     def test_locate_shows_all_locations(self, isolated_config_dirs):

--- a/tests/infrastructure/test_config.py
+++ b/tests/infrastructure/test_config.py
@@ -12,8 +12,31 @@ from clm.infrastructure.config import (
     find_config_files,
     get_config,
     get_config_file_locations,
+    resolve_setting,
     write_example_config,
 )
+
+
+class TestResolveSetting:
+    """Test the shared CLI > env/file > default resolver."""
+
+    def test_cli_value_wins(self):
+        assert resolve_setting("cli", config_value="cfg", default="def") == "cli"
+
+    def test_config_value_when_no_cli(self):
+        assert resolve_setting(None, config_value="cfg", default="def") == "cfg"
+
+    def test_default_when_nothing_set(self):
+        assert resolve_setting(None, config_value=None, default="def") == "def"
+
+    def test_empty_string_config_is_unset(self):
+        # ClmConfig string fields default to "" to mean "not configured".
+        assert resolve_setting(None, config_value="", default="def") == "def"
+
+    def test_falsy_non_empty_cli_value_still_wins(self):
+        # 0 / False are explicit CLI choices, not "unset" (only None is unset).
+        assert resolve_setting(0, config_value=5, default=9) == 0
+        assert resolve_setting(False, config_value=True, default=True) is False
 
 
 class TestConfigDefaults:
@@ -56,13 +79,12 @@ class TestConfigDefaults:
     def test_default_workers(self, monkeypatch):
         """Test default workers configuration."""
         # Clear any environment variables that might interfere
-        for var in ["WORKER_TYPE", "WORKER_ID", "USE_SQLITE_QUEUE"]:
+        for var in ["WORKER_TYPE", "WORKER_ID"]:
             monkeypatch.delenv(var, raising=False)
 
         config = ClmConfig()
         assert config.workers.worker_type == ""
         assert config.workers.worker_id == ""
-        assert config.workers.use_sqlite_queue is True
 
 
 class TestEnvironmentVariables:
@@ -406,7 +428,6 @@ plantuml_jar = "/project/plantuml.jar"
             "DRAWIO_EXECUTABLE",
             "WORKER_TYPE",
             "WORKER_ID",
-            "USE_SQLITE_QUEUE",
             "JINJA_LINE_STATEMENT_PREFIX",
             "JINJA_TEMPLATES_PATH",
             "LOG_CELL_PROCESSING",
@@ -437,7 +458,6 @@ log_cell_processing = true
 [workers]
 worker_type = "plantuml"
 worker_id = "test-worker-1"
-use_sqlite_queue = false
 """)
 
         monkeypatch.chdir(tmp_path)
@@ -457,7 +477,6 @@ use_sqlite_queue = false
         assert config.jupyter.log_cell_processing is True
         assert config.workers.worker_type == "plantuml"
         assert config.workers.worker_id == "test-worker-1"
-        assert config.workers.use_sqlite_queue is False
 
 
 class TestWorkerManagementConfig:

--- a/tests/infrastructure/workers/test_worker_executor.py
+++ b/tests/infrastructure/workers/test_worker_executor.py
@@ -168,7 +168,6 @@ class TestDirectWorkerExecutor:
         assert env["WORKER_ID"] == worker_id
         assert env["DB_PATH"] == str(db_path.absolute())
         assert env["WORKSPACE_PATH"] == str(workspace_path.absolute())
-        assert env["USE_SQLITE_QUEUE"] == "true"
 
         # Verify worker is tracked
         assert worker_id in executor.processes


### PR DESCRIPTION
## Summary

Phase 1 of the config/CLI/env unification proposed in #500. It lays the foundation and delivers two of your decisions (machine-readable `config show`, remove `use_sqlite_queue`), plus the removed-variable table for your migration email.

### 1. Shared resolver (foundation)

`resolve_setting(cli_value, *, config_value, default)` in `config.py` — the single precedence seam (`CLI flag > env var > config file > default`) that Phases 2–4 will route each multi-channel setting through. `ClmConfig` already folds `env > file > default`, so the helper just layers the CLI value on top: `None` cli value = "flag unset", `""` config value = "not configured", falsy-but-not-None (`0`/`False`) counts as an explicit choice. Unit-tested.

### 2. `clm config show --json`

Machine-readable dump of the **effective** configuration — resolved DB paths, LLM-cache location, and every `ClmConfig` section (via `model_dump`). The text view already reports effective DB paths under `[Databases]` (from #499); `--json` makes it scriptable.

### 3. Removed `USE_SQLITE_QUEUE` / `workers.use_sqlite_queue` (hard cut)

A leftover from the multi-queue era. SQLite is the only job queue now, and nothing read the flag — the pool manager set it in the worker env but no worker consumed it, and the config field had zero consumers. Removed the field, the legacy-env mapping, the pool-manager env injection, the example-config entry, the `config show` line, and the dev doc.

### 4. Removed/renamed variable table (for the email)

Per your ask, `clm info migration` now has a **removed → replacement** table (hard cuts, no deprecation window):

| Removed | Replacement |
|---|---|
| `CLM_PATHS__CACHE_DB_PATH` | `CLM_CACHE_DB_PATH` / `--cache-db-path` |
| `CLM_PATHS__JOBS_DB_PATH` | `CLM_JOBS_DB_PATH` / `--jobs-db-path` |
| `CLM_PATHS__WORKSPACE_PATH` | *(none — vestigial)* |
| `[paths]` config section | CLI options / `CLM_*_DB_PATH` |
| `USE_SQLITE_QUEUE` | *(none — SQLite is the only queue)* |

## Testing

`ruff`/`mypy` clean; pre-push fast suite green. Added unit tests for `resolve_setting` (precedence + empty-string/falsy semantics) and `config show --json` (structure + that `use_sqlite_queue` is gone); updated the config / worker-executor tests. Ran `tests/infrastructure/test_config.py`, `tests/cli/test_config_command.py`, `tests/infrastructure/workers/test_worker_executor.py` locally (90 passed).

## Not in this PR (later phases, per the proposal)

Wiring the currently-inert sections (`external_tools`, `logging`, `jupyter`) through the resolver + worker-env injection so config-file values take effect — Phases 2–4, each its own PR. The env-spelling hard cuts (`CLM_DB_PATH`, `CLM_MAX_WORKERS`, `CLM_E2E_*`) land in Phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
