### PR TITLE
fix(recordings): language-aware split decks + collapsible sections

### DIFF
--- a/changelog.d/recordings-split-deck-language.fixed.md
+++ b/changelog.d/recordings-split-deck-language.fixed.md
@@ -1,0 +1,15 @@
+- **Recordings dashboard: split decks no longer show both languages at once.**
+  The lecture list enumerated every notebook in a section, so a split deck
+  (`slides_foo.de.py` + `slides_foo.en.py`) appeared as two rows regardless of
+  the selected language. The DE/EN toggle now filters split companions by their
+  `output_language_filter`, so it actually switches between languages and a
+  split deck contributes a single row.
+- **Recordings dashboard: same-named DE/EN decks are controlled independently.**
+  When a split deck's German and English titles coincided, both rows shared a
+  `deck_name` and reacted to a single Record/Arm/Stop control (recording one
+  language appeared to record the other). The row-level armed match now also
+  compares the recording language, so DE and EN versions of a deck can be
+  recorded independently.
+- **Recordings dashboard: section cards are collapsible.** Each section is now a
+  `<details>` block whose open/closed state is remembered across live updates,
+  so a long lecture list can be collapsed down instead of scrolling.

--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -288,6 +288,20 @@ async def lectures(request: Request):
                 decks = []
                 section_name = section.name[lang]
                 for nb in section.notebooks:
