### PR TITLE
feat(config): make clm build honor the configured log level (Phase 3)

### DIFF
--- a/changelog.d/log-level-config-file.changed.md
+++ b/changelog.d/log-level-config-file.changed.md
@@ -1,0 +1,8 @@
+- **`clm build` now honors the configured log level.** `[logging] log_level`
+  in `clm.toml` and the `CLM_LOGGING__LOG_LEVEL` environment variable previously
+  had no effect on a build — `--log-level` hard-defaulted to `INFO`, so the
+  config value was always overridden. `--log-level` now defaults to "unset" and
+  the effective level resolves as `--log-level` > `CLM_LOGGING__LOG_LEVEL` >
+  `[logging] log_level` > `INFO`, applied to both host and worker logging. Phase
+  3 of the config/CLI/env unification
+  (`docs/proposals/config-cli-precedence-unification.md`).

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -247,7 +247,7 @@ tidy` to move *existing* sidecars between layouts in bulk.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `CLM_LOGGING__LOG_LEVEL` | Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL) | `INFO` |
+| `CLM_LOGGING__LOG_LEVEL` | Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL). Honored by `clm build` for both host and worker logging; the `--log-level` flag overrides it. Also settable as `[logging] log_level` in `clm.toml`. | `INFO` |
 | `CLM_LOGGING__ENABLE_TEST_LOGGING` | Enable logging during tests | `false` |
 | `CLM_LOG_DIR` | Directory for `clm.log` and `workers/` logs. Overrides the platform default (Windows: `%LOCALAPPDATA%/clm/Logs`; macOS: `~/Library/Logs/clm`; Linux: `~/.local/state/clm/log`). Useful to relocate logs, or to give parallel processes their own log file so they don't race to open/rotate the shared one. | platform default |
 

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -181,6 +181,28 @@ def _resolve_explain_rebuilds(cli_flag: bool) -> bool:
     return False
 
 
+def _resolve_log_level(cli_log_level: str | None) -> str:
+    """Effective logging level: ``--log-level`` > env/config file > ``INFO``.
+
+    Phase 3 of the config/CLI/env unification: ``--log-level`` now defaults to
+    ``None`` (unset), so a ``[logging] log_level`` in ``clm.toml`` — or
+    ``CLM_LOGGING__LOG_LEVEL`` — finally takes effect when the flag is absent
+    (``ClmConfig.logging.log_level`` already folds env over config file, and
+    itself defaults to ``INFO``). The resolved level flows to both host logging
+    (``setup_logging``) and, via ``logger.getEffectiveLevel()`` at pool-manager
+    creation, to the workers.
+    """
+    from clm.infrastructure.config import get_config, resolve_setting
+
+    resolved = resolve_setting(
+        cli_log_level,
+        config_value=get_config().logging.log_level,
+        default="INFO",
+    )
+    # resolve_setting is typed -> Any; the inputs here are always level strings.
+    return str(resolved)
+
+
 def _resolve_write_provenance_manifest(
     *, requested: bool, is_snapshot: bool, verify_against_dir: Path | None
 ) -> bool:
@@ -378,7 +400,7 @@ class BuildConfig:
     spec_file: Path
     data_dir: Path
     output_dir: Path
-    log_level: str
+    log_level: str | None
     cache_db_path: Path
     jobs_db_path: Path
     ignore_cache: bool
@@ -688,7 +710,7 @@ async def print_all_correlation_ids():
 def initialize_paths_and_course(config: BuildConfig) -> tuple[Course, list[Path], Path]:
     """Initialize paths, load course spec, and create course object."""
     spec_file = config.spec_file.absolute()
-    setup_logging(config.log_level, console_logging=config.verbose_logging)
+    setup_logging(_resolve_log_level(config.log_level), console_logging=config.verbose_logging)
 
     # Resolve course paths using centralized helper
     data_dir, default_output = resolve_course_paths(spec_file, config.data_dir)
@@ -2087,8 +2109,11 @@ async def main_build(
 @click.option(
     "--log-level",
     type=click.Choice(LOG_LEVELS, case_sensitive=False),
-    default="INFO",
-    help="Set the logging level.",
+    default=None,
+    help=(
+        "Set the logging level. Overrides [logging] log_level / "
+        "CLM_LOGGING__LOG_LEVEL; defaults to INFO when unset."
+    ),
 )
 @click.option(
     "--ignore-cache",

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -3076,7 +3076,7 @@ clm mcp [OPTIONS]
 | Option | Description |
 |--------|-------------|
 | `--data-dir DIR` | Course data directory (default: `CLM_DATA_DIR` or cwd) |
-| `--log-level TEXT` | Log level for stderr output |
+| `--log-level TEXT` | Log level (DEBUG/INFO/WARNING/ERROR/CRITICAL) for host and worker logging. Overrides `CLM_LOGGING__LOG_LEVEL` / `[logging] log_level`; defaults to `INFO` when unset. |
 
 The MCP server exposes 16 tools over stdio transport. Tool names mirror the
 CLI verb-group structure (group-first); the flat pre-1.8 names

--- a/tests/cli/test_build_command.py
+++ b/tests/cli/test_build_command.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import click
 import pytest
@@ -33,6 +33,7 @@ from clm.cli.commands.build import (
     _resolve_fail_on_missing_xref,
     _resolve_http_replay_mode,
     _resolve_http_replay_transport,
+    _resolve_log_level,
     _resolve_write_provenance_manifest,
     _should_emit_provenance_manifest,
     configure_workers,
@@ -105,6 +106,34 @@ class TestFindEnvFile:
         # Guard against an ancestor having a .env on the dev machine
         # by checking behaviour relative to tmp_path itself.
         assert _find_env_file(nested) is None or _find_env_file(nested).parent != tmp_path
+
+
+# ---------------------------------------------------------------------------
+# _resolve_log_level
+# ---------------------------------------------------------------------------
+
+
+class TestResolveLogLevel:
+    """Effective log level: --log-level > CLM_LOGGING__LOG_LEVEL/config > INFO."""
+
+    def test_cli_flag_wins(self) -> None:
+        # Even when the config/env resolves to WARNING, an explicit flag wins.
+        with patch("clm.infrastructure.config.get_config") as gc:
+            gc.return_value.logging.log_level = "WARNING"
+            assert _resolve_log_level("DEBUG") == "DEBUG"
+
+    def test_config_used_when_flag_unset(self) -> None:
+        # ClmConfig.logging.log_level already folds CLM_LOGGING__LOG_LEVEL over
+        # the config file; with no flag it takes effect.
+        with patch("clm.infrastructure.config.get_config") as gc:
+            gc.return_value.logging.log_level = "WARNING"
+            assert _resolve_log_level(None) == "WARNING"
+
+    def test_defaults_to_info(self) -> None:
+        # ClmConfig.logging.log_level defaults to INFO when nothing is set.
+        with patch("clm.infrastructure.config.get_config") as gc:
+            gc.return_value.logging.log_level = "INFO"
+            assert _resolve_log_level(None) == "INFO"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 3 of the config/CLI/env unification (#500). Wires `logging.log_level` through the resolver so the config file and `CLM_LOGGING__LOG_LEVEL` finally take effect for `clm build`.

**The gap:** `--log-level` hard-defaulted to `INFO`, so `config.log_level` was never "unset" — `[logging] log_level` in `clm.toml` and `CLM_LOGGING__LOG_LEVEL` were always overridden by that default. A dead config-file channel (that `clm config show` nonetheless displayed).

**The fix:** `--log-level` now defaults to `None`, and the effective level resolves via the shared `resolve_setting` seam:

```
--log-level  >  CLM_LOGGING__LOG_LEVEL  >  [logging] log_level  >  INFO
```

applied at the single `setup_logging` call in `initialize_paths_and_course`.

**Workers come along for free:** the pool manager already derives its level from `logging.getLevelName(logger.getEffectiveLevel())` at creation time (`lifecycle_manager.py`), so once the host logger is set to the resolved level, workers inherit it — no worker-side change needed. (So `--log-level DEBUG` already reached workers; this PR is what makes the *config file / env* reach both.)

## Details

- New `_resolve_log_level` helper (mirrors the existing `_resolve_*` build helpers).
- `BuildConfig.log_level` is now `str | None`; an explicit `--log-level X` still wins everywhere.

## Testing

`TestResolveLogLevel` (flag wins / config used when unset / defaults to INFO), patching `get_config` for isolation. Ran `test_build_command.py`, `test_cli_unit.py`, `test_cli_integration.py` — **177 passed**. ruff/mypy clean; pre-push fast suite green.

## Next

Phase 4 (`jupyter.*` — same host-resolve-and-inject-into-worker pattern as Phase 2), then Phase 5 (env-spelling hard cuts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
