### PR TITLE
feat(recordings): expand/collapse-all + collapsed-by-default sections

### DIFF
--- a/changelog.d/recordings-collapse-defaults.changed.md
+++ b/changelog.d/recordings-collapse-defaults.changed.md
@@ -1,0 +1,6 @@
+- **Recordings dashboard: sections start collapsed and remember state across
+  restarts.** The lecture list now renders every section collapsed by default,
+  so it opens as a compact list of section headers instead of a long scroll.
+  A section's open/closed state is now stored in `localStorage` (was
+  `sessionStorage`), so a user's choices survive not just a page refresh but a
+  browser restart and a `clm recordings serve` restart.

--- a/changelog.d/recordings-expand-collapse-controls.added.md
+++ b/changelog.d/recordings-expand-collapse-controls.added.md
@@ -1,0 +1,3 @@
+- **Recordings dashboard: Expand all / Collapse all controls.** The lecture
+  list toolbar gained buttons to expand or collapse every section at once,
+  making a long list quick to fold down to just its section headers.

--- a/src/clm/recordings/web/templates/base.html
+++ b/src/clm/recordings/web/templates/base.html
@@ -192,13 +192,16 @@
 
     /* Collapsible-section persistence.
        Each <details data-section-collapse> remembers its open/closed
-       state in sessionStorage keyed by section name, so the frequent
-       SSE-driven #lectures-dynamic swaps (which re-render every section
-       as `open`) don't undo a section the user collapsed. Restoration
-       runs synchronously inside htmx:afterSwap — before the browser
-       paints the freshly-swapped subtree — so a collapsed section never
-       flashes open. `toggle` doesn't bubble, so the listener is attached
-       in the capture phase to catch it from the document root. */
+       state in localStorage keyed by section name. localStorage (not
+       sessionStorage) so the choice survives a browser/tab restart and a
+       `clm recordings serve` restart — not just an in-tab refresh.
+       Sections default to *collapsed*: the server renders them without
+       `open`, and only sections explicitly stored "open" are expanded on
+       load, so the page starts fully collapsed the first time. Restoration
+       runs synchronously inside htmx:afterSwap — before the browser paints
+       the freshly-swapped subtree — so the expanded set never flashes.
+       `toggle` doesn't bubble, so the listener is attached in the capture
+       phase to catch it from the document root. */
     var SECTION_STORAGE_PREFIX = 'clm:sectionOpen:';
     function _restoreSectionCollapse(scope) {
         var root = scope || document;
@@ -206,21 +209,40 @@
             var key = d.getAttribute('data-section-key');
             if (!key) return;
             var stored;
-            try { stored = sessionStorage.getItem(SECTION_STORAGE_PREFIX + key); }
+            try { stored = localStorage.getItem(SECTION_STORAGE_PREFIX + key); }
             catch (e) { stored = null; }
-            if (stored === 'closed') d.removeAttribute('open');
-            else if (stored === 'open') d.setAttribute('open', '');
+            // Default (no stored value) and "closed" both collapse; only an
+            // explicit "open" expands.
+            if (stored === 'open') d.setAttribute('open', '');
+            else d.removeAttribute('open');
         });
+    }
+    function _persistSectionState(d) {
+        var key = d.getAttribute('data-section-key');
+        if (!key) return;
+        try {
+            localStorage.setItem(SECTION_STORAGE_PREFIX + key, d.open ? 'open' : 'closed');
+        } catch (e) { /* private browsing / quota exceeded — ignore */ }
     }
     document.addEventListener('toggle', function (evt) {
         var d = evt.target;
         if (!d || !d.hasAttribute || !d.hasAttribute('data-section-collapse')) return;
-        var key = d.getAttribute('data-section-key');
-        if (!key) return;
-        try {
-            sessionStorage.setItem(SECTION_STORAGE_PREFIX + key, d.open ? 'open' : 'closed');
-        } catch (e) { /* private browsing / quota exceeded — ignore */ }
+        _persistSectionState(d);
     }, true);
+    /* Expand-all / collapse-all toolbar controls. Set every section and
+       persist the new state so the choice survives reloads and restarts. */
+    function _setAllSections(open) {
+        document.querySelectorAll('[data-section-collapse]').forEach(function (d) {
+            if (open) d.setAttribute('open', '');
+            else d.removeAttribute('open');
+            _persistSectionState(d);
+        });
+    }
+    document.addEventListener('click', function (evt) {
+        if (!evt.target || !evt.target.closest) return;
+        if (evt.target.closest('[data-expand-all]')) { _setAllSections(true); return; }
+        if (evt.target.closest('[data-collapse-all]')) { _setAllSections(false); return; }
+    });
     document.addEventListener('htmx:afterSwap', function () {
         _restoreSectionCollapse();
     });

