### PR TITLE
feat(sync): companion-aware read modes for separated voiceover (#501 Phase 1)

### DIFF
--- a/changelog.d/501-sync-companion-read-modes.added.md
+++ b/changelog.d/501-sync-companion-read-modes.added.md
@@ -1,0 +1,16 @@
+- **`clm slides sync` now sees separated voiceover companions (read modes).**
+  When a split deck keeps its voiceover in separated companion files
+  (`voiceover_*.de.py` / `voiceover_*.en.py`), `sync report` / `verify` /
+  `diagnose` inline each companion in memory and reconcile the narration like any
+  other cell — so a companion edited on only one language now surfaces as
+  `add …/voiceover [translation pending]` instead of drifting silently until
+  `clm validate` (issue #501). A standing, in-sync separated pair reports **0
+  changes** (the git-HEAD baseline is projected the same way, so a companion
+  present on both sides is not mistaken for a new add). Pointing `sync` at a
+  `voiceover_*` file now reconciles its deck pair. A deck whose voiceover is
+  stored *both* inline and in a companion (mixed), or inconsistently across the
+  two languages (one inline, one separated), is refused with a normalize hint, and
+  an orphaned companion cell (its slide was renamed or removed) refuses rather than
+  dropping the narration. Applying the reconciliation (the four-file write-back) is
+  not yet implemented — `sync apply` on a separated pair reports the drift and
+  writes nothing.

--- a/docs/claude/design/sync-separated-voiceover-companions.md
+++ b/docs/claude/design/sync-separated-voiceover-companions.md
@@ -492,3 +492,15 @@ line and asserts no working-tree re-read.
   by the walker. A known ceiling for a future native-awareness v2.
 - **Mixed decks stay unsupported by design;** the refusal is the safety net.
   Reopening partial splits reopens obstacle 2 (provenance) as a separate design.
+- **A *standing* one-sided narration propagates, it is not suppressed (Phase 1
+  finding).** §5.5 anticipated that with the inlined baseline a *standing* one-sided
+  asymmetry would classify as `in_sync` and only a *genuinely new* narrative would
+  propagate. In practice the engine's narrative-add detection is a **current-state
+  pairing gap**, not a baseline delta: a narrative present on one half with no twin
+  on the other proposes `add …/voiceover [translation pending]` regardless of the
+  baseline — and it already does so today for a *standing one-sided inline*
+  voiceover (a committed, unchanged deck). Phase 1 therefore keeps companion
+  behavior **identical to inline** (propagate, the core ask) rather than adding a
+  baseline-aware suppression that would diverge companion from inline and change
+  shipped inline behavior. Suppressing a deliberately-permanent one-sided asymmetry
+  is a separate, engine-wide narrative-baseline refinement (deferred).

--- a/src/clm/cli/commands/slides/sync.py
+++ b/src/clm/cli/commands/slides/sync.py
@@ -98,6 +98,7 @@ from clm.slides.sync_task import (
     build_tasks,
 )
 from clm.slides.sync_verify import VerifyResult, verify_pair
+from clm.slides.voiceover_tools import COMPANION_SUBDIR, resolve_companion
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -178,6 +179,37 @@ def _resolve_sync_pair(de_path: Path, en_path: Path) -> tuple[Path, Path]:
     return ordered
 
 
+def _deck_for_companion(companion_path: Path) -> Path | None:
+    """Map a ``voiceover_*`` companion argument back to its slide-deck half (#501).
+
+    ``clm slides sync voiceover_x.de.py`` should reconcile the *deck* the companion
+    belongs to. The companion may sit beside the deck or one directory up (a
+    relocated ``voiceover/`` companion), and its stem prefix (``slides_`` / ``topic_``
+    / ``project_`` / none) is not recoverable from the companion name alone — so we
+    generate every candidate deck path and keep the one whose own
+    :func:`resolve_companion` round-trips back to this file. ``None`` when no deck
+    claims the companion.
+    """
+    name = companion_path.name
+    prefix = "voiceover_"
+    if not name.startswith(prefix):
+        return None
+    rest = name[len(prefix) :]  # "<stem>.<lang>.<ext>"
+    deck_dirs = [companion_path.parent]
+    if companion_path.parent.name == COMPANION_SUBDIR:
+        deck_dirs.append(companion_path.parent.parent)
+    resolved = companion_path.resolve()
+    for deck_dir in deck_dirs:
+        for deck_prefix in ("slides_", "topic_", "project_", ""):
+            candidate = deck_dir / f"{deck_prefix}{rest}"
+            if not candidate.exists():
+                continue
+            comp = resolve_companion(candidate)
+            if comp is not None and comp.resolve() == resolved:
+                return candidate
+    return None
+
+
 def _resolve_single_path(de_path: Path, en_path: Path | None) -> tuple[Path, Path]:
     """Single-path contract: when EN_PATH is omitted, derive the second half from
     DE_PATH so the author can run ``clm slides sync <deck>.de.<ext>``.
@@ -198,10 +230,15 @@ def _resolve_single_path(de_path: Path, en_path: Path | None) -> tuple[Path, Pat
         twin = derive_split_twin(de_path)
         if twin is None:
             if de_path.name.startswith("voiceover_"):
+                # Issue #501: pointing sync at a companion reconciles its *deck* pair.
+                deck = _deck_for_companion(de_path)
+                if deck is not None:
+                    return _resolve_single_path(deck, None)
                 raise click.UsageError(
-                    f"{de_path.name} is a voiceover companion, not a deck half; "
-                    f"`clm slides sync` reconciles slide decks (<deck>.de.<ext> / "
-                    f"<deck>.en.<ext>), not their voiceover companions."
+                    f"{de_path.name} is a voiceover companion, but its slide deck could "
+                    f"not be found; expected the deck half (<deck>.de.<ext> / "
+                    f"<deck>.en.<ext>) beside it or one directory up from a "
+                    f"`{COMPANION_SUBDIR}/` companion. Pass the deck half instead."
                 )
             other = "EN" if tag == "de" else "DE"
             raise click.UsageError(

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1775,6 +1775,21 @@ clm slides sync autopilot DECK [opts]              # legacy all-in-one WITH mode
 `--llm-timeout`) and the legacy write-everything behavior all live on
 **`autopilot`** now; never run `autopilot` in CI.
 
+**Separated voiceover companions (read modes, since CLM {version}).** When a
+deck keeps its voiceover in **separated companion files** (`voiceover_*.de.<ext>`
+/ `voiceover_*.en.<ext>`, the sticky default after `clm voiceover extract`), the
+read verbs (`report` / `verify` / `diagnose`) inline each companion **in memory**
+and reconcile the narration like any other cell — so a companion edited on only
+one language surfaces as `add …/voiceover [translation pending]` instead of
+drifting silently until `clm validate`. A standing, in-sync separated pair still
+reports **0 changes**. Pointing sync at a `voiceover_*` file reconciles its deck
+pair. A deck that keeps voiceover **both** inline and in a companion (mixed), or
+inconsistently across the two languages (one inline, one separated), is refused
+with a normalize hint (`clm voiceover inline` / `extract`); an orphaned companion
+cell (its slide was renamed or removed) is refused rather than dropped.
+*Applying* the reconciliation (the four-file write-back) is not yet implemented —
+`apply` on a separated pair reports the drift and writes nothing.
+
 **Pairing guard (since CLM {version}).** Before anything is read or written,
 sync checks that `DE_PATH` and `EN_PATH` are the two halves of **one** deck —
 one `.de` half and one `.en` half of the same name (the routing prefix is not

--- a/src/clm/infrastructure/llm/cache.py
+++ b/src/clm/infrastructure/llm/cache.py
@@ -839,6 +839,16 @@ class SyncWatermarkCache:
         meta_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(sync_watermark_meta)")}
         if "hash_version" not in meta_cols:
             self._conn.execute("ALTER TABLE sync_watermark_meta ADD COLUMN hash_version INTEGER")
+        # ``representation`` (Issue #501): whether the pair's watermark rows were
+        # recorded over the plain deck text (``"plain"`` / NULL — the legacy default)
+        # or over the *companion-inlined* projection of a separated-voiceover deck
+        # (``"separated"``). A ``sync`` run whose current computed representation
+        # disagrees with this marker demotes to a git-HEAD cold-start rather than
+        # diffing across representations (which would silently swallow the very
+        # cross-language voiceover drift #501 exists to catch). Additive; pre-#501
+        # rows backfill to NULL, read as ``"plain"``.
+        if "representation" not in meta_cols:
+            self._conn.execute("ALTER TABLE sync_watermark_meta ADD COLUMN representation TEXT")
         self._conn.commit()
 
     def _key(self, de_path: str, en_path: str) -> tuple[str, str]:
@@ -1041,6 +1051,36 @@ class SyncWatermarkCache:
         de_path, en_path = self._key(de_path, en_path)
         row = self._conn.execute(
             "SELECT synced_commit FROM sync_watermark_meta WHERE de_path=? AND en_path=?",
+            (de_path, en_path),
+        ).fetchone()
+        return row[0] if row else None
+
+    def set_representation(self, de_path: str, en_path: str, representation: str) -> None:
+        """Record how the pair's watermark rows are represented (Issue #501).
+
+        ``"plain"`` for a deck synced over its plain text, ``"separated"`` for a
+        separated-voiceover deck synced over the companion-inlined projection. Read
+        back by :meth:`get_representation`; a later run whose computed representation
+        disagrees cold-starts off git HEAD rather than diffing across representations.
+        """
+        de_path, en_path = self._key(de_path, en_path)
+        with self._conn:
+            self._conn.execute(
+                "INSERT INTO sync_watermark_meta (de_path, en_path, representation) "
+                "VALUES (?, ?, ?) "
+                "ON CONFLICT(de_path, en_path) DO UPDATE SET representation=excluded.representation",
+                (de_path, en_path, representation),
+            )
+
+    def get_representation(self, de_path: str, en_path: str) -> str | None:
+        """The representation the pair's watermark was recorded in, or ``None``.
+
+        ``None`` for a pre-#501 watermark (no marker), which the caller reads as the
+        legacy ``"plain"`` representation.
+        """
+        de_path, en_path = self._key(de_path, en_path)
+        row = self._conn.execute(
+            "SELECT representation FROM sync_watermark_meta WHERE de_path=? AND en_path=?",
             (de_path, en_path),
         ).fetchone()
         return row[0] if row else None

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -360,6 +360,21 @@ def apply_plan(
     """
     result = ApplyResult()
 
+    # Issue #501 Phase 1: a companion-involving pair (separated voiceover) is READ-ONLY
+    # until the ≤4-file companion write-back lands (Phase 2). The plan was built over the
+    # in-memory inlined projection, so the 2-file flush below would write the inlined
+    # voiceover back into the deck on disk — breaking the wholly-sidecar invariant — and a
+    # mixed / cross-language pair has already refused with a blocking issue. Refuse and
+    # write nothing; ``report`` / ``verify`` / ``diagnose`` still surface the drift.
+    if plan.companion_aware:
+        result.errors.append(
+            "voiceover for this deck lives in a separated companion file; "
+            "`clm slides sync` can report the cross-language drift but cannot yet apply it "
+            "(companion write-back is not implemented). Reconcile the companions manually "
+            "for now."
+        )
+        return result
+
     # Stage 2b/3 for a cold-start mint (#216 §12): a `pending` mint candidate is the
     # whole plan (a cold pair carries no other ops), so handle it on its own path —
     # verify correspondence, then mint shared ids via the file-level minter — and

--- a/src/clm/slides/sync_companion.py
+++ b/src/clm/slides/sync_companion.py
@@ -1,0 +1,208 @@
+"""Companion-aware projection for ``clm slides sync`` (issue #501).
+
+``clm slides sync`` reconciles the two deck halves of a split pair but is
+structurally blind to **separated voiceover companion files**
+(``voiceover_*.de.py`` / ``voiceover_*.en.py``): editing one companion is never
+propagated to the other language and no ``sync`` subcommand reports it. This
+module bridges that gap with an *in-memory projection*: a separated pair's
+voiceover is inlined into each half's deck text (a pure text→text transform,
+:func:`clm.slides.voiceover_tools.inline_pair_text`) so the existing plan engine
+sees — and translates — the narration like any other cell, and read modes surface
+the cross-language drift without touching disk.
+
+The projection is designed so the plan is built over the *same* representation the
+apply write-back will produce (design ``sync-separated-voiceover-companions.md``):
+
+* **plain** — neither half has a companion → the projection is the identity, the
+  deck text is byte-untouched, and the engine behaves exactly as before.
+* **separated** — ≥1 half has a companion and no half keeps voiceover *both*
+  inline and in a companion → inline each companion in memory and reconcile. This
+  is the feature.
+* **mixed** — a half keeps ``voiceover`` inline **and** in a companion (a genuine
+  partial split, out of scope per the maintainer decision) → **refuse** with a
+  normalize hint.
+* **cross-language** — one half is separated while the other carries inline
+  ``voiceover`` → **refuse** (the two languages disagree on representation).
+
+An *unplaceable* companion cell (its ``for_slide`` no longer resolves in the deck
+— a renamed or removed slide) is a total-transform failure: the pair refuses and
+writes nothing rather than silently dropping the narration.
+
+The classification predicate is deliberately **voiceover-only**: a separated deck
+legitimately keeps ``notes`` inline while its voiceover lives in the companion
+(the post-#387 default), so inline *notes* never make a pair *mixed*.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from clm.notebooks.slide_parser import comment_token_for_path
+from clm.slides.voiceover_tools import (
+    has_voiceover_cells_text,
+    inline_pair_text,
+    resolve_companion,
+)
+
+
+class Representation(Enum):
+    """How a resolved DE/EN deck pair stores its voiceover (issue #501)."""
+
+    PLAIN = "plain"
+    SEPARATED = "separated"
+    MIXED = "mixed"
+    CROSS_LANGUAGE = "cross-language"
+
+
+@dataclass(frozen=True)
+class _HalfState:
+    """One half's voiceover representation, read from the working tree."""
+
+    companion: Path | None
+    has_inline_voiceover: bool
+
+
+@dataclass
+class ProjectedPair:
+    """The companion-aware projection of a resolved ``(de, en)`` deck pair.
+
+    ``de_text`` / ``en_text`` are the deck texts the plan engine should read: the
+    companion-inlined projection for a **separated** pair, and the raw working-tree
+    text (byte-untouched) for every other representation. ``refusal`` is a blocking
+    reason (mixed / cross-language / unplaceable-companion-cell) or ``None``.
+    """
+
+    representation: Representation
+    de_text: str
+    en_text: str
+    de_companion: Path | None
+    en_companion: Path | None
+    refusal: str | None = None
+
+    @property
+    def is_separated(self) -> bool:
+        """True for the projected (companion-inlined) case with no refusal."""
+        return self.representation is Representation.SEPARATED and self.refusal is None
+
+    @property
+    def touches_companion(self) -> bool:
+        """True whenever ≥1 companion is involved (separated / mixed / cross-language).
+
+        The 2-file deck engine must never *write* such a pair through its plain
+        flush: a separated pair needs the ≤4-file companion write-back (Phase 2),
+        and a mixed / cross-language pair is refused outright. Plain pairs are
+        ``False`` and keep the untouched fast path.
+        """
+        return self.representation is not Representation.PLAIN
+
+
+def _half_state(deck_path: Path, deck_text: str) -> _HalfState:
+    return _HalfState(
+        companion=resolve_companion(deck_path),
+        # Voiceover-only (never notes): inline notes beside a voiceover companion is
+        # the sanctioned steady state, not a partial split (see module docstring).
+        has_inline_voiceover=has_voiceover_cells_text(deck_text, comment_token_for_path(deck_path)),
+    )
+
+
+def _classify(de: _HalfState, en: _HalfState) -> Representation:
+    de_comp = de.companion is not None
+    en_comp = en.companion is not None
+    # A half with BOTH a companion and inline voiceover is a partial split.
+    if (de_comp and de.has_inline_voiceover) or (en_comp and en.has_inline_voiceover):
+        return Representation.MIXED
+    if not de_comp and not en_comp:
+        return Representation.PLAIN
+    # ≥1 companion, and no half is mixed. If the *other* half carries inline
+    # voiceover, the two languages disagree on how they store narration.
+    if (de_comp and en.has_inline_voiceover) or (en_comp and de.has_inline_voiceover):
+        return Representation.CROSS_LANGUAGE
+    return Representation.SEPARATED
+
+
+_MIXED_REFUSAL = (
+    "voiceover is stored both inline in the deck and in a separated companion file "
+    "(a partial split); `clm slides sync` needs one representation. Run "
+    "`clm voiceover inline <deck>` to fold all voiceover into the deck, or "
+    "`clm voiceover extract <deck>` to move it all into the companion, then re-run sync."
+)
+
+_CROSS_LANGUAGE_REFUSAL = (
+    "the two languages store voiceover differently — one half keeps it in a "
+    "separated companion while the other carries it inline. Normalize both halves "
+    "to the same representation (`clm voiceover extract` or `clm voiceover inline`) "
+    "before syncing."
+)
+
+
+def _inline_half(deck_path: Path, deck_text: str, companion: Path | None) -> tuple[str, list[str]]:
+    """Return ``(inlined_text, unmatched_for_slide_ids)`` for one half.
+
+    A half with no companion projects to itself with no unmatched cells. The
+    companion cells are parsed fresh inside :func:`inline_pair_text`, so this never
+    mutates a caller's cell objects — the projection is safe in a non-mutating read
+    mode (design §5.7).
+    """
+    if companion is None:
+        return deck_text, []
+    companion_text = companion.read_text(encoding="utf-8")
+    result = inline_pair_text(deck_text, companion_text, comment_token_for_path(deck_path))
+    unmatched = [c.metadata.for_slide or "<no for_slide>" for c in result.unmatched]
+    return result.inlined_text, unmatched
+
+
+def project_pair(de_path: Path, en_path: Path, de_text: str, en_text: str) -> ProjectedPair:
+    """Classify the pair's voiceover representation and project it in memory.
+
+    ``de_text`` / ``en_text`` are the raw working-tree texts (the caller already
+    read them). Returns a :class:`ProjectedPair`: for a **separated** pair the deck
+    texts are companion-inlined and ready for the plan engine; for **plain** they
+    are returned untouched; for **mixed** / **cross-language** they are returned
+    untouched with a blocking ``refusal``. A separated pair whose companion holds a
+    cell that no longer resolves to a slide also carries a ``refusal`` (total
+    transform — never drop narration).
+    """
+    de = _half_state(de_path, de_text)
+    en = _half_state(en_path, en_text)
+    representation = _classify(de, en)
+
+    if representation is Representation.PLAIN:
+        return ProjectedPair(representation, de_text, en_text, None, None)
+
+    if representation is Representation.MIXED:
+        return ProjectedPair(
+            representation, de_text, en_text, de.companion, en.companion, refusal=_MIXED_REFUSAL
+        )
+
+    if representation is Representation.CROSS_LANGUAGE:
+        return ProjectedPair(
+            representation,
+            de_text,
+            en_text,
+            de.companion,
+            en.companion,
+            refusal=_CROSS_LANGUAGE_REFUSAL,
+        )
+
+    # SEPARATED: inline each half that has a companion.
+    de_inlined, de_unmatched = _inline_half(de_path, de_text, de.companion)
+    en_inlined, en_unmatched = _inline_half(en_path, en_text, en.companion)
+    refusal: str | None = None
+    unmatched = de_unmatched + en_unmatched
+    if unmatched:
+        refusal = (
+            "a voiceover companion carries narration whose owning slide no longer "
+            "exists in the deck (unresolved for_slide: "
+            f"{', '.join(sorted(set(unmatched)))}); syncing would drop it. Fix the "
+            "slide_id / for_slide, or remove the orphaned narration, then re-run."
+        )
+    return ProjectedPair(
+        Representation.SEPARATED,
+        de_inlined,
+        en_inlined,
+        de.companion,
+        en.companion,
+        refusal=refusal,
+    )

--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -43,6 +43,7 @@ from clm.notebooks.slide_parser import Cell, CellMetadata, comment_token_for_pat
 from clm.slides.anchor_primitives import narrative_anchor_token, owning_group
 from clm.slides.pairing import TITLE_SLIDE_ID, is_title_macro_cell
 from clm.slides.raw_cells import RawCell, split_cells
+from clm.slides.sync_companion import ProjectedPair, Representation, project_pair
 from clm.slides.sync_writeback import (
     cell_content_hash,
     construct_of,
@@ -50,6 +51,7 @@ from clm.slides.sync_writeback import (
     role_of,
     row_anchor,
 )
+from clm.slides.voiceover_tools import COMPANION_SUBDIR, companion_name, inline_pair_text
 
 if TYPE_CHECKING:
     from clm.infrastructure.llm.cache import SyncWatermarkCache
@@ -347,6 +349,18 @@ class SyncPlan:
     # suppressed this run (slides byte-stable since a recorded confirmation, so not
     # re-litigated). 0 when no ledger was supplied.
     ledger_skipped: int = 0
+    # Issue #501: this pair involves a separated voiceover companion (separated /
+    # mixed / cross-language — never plain). The 2-file deck engine must not *write*
+    # it: apply refuses (the ≤4-file companion write-back is Phase 2), while the read
+    # modes still surface the drift. Distinct from ``projected_*_text``: a mixed /
+    # cross-language pair is companion-aware but *not* projected (it refuses).
+    companion_aware: bool = False
+    # Issue #501: the companion-inlined working-tree text the plan was built over,
+    # per language — set only for a projected (separated) pair, ``None`` otherwise.
+    # Excerpt resolvers and ``verify`` read this instead of the voiceover-free
+    # working tree, whose positions would not match the plan's inlined-cell indices.
+    projected_de_text: str | None = None
+    projected_en_text: str | None = None
 
     @property
     def has_baseline(self) -> bool:
@@ -1684,7 +1698,42 @@ def _bundle_from_texts(
     )
 
 
-def _bundle_from_git_ref(de_path: Path, en_path: Path, ref: str = "HEAD") -> BaselineBundle | None:
+def _companion_text_at_ref(deck_path: Path, ref: str) -> str | None:
+    """Companion text for ``deck_path`` at git ``ref``, or ``None`` (Issue #501).
+
+    Mirrors :func:`clm.slides.voiceover_tools.resolve_companion`'s on-disk
+    precedence — the relocated ``voiceover/<name>`` before the sibling ``<name>`` —
+    but reads from git so the *baseline* is projected the same way the working tree
+    is (design §5.3). ``None`` when git is unavailable or the companion did not
+    exist at ``ref`` (then the baseline is the raw deck, correctly modeling
+    "voiceover added since ``ref``" as a real add).
+    """
+    name = companion_name(deck_path)
+    for rel in (f"{COMPANION_SUBDIR}/{name}", name):
+        text = _git_show(deck_path.parent, f"{ref}:./{rel}")
+        if text is not None:
+            return text
+    return None
+
+
+def _inline_companion_at_ref(deck_path: Path, deck_text: str, ref: str) -> str:
+    """Project ``deck_text`` by inlining its companion at ``ref`` (Issue #501).
+
+    The identity when no companion exists at ``ref``. The baseline projection must
+    use the SAME inline transform as the working tree so a standing companion reads
+    as in-sync and only a genuine drift diffs (design §5.3, the keystone).
+    """
+    companion_text = _companion_text_at_ref(deck_path, ref)
+    if companion_text is None:
+        return deck_text
+    return inline_pair_text(
+        deck_text, companion_text, comment_token_for_path(deck_path)
+    ).inlined_text
+
+
+def _bundle_from_git_ref(
+    de_path: Path, en_path: Path, ref: str = "HEAD", *, project_companion: bool = False
+) -> BaselineBundle | None:
     """The pair at git ``ref`` re-derived as a :class:`BaselineBundle`, or ``None``.
 
     Reads each half's text at ``ref`` (rename-following, via :func:`_git_ref_text`)
@@ -1695,6 +1744,10 @@ def _bundle_from_git_ref(de_path: Path, en_path: Path, ref: str = "HEAD") -> Bas
     ``source`` is ``"git-head"`` for the default HEAD fallback (unchanged) and
     ``"git:<ref>"`` for an explicit ``--baseline`` ref (e.g. ``git:HEAD^`` for the
     committed-rename auto-follow), so the plan headline names the baseline used.
+
+    ``project_companion`` (Issue #501) inlines each half's voiceover companion at
+    ``ref`` before deriving the bundle, so a separated-voiceover deck's baseline is
+    projected identically to its working tree.
     """
     if _lang_for_path(de_path) is None or _lang_for_path(en_path) is None:
         return None
@@ -1702,6 +1755,9 @@ def _bundle_from_git_ref(de_path: Path, en_path: Path, ref: str = "HEAD") -> Bas
     en_text = _git_ref_text(en_path, ref)
     if de_text is None or en_text is None:
         return None
+    if project_companion:
+        de_text = _inline_companion_at_ref(de_path, de_text, ref)
+        en_text = _inline_companion_at_ref(en_path, en_text, ref)
     return _bundle_from_texts(
         de_text,
         en_text,
@@ -1711,12 +1767,34 @@ def _bundle_from_git_ref(de_path: Path, en_path: Path, ref: str = "HEAD") -> Bas
     )
 
 
+def _companion_text_at_old_path(cwd: Path, root: Path, old_deck: Path, ref: str) -> str | None:
+    """Companion text for a deck's *pre-rename* ``old_deck`` path at ``ref`` (Issue #501).
+
+    The rename-recovery analogue of :func:`_companion_text_at_ref`: addresses the
+    companion repo-root-relative (subdir before sibling) so it resolves at ``ref``
+    even though the old directory is gone from the work tree, running git from the
+    deck's current ``cwd``. ``None`` when the companion is absent at ``ref``.
+    """
+    try:
+        base_rel = old_deck.resolve().relative_to(root)
+    except ValueError:
+        return None
+    name = companion_name(old_deck)
+    for rel in (base_rel.parent / COMPANION_SUBDIR / name, base_rel.parent / name):
+        text = _git_show(cwd, f"{ref}:{rel.as_posix()}")
+        if text is not None:
+            return text
+    return None
+
+
 def _bundle_from_explicit_paths(
     de_path: Path,
     en_path: Path,
     old_de: Path,
     old_en: Path,
     ref: str,
+    *,
+    project_companion: bool = False,
 ) -> BaselineBundle | None:
     """Baseline bundle read from explicit *old* paths at ``ref`` (rename recovery).
 
@@ -1728,6 +1806,9 @@ def _bundle_from_explicit_paths(
     untracked-rename recovery (epic #440). ``None`` when git is unavailable, a deck's
     language cannot be inferred, the old paths lie outside the repo, or the old text
     is absent at ``ref``.
+
+    ``project_companion`` (Issue #501) inlines each half's voiceover companion at the
+    *old* path so the rename-recovered baseline is projected like the working tree.
     """
     if _lang_for_path(de_path) is None or _lang_for_path(en_path) is None:
         return None
@@ -1746,6 +1827,17 @@ def _bundle_from_explicit_paths(
     en_text = _git_show(cwd, f"{ref}:{en_rel}")
     if de_text is None or en_text is None:
         return None
+    if project_companion:
+        de_comp = _companion_text_at_old_path(cwd, root, old_de, ref)
+        if de_comp is not None:
+            de_text = inline_pair_text(
+                de_text, de_comp, comment_token_for_path(de_path)
+            ).inlined_text
+        en_comp = _companion_text_at_old_path(cwd, root, old_en, ref)
+        if en_comp is not None:
+            en_text = inline_pair_text(
+                en_text, en_comp, comment_token_for_path(en_path)
+            ).inlined_text
     return _bundle_from_texts(
         de_text,
         en_text,
@@ -1755,10 +1847,12 @@ def _bundle_from_explicit_paths(
     )
 
 
-def _bundle_from_git_head(de_path: Path, en_path: Path) -> BaselineBundle | None:
+def _bundle_from_git_head(
+    de_path: Path, en_path: Path, *, project_companion: bool = False
+) -> BaselineBundle | None:
     """The committed (HEAD) pair as a :class:`BaselineBundle` — wrapper over
     :func:`_bundle_from_git_ref`."""
-    return _bundle_from_git_ref(de_path, en_path, "HEAD")
+    return _bundle_from_git_ref(de_path, en_path, "HEAD", project_companion=project_companion)
 
 
 def _baseline_ref_unresolved_reason(de_path: Path, en_path: Path, ref: str) -> str | None:
@@ -3784,6 +3878,37 @@ def _pair_is_unbootstrapped(de_current: list[CurrentCell], en_current: list[Curr
     return de_ids.isdisjoint(en_ids)
 
 
+def _refused_sync_plan(de_path: Path, en_path: Path, projection: ProjectedPair) -> SyncPlan:
+    """A minimal plan carrying only a companion refusal (Issue #501).
+
+    A *mixed* / *cross-language* representation, or a *separated* pair whose companion
+    holds an unplaceable cell, cannot be reconciled: the plan proposes nothing and
+    raises one blocking ``error`` issue so ``report`` / ``diagnose`` surface it and
+    ``apply`` refuses. ``companion_aware`` is set so the apply-side guard also trips.
+    """
+    plan = SyncPlan(de_path=de_path, en_path=en_path, baseline_source="none", companion_aware=True)
+    plan.issues.append(PlanIssue(severity="error", slide_id=None, reason=projection.refusal or ""))
+    return plan
+
+
+def _watermark_representation_matches(
+    cache: SyncWatermarkCache, de_path: Path, en_path: Path, projection: ProjectedPair
+) -> bool:
+    """Whether the pair's watermark was recorded in its *current* representation (#501).
+
+    A legacy voiceover-free watermark (no marker → read as ``"plain"``) on a
+    now-separated deck, or an inlined watermark on a now-plain deck, mismatches — the
+    caller then demotes to a projected git-HEAD cold-start rather than diffing across
+    representations. A plain pair with a legacy watermark matches (``"plain"`` both
+    sides), so the pre-#501 path is unchanged.
+    """
+    stored = cache.get_representation(str(de_path), str(en_path)) or Representation.PLAIN.value
+    current = (
+        Representation.SEPARATED.value if projection.is_separated else Representation.PLAIN.value
+    )
+    return stored == current
+
+
 def build_sync_plan(
     de_path: Path,
     en_path: Path,
@@ -3841,10 +3966,25 @@ def build_sync_plan(
     drifted slide does not match and surfaces normally; ``None`` (the default) is the
     pre-ledger behavior exactly.
     """
-    de_text = de_path.read_text(encoding="utf-8")
-    en_text = en_path.read_text(encoding="utf-8")
+    raw_de_text = de_path.read_text(encoding="utf-8")
+    raw_en_text = en_path.read_text(encoding="utf-8")
     de_token = comment_token_for_path(de_path)
     en_token = comment_token_for_path(en_path)
+    # Issue #501: classify the pair's voiceover representation and, for a *separated*
+    # pair, inline each half's companion IN MEMORY so the plan is built over the same
+    # representation the apply write-back produces (design
+    # ``sync-separated-voiceover-companions.md`` §5). A *mixed* / *cross-language* pair,
+    # or a separated pair whose companion holds an unplaceable cell, refuses and writes
+    # nothing — surfaced as one blocking issue, with ``apply`` guarded. A *plain* pair
+    # projects to itself, byte-untouched, so the raw texts flow through unchanged. The
+    # raw (voiceover-free) texts are retained for the git-HEAD identity comparisons
+    # below, whose committed bytes never carry the inlined voiceover.
+    projection = project_pair(de_path, en_path, raw_de_text, raw_en_text)
+    if projection.refusal is not None:
+        return _refused_sync_plan(de_path, en_path, projection)
+    de_text = projection.de_text
+    en_text = projection.en_text
+    project_companion = projection.is_separated
     de_cells = parse_cells(de_text, de_token)
     en_cells = parse_cells(en_text, en_token)
     # Issue #403 Phase B: narrative identity (owning slide + positional anchor),
@@ -3890,14 +4030,26 @@ def build_sync_plan(
         # given ref, ignoring the watermark and the HEAD fallback (epic #440).
         if bootstrapped:
             old_de, old_en, from_ref = baseline_from
-            bundle = _bundle_from_explicit_paths(de_path, en_path, old_de, old_en, from_ref)
+            bundle = _bundle_from_explicit_paths(
+                de_path, en_path, old_de, old_en, from_ref, project_companion=project_companion
+            )
     elif baseline_ref is not None:
         # Explicit --baseline ref: diff against this git ref, ignoring the
         # watermark, and do NOT fall back to HEAD if it is unavailable.
         if bootstrapped:
-            bundle = _bundle_from_git_ref(de_path, en_path, baseline_ref)
+            bundle = _bundle_from_git_ref(
+                de_path, en_path, baseline_ref, project_companion=project_companion
+            )
     else:
-        if watermark_cache is not None:
+        # Issue #501: only trust the watermark when its recorded representation
+        # matches the pair's current one. A legacy voiceover-free watermark on a
+        # now-separated deck (or an inlined watermark on a now-plain deck) would diff
+        # across representations and silently swallow the cross-language drift — so on
+        # a marker mismatch we leave ``bundle`` None and fall through to the git-HEAD
+        # baseline, which is projected identically (the automatic first-run re-baseline).
+        if watermark_cache is not None and _watermark_representation_matches(
+            watermark_cache, de_path, en_path, projection
+        ):
             bundle = _bundle_from_watermark(watermark_cache, de_path, en_path)
         if bundle is None and allow_git_fallback and bootstrapped:
             # Rename recovery (epic #440), only on the pure-git read path. An
@@ -3908,9 +4060,13 @@ def build_sync_plan(
                 detected = _detect_untracked_rename(de_path, en_path, de_cells)
                 if detected is not None:
                     od, oe, dref = detected
-                    bundle = _bundle_from_explicit_paths(de_path, en_path, od, oe, dref)
+                    bundle = _bundle_from_explicit_paths(
+                        de_path, en_path, od, oe, dref, project_companion=project_companion
+                    )
             if bundle is None:
-                bundle = _bundle_from_git_head(de_path, en_path)
+                bundle = _bundle_from_git_head(
+                    de_path, en_path, project_companion=project_companion
+                )
                 # A *committed* rename (rename + edits in one commit) leaves HEAD ==
                 # the work tree, so the HEAD baseline reads "clean" and hides the
                 # one-sided revision. When the deck was renamed into its current name
@@ -3920,11 +4076,13 @@ def build_sync_plan(
                     detect_rename
                     and bundle is not None
                     and bundle.source == "git-head"
-                    and _working_tree_matches_head(de_path, de_text)
-                    and _working_tree_matches_head(en_path, en_text)
+                    and _working_tree_matches_head(de_path, raw_de_text)
+                    and _working_tree_matches_head(en_path, raw_en_text)
                     and _detect_committed_rename(de_path, en_path)
                 ):
-                    caret = _bundle_from_git_ref(de_path, en_path, "HEAD^")
+                    caret = _bundle_from_git_ref(
+                        de_path, en_path, "HEAD^", project_companion=project_companion
+                    )
                     if caret is not None:
                         bundle = caret
 
@@ -3973,11 +4131,16 @@ def build_sync_plan(
         source == "none"
         and baseline_ref is None
         and baseline_from is None
-        and _working_tree_matches_head(de_path, de_text)
-        and _working_tree_matches_head(en_path, en_text)
+        and _working_tree_matches_head(de_path, raw_de_text)
+        and _working_tree_matches_head(en_path, raw_en_text)
         and _committed_pair_is_consistent(de_cells, en_cells, de_path, en_path)
     ):
-        return SyncPlan(de_path=de_path, en_path=en_path, baseline_source="git-head")
+        return SyncPlan(
+            de_path=de_path,
+            en_path=en_path,
+            baseline_source="git-head",
+            companion_aware=projection.touches_companion,
+        )
 
     plan = classify_changes(
         de_current,
@@ -3997,6 +4160,14 @@ def build_sync_plan(
     plan.idless_baseline_de = de_idless_baseline
     plan.idless_baseline_en = en_idless_baseline
     plan.baseline_bundle = bundle
+    # Issue #501: mark a companion-involving pair so the apply-side guard refuses the
+    # 2-file flush (the ≤4-file write-back is Phase 2), and carry the projected
+    # inlined texts so excerpt resolvers / verify read the same representation the
+    # plan's positions index rather than the voiceover-free working tree.
+    plan.companion_aware = projection.touches_companion
+    if projection.is_separated:
+        plan.projected_de_text = de_text
+        plan.projected_en_text = en_text
 
     # Issue #2: an explicit --baseline ref that yielded no bundle used to degrade
     # silently to baseline=none. Surface the concrete reason (rename not followable,

--- a/src/clm/slides/sync_report.py
+++ b/src/clm/slides/sync_report.py
@@ -239,7 +239,19 @@ class _SourceIndex:
     than the wrong cell.
     """
 
-    def __init__(self, de_path: Path, en_path: Path) -> None:
+    def __init__(
+        self,
+        de_path: Path,
+        en_path: Path,
+        *,
+        de_text: str | None = None,
+        en_text: str | None = None,
+    ) -> None:
+        # Issue #501: a separated-voiceover plan's positions index the *companion-inlined*
+        # projection, not the voiceover-free working tree — so the caller passes the
+        # projected text (``SyncPlan.projected_*_text``) and we parse that instead of
+        # re-reading disk, which would mis-resolve every position past a narration cell.
+        texts = {"de": de_text, "en": en_text}
         self._sync: dict[str, list[Cell]] = {}
         self._localized: dict[str, list[Cell]] = {}
         # ``(slide_id, role) -> Cell`` per language for keyed lookups (#451). The
@@ -248,7 +260,10 @@ class _SourceIndex:
         # is surfaced as an error elsewhere, never as a clean keyed conflict.
         self._by_key: dict[str, dict[tuple[str, str], Cell]] = {}
         for lang, path in (("de", de_path), ("en", en_path)):
-            cells = parse_cells(path.read_text(encoding="utf-8"), comment_token_for_path(path))
+            text = texts[lang]
+            if text is None:
+                text = path.read_text(encoding="utf-8")
+            cells = parse_cells(text, comment_token_for_path(path))
             self._sync[lang] = [
                 c for c in cells if role_of(c.metadata) is not None and c.metadata.lang == lang
             ]
@@ -403,15 +418,26 @@ def _enrich(item: ReconciliationItem, index: _SourceIndex) -> None:
         )
 
 
-def _enrich_report(report: ReconciliationReport, de_path: Path, en_path: Path) -> None:
+def _enrich_report(
+    report: ReconciliationReport,
+    de_path: Path,
+    en_path: Path,
+    *,
+    de_text: str | None = None,
+    en_text: str | None = None,
+) -> None:
     """Attach cell bytes to every assisted / ambiguity item (best-effort, in place).
 
     Mechanical items are skipped — the agent applies them without reading the cell.
     A file that cannot be read or parsed leaves the whole report un-enriched: the
     tiers stay valid; only the excerpts are absent.
+
+    ``de_text`` / ``en_text`` (Issue #501) override the working-tree read with the
+    plan's companion-inlined projection so a separated-voiceover excerpt resolves to
+    the correct narration bytes.
     """
     try:
-        index = _SourceIndex(de_path, en_path)
+        index = _SourceIndex(de_path, en_path, de_text=de_text, en_text=en_text)
     except (OSError, ValueError):  # unreadable / undecodable file — degrade to no excerpts
         return
     for item in (*report.assisted, *report.ambiguity):
@@ -555,7 +581,13 @@ def build_report(plan: SyncPlan, *, with_excerpts: bool = False) -> Reconciliati
         ambiguity=ambiguity,
     )
     if with_excerpts:
-        _enrich_report(report, plan.de_path, plan.en_path)
+        _enrich_report(
+            report,
+            plan.de_path,
+            plan.en_path,
+            de_text=plan.projected_de_text,
+            en_text=plan.projected_en_text,
+        )
         _append_idmigration_residue(report, plan)
     # Assign item ids last, so the realign residue items (appended above) are
     # numbered too and the dedup order is stable for this deck state.

--- a/src/clm/slides/sync_verify.py
+++ b/src/clm/slides/sync_verify.py
@@ -56,6 +56,7 @@ from pathlib import Path
 from clm.notebooks.slide_parser import comment_token_for_path
 from clm.slides.raw_cells import split_cells
 from clm.slides.split import UnifyError, unify_texts
+from clm.slides.sync_companion import project_pair
 from clm.slides.sync_plan import _git_ref_text
 from clm.slides.sync_writeback import role_of
 
@@ -316,8 +317,18 @@ def verify_pair(de_path: Path, en_path: Path) -> VerifyResult:
     (``git_baseline=False``) when neither is.
     """
     comment_token = comment_token_for_path(de_path)
-    de_text = de_path.read_text(encoding="utf-8")
-    en_text = en_path.read_text(encoding="utf-8")
+    raw_de_text = de_path.read_text(encoding="utf-8")
+    raw_en_text = en_path.read_text(encoding="utf-8")
+
+    # Issue #501: verify the companion-inlined projection. A separated-voiceover pair
+    # whose narration drifted to one language now leaves an inlined voiceover cell on
+    # only one half, which ``unify_texts`` reports as a structural violation; a
+    # symmetric companion pair inlines identically on both halves and verifies clean.
+    # A plain pair projects to itself, and a mixed / cross-language pair falls back to
+    # its raw text (``sync`` surfaces that refusal separately).
+    projection = project_pair(de_path, en_path, raw_de_text, raw_en_text)
+    de_text = projection.de_text
+    en_text = projection.en_text
 
     violations = structural_violations(de_text, en_text, comment_token)
 

--- a/src/clm/slides/voiceover_tools.py
+++ b/src/clm/slides/voiceover_tools.py
@@ -576,16 +576,34 @@ def _find_owning_slide_id(cells: list[_RawCell], voiceover_idx: int) -> str | No
     return None
 
 
+def has_voiceover_cells_text(
+    text: str, comment_token: str = "#", *, include_notes: bool = False
+) -> bool:
+    """True iff slide *text* carries at least one cell ``extract`` would pull out.
+
+    The IO-free core of :func:`_has_voiceover_cells`. By default only a
+    ``voiceover``-tagged cell counts; with ``include_notes`` a ``notes`` cell
+    counts too (see :func:`_is_extractable_cell`). The ``clm slides sync`` companion
+    projection (issue #501) uses the voiceover-only form to tell a *mixed* deck
+    (inline ``voiceover`` cells **and** a companion — refused) from the sanctioned
+    steady state (inline ``notes`` beside a voiceover companion, post-#387), so the
+    predicate must never count ``notes``.
+    """
+    _preamble, cells = _split_raw_cells(text, comment_token)
+    return any(_is_extractable_cell(c, include_notes=include_notes) for c in cells)
+
+
 def _has_voiceover_cells(path: Path, *, include_notes: bool = False) -> bool:
     """True iff ``path`` has at least one cell ``extract`` would pull out.
 
     By default that means a ``voiceover``-tagged cell; with ``include_notes``
     a ``notes`` cell also counts (see :func:`_is_extractable_cell`).
     """
-    _preamble, cells = _split_raw_cells(
-        path.read_text(encoding="utf-8"), comment_token_for_path(path)
+    return has_voiceover_cells_text(
+        path.read_text(encoding="utf-8"),
+        comment_token_for_path(path),
+        include_notes=include_notes,
     )
-    return any(_is_extractable_cell(c, include_notes=include_notes) for c in cells)
 
 
 def _slide_start_ids_of(path: Path) -> list[str | None]:

--- a/tests/slides/test_sync_companion.py
+++ b/tests/slides/test_sync_companion.py
@@ -1,0 +1,500 @@
+"""Companion-aware ``clm slides sync`` — Phase 1 (issue #501).
+
+``clm slides sync`` was structurally blind to **separated voiceover companion
+files** (``voiceover_*.de.py`` / ``voiceover_*.en.py``): editing one companion was
+never propagated to the other language and no ``sync`` subcommand reported it.
+Phase 1 makes the read modes companion-aware by inlining each half's companion in
+memory (design ``sync-separated-voiceover-companions.md``) so the existing plan
+engine sees the narration like any other cell — while writing nothing (apply is
+guarded; the ≤4-file write-back is Phase 2).
+
+These tests pin the Phase 1 contract:
+
+* a **standing** separated pair reports **0 changes** — the keystone: the git-HEAD
+  baseline is projected identically to the working tree, so a companion present on
+  both sides now and at HEAD reads as in-sync, *not* a spurious add (§5.3);
+* a **drifted** companion surfaces as ``add …/voiceover [translation pending]`` in
+  ``report`` — exactly as inline voiceover already does (the headline fix);
+* **mixed** / **cross-language** representations, and an **unplaceable** companion
+  cell, **refuse** and write nothing;
+* a legacy voiceover-free **watermark** on a now-separated deck **demotes** to a
+  projected git-HEAD baseline (the automatic re-baseline);
+* ``apply`` on a separated pair **refuses** (Phase 1 is read-only);
+* pointing ``sync`` at a ``voiceover_*`` file reconciles its **deck pair**.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.llm.cache import SyncWatermarkCache
+from clm.slides.sync_apply import apply_plan
+from clm.slides.sync_companion import Representation, project_pair
+from clm.slides.sync_plan import build_sync_plan
+from clm.slides.sync_report import build_report
+from clm.slides.sync_verify import verify_pair
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git not on PATH")
+
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "t",
+    "GIT_AUTHOR_EMAIL": "t@example.com",
+    "GIT_COMMITTER_NAME": "t",
+    "GIT_COMMITTER_EMAIL": "t@example.com",
+}
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        env={**os.environ, **_GIT_ENV},
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Deck / companion builders — a two-slide split pair whose voiceover lives in a
+# separated companion (no inline voiceover in the deck itself).
+# ---------------------------------------------------------------------------
+
+
+def _deck(lang: str) -> str:
+    title = {"de": "Einführung", "en": "Introduction"}[lang]
+    end = {"de": "Ende", "en": "The End"}[lang]
+    return (
+        f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="intro"\n'
+        f"#\n# ## {title}\n"
+        "\n"
+        f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="ende"\n'
+        f"#\n# ## {end}\n"
+    )
+
+
+def _companion(lang: str, *cells: tuple[str, str]) -> str:
+    """A companion file of ``(for_slide, narration)`` voiceover cells."""
+    out = []
+    for for_slide, narration in cells:
+        out.append(
+            f'# %% [markdown] lang="{lang}" tags=["voiceover"] for_slide="{for_slide}"\n'
+            f"#\n# - {narration}\n"
+        )
+    return "\n".join(out)
+
+
+def _inline_vo_deck(lang: str) -> str:
+    """A deck carrying its intro voiceover *inline* (the mixed / cross-lang probe)."""
+    title = {"de": "Einführung", "en": "Introduction"}[lang]
+    end = {"de": "Ende", "en": "The End"}[lang]
+    inline = {"de": "Inline-Erzählung.", "en": "Inline narration."}[lang]
+    return (
+        f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="intro"\n'
+        f"#\n# ## {title}\n"
+        "\n"
+        f'# %% [markdown] lang="{lang}" tags=["voiceover"]\n'
+        f"#\n# - {inline}\n"
+        "\n"
+        f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="ende"\n'
+        f"#\n# ## {end}\n"
+    )
+
+
+class _Pair:
+    """A committed split pair in a throwaway git repo, with optional companions."""
+
+    def __init__(self, folder: Path, repo: Path):
+        self.folder = folder
+        self.repo = repo
+        self.de = folder / "slides_x.de.py"
+        self.en = folder / "slides_x.en.py"
+        self.de_comp = folder / "voiceover_x.de.py"
+        self.en_comp = folder / "voiceover_x.en.py"
+
+    def commit(self, msg: str = "c") -> None:
+        _git(self.repo, "add", "-A")
+        _git(self.repo, "commit", "-qm", msg)
+
+
+def _make_pair(
+    tmp_path: Path,
+    *,
+    de_text: str | None = None,
+    en_text: str | None = None,
+    de_comp: str | None = None,
+    en_comp: str | None = None,
+    subdir: bool = False,
+    commit: bool = True,
+) -> _Pair:
+    repo = tmp_path / "repo"
+    repo.mkdir(exist_ok=True)
+    _git(repo, "init", "-q")
+    folder = repo / "t"
+    folder.mkdir(parents=True, exist_ok=True)
+    pair = _Pair(folder, repo)
+    pair.de.write_text(de_text if de_text is not None else _deck("de"), encoding="utf-8")
+    pair.en.write_text(en_text if en_text is not None else _deck("en"), encoding="utf-8")
+    comp_dir = folder / "voiceover" if subdir else folder
+    if subdir and (de_comp is not None or en_comp is not None):
+        comp_dir.mkdir(exist_ok=True)
+        pair.de_comp = comp_dir / "voiceover_x.de.py"
+        pair.en_comp = comp_dir / "voiceover_x.en.py"
+    if de_comp is not None:
+        pair.de_comp.write_text(de_comp, encoding="utf-8")
+    if en_comp is not None:
+        pair.en_comp.write_text(en_comp, encoding="utf-8")
+    if commit:
+        pair.commit("init")
+    return pair
+
+
+def _proposals(plan) -> list[tuple[str, str | None, str]]:
+    return [(p.kind, p.direction, p.role) for p in plan.proposals]
+
+
+# ---------------------------------------------------------------------------
+# Keystone (§5.3): a standing separated pair reports zero spurious changes.
+# ---------------------------------------------------------------------------
+
+
+class TestSpuriousAddRegression:
+    def test_in_sync_separated_pair_is_a_noop(self, tmp_path: Path) -> None:
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        plan = build_sync_plan(pair.de, pair.en)
+        assert plan.proposals == []
+        assert not plan.has_errors
+        assert plan.companion_aware is True
+        assert plan.projected_de_text is not None
+
+    def test_in_sync_against_explicit_baseline_ref(self, tmp_path: Path) -> None:
+        # The projection must apply to the explicit `--baseline <ref>` source too.
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        plan = build_sync_plan(pair.de, pair.en, baseline_ref="HEAD")
+        assert plan.proposals == []
+        assert not plan.has_errors
+
+    def test_in_sync_with_subdir_companion_layout(self, tmp_path: Path) -> None:
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+            subdir=True,
+        )
+        plan = build_sync_plan(pair.de, pair.en)
+        assert plan.proposals == []
+        assert plan.companion_aware is True
+
+
+# ---------------------------------------------------------------------------
+# Headline fix: a drifted companion surfaces as an add [translation pending].
+# ---------------------------------------------------------------------------
+
+
+class TestCompanionDriftSurfaces:
+    def test_new_de_narration_reports_add_to_en(self, tmp_path: Path) -> None:
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        # Author adds a NEW narration on the DE side only (working tree, uncommitted).
+        pair.de_comp.write_text(
+            _companion("de", ("intro", "Willkommen."), ("ende", "Danke fürs Zuschauen.")),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(pair.de, pair.en)
+        assert ("add", "de->en", "voiceover") in _proposals(plan)
+
+    def test_report_excerpt_quotes_the_projected_narration(self, tmp_path: Path) -> None:
+        # §5.7 read purity: the excerpt must come from the in-memory inlined
+        # projection, never the voiceover-free working tree (which lacks the line).
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        pair.de_comp.write_text(
+            _companion("de", ("intro", "Willkommen."), ("ende", "Danke fürs Zuschauen.")),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(pair.de, pair.en)
+        report = build_report(plan, with_excerpts=True)
+        excerpts = " ".join(
+            item.source_excerpt or "" for item in (*report.assisted, *report.mechanical)
+        )
+        assert "Danke fürs Zuschauen." in excerpts
+        # The raw DE deck on disk never contained that narration line.
+        assert "Danke fürs Zuschauen." not in pair.de.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# One-sided companion — propagate (parity with inline voiceover, the core ask).
+# ---------------------------------------------------------------------------
+
+
+class TestOneSidedCompanion:
+    def test_de_only_companion_proposes_add_to_en(self, tmp_path: Path) -> None:
+        # A half with a companion, the other with NO voiceover, is classified
+        # SEPARATED (legal) and — exactly like a one-sided *inline* voiceover —
+        # proposes `add de->en [translation pending]`. (Suppressing a *standing*
+        # one-sided asymmetry is a separate engine-wide refinement; the current
+        # engine propagates for inline too, and Phase 1 keeps companion == inline.)
+        pair = _make_pair(tmp_path, de_comp=_companion("de", ("intro", "Willkommen.")))
+        proj = project_pair(pair.de, pair.en, pair.de.read_text(), pair.en.read_text())
+        assert proj.representation is Representation.SEPARATED
+        plan = build_sync_plan(pair.de, pair.en)
+        assert ("add", "de->en", "voiceover") in _proposals(plan)
+
+
+# ---------------------------------------------------------------------------
+# Representation invariants: mixed / cross-language / notes-not-mixed.
+# ---------------------------------------------------------------------------
+
+
+class TestRepresentationRefusals:
+    def test_mixed_deck_refuses(self, tmp_path: Path) -> None:
+        # DE keeps voiceover BOTH inline and in a companion — a partial split.
+        pair = _make_pair(
+            tmp_path,
+            de_text=_inline_vo_deck("de"),
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+            commit=False,
+        )
+        proj = project_pair(pair.de, pair.en, pair.de.read_text(), pair.en.read_text())
+        assert proj.representation is Representation.MIXED
+        assert proj.refusal is not None
+        plan = build_sync_plan(pair.de, pair.en)
+        assert plan.has_errors
+        assert plan.companion_aware is True
+        assert plan.proposals == []
+
+    def test_cross_language_asymmetry_refuses(self, tmp_path: Path) -> None:
+        # DE separated (companion), EN carries inline voiceover — inconsistent.
+        pair = _make_pair(
+            tmp_path,
+            en_text=_inline_vo_deck("en"),
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            commit=False,
+        )
+        proj = project_pair(pair.de, pair.en, pair.de.read_text(), pair.en.read_text())
+        assert proj.representation is Representation.CROSS_LANGUAGE
+        plan = build_sync_plan(pair.de, pair.en)
+        assert plan.has_errors
+
+    def test_inline_notes_beside_voiceover_companion_is_not_mixed(self, tmp_path: Path) -> None:
+        # The sanctioned steady state (post-#387): notes inline, voiceover in the
+        # companion. The mixed predicate is voiceover-ONLY, so this is SEPARATED.
+        de_with_notes = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
+            "#\n# ## Einführung\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["notes"]\n'
+            "#\n# - Eine Sprechernotiz.\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="ende"\n'
+            "#\n# ## Ende\n"
+        )
+        en_with_notes = de_with_notes.replace('lang="de"', 'lang="en"').replace(
+            "Eine Sprechernotiz.", "A speaker note."
+        )
+        pair = _make_pair(
+            tmp_path,
+            de_text=de_with_notes,
+            en_text=en_with_notes,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        proj = project_pair(pair.de, pair.en, pair.de.read_text(), pair.en.read_text())
+        assert proj.representation is Representation.SEPARATED
+        assert proj.refusal is None
+
+
+# ---------------------------------------------------------------------------
+# Total transform: an unplaceable companion cell refuses (never a silent drop).
+# ---------------------------------------------------------------------------
+
+
+class TestTotalTransform:
+    def test_orphaned_companion_cell_refuses(self, tmp_path: Path) -> None:
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("ghost", "Für eine gelöschte Folie.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        proj = project_pair(pair.de, pair.en, pair.de.read_text(), pair.en.read_text())
+        assert proj.refusal is not None
+        assert "ghost" in proj.refusal
+        plan = build_sync_plan(pair.de, pair.en)
+        assert plan.has_errors
+        assert plan.proposals == []
+        # Nothing was dropped: the companion file is untouched on disk.
+        assert "ghost" in pair.de_comp.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Representation marker: a legacy voiceover-free watermark demotes to git-HEAD.
+# ---------------------------------------------------------------------------
+
+
+class TestRepresentationMarker:
+    def test_get_set_representation_roundtrip(self, tmp_path: Path) -> None:
+        cache = SyncWatermarkCache(tmp_path / "wm.db")
+        assert cache.get_representation("a", "b") is None  # no marker → legacy plain
+        cache.set_representation("a", "b", "separated")
+        assert cache.get_representation("a", "b") == "separated"
+
+    def test_legacy_watermark_on_separated_deck_demotes_to_git_head(self, tmp_path: Path) -> None:
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        cache = SyncWatermarkCache(tmp_path / "wm.db")
+        # A legacy (voiceover-free, no representation marker) watermark for the pair.
+        cache.put_deck(
+            de_path=str(pair.de),
+            en_path=str(pair.en),
+            lang="de",
+            cells=[(0, "intro", "slide", "deadbeef", None)],
+        )
+        assert cache.has_pair(str(pair.de), str(pair.en))
+        plan = build_sync_plan(pair.de, pair.en, watermark_cache=cache)
+        # The marker mismatch (stored plain vs current separated) demotes to the
+        # projected git-HEAD baseline instead of the voiceover-free watermark.
+        assert plan.baseline_source == "git-head"
+
+    def test_plain_pair_still_uses_its_watermark(self, tmp_path: Path) -> None:
+        # A plain pair with a legacy watermark matches (plain == plain) — no demotion.
+        pair = _make_pair(tmp_path)
+        cache = SyncWatermarkCache(tmp_path / "wm.db")
+        cache.put_deck(
+            de_path=str(pair.de),
+            en_path=str(pair.en),
+            lang="de",
+            cells=[(0, "intro", "slide", "deadbeef", None)],
+        )
+        plan = build_sync_plan(pair.de, pair.en, watermark_cache=cache)
+        assert plan.baseline_source == "watermark"
+
+
+# ---------------------------------------------------------------------------
+# Apply is guarded (Phase 1 is read-only) and plain pairs are untouched.
+# ---------------------------------------------------------------------------
+
+
+class TestApplyGuardAndPlainParity:
+    def test_apply_refuses_a_separated_pair(self, tmp_path: Path) -> None:
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        before_de = pair.de.read_text(encoding="utf-8")
+        before_comp = pair.de_comp.read_text(encoding="utf-8")
+        plan = build_sync_plan(pair.de, pair.en)
+        result = apply_plan(plan, judge=None)
+        assert result.has_errors
+        assert result.flushed is False
+        # Neither the deck nor the companion was written.
+        assert pair.de.read_text(encoding="utf-8") == before_de
+        assert pair.de_comp.read_text(encoding="utf-8") == before_comp
+
+    def test_plain_pair_is_not_companion_aware(self, tmp_path: Path) -> None:
+        pair = _make_pair(tmp_path)
+        plan = build_sync_plan(pair.de, pair.en)
+        assert plan.companion_aware is False
+        assert plan.projected_de_text is None
+
+
+# ---------------------------------------------------------------------------
+# verify_pair over the inlined projection.
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyProjection:
+    def test_symmetric_separated_pair_verifies_clean(self, tmp_path: Path) -> None:
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        result = verify_pair(pair.de, pair.en)
+        assert [v for v in result.violations if v.severity == "error"] == []
+
+    def test_one_sided_companion_is_not_a_structural_error(self, tmp_path: Path) -> None:
+        # A one-sided narration is legal bilingual content (a DE-only localized cell),
+        # not a structural corruption — `unify_texts` degrades gracefully. Surfacing
+        # that *drift* is `report`'s job (the `add de->en` proposal), not verify's; the
+        # projection must therefore not manufacture a spurious verify error.
+        pair = _make_pair(tmp_path, de_comp=_companion("de", ("intro", "Willkommen.")))
+        result = verify_pair(pair.de, pair.en)
+        assert [v for v in result.violations if v.severity == "error"] == []
+
+
+# ---------------------------------------------------------------------------
+# CLI: pointing `sync` at a voiceover_* companion resolves its deck pair.
+# ---------------------------------------------------------------------------
+
+
+class TestCompanionArgResolution:
+    def test_sibling_companion_resolves_to_deck_pair(self, tmp_path: Path) -> None:
+        from clm.cli.commands.slides.sync import _resolve_single_path
+
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        de, en = _resolve_single_path(pair.de_comp, None)
+        assert (de, en) == (pair.de, pair.en)
+
+    def test_en_companion_resolves_ordered_de_first(self, tmp_path: Path) -> None:
+        from clm.cli.commands.slides.sync import _resolve_single_path
+
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        de, en = _resolve_single_path(pair.en_comp, None)
+        assert (de, en) == (pair.de, pair.en)
+
+    def test_subdir_companion_resolves_to_deck_one_level_up(self, tmp_path: Path) -> None:
+        from clm.cli.commands.slides.sync import _resolve_single_path
+
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+            subdir=True,
+        )
+        de, en = _resolve_single_path(pair.de_comp, None)
+        assert (de, en) == (pair.de, pair.en)
+
+    def test_orphan_companion_errors_clearly(self, tmp_path: Path) -> None:
+        import click
+
+        from clm.cli.commands.slides.sync import _resolve_single_path
+
+        # A companion with no deck beside it.
+        folder = tmp_path / "t"
+        folder.mkdir(parents=True)
+        orphan = folder / "voiceover_missing.de.py"
+        orphan.write_text(_companion("de", ("intro", "x")), encoding="utf-8")
+        with pytest.raises(click.UsageError, match="voiceover companion"):
+            _resolve_single_path(orphan, None)


### PR DESCRIPTION
## Summary

`clm slides sync` was structurally blind to **separated voiceover companion
files** (`voiceover_*.de.py` / `.en.py`): a companion edited on one language
never propagated cross-language, and no `sync` subcommand reported it — only
`clm validate`, late (commit time). This is issue #501.

**Phase 1** (of the phased plan in `docs/claude/design/sync-separated-voiceover-companions.md`)
makes the **read modes** companion-aware by inlining each half's companion **in
memory** (a pure text→text projection), so the existing plan engine sees and
translates the narration like any other cell — while writing nothing. This phase
alone ends *"only `validate` catches companion drift, late."*

## What's in this PR

- **New `clm.slides.sync_companion`** — classify a resolved pair as
  `plain` / `separated` / `mixed` / `cross-language`, and project a separated
  pair's companions via the Phase 0 `inline_pair_text` core. Mixed and
  cross-language **refuse** with a normalize hint; an **unplaceable** companion
  cell (its slide was renamed/removed) refuses (total transform — never a silent
  drop).
- **`build_sync_plan`** projects the working tree **and all five baseline
  sources** uniformly — the §5.3 keystone: a *standing* separated pair reports
  **0 changes** (the git-HEAD baseline is projected identically), not a spurious
  add; a genuine drift surfaces as `add …/voiceover [translation pending]`.
- **Representation marker** on the watermark (`sync_watermark_meta.representation`)
  → a legacy voiceover-free watermark on a now-separated deck **demotes** to a
  projected git-HEAD cold-start (the automatic first-run re-baseline).
- **Read surfaces over the projection** — `report` excerpts and `verify` resolve
  against the inlined text, not the voiceover-free working tree (§5.7).
- **`apply` refuses** a separated pair (the ≤4-file write-back is Phase 2), so
  Phase 1 is strictly non-mutating.
- Pointing `sync` at a `voiceover_*` file **resolves its deck pair**.

## Design deviation worth a look

A **one-sided** companion narration proposes `add de->en [translation pending]`
(propagate — #501's core ask). §5.5 anticipated a *standing* one-sided asymmetry
would classify as `in_sync`; in practice the engine's narrative-add detection is
a current-state pairing gap, not a baseline delta — and it already propagates for
a standing one-sided **inline** voiceover today. Phase 1 keeps companion behavior
**identical to inline** rather than diverging the two; suppressing a deliberately
permanent one-sided asymmetry is deferred as an engine-wide refinement
(documented in design §11).

## Testing

- New `tests/slides/test_sync_companion.py` (21 tests): spurious-add regression
  across baseline sources, headline drift → `add`, read-purity excerpt, mixed /
  cross-language / total-transform refusals, notes-not-mixed, marker demotion,
  apply guard, companion-arg resolution (sibling / subdir / orphan), verify.
- ~730 existing sync / voiceover / watermark / report / info-topic tests pass
  unchanged; `ruff` + `mypy` clean.

Part of #501 (does not close it — Phase 2 write-back and Phase 3 ledger/docs
parity remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
