### PR TITLE
feat(config): wire [external_tools] through to Direct workers (Phase 2)

### DIFF
--- a/changelog.d/external-tools-config-file.changed.md
+++ b/changelog.d/external-tools-config-file.changed.md
@@ -1,0 +1,9 @@
+- **`[external_tools]` config-file settings now take effect.** `plantuml_jar`
+  and `drawio_executable` set in `clm.toml` / `.clm/config.toml` were previously
+  ignored — only the raw `PLANTUML_JAR` / `DRAWIO_EXECUTABLE` env vars reached
+  the converters. The host now resolves each through the config system
+  (env var > config file) and injects the effective value into **Direct**
+  workers, so a config-file path is honored (the env var still wins when both
+  are set). Docker workers continue to use the tools baked into the worker
+  image. This is Phase 2 of the config/CLI/env unification
+  (`docs/proposals/config-cli-precedence-unification.md`).

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -175,6 +175,18 @@ default is):
 | `PLANTUML_JAR` | Path to PlantUML JAR file |
 | `DRAWIO_EXECUTABLE` | Path to Draw.io executable |
 
+These can equivalently be set in the config file, which now takes effect for
+**Direct** workers (the env var still wins if both are set):
+
+```toml
+[external_tools]
+plantuml_jar = "/usr/local/share/plantuml.jar"
+drawio_executable = "/usr/bin/drawio"
+```
+
+(Docker workers use the tools baked into the worker image, so a host path does
+not apply to them.)
+
 **Platform-specific Draw.io paths**:
 ```bash
 # Linux

--- a/src/clm/infrastructure/workers/worker_executor.py
+++ b/src/clm/infrastructure/workers/worker_executor.py
@@ -646,12 +646,26 @@ class DirectWorkerExecutor(WorkerExecutor):
                 env["CACHE_DB_PATH"] = str(self.cache_db_path.absolute())
                 logger.debug(f"Passing CACHE_DB_PATH={env['CACHE_DB_PATH']} to worker")
 
-            # Ensure converter-specific environment variables are passed through
-            # These are needed by PlantUML and Draw.io converters
-            for var in ["PLANTUML_JAR", "DRAWIO_EXECUTABLE"]:
-                if var in os.environ:
-                    env[var] = os.environ[var]
-                    logger.debug(f"Passing {var}={env[var]} to worker")
+            # Converter-specific paths (PlantUML jar / Draw.io executable) needed
+            # by the plantuml and drawio Direct workers, which read these env
+            # vars at import time. Resolve through the config system so a
+            # ``clm.toml`` ``[external_tools]`` value reaches the worker, not just
+            # a host env var: ``get_config().external_tools.*`` already folds
+            # ``PLANTUML_JAR``/``DRAWIO_EXECUTABLE`` (env) over the config file, and
+            # ``resolve_setting`` layers a CLI value on top (none exists for these
+            # yet, so the CLI tier is always None). Docker workers use the jar
+            # baked into the image, so they are intentionally not injected here.
+            from clm.infrastructure.config import get_config, resolve_setting
+
+            external_tools = get_config().external_tools
+            for env_var, config_value in (
+                ("PLANTUML_JAR", external_tools.plantuml_jar),
+                ("DRAWIO_EXECUTABLE", external_tools.drawio_executable),
+            ):
+                resolved = resolve_setting(None, config_value=config_value, default="")
+                if resolved:
+                    env[env_var] = resolved
+                    logger.debug(f"Passing {env_var}={resolved} to worker")
 
             # Build command
             cmd = [sys.executable, "-m", module]

--- a/tests/infrastructure/workers/test_worker_executor.py
+++ b/tests/infrastructure/workers/test_worker_executor.py
@@ -176,6 +176,61 @@ class TestDirectWorkerExecutor:
         assert executor.worker_info[worker_id]["pid"] == 12345
 
     @patch("subprocess.Popen")
+    def test_start_worker_injects_external_tools_from_config(
+        self, mock_popen, db_path, workspace_path
+    ):
+        """Config-resolved PlantUML/Draw.io paths reach the Direct worker env.
+
+        This is the Phase 2 wiring: a ``clm.toml`` ``[external_tools]`` value
+        (folded into ``get_config().external_tools`` — proven by the config
+        tests) must be injected into the worker environment, not just a host
+        ``PLANTUML_JAR`` env var.
+        """
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_popen.return_value = mock_process
+
+        fake_cfg = MagicMock()
+        fake_cfg.external_tools.plantuml_jar = "/cfg/plantuml.jar"
+        fake_cfg.external_tools.drawio_executable = "/cfg/drawio"
+
+        executor = DirectWorkerExecutor(db_path=db_path, workspace_path=workspace_path)
+        config = WorkerConfig(worker_type="plantuml", count=1, execution_mode="direct")
+
+        with patch("clm.infrastructure.config.get_config", return_value=fake_cfg):
+            executor.start_worker("plantuml", 0, config)
+
+        env = mock_popen.call_args[1]["env"]
+        assert env["PLANTUML_JAR"] == "/cfg/plantuml.jar"
+        assert env["DRAWIO_EXECUTABLE"] == "/cfg/drawio"
+
+    @patch("subprocess.Popen")
+    def test_start_worker_omits_unset_external_tools(
+        self, mock_popen, db_path, workspace_path, monkeypatch
+    ):
+        """When neither env nor config sets the tool paths, nothing is injected."""
+        monkeypatch.delenv("PLANTUML_JAR", raising=False)
+        monkeypatch.delenv("DRAWIO_EXECUTABLE", raising=False)
+
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_popen.return_value = mock_process
+
+        fake_cfg = MagicMock()
+        fake_cfg.external_tools.plantuml_jar = ""
+        fake_cfg.external_tools.drawio_executable = ""
+
+        executor = DirectWorkerExecutor(db_path=db_path, workspace_path=workspace_path)
+        config = WorkerConfig(worker_type="plantuml", count=1, execution_mode="direct")
+
+        with patch("clm.infrastructure.config.get_config", return_value=fake_cfg):
+            executor.start_worker("plantuml", 0, config)
+
+        env = mock_popen.call_args[1]["env"]
+        assert "PLANTUML_JAR" not in env
+        assert "DRAWIO_EXECUTABLE" not in env
+
+    @patch("subprocess.Popen")
     def test_start_worker_unknown_type(self, mock_popen, db_path, workspace_path):
         """Test that starting unknown worker type fails."""
         executor = DirectWorkerExecutor(db_path=db_path, workspace_path=workspace_path)


### PR DESCRIPTION
## Summary

Phase 2 of the config/CLI/env unification (#500) — the first "make the config file real" step. Follows #502 (Phase 1).

**Before:** `plantuml_jar` / `drawio_executable` set in `clm.toml` `[external_tools]` were silently ignored. The Direct worker executor forwarded only the host's raw `PLANTUML_JAR` / `DRAWIO_EXECUTABLE` env vars into the worker, never the config-file value — so `clm config show` displayed a setting that did nothing.

**After:** the host resolves each tool path through the config system (`get_config().external_tools.*`, which already folds env > config file) via the shared `resolve_setting` seam, and injects the effective value into the Direct worker's environment. The worker's import-time env read is unchanged (per the proposal's worker-boundary rule — no worker refactor needed).

Precedence preserved: an env var still wins over the config file. Docker workers use the tools baked into the worker image, so they're intentionally not injected.

## Testing

Two new tests: a config-resolved path is injected into the worker env; an unset value (no env, empty config) is not injected. Full `test_worker_executor.py` suite: **33 passed**. Combined with the existing config tests (which prove a `clm.toml` value populates `ClmConfig.external_tools`), this covers the whole chain config-file → `ClmConfig` → worker env. ruff/mypy clean; pre-push fast suite green.

## Next

Phase 3 (`logging.log_level` — host + worker) and Phase 4 (`jupyter.*`) follow the same pattern; Phase 5 does the env-spelling hard cuts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
