### PR TITLE
feat(config): unify duplicate env-var spellings (Phase 5, final)

### DIFF
--- a/changelog.d/env-spelling-unification.changed.md
+++ b/changelog.d/env-spelling-unification.changed.md
@@ -1,0 +1,18 @@
+- **Unified duplicate environment-variable spellings (hard cut).** Settings that
+  had two env names now have one canonical form (old names no longer work; see
+  `clm info migration` for the full table):
+  - `CLM_DB_PATH` → `CLM_JOBS_DB_PATH` (the legacy jobs-DB auto-detect for
+    `clm status` / `monitor`).
+  - `CLM_E2E_PROGRESS_INTERVAL` / `CLM_E2E_LONG_JOB_THRESHOLD` /
+    `CLM_E2E_SHOW_WORKER_DETAILS` → `CLM_PROGRESS__UPDATE_INTERVAL` /
+    `CLM_PROGRESS__LONG_JOB_THRESHOLD` / `CLM_PROGRESS__SHOW_WORKER_DETAILS`
+    (also settable as `[progress]` in `clm.toml`). These drive **real build**
+    progress output (not just E2E tests), so they moved out of the misleading
+    `logging.testing.e2e_*` home into a top-level `[progress]` section. They now
+    flow through the config system with the defaults the build had always used
+    (5 s / 30 s / show-details), so build output is unchanged.
+
+  The worker-count cap keeps its friendly short env var — **`CLM_MAX_WORKERS`**
+  is the canonical spelling (the env form of `[worker_management] max_workers_cap`)
+  and is now documented as such. Phase 5 of the config/CLI/env unification
+  (`docs/proposals/config-cli-precedence-unification.md`).

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -298,9 +298,21 @@ from a project `.env` automatically (pass `--no-env-file` to skip).
 
 | Variable | Description | Default |
 |----------|-------------|---------|
+| `CLM_MAX_WORKERS` | Hard cap on the effective worker count per type (the friendly short form of the `[worker_management] max_workers_cap` config field). Further clamped against CPU/RAM-derived caps at pool start. `--max-workers` on `clm build` overrides it. | (auto caps only) |
 | `CLM_MAX_CONCURRENCY` | Max concurrent operations | `50` |
 | `CLM_MAX_WORKER_STARTUP_CONCURRENCY` | Max concurrent worker starts | `10` |
 | `CLM_OUTPUT_DEDUP_HASH_LIMIT_MB` | Skip output-write deduplication for files larger than this many megabytes. Repeat writes to a large-file output are reported as a single summary collision counter rather than per-event warnings. Set to `0` to force every write through the large-file fast path (useful for tests). | `50` |
+
+### Build progress
+
+Tuning for the build's progress logging (also settable as `[progress]` in
+`clm.toml`):
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `CLM_PROGRESS__UPDATE_INTERVAL` | Seconds between progress log updates | `5` |
+| `CLM_PROGRESS__LONG_JOB_THRESHOLD` | Seconds before warning about a long-running job | `30` |
+| `CLM_PROGRESS__SHOW_WORKER_DETAILS` | Show per-worker details in progress output | `true` |
 
 ### Database Retention
 

--- a/src/clm/cli/commands/config.py
+++ b/src/clm/cli/commands/config.py
@@ -152,9 +152,11 @@ def config_show(ctx, as_json):
     click.echo("\n[Logging]")
     click.echo(f"  log_level: {cfg.logging.log_level}")
     click.echo(f"  enable_test_logging: {cfg.logging.enable_test_logging}")
-    click.echo(f"  e2e_progress_interval: {cfg.logging.testing.e2e_progress_interval}")
-    click.echo(f"  e2e_long_job_threshold: {cfg.logging.testing.e2e_long_job_threshold}")
-    click.echo(f"  e2e_show_worker_details: {cfg.logging.testing.e2e_show_worker_details}")
+
+    click.echo("\n[Progress]")
+    click.echo(f"  update_interval: {cfg.progress.update_interval}")
+    click.echo(f"  long_job_threshold: {cfg.progress.long_job_threshold}")
+    click.echo(f"  show_worker_details: {cfg.progress.show_worker_details}")
 
     click.echo("\n[Jupyter]")
     click.echo(f"  jinja_line_statement_prefix: {cfg.jupyter.jinja_line_statement_prefix}")

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -9,8 +9,10 @@ their `CLM_*_DB_PATH` environment variables (resolved once in `clm.cli.main`).
 A parallel `[paths]` config section / `CLM_PATHS__*` family used to shadow them
 but never actually relocated the database a command opened — it has been
 removed. The `USE_SQLITE_QUEUE` flag is also gone: SQLite is the only job queue,
