### PR TITLE
test: isolate CLM_*_DB_PATH env vars so default-detection tests are hermetic

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -161,6 +161,41 @@ def _isolate_http_replay_env():
                 os.environ[key] = value
 
 
+@pytest.fixture(autouse=True)
+def _isolate_db_path_env():
+    """Clear the ``CLM_*_DB_PATH`` env vars for the duration of every test.
+
+    The cache / jobs / telemetry DB paths *default* to a project-root-anchored
+    location (issue #477). A developer who points one at a scratch disk in their
+    shell — e.g. ``CLM_JOBS_DB_PATH=Z:\\clm_jobs.db`` — would otherwise have that
+    value bleed into the test process and override the default *inside* every
+    test that asserts the resolved default (``test_default_db_path_detection``,
+    the db-path anchoring sweep, …). CI runs with a clean environment, so such a
+    test passes in CI but fails on the configured dev machine — exactly the
+    ambient-environment dependence a hermetic suite must not have.
+
+    Snapshotting, clearing, and restoring here makes default-path resolution
+    deterministic regardless of the developer's shell. A test that needs a
+    specific path *set* does so in its own body via ``monkeypatch.setenv``
+    (test_status_collector's env-var tests, test_sqlite_backend_resilience's
+    decoy) — that runs after this fixture, so those are unaffected. Mirrors the
+    ``_isolate_http_replay_env`` / ``_neutralise_pool_size_cap`` precedents.
+    """
+    keys = (
+        "CLM_CACHE_DB_PATH",
+        "CLM_JOBS_DB_PATH",
+        "CLM_TELEMETRY_DB_PATH",
+        "CLM_DB_PATH",
+    )
+    saved = {k: os.environ.pop(k, None) for k in keys}
+    try:
+        yield
+    finally:
+        for key, value in saved.items():
+            if value is not None:
+                os.environ[key] = value
+
+
 # ====================================================================
 # Tool Availability Detection
 # ====================================================================


### PR DESCRIPTION
## Problem

Two tests assert the *default* (project-root-anchored, #477) DB path:

- `tests/cli/test_cli_db_path_anchoring.py::test_default_db_paths_anchor_to_root_from_subdir`
- `tests/cli/test_status_collector.py::TestStatusCollector::test_default_db_path_detection`

They read the ambient environment, so a developer who points a DB at a scratch/RAM disk in their shell — e.g. `CLM_JOBS_DB_PATH=Z:\clm_jobs.db` — has that value bleed into the test process and override the default the tests assert:

```
assert 'JOBS=...\repo\clm_jobs.db' in 'CACHE=...\repo\clm_cache.db\nJOBS=Z:\clm_jobs.db\n'
```

CI (clean env) passes; the configured dev machine fails. That ambient-environment dependence is exactly what a hermetic suite must not have — and it's what surfaced during local pre-push runs.

## Fix

A global autouse fixture `_isolate_db_path_env` in `tests/conftest.py` that snapshots, **clears**, and restores `CLM_CACHE_DB_PATH` / `CLM_JOBS_DB_PATH` / `CLM_TELEMETRY_DB_PATH` / `CLM_DB_PATH` around every test — mirroring the existing `_isolate_http_replay_env` (restore-around) and `_neutralise_pool_size_cap` (`delenv`) precedents.

Tests that need a specific path *set* do so in their own body via `monkeypatch.setenv` (runs after the fixture), so `test_status_collector`'s env-var tests and `test_sqlite_backend_resilience`'s decoy are unaffected.

## Verification

- With `CLM_JOBS_DB_PATH` **and** `CLM_CACHE_DB_PATH` set in the environment, the affected suites go from 2 failing → **47 passed**.
- The full fast suite passes through the pre-push gate **with `CLM_JOBS_DB_PATH` still set** in the ambient shell.

Found while running Phase 0 of #501 locally; independent of that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