--- a/src/clm/recordings/web/templates/lectures.html
+++ b/src/clm/recordings/web/templates/lectures.html
@@ -39,6 +39,13 @@
         <button type="submit" class="btn btn-sm {% if lang == 'en' %}btn-primary{% endif %}">EN</button>
     </form>
     <span class="spacer"></span>
+    {% if sections %}
+    {# Expand/collapse the whole list. Client-side only (see base.html):
+       they toggle every section's <details> and persist the choice, so no
+       server round-trip and no full-page reset. #}
+    <button type="button" class="btn btn-sm btn-ghost" data-expand-all>Expand all</button>
+    <button type="button" class="btn btn-sm btn-ghost" data-collapse-all>Collapse all</button>
+    {% endif %}
     <form hx-post="/lectures/refresh" hx-disabled-elt="find button" class="u-inline">
         <button type="submit" class="btn btn-sm btn-ghost">Refresh</button>
     </form>
@@ -93,11 +100,12 @@
 {% endif %}
 
 {% for section in sections %}
-{# Collapsible section. Rendered ``open`` by default; the collapse state
-   is persisted client-side (see base.html) so the frequent SSE-driven
-   ``#lectures-dynamic`` swaps don't re-expand a section the user closed.
-   ``data-section-key`` keys that persistence. #}
-<details class="card section-card" open data-section-collapse data-section-key="{{ section.name }}">
+{# Collapsible section. Rendered *collapsed* by default (no ``open``); the
+   collapse state is persisted client-side in localStorage (see base.html),
+   so the page starts fully collapsed the first time and a user's choices
+   survive reloads, the frequent SSE-driven ``#lectures-dynamic`` swaps, and
+   server restarts. ``data-section-key`` keys that persistence. #}
+<details class="card section-card" data-section-collapse data-section-key="{{ section.name }}">
     <summary class="card-header section-summary">
         <h3 class="card-title">{{ section.name }}</h3>
         <span class="section-chevron" aria-hidden="true">▾</span>

--- a/tests/recordings/test_web.py
+++ b/tests/recordings/test_web.py
@@ -247,6 +247,28 @@ class TestLectures:
         assert "data-section-collapse" in html
         assert 'data-section-key="Woche 1"' in html
 
+    def test_sections_start_collapsed(self, app, recording_root: Path):
+        """Section cards render collapsed by default (no ``open`` attribute).
+
+        The page starts fully collapsed; client-side JS re-expands only
+        the sections a user previously opened (persisted in localStorage).
+        """
+        self._set_split_course(app, de_name="01 Einführung", en_name="01 Introduction")
+
+        with TestClient(app) as c:
+            html = c.get("/lectures").text
+        assert '<details class="card section-card" data-section-collapse' in html
+        assert '<details class="card section-card" open' not in html
+
+    def test_lectures_has_expand_collapse_controls(self, app, recording_root: Path):
+        """The toolbar exposes expand-all / collapse-all controls."""
+        self._set_split_course(app, de_name="01 Einführung", en_name="01 Introduction")
+
+        with TestClient(app) as c:
+            html = c.get("/lectures").text
+        assert "data-expand-all" in html
+        assert "data-collapse-all" in html
+
     def test_lectures_shows_course_slug(self, app, recording_root: Path):
         """The arm form should include the correct course_slug."""
         from clm.core.utils.text_utils import Text


### PR DESCRIPTION
Follow-up to #512 (collapsible section cards), addressing three points raised after using them.

## Changes

- **Expand all / Collapse all controls** in the lecture-list toolbar. Client-side only — they toggle every section's `<details>` and persist the choice — so there's no server round-trip or full-page reset.
- **Sections start collapsed.** The server now renders each section's `<details>` without `open`, so a long lecture list opens as a compact list of section headers. Only sections explicitly stored `"open"` are expanded on load (and no-JS users can still click to expand).
- **Durable persistence.** Collapse state moved from `sessionStorage` to `localStorage`, so a user's choices survive a browser restart and a `clm recordings serve` restart — not just an in-tab refresh. (`localStorage` is entirely client-side and server-independent.)

## Verification

Ran the collapse JS + real `app.css` in a browser harness:
- Fresh visit → both sections collapsed, empty storage.
- **Expand all** → both open, both persisted `open`; survives reload.
- **Collapse all** → both closed, both persisted `closed`.
- Per-section toggle → only that section persisted; survives reload (equivalent to a server restart).
- Chevron rotates: right when collapsed, down when expanded.

New tests in `tests/recordings/test_web.py`: `test_sections_start_collapsed` (no `open` attribute by default) and `test_lectures_has_expand_collapse_controls`. Full `test_web.py` (111 tests) passes; ruff clean; pre-push fast suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