-so the switch had no effect. These are **hard cuts** — the old names no longer
-work.
+so the switch had no effect. Several env vars that duplicated a nested config
+key (`CLM_DB_PATH`, the `CLM_E2E_*` progress knobs) were renamed to their
+canonical `CLM_<SECTION>__<KEY>` form. These are **hard cuts** — the old names
+no longer work.
 
 | Removed variable | Replacement | Notes |
 |---|---|---|
@@ -19,9 +21,14 @@ work.
 | `CLM_PATHS__WORKSPACE_PATH` | *(none)* | Was vestigial; the worker workspace is derived from the output dir. |
 | `[paths]` section in `clm.toml` / `.clm/config.toml` | CLI options / `CLM_*_DB_PATH` | An old `[paths]` block still loads (it is ignored). |
 | `USE_SQLITE_QUEUE` | *(none)* | SQLite is the only queue; the flag had no consumer. |
+| `CLM_DB_PATH` | `CLM_JOBS_DB_PATH` | The legacy jobs-DB auto-detect for `clm status` / `monitor`; the `CLM_JOBS_DB_PATH` form is now the only one. |
+| `CLM_E2E_PROGRESS_INTERVAL` | `CLM_PROGRESS__UPDATE_INTERVAL` | Build progress-log interval (drives real builds, not just E2E tests). Also `[progress] update_interval` in `clm.toml`. |
+| `CLM_E2E_LONG_JOB_THRESHOLD` | `CLM_PROGRESS__LONG_JOB_THRESHOLD` | `[progress] long_job_threshold`. |
+| `CLM_E2E_SHOW_WORKER_DETAILS` | `CLM_PROGRESS__SHOW_WORKER_DETAILS` | `[progress] show_worker_details`. |
 
-`CLM_DB_PATH` (the legacy jobs-DB auto-detect used by `clm status` / `monitor`)
-still works but is superseded by `CLM_JOBS_DB_PATH`, which now takes precedence.
+The worker-count cap keeps its friendly short env var: **`CLM_MAX_WORKERS`** is
+the canonical spelling (the env form of the `[worker_management] max_workers_cap`
+config field). Nothing there was removed.
 
 Run `clm config show` (or `clm config show --json`) to see the **effective**
 database paths and configuration for the current invocation.

--- a/src/clm/cli/status/collector.py
+++ b/src/clm/cli/status/collector.py
@@ -58,11 +58,10 @@ class StatusCollector:
 
     def _get_default_db_path(self) -> Path:
         """Get default database path from environment or config."""
-        # Prefer CLM_JOBS_DB_PATH — the env var for the global ``--jobs-db-path``
-        # that ``clm build`` honors — so ``clm status`` / ``clm monitor`` open the
-        # same jobs DB a redirected build wrote (e.g. a RAM-disk path). Fall back
-        # to the legacy CLM_DB_PATH for compatibility.
-        db_path = os.getenv("CLM_JOBS_DB_PATH") or os.getenv("CLM_DB_PATH")
+        # CLM_JOBS_DB_PATH is the env var for the global ``--jobs-db-path`` that
+        # ``clm build`` honors, so ``clm status`` / ``clm monitor`` open the same
+        # jobs DB a redirected build wrote (e.g. a RAM-disk path).
+        db_path = os.getenv("CLM_JOBS_DB_PATH")
         if db_path:
             return Path(db_path)
 

--- a/src/clm/infrastructure/config.py
+++ b/src/clm/infrastructure/config.py
@@ -183,22 +183,27 @@ class ExternalToolsConfig(BaseModel):
     )
 
 