+                    # Split decks live as two source files (``foo.de.py`` /
+                    # ``foo.en.py``); both are separate notebooks that share a
+                    # slot number, so ``section.notebooks`` yields both. Each
+                    # split companion carries an intrinsic
+                    # ``output_language_filter`` ("de"/"en"); skip the ones
+                    # that don't match the language currently being shown so a
+                    # split deck contributes a single row for the selected
+                    # language instead of one row per companion (which, when
+                    # the DE/EN titles coincide, share a name and both react
+                    # to the same control). Bilingual notebooks leave the
+                    # filter ``None`` and always show.
+                    nb_lang = getattr(nb, "output_language_filter", None)
+                    if nb_lang in ("de", "en") and nb_lang != lang:
+                        continue
                     deck_name = nb.file_name(lang, "")
                     decks.append(
                         {

--- a/src/clm/recordings/web/static/app.css
+++ b/src/clm/recordings/web/static/app.css
@@ -292,6 +292,30 @@ footer {
     flex-wrap: wrap;
 }
 
+/* Collapsible section cards (lectures page). The section header is a
+   <summary>; hide the native disclosure triangle and use a chevron that
+   rotates with the open state. Collapse state is persisted client-side
+   (see base.html) so SSE-driven swaps don't reset it. */
+.section-summary {
+    cursor: pointer;
+    list-style: none;      /* Firefox: drop the default marker */
+    user-select: none;
+}
+.section-summary::-webkit-details-marker { display: none; }  /* Safari/Chrome */
+.section-chevron {
+    display: inline-block;
+    color: var(--c-fg-muted);
+    font-size: var(--t-sm);
+    transform: rotate(-90deg);   /* collapsed: chevron points right */
+    transition: transform 0.15s ease;
+}
+.section-card[open] > .section-summary .section-chevron {
+    transform: rotate(0deg);     /* expanded: chevron points down */
+}
+/* The header keeps its bottom margin only while the section is open, so a
+   collapsed card is a tight single-line summary. */
+.section-card:not([open]) > .section-summary { margin-bottom: 0; }
+
 /* Buttons */
 .btn {
     display: inline-flex;

--- a/src/clm/recordings/web/templates/base.html
+++ b/src/clm/recordings/web/templates/base.html
@@ -190,6 +190,44 @@
         _hydrateAllChipStrips();
     });
 
+    /* Collapsible-section persistence.
+       Each <details data-section-collapse> remembers its open/closed
+       state in sessionStorage keyed by section name, so the frequent
+       SSE-driven #lectures-dynamic swaps (which re-render every section
+       as `open`) don't undo a section the user collapsed. Restoration
+       runs synchronously inside htmx:afterSwap — before the browser
+       paints the freshly-swapped subtree — so a collapsed section never
+       flashes open. `toggle` doesn't bubble, so the listener is attached
+       in the capture phase to catch it from the document root. */
+    var SECTION_STORAGE_PREFIX = 'clm:sectionOpen:';
+    function _restoreSectionCollapse(scope) {
+        var root = scope || document;
+        root.querySelectorAll('[data-section-collapse]').forEach(function (d) {
+            var key = d.getAttribute('data-section-key');
+            if (!key) return;
+            var stored;
+            try { stored = sessionStorage.getItem(SECTION_STORAGE_PREFIX + key); }
+            catch (e) { stored = null; }
+            if (stored === 'closed') d.removeAttribute('open');
+            else if (stored === 'open') d.setAttribute('open', '');
+        });
+    }
+    document.addEventListener('toggle', function (evt) {
+        var d = evt.target;
+        if (!d || !d.hasAttribute || !d.hasAttribute('data-section-collapse')) return;
+        var key = d.getAttribute('data-section-key');
+        if (!key) return;
+        try {
+            sessionStorage.setItem(SECTION_STORAGE_PREFIX + key, d.open ? 'open' : 'closed');
+        } catch (e) { /* private browsing / quota exceeded — ignore */ }
+    }, true);
+    document.addEventListener('htmx:afterSwap', function () {
+        _restoreSectionCollapse();
+    });
+    document.addEventListener('DOMContentLoaded', function () {
+        _restoreSectionCollapse();
+    });
+
     /* Elapsed-time ticker.
        Any element carrying `data-elapsed-base-seconds="N"` is anchored
        on render (we capture Date.now() at anchor time) and re-rendered

--- a/src/clm/recordings/web/templates/lectures.html
+++ b/src/clm/recordings/web/templates/lectures.html
@@ -93,8 +93,15 @@
 {% endif %}
 
 {% for section in sections %}
-<section class="card">
-    <div class="card-header"><h3 class="card-title">{{ section.name }}</h3></div>
+{# Collapsible section. Rendered ``open`` by default; the collapse state
+   is persisted client-side (see base.html) so the frequent SSE-driven
+   ``#lectures-dynamic`` swaps don't re-expand a section the user closed.
+   ``data-section-key`` keys that persistence. #}
+<details class="card section-card" open data-section-collapse data-section-key="{{ section.name }}">
+    <summary class="card-header section-summary">
+        <h3 class="card-title">{{ section.name }}</h3>
+        <span class="section-chevron" aria-hidden="true">▾</span>
+    </summary>
     <table>
         <thead>
             <tr>
@@ -105,7 +112,7 @@
         </thead>
         <tbody>
             {% for deck in section.decks %}
-            {% set is_armed = snapshot.armed_deck and snapshot.armed_deck.deck_name == deck.deck_name and snapshot.armed_deck.section_name == section.name %}
+            {% set is_armed = snapshot.armed_deck and snapshot.armed_deck.deck_name == deck.deck_name and snapshot.armed_deck.section_name == section.name and snapshot.armed_deck.lang == lang %}
             {% set armed_part = snapshot.armed_deck.part_number if is_armed else 0 %}
             {% set has_existing_parts = deck.status and deck.status.parts_status %}
             {% set unprocessed_count = deck.status.raw_parts | length if deck.status else 0 %}
@@ -250,7 +257,7 @@
             {% endfor %}
         </tbody>
     </table>
-</section>
+</details>
 {% endfor %}
 
 {% if not sections and not error %}

--- a/tests/recordings/test_web.py
+++ b/tests/recordings/test_web.py
@@ -151,6 +151,102 @@ class TestLectures:
         assert "Week 1" in resp.text
         assert "01 Introduction" in resp.text
 
+    @staticmethod
+    def _set_split_course(app, *, de_name: str, en_name: str) -> None:
+        """Cache a course with one *split* deck (``.de.py`` + ``.en.py``).
+
+        A split deck lives as two separate ``NotebookFile`` objects that
+        share a slot number; each carries an ``output_language_filter``
+        ("de"/"en"). ``section.notebooks`` yields both, so the lectures
+        route must pick the one matching the shown language.
+        """
+        from clm.core.utils.text_utils import Text
+
+        mock_course = MagicMock()
+        mock_section = MagicMock()
+        mock_section.name = Text(de="Woche 1", en="Week 1")
+
+        de_nb = MagicMock()
+        de_nb.title = Text(de="Einführung", en="Einführung")
+        de_nb.number_in_section = 1
+        de_nb.output_language_filter = "de"
+        de_nb.file_name.return_value = de_name
+
+        en_nb = MagicMock()
+        en_nb.title = Text(de="Introduction", en="Introduction")
+        en_nb.number_in_section = 1
+        en_nb.output_language_filter = "en"
+        en_nb.file_name.return_value = en_name
+
+        mock_section.notebooks = [de_nb, en_nb]
+        mock_course.sections = [mock_section]
+        mock_course.output_dir_name = Text(de="kurs-de", en="course-en")
+        app.state.course = mock_course
+
+    def test_split_deck_shows_only_selected_language(self, app, recording_root: Path):
+        """A split deck contributes one row for the shown language, not both.
+
+        Both ``.de.py`` and ``.en.py`` companions are separate notebooks;
+        the route filters by ``output_language_filter`` so switching the
+        DE/EN toggle actually switches languages instead of listing both.
+        """
+        self._set_split_course(app, de_name="01 Einführung", en_name="01 Introduction")
+
+        with TestClient(app) as c:  # default cookie -> "de"
+            de_html = c.get("/lectures").text
+        assert "01 Einführung" in de_html
+        assert "01 Introduction" not in de_html
+
+        with TestClient(app, cookies={"clm_lang": "en"}) as c:
+            en_html = c.get("/lectures").text
+        assert "01 Introduction" in en_html
+        assert "01 Einführung" not in en_html
+
+    def test_split_deck_same_name_yields_single_row(self, app, recording_root: Path):
+        """When the DE and EN titles coincide, only one row shows per language.
+
+        This is the collision the user hit: both companions rendered the
+        same ``deck_name`` and reacted to a single control. Filtering by
+        language collapses them to one row.
+        """
+        self._set_split_course(app, de_name="01 Intro", en_name="01 Intro")
+
+        with TestClient(app) as c:  # "de"
+            html = c.get("/lectures").text
+        # ``data-deck-row`` also appears as a JS selector in base.html, so
+        # count the row-specific attribute sequence that only the <tr>
+        # emits — exactly once per rendered deck row.
+        assert html.count("data-deck-row data-deck-key=") == 1
+
+    def test_armed_deck_not_marked_in_other_language(self, app, recording_root: Path):
+        """A deck armed in DE must not appear armed when viewing EN.
+
+        Even with identical DE/EN deck names, the row-level armed match
+        compares ``lang`` so the other language's row stays inert — the
+        precondition for recording DE and EN independently.
+        """
+        self._set_split_course(app, de_name="01 Intro", en_name="01 Intro")
+        session = app.state.session
+        session.arm("kurs-de", "Woche 1", "01 Intro", lang="de")
+
+        with TestClient(app) as c:  # "de" — same language as the arm
+            de_html = c.get("/lectures").text
+        assert 'class="row-armed"' in de_html
+
+        with TestClient(app, cookies={"clm_lang": "en"}) as c:
+            en_html = c.get("/lectures").text
+        assert 'class="row-armed"' not in en_html
+
+    def test_sections_are_collapsible(self, app, recording_root: Path):
+        """Section cards render as persisted-collapsible ``<details>`` blocks."""
+        self._set_split_course(app, de_name="01 Einführung", en_name="01 Introduction")
+
+        with TestClient(app) as c:
+            html = c.get("/lectures").text
+        assert "<details" in html
+        assert "data-section-collapse" in html
+        assert 'data-section-key="Woche 1"' in html
+
     def test_lectures_shows_course_slug(self, app, recording_root: Path):
         """The arm form should include the correct course_slug."""
         from clm.core.utils.text_utils import Text
@@ -196,8 +292,11 @@ class TestLectures:
         app.state.course = mock_course
 
         # Arm and move the session into RECORDING with a known start time.
+        # Arm in the language the page is rendered in (default cookie "de")
+        # so the row-level armed match — which now compares lang — holds,
+        # mirroring the cookie-driven /arm route in production.
         session = app.state.session
-        session.arm("kurs-de", "Woche 1", "01 Intro")
+        session.arm("kurs-de", "Woche 1", "01 Intro", lang="de")
         with session._lock:
             session._state = SessionState.RECORDING
             session._recording_started_at = _time.monotonic() - 12.0
@@ -1642,7 +1741,9 @@ class TestPartsInlineChipStrip:
         """When a deck is armed, its chip strip carries data-armed-part."""
         self._set_course(app)
         session = app.state.session
-        session.arm("kurs-de", "W1", "01 Hello", part_number=2)
+        # Default view lang is "de"; arm in the same language so the
+        # row-level armed match (which compares lang) holds.
+        session.arm("kurs-de", "W1", "01 Hello", part_number=2, lang="de")
 
         with TestClient(app) as c:
             html = c.get("/lectures").text


### PR DESCRIPTION
## Problem

Three UX issues in the **recordings dashboard** lecture list, all rooted in how split decks are enumerated:

1. **Split decks show both languages at once.** A split deck (`slides_foo.de.py` + `slides_foo.en.py`) is two `NotebookFile` objects sharing one slot number; `section.notebooks` yields both, and the `/lectures` route emitted a row for each — regardless of the language shown.
2. **Same-named DE/EN decks share controls.** When the German and English titles coincide, both rows render an identical `deck_name`. Because deck identity was `(section_name, deck_name)` only (including in the template's `is_armed` test), recording the German deck also lit up the English one, so the two could not be recorded independently.
3. **Long lecture lists don't collapse.** Every section was a flat, always-expanded card, forcing a long scroll.

## Fix

- **Filter split companions by language** in the `/lectures` route using `output_language_filter` ("de"/"en"), so the existing DE/EN toggle actually switches languages and a split deck contributes a single row. Bilingual notebooks (`output_language_filter is None`) are unaffected.
- **Language-aware `is_armed`**: the row-level armed match now also compares the recording language, so a deck armed in one language never appears armed in the other. In production, arm-lang always equals view-lang (both from the `clm_lang` cookie), so this only affects the cross-language case.
- **Collapsible section cards**: sections render as `<details>` blocks whose collapsed state is persisted in `sessionStorage` and restored inside `htmx:afterSwap` (before paint), so the frequent SSE-driven `#lectures-dynamic` swaps don't re-expand a section the user closed.

## Tests

New cases in `tests/recordings/test_web.py`:
- `test_split_deck_shows_only_selected_language` — DE/EN filtering.
- `test_split_deck_same_name_yields_single_row` — de-dup when titles coincide.
- `test_armed_deck_not_marked_in_other_language` — cross-language armed independence.
- `test_sections_are_collapsible` — collapsible `<details>` markup.

Two existing tests that armed the session directly (bypassing the cookie-driven route) were updated to arm with `lang="de"` to match their default view, mirroring production.

Full recordings suite (863 tests) passes; ruff + mypy clean; pre-push fast suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
