### PR TITLE
feat(config): wire [jupyter] through to notebook workers (Phase 4)

### DIFF
--- a/changelog.d/jupyter-config-file.changed.md
+++ b/changelog.d/jupyter-config-file.changed.md
@@ -1,0 +1,10 @@
+- **`[jupyter]` config-file settings now take effect.** `jinja_line_statement_prefix`,
+  `jinja_templates_path`, and `log_cell_processing` set in `clm.toml` (or via
+  `JINJA_LINE_STATEMENT_PREFIX` / `JINJA_TEMPLATES_PATH` / `LOG_CELL_PROCESSING`)
+  were previously ignored — the notebook worker read only the raw env vars, and
+  the host never injected the config-folded value. The host now injects the
+  resolved settings (env > config file > default, via `ClmConfig.jupyter`) into
+  both Direct and Docker notebook workers. `log_cell_processing` is normalized to
+  the exact `True`/`False` the worker compares against (a prior `LOG_CELL_PROCESSING=true`
+  lowercase env value silently did nothing). Phase 4 of the config/CLI/env
+  unification (`docs/proposals/config-cli-precedence-unification.md`).

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -116,10 +116,8 @@ clm config locate
 
 ```toml
 # CLM Configuration File (config.toml)
-
-[paths]
-cache_db_path = "clm_cache.db"
-jobs_db_path = "clm_jobs.db"
+# Note: database paths are NOT configured here — use --cache-db-path /
+# --jobs-db-path (or the CLM_*_DB_PATH env vars).
 
 [external_tools]
 plantuml_jar = "/usr/local/share/plantuml-1.2024.6.jar"

--- a/src/clm/infrastructure/workers/worker_executor.py
+++ b/src/clm/infrastructure/workers/worker_executor.py
@@ -38,6 +38,32 @@ _DOCKER_HOST_ALIAS = "host.docker.internal"
 _MITM_CA_CONTAINER_PATH = "/clm/mitmproxy-ca-bundle.pem"
 
 
+def _notebook_worker_jupyter_env() -> dict[str, str]:
+    """Config-resolved Jupyter settings to inject into a worker's environment.
+
+    The notebook worker reads ``JINJA_LINE_STATEMENT_PREFIX`` /
+    ``JINJA_TEMPLATES_PATH`` / ``LOG_CELL_PROCESSING`` from the environment at
+    import time. Injecting the config-folded values here (env var >
+    ``clm.toml`` ``[jupyter]`` > default, already resolved by
+    ``ClmConfig.jupyter``) makes a config-file setting actually take effect —
+    Phase 4 of the config/CLI/env unification. Unlike the PlantUML/Draw.io tool
+    paths these are behavioural (not host-specific), so they are injected into
+    both Direct and Docker workers. There is no CLI flag for them, so no
+    ``resolve_setting`` CLI tier applies. Harmless for non-notebook workers,
+    which ignore these variables.
+    """
+    from clm.infrastructure.config import get_config
+
+    jupyter = get_config().jupyter
+    return {
+        "JINJA_LINE_STATEMENT_PREFIX": jupyter.jinja_line_statement_prefix,
+        "JINJA_TEMPLATES_PATH": jupyter.jinja_templates_path,
+        # notebook_processor reads this as an exact ``== "True"`` match, so emit
+        # that canonical form rather than a lowercase ``"true"``.
+        "LOG_CELL_PROCESSING": "True" if jupyter.log_cell_processing else "False",
+    }
+
+
 def _mitmproxy_docker_env(
     host_environ: dict[str, str],
 ) -> tuple[dict[str, str], tuple[str, str] | None]:
@@ -298,6 +324,10 @@ class DockerWorkerExecutor(WorkerExecutor):
                 ),  # For output path conversion
                 "LOG_LEVEL": self.log_level,
                 "PYTHONUNBUFFERED": "1",  # Enable immediate log output
+                # Config-resolved Jupyter settings for the notebook worker
+                # (Phase 4). Behavioural (not host-path) settings, so they apply
+                # inside the container too.
+                **_notebook_worker_jupyter_env(),
             }
 
             # Pass pre-assigned worker ID if provided (enables pre-registration)
@@ -666,6 +696,9 @@ class DirectWorkerExecutor(WorkerExecutor):
                 if resolved:
                     env[env_var] = resolved
                     logger.debug(f"Passing {env_var}={resolved} to worker")
+
+            # Config-resolved Jupyter settings for the notebook worker (Phase 4).
+            env.update(_notebook_worker_jupyter_env())
 
             # Build command
             cmd = [sys.executable, "-m", module]

--- a/tests/infrastructure/workers/test_worker_executor.py
+++ b/tests/infrastructure/workers/test_worker_executor.py
@@ -18,6 +18,7 @@ from clm.infrastructure.workers.worker_executor import (
     WorkerConfig,
     WorkerExecutor,
     _mitmproxy_docker_env,
+    _notebook_worker_jupyter_env,
 )
 
 
@@ -119,6 +120,34 @@ class TestWorkerConfig:
         """Test that default execution mode is docker."""
         config = WorkerConfig(worker_type="notebook", count=2, image="test:latest")
         assert config.execution_mode == "docker"
+
+
+class TestNotebookWorkerJupyterEnv:
+    """The config → worker-env mapping for Jupyter settings (Phase 4)."""
+
+    def test_maps_config_values(self):
+        fake_cfg = MagicMock()
+        fake_cfg.jupyter.jinja_line_statement_prefix = "# j2"
+        fake_cfg.jupyter.jinja_templates_path = "templates"
+        fake_cfg.jupyter.log_cell_processing = False
+        with patch("clm.infrastructure.config.get_config", return_value=fake_cfg):
+            env = _notebook_worker_jupyter_env()
+        assert env == {
+            "JINJA_LINE_STATEMENT_PREFIX": "# j2",
+            "JINJA_TEMPLATES_PATH": "templates",
+            # False must serialize to the exact "False" the worker compares against.
+            "LOG_CELL_PROCESSING": "False",
+        }
+
+    def test_log_cell_processing_true_serializes_to_capital_true(self):
+        # The worker reads LOG_CELL_PROCESSING with an exact `== "True"` match.
+        fake_cfg = MagicMock()
+        fake_cfg.jupyter.jinja_line_statement_prefix = "# j2"
+        fake_cfg.jupyter.jinja_templates_path = "templates"
+        fake_cfg.jupyter.log_cell_processing = True
+        with patch("clm.infrastructure.config.get_config", return_value=fake_cfg):
+            env = _notebook_worker_jupyter_env()
+        assert env["LOG_CELL_PROCESSING"] == "True"
 
 
 class TestDirectWorkerExecutor:
@@ -229,6 +258,31 @@ class TestDirectWorkerExecutor:
         env = mock_popen.call_args[1]["env"]
         assert "PLANTUML_JAR" not in env
         assert "DRAWIO_EXECUTABLE" not in env
+
+    @patch("subprocess.Popen")
+    def test_start_worker_injects_jupyter_config(self, mock_popen, db_path, workspace_path):
+        """Config-resolved Jupyter settings reach the Direct worker env (Phase 4)."""
+        mock_process = MagicMock()
+        mock_process.pid = 12345
+        mock_popen.return_value = mock_process
+
+        fake_cfg = MagicMock()
+        fake_cfg.external_tools.plantuml_jar = ""
+        fake_cfg.external_tools.drawio_executable = ""
+        fake_cfg.jupyter.jinja_line_statement_prefix = "# jj"
+        fake_cfg.jupyter.jinja_templates_path = "/tpl"
+        fake_cfg.jupyter.log_cell_processing = True
+
+        executor = DirectWorkerExecutor(db_path=db_path, workspace_path=workspace_path)
+        config = WorkerConfig(worker_type="notebook", count=1, execution_mode="direct")
+
+        with patch("clm.infrastructure.config.get_config", return_value=fake_cfg):
+            executor.start_worker("notebook", 0, config)
+
+        env = mock_popen.call_args[1]["env"]
+        assert env["JINJA_LINE_STATEMENT_PREFIX"] == "# jj"
+        assert env["JINJA_TEMPLATES_PATH"] == "/tpl"
+        assert env["LOG_CELL_PROCESSING"] == "True"
 
     @patch("subprocess.Popen")
     def test_start_worker_unknown_type(self, mock_popen, db_path, workspace_path):


### PR DESCRIPTION
## Summary

Phase 4 of the config/CLI/env unification (#500) — makes the `[jupyter]` config-file settings real, following the Phase 2 pattern.

**Before:** `jinja_line_statement_prefix`, `jinja_templates_path`, and `log_cell_processing` in `clm.toml` were ignored. The notebook worker reads the raw `JINJA_*` / `LOG_CELL_PROCESSING` env vars at import, and the host never injected the config value.

**After:** the host injects the config-folded values (env > `[jupyter]` > default, via `ClmConfig.jupyter`) into notebook workers through one shared `_notebook_worker_jupyter_env()` helper. Unlike the PlantUML/Draw.io tool paths (host-specific → Direct only in Phase 2), these are **behavioural**, so they're injected into **both Direct and Docker** workers.

**Bonus bug fix:** `log_cell_processing` is normalized to the exact `"True"`/`"False"` string the worker compares against (`== "True"`). Previously a `LOG_CELL_PROCESSING=true` (lowercase) env value silently did nothing.

Also drops a stale `[paths]` block from the `configuration.md` example (that config section was removed in #499).

## Testing

`TestNotebookWorkerJupyterEnv` (config → env mapping, incl. the `True`/`False` serialization both ways) + a Direct-worker injection test. Full `test_worker_executor.py`: **36 passed**. ruff/mypy clean; pre-push fast suite green. The Docker path uses the same helper, so it's covered by the helper's unit test.

## Next

Phase 5 — the env-spelling hard cuts (`CLM_DB_PATH`, `CLM_MAX_WORKERS`, `CLM_E2E_*`), each adding a row to the `clm info migration` table. That completes the program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