-class LoggingTestingConfig(BaseModel):
-    """Test-specific logging configuration."""
+class ProgressConfig(BaseModel):
+    """Build progress-reporting configuration.
 
-    e2e_progress_interval: int = Field(
-        default=10,
-        description="Progress update interval for E2E tests (seconds)",
+    Drives the :class:`ProgressTracker` used by every build (via
+    ``get_progress_tracker_config``) — not a test-only knob, despite the
+    former ``logging.testing.e2e_*`` home these settings used to live under.
+    """
+
+    update_interval: int = Field(
+        default=5,
+        description="Seconds between progress log updates",
     )
 
-    e2e_long_job_threshold: int = Field(
-        default=60,
-        description="Long job warning threshold (seconds)",
+    long_job_threshold: int = Field(
+        default=30,
+        description="Seconds before warning about a long-running job",
     )
 
-    e2e_show_worker_details: bool = Field(
-        default=False,
-        description="Show worker details in E2E tests",
+    show_worker_details: bool = Field(
+        default=True,
+        description="Show per-worker details in progress output",
     )
 
 
@@ -213,11 +218,6 @@ class LoggingConfig(BaseModel):
     enable_test_logging: bool = Field(
         default=False,
         description="Enable logging for tests",
-    )
-
-    testing: LoggingTestingConfig = Field(
-        default_factory=LoggingTestingConfig,
-        description="Test-specific logging settings",
     )
 
     @field_validator("log_level")
@@ -772,6 +772,11 @@ class ClmConfig(BaseSettings):
         description="Logging configuration",
     )
 
+    progress: ProgressConfig = Field(
+        default_factory=ProgressConfig,
+        description="Build progress-reporting configuration",
+    )
+
     jupyter: JupyterConfig = Field(
         default_factory=JupyterConfig,
         description="Jupyter notebook processing configuration",
@@ -1087,18 +1092,18 @@ log_level = "INFO"
 # Environment variable: CLM_LOGGING__ENABLE_TEST_LOGGING
 enable_test_logging = false
 
-[logging.testing]
-# Progress update interval for E2E tests (seconds)
-# Environment variable: CLM_LOGGING__TESTING__E2E_PROGRESS_INTERVAL
-e2e_progress_interval = 10
+[progress]
+# Seconds between build progress log updates
+# Environment variable: CLM_PROGRESS__UPDATE_INTERVAL
+update_interval = 5
 
-# Long job warning threshold (seconds)
-# Environment variable: CLM_LOGGING__TESTING__E2E_LONG_JOB_THRESHOLD
-e2e_long_job_threshold = 60
+# Seconds before warning about a long-running job
+# Environment variable: CLM_PROGRESS__LONG_JOB_THRESHOLD
+long_job_threshold = 30
 
-# Show worker details in E2E tests
-# Environment variable: CLM_LOGGING__TESTING__E2E_SHOW_WORKER_DETAILS
-e2e_show_worker_details = false
+# Show per-worker details in progress output
+# Environment variable: CLM_PROGRESS__SHOW_WORKER_DETAILS
+show_worker_details = true
 
 [jupyter]
 # Jinja2 line statement prefix for template processing

--- a/src/clm/infrastructure/workers/pool_manager.py
+++ b/src/clm/infrastructure/workers/pool_manager.py
@@ -1147,7 +1147,7 @@ if __name__ == "__main__":
     )
 
     # Example configuration
-    db_path = Path(os.getenv("CLM_DB_PATH", "clm_jobs.db"))
+    db_path = Path(os.getenv("CLM_JOBS_DB_PATH", "clm_jobs.db"))
     workspace_path = Path(os.getenv("CLM_WORKSPACE_PATH", os.getcwd()))
 
     logger.info("Configuration:")

--- a/src/clm/infrastructure/workers/progress_tracker.py
+++ b/src/clm/infrastructure/workers/progress_tracker.py
@@ -5,7 +5,6 @@ for monitoring job execution during e2e tests and production workloads.
 """
 
 import logging
-import os
 import threading
 from collections import defaultdict
 from collections.abc import Callable
@@ -370,14 +369,22 @@ class ProgressTracker:
 
 
 def get_progress_tracker_config() -> dict:
-    """Get progress tracker configuration from environment variables.
+    """Progress-tracker configuration, resolved through the config system.
+
+    Reads the ``[progress]`` config section (env: ``CLM_PROGRESS__*``, or a
+    ``clm.toml`` block), which ``ClmConfig`` already folds over env > file >
+    default. Phase 5 of the config/CLI/env unification replaced the raw
+    ``CLM_E2E_*`` reads; the defaults match the values the build had always
+    used (5s / 30s / show-details), so build behaviour is unchanged.
 
     Returns:
-        Dictionary with configuration values
+        Dictionary with configuration values.
     """
+    from clm.infrastructure.config import get_config
+
+    progress = get_config().progress
     return {
-        "progress_interval": float(os.environ.get("CLM_E2E_PROGRESS_INTERVAL", "5.0")),
-        "long_job_threshold": float(os.environ.get("CLM_E2E_LONG_JOB_THRESHOLD", "30.0")),
-        "show_worker_details": os.environ.get("CLM_E2E_SHOW_WORKER_DETAILS", "true").lower()
-        in ("true", "1", "yes"),
+        "progress_interval": float(progress.update_interval),
+        "long_job_threshold": float(progress.long_job_threshold),
+        "show_worker_details": progress.show_worker_details,
     }

--- a/tests/cli/test_status_collector.py
+++ b/tests/cli/test_status_collector.py
@@ -372,21 +372,10 @@ class TestStatusCollector:
         would leave `clm status` / `clm monitor` opening a different, idle DB.
         """
         monkeypatch.chdir(tmp_path)
-        monkeypatch.delenv("CLM_DB_PATH", raising=False)
         # The anchored default exists, but the env var must take precedence.
         (tmp_path / "clm_jobs.db").touch()
         target = tmp_path / "ram" / "jobs.db"
         monkeypatch.setenv("CLM_JOBS_DB_PATH", str(target))
-
-        collector = StatusCollector()
-        assert collector.db_path == target
-
-    def test_default_db_path_legacy_env_still_works(self, tmp_path, monkeypatch):
-        """The legacy CLM_DB_PATH still works when CLM_JOBS_DB_PATH is unset."""
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.delenv("CLM_JOBS_DB_PATH", raising=False)
-        target = tmp_path / "legacy.db"
-        monkeypatch.setenv("CLM_DB_PATH", str(target))
 
         collector = StatusCollector()
         assert collector.db_path == target

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,8 @@ To enable logging for any test:
 Environment variables:
 - CLM_LOG_LEVEL: Set log level (DEBUG, INFO, WARNING, ERROR) - default: INFO
 - CLM_ENABLE_TEST_LOGGING: Enable logging for all tests (set to any value)
-- CLM_E2E_PROGRESS_INTERVAL: Seconds between progress updates (default: 5)
-- CLM_E2E_LONG_JOB_THRESHOLD: Seconds before warning about long jobs (default: 30)
+- CLM_PROGRESS__UPDATE_INTERVAL: Seconds between progress updates (default: 5)
+- CLM_PROGRESS__LONG_JOB_THRESHOLD: Seconds before warning about long jobs (default: 30)
 """
 
 # ---------------------------------------------------------------------------
@@ -703,8 +703,8 @@ def configure_test_logging(request):
 
     Environment variables:
     - CLM_LOG_LEVEL: Log level (DEBUG, INFO, WARNING, ERROR) - default: INFO
-    - CLM_E2E_PROGRESS_INTERVAL: Seconds between progress updates (default: 5)
-    - CLM_E2E_LONG_JOB_THRESHOLD: Seconds before warning about long jobs (default: 30)
+    - CLM_LOGGING__TESTING__E2E_PROGRESS_INTERVAL: Seconds between progress updates (default: 5)
+    - CLM_LOGGING__TESTING__E2E_LONG_JOB_THRESHOLD: Seconds before warning about long jobs (default: 30)
     """
     # Get log level from environment, default to INFO
     log_level_name = os.environ.get("CLM_LOG_LEVEL", "INFO").upper()

--- a/tests/infrastructure/test_config.py
+++ b/tests/infrastructure/test_config.py
@@ -45,15 +45,22 @@ class TestConfigDefaults:
     def test_default_logging(self, monkeypatch):
         """Test default logging configuration."""
         # Clear any environment variables that might interfere
-        for var in ["CLM_LOGGING__LOG_LEVEL", "CLM_LOGGING__ENABLE_TEST_LOGGING"]:
+        for var in [
+            "CLM_LOGGING__LOG_LEVEL",
+            "CLM_LOGGING__ENABLE_TEST_LOGGING",
+            "CLM_PROGRESS__UPDATE_INTERVAL",
+            "CLM_PROGRESS__LONG_JOB_THRESHOLD",
+            "CLM_PROGRESS__SHOW_WORKER_DETAILS",
+        ]:
             monkeypatch.delenv(var, raising=False)
 
         config = ClmConfig()
         assert config.logging.log_level == "INFO"
         assert config.logging.enable_test_logging is False
-        assert config.logging.testing.e2e_progress_interval == 10
-        assert config.logging.testing.e2e_long_job_threshold == 60
-        assert config.logging.testing.e2e_show_worker_details is False
+        # Progress defaults match the build's live progress behaviour.
+        assert config.progress.update_interval == 5
+        assert config.progress.long_job_threshold == 30
+        assert config.progress.show_worker_details is True
 
     def test_default_external_tools(self, monkeypatch):
         """Test default external tools configuration."""
@@ -103,14 +110,14 @@ class TestEnvironmentVariables:
 
     def test_nested_env_vars(self, monkeypatch):
         """Test nested environment variables with double underscores."""
-        monkeypatch.setenv("CLM_LOGGING__TESTING__E2E_PROGRESS_INTERVAL", "5")
-        monkeypatch.setenv("CLM_LOGGING__TESTING__E2E_LONG_JOB_THRESHOLD", "30")
-        monkeypatch.setenv("CLM_LOGGING__TESTING__E2E_SHOW_WORKER_DETAILS", "true")
+        monkeypatch.setenv("CLM_PROGRESS__UPDATE_INTERVAL", "5")
+        monkeypatch.setenv("CLM_PROGRESS__LONG_JOB_THRESHOLD", "30")
+        monkeypatch.setenv("CLM_PROGRESS__SHOW_WORKER_DETAILS", "true")
 
         config = ClmConfig()
-        assert config.logging.testing.e2e_progress_interval == 5
-        assert config.logging.testing.e2e_long_job_threshold == 30
-        assert config.logging.testing.e2e_show_worker_details is True
+        assert config.progress.update_interval == 5
+        assert config.progress.long_job_threshold == 30
+        assert config.progress.show_worker_details is True
 
     def test_legacy_env_vars(self, monkeypatch):
         """Test legacy environment variables without CLM_ prefix."""
@@ -445,10 +452,10 @@ drawio_executable = "/test/drawio"
 log_level = "DEBUG"
 enable_test_logging = true
 
-[logging.testing]
-e2e_progress_interval = 5
-e2e_long_job_threshold = 30
-e2e_show_worker_details = true
+[progress]
+update_interval = 5
+long_job_threshold = 30
+show_worker_details = true
 
 [jupyter]
 jinja_line_statement_prefix = "## custom"
@@ -469,9 +476,9 @@ worker_id = "test-worker-1"
         assert config.external_tools.drawio_executable == "/test/drawio"
         assert config.logging.log_level == "DEBUG"
         assert config.logging.enable_test_logging is True
-        assert config.logging.testing.e2e_progress_interval == 5
-        assert config.logging.testing.e2e_long_job_threshold == 30
-        assert config.logging.testing.e2e_show_worker_details is True
+        assert config.progress.update_interval == 5
+        assert config.progress.long_job_threshold == 30
+        assert config.progress.show_worker_details is True
         assert config.jupyter.jinja_line_statement_prefix == "## custom"
         assert config.jupyter.jinja_templates_path == "/test/templates"
         assert config.jupyter.log_cell_processing is True

--- a/tests/infrastructure/workers/test_progress_tracker_extended.py
+++ b/tests/infrastructure/workers/test_progress_tracker_extended.py
@@ -376,30 +376,21 @@ class TestSetStage:
 
 
 class TestGetProgressTrackerConfig:
-    """Test get_progress_tracker_config function."""
+    """get_progress_tracker_config reads [logging.testing] via the config system."""
 
-    def test_default_config(self):
-        """Should return default config."""
-        config = get_progress_tracker_config()
+    def test_reads_from_config(self):
+        """Values come from ClmConfig.progress (env/file precedence lives there)."""
+        fake_cfg = MagicMock()
+        fake_cfg.progress.update_interval = 7  # int → coerced to float
+        fake_cfg.progress.long_job_threshold = 42
+        fake_cfg.progress.show_worker_details = False
 
-        assert config["progress_interval"] == 5.0
-        assert config["long_job_threshold"] == 30.0
-        assert config["show_worker_details"] is True
-
-    def test_config_from_environment(self):
-        """Should read from environment variables."""
-        with patch.dict(
-            os.environ,
-            {
-                "CLM_E2E_PROGRESS_INTERVAL": "10.0",
-                "CLM_E2E_LONG_JOB_THRESHOLD": "60.0",
-                "CLM_E2E_SHOW_WORKER_DETAILS": "false",
-            },
-        ):
+        with patch("clm.infrastructure.config.get_config", return_value=fake_cfg):
             config = get_progress_tracker_config()
 
-        assert config["progress_interval"] == 10.0
-        assert config["long_job_threshold"] == 60.0
+        assert config["progress_interval"] == 7.0
+        assert isinstance(config["progress_interval"], float)
+        assert config["long_job_threshold"] == 42.0
         assert config["show_worker_details"] is False
 
 


### PR DESCRIPTION
## Summary

The **final** phase of the config/CLI/env unification (#500). Hard-cuts the env vars that duplicated a canonical config key. Documented in the `clm info migration` table for your rollout email.

Investigation flipped one of the proposal's assumptions, and review caught a naming problem, so the three cuts are:

### `CLM_DB_PATH` → removed (canonical `CLM_JOBS_DB_PATH`)
The legacy jobs-DB auto-detect for `clm status` / `monitor` (the fallback I added in #499). Dropped; `pool_manager.__main__` reads `CLM_JOBS_DB_PATH` too.

### `CLM_E2E_*` → `CLM_PROGRESS__*` (new top-level `[progress]` section)
`get_progress_tracker_config()` now reads a new `[progress]` config section (env `CLM_PROGRESS__UPDATE_INTERVAL` / `CLM_PROGRESS__LONG_JOB_THRESHOLD` / `CLM_PROGRESS__SHOW_WORKER_DETAILS`).

**Naming fix (per review):** these drive the **production** ProgressTracker (via `sqlite_backend`), not just E2E tests — so `CLM_LOGGING__TESTING__E2E_*` would have been actively misleading. They were lifted out of the dead, mis-homed `logging.testing.e2e_*` field (`LoggingTestingConfig` removed) into an accurately-named top-level section. Defaults match the values the build had **always** used (5 s / 30 s / show-details), so **build output is unchanged**. `clm config show` gains a `[Progress]` section.

### `CLM_MAX_WORKERS` → **kept** as canonical (reverses the proposal)
The code showed `CLM_MAX_WORKERS` is the documented, intended short convenience; the *duplicate* is the auto-derived `CLM_WORKER_MANAGEMENT__MAX_WORKERS_CAP`. Nothing removed here — `CLM_MAX_WORKERS` stays and is now documented in `configuration.md`.

## Testing

Updated config/progress-tracker/collector tests for the `[progress]` section and the dropped `CLM_DB_PATH` fallback. Ran `test_config.py`, `test_progress_tracker_extended.py`, `test_status_collector.py`, `test_config_command.py`, `test_sqlite_backend.py` — all green. ruff/mypy clean; pre-push fast suite green.

## Program complete

Finishes `docs/proposals/config-cli-precedence-unification.md`: one precedence order everywhere, the inert `[external_tools]` / `[logging]` / `[jupyter]` sections wired to actually take effect, duplicate env spellings unified, and a real `[progress]` section for build progress. `clm config show` (and `--json`) reports the true effective config; `clm info migration` lists every removed/renamed variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
