### PR TITLE
feat(sync): companion write-back for separated voiceover (#501 Phase 2)

### DIFF
--- a/changelog.d/501-sync-companion-apply-writeback.added.md
+++ b/changelog.d/501-sync-companion-apply-writeback.added.md
@@ -1,0 +1,15 @@
+- **`clm slides sync` now reconciles separated voiceover companions (write-back).**
+  Building on the read-mode support, `sync apply` / `autopilot` / `accept` now
+  *write* a separated-voiceover pair: a narration added, edited, moved, or removed
+  in one language's companion (`voiceover_*.de.py` / `.en.py`) is propagated —
+  translated when needed — into the other language's companion, committing the ≤4
+  files (both decks + both companions) in one atomic batch (issue #501). The deck
+  stays voiceover-free on disk before and after, so a crash can never leave a
+  half-inlined deck. A one-sided narration creates the missing companion pinned to
+  the twin's layout (`voiceover/` subdir vs sibling); an emptied companion is
+  deleted. An in-sync pair writes nothing, and the reconciled state is recorded in
+  the watermark under a `separated` representation marker so later runs diff in the
+  same representation (a legacy voiceover-free watermark auto-re-baselines on the
+  first companion-aware run). Speaker `notes` stay inline in the deck (voiceover-only
+  extract). A mixed / cross-language / orphaned-cell pair still refuses and writes
+  nothing.

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1775,20 +1775,25 @@ clm slides sync autopilot DECK [opts]              # legacy all-in-one WITH mode
 `--llm-timeout`) and the legacy write-everything behavior all live on
 **`autopilot`** now; never run `autopilot` in CI.
 
-**Separated voiceover companions (read modes, since CLM {version}).** When a
-deck keeps its voiceover in **separated companion files** (`voiceover_*.de.<ext>`
-/ `voiceover_*.en.<ext>`, the sticky default after `clm voiceover extract`), the
-read verbs (`report` / `verify` / `diagnose`) inline each companion **in memory**
-and reconcile the narration like any other cell — so a companion edited on only
-one language surfaces as `add …/voiceover [translation pending]` instead of
-drifting silently until `clm validate`. A standing, in-sync separated pair still
-reports **0 changes**. Pointing sync at a `voiceover_*` file reconciles its deck
+**Separated voiceover companions (since CLM {version}).** When a deck keeps its
+voiceover in **separated companion files** (`voiceover_*.de.<ext>` /
+`voiceover_*.en.<ext>`, the sticky default after `clm voiceover extract`), sync
+inlines each companion **in memory** and reconciles the narration like any other
+cell. The read verbs (`report` / `verify` / `diagnose`) surface a companion edited
+on only one language as `add …/voiceover [translation pending]` instead of letting
+it drift silently until `clm validate`, and the write verbs (`apply` / `accept` /
+`autopilot`) propagate it — translated when needed — into the other language's
+companion, committing both decks and both companions in one atomic write. A
+standing, in-sync separated pair reports **0 changes** and writes nothing. A
+one-sided narration creates the missing companion pinned to the twin's layout;
+speaker `notes` stay inline in the deck (voiceover-only extract). The reconciled
+state records a `separated` marker in the watermark so later runs diff in the same
+representation (a legacy voiceover-free watermark auto-re-baselines on the first
+companion-aware run). Pointing sync at a `voiceover_*` file reconciles its deck
 pair. A deck that keeps voiceover **both** inline and in a companion (mixed), or
 inconsistently across the two languages (one inline, one separated), is refused
 with a normalize hint (`clm voiceover inline` / `extract`); an orphaned companion
 cell (its slide was renamed or removed) is refused rather than dropped.
-*Applying* the reconciliation (the four-file write-back) is not yet implemented —
-`apply` on a separated pair reports the drift and writes nothing.
 
 **Pairing guard (since CLM {version}).** Before anything is read or written,
 sync checks that `DE_PATH` and `EN_PATH` are the two halves of **one** deck —

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -53,6 +53,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from clm.infrastructure.llm.ollama_client import OllamaError
+from clm.infrastructure.utils.path_utils import atomic_write_all
 from clm.notebooks.slide_parser import Cell, comment_token_for_path, parse_cell_header, parse_cells
 from clm.slides.anchor_primitives import (
     TITLE_MACRO_KIND,
@@ -110,6 +111,12 @@ from clm.slides.sync_writeback import (
     hash_cell,
     role_of,
     row_anchor,
+)
+from clm.slides.voiceover_tools import (
+    COMPANION_SUBDIR,
+    _prune_other_companions,
+    extract_pair_text,
+    resolve_companion,
 )
 
 if TYPE_CHECKING:
@@ -360,18 +367,23 @@ def apply_plan(
     """
     result = ApplyResult()
 
-    # Issue #501 Phase 1: a companion-involving pair (separated voiceover) is READ-ONLY
-    # until the ≤4-file companion write-back lands (Phase 2). The plan was built over the
-    # in-memory inlined projection, so the 2-file flush below would write the inlined
-    # voiceover back into the deck on disk — breaking the wholly-sidecar invariant — and a
-    # mixed / cross-language pair has already refused with a blocking issue. Refuse and
-    # write nothing; ``report`` / ``verify`` / ``diagnose`` still surface the drift.
-    if plan.companion_aware:
+    # Issue #501: a *separated*-voiceover pair applies through the ≤4-file companion
+    # write-back below — the plan (and the FileStates it drives) are built over the
+    # in-memory inlined projection, and the flush extracts back to deck + companion.
+    # ``plan.projected_de_text is not None`` iff the pair is separated-and-projectable
+    # (a mixed / cross-language / orphaned-cell pair carries a blocking issue and no
+    # projection, so it writes nothing via the normal error gating). Cold-start
+    # *bootstrap* over a separated deck (mint / adopt / reconcile) is out of scope —
+    # those paths mint ids on the raw deck and can't coordinate the companion; refuse
+    # so the author bootstraps ids first rather than half-applying.
+    companion_writeback = plan.projected_de_text is not None
+    if companion_writeback and any(
+        p.kind in ("mint", "adopt", "reconcile") for p in plan.proposals
+    ):
         result.errors.append(
-            "voiceover for this deck lives in a separated companion file; "
-            "`clm slides sync` can report the cross-language drift but cannot yet apply it "
-            "(companion write-back is not implemented). Reconcile the companions manually "
-            "for now."
+            "this separated-voiceover deck still needs its slide ids bootstrapped; run "
+            "`clm slides assign-ids` on the deck halves (and `clm slides sync verify`), "
+            "then re-run sync."
         )
         return result
 
@@ -404,12 +416,16 @@ def apply_plan(
         return result
 
     # Pre-apply content (parser-stripped) for the judge, keyed by (slide_id,
-    # role). Read before FileState mutates anything.
-    de_content = content_index(plan.de_path, "de")
-    en_content = content_index(plan.en_path, "en")
+    # role). Read before FileState mutates anything. For a separated pair every read
+    # is over the companion-inlined projection (Issue #501), so the apply engine sees
+    # and mutates the SAME text the plan's positions index; the flush extracts it back.
+    de_src = plan.projected_de_text
+    en_src = plan.projected_en_text
+    de_content = content_index(plan.de_path, "de", text=de_src)
+    en_content = content_index(plan.en_path, "en", text=en_src)
 
-    de_state = FileState.load(plan.de_path)
-    en_state = FileState.load(plan.en_path)
+    de_state = FileState.load(plan.de_path, text=de_src)
+    en_state = FileState.load(plan.en_path, text=en_src)
 
     # Stage 2b (edit path): resolve every edit — and every conflict the caller
     # chose to win — into a materialized outcome up front, the only place an edit
@@ -523,7 +539,10 @@ def apply_plan(
         # above, so a scoped flush is all an edit accept needs. The watermark never
         # advances here (a single-item accept must not bank the rest of the deck).
         if not result.has_errors and not plan.has_errors:
-            _flush_states_atomically(de_state, en_state)
+            if companion_writeback:
+                _flush_companion_writeback(de_state, en_state)
+            else:
+                _flush_states_atomically(de_state, en_state)
             result.flushed = True
         return result
 
@@ -614,7 +633,10 @@ def apply_plan(
     # independently declines on any plan issue / error, so "wrote nothing" and
     # "held the watermark" stay consistent.
     if not result.has_errors and not plan.has_errors:
-        _flush_states_atomically(de_state, en_state)
+        if companion_writeback:
+            _flush_companion_writeback(de_state, en_state)
+        else:
+            _flush_states_atomically(de_state, en_state)
         result.flushed = True
 
     # Watermark advance. A fully clean pass advances the whole deck. A
@@ -635,7 +657,27 @@ def apply_plan(
     # silently baseline them), where its own cell's tags are pinned at the old
     # baseline so the conflict re-surfaces while everything else banks.
     if watermark_cache is not None and not plan.blocking_issues:
-        if _pass_is_clean(plan, result) and not plan.tag_holds:
+        if companion_writeback:
+            # Issue #501: record the watermark over the INLINED projection with the
+            # "separated" marker so a later run diffs in the same representation. Only
+            # on a fully clean pass — a partial (deferred) separated pass holds the
+            # watermark and re-baselines off the projected git-HEAD next run (the
+            # partial-advance path is not modeled over inlined text in Phase 2).
+            if _pass_is_clean(plan, result) and not plan.tag_holds:
+                # Record over the RE-PROJECTION of the just-written files, not the
+                # in-memory render: ``extract`` canonicalizes headers that ``inline``
+                # keeps, so the next run reads ``inline(disk)`` — record exactly that
+                # so a clean pair does not re-surface as drift next run.
+                _record_watermark(
+                    watermark_cache,
+                    plan.de_path,
+                    plan.en_path,
+                    de_text=_inlined_from_disk(plan.de_path),
+                    en_text=_inlined_from_disk(plan.en_path),
+                    representation="separated",
+                )
+                result.watermark_recorded = True
+        elif _pass_is_clean(plan, result) and not plan.tag_holds:
             _record_watermark(watermark_cache, plan.de_path, plan.en_path)
             result.watermark_recorded = True
         elif (
@@ -3309,7 +3351,115 @@ def _atomic_write_text(path: Path, text: str) -> None:
         raise
 
 
-def content_index(path: Path, lang: str) -> dict[tuple[str, str], str]:
+def _read_or_none(path: Path) -> str | None:
+    """The text of ``path``, or ``None`` when it does not exist / cannot be read."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _inlined_from_disk(path: Path) -> str:
+    """Re-project ``path``'s on-disk deck + companion into inlined text (Issue #501).
+
+    Recomputes exactly what the *next* ``build_sync_plan`` will read for this half —
+    ``inline(deck, companion)`` over the freshly written files — so a separated pair's
+    watermark is recorded in the SAME representation the next run diffs against.
+    Because ``extract`` canonicalizes a voiceover header that ``inline`` does not
+    strip, recording over the pre-write ``FileState.render()`` would drift by exactly
+    that canonicalization; re-projecting the written files closes the gap.
+    """
+    companion = resolve_companion(path)
+    deck = path.read_text(encoding="utf-8")
+    if companion is None:
+        return deck
+    from clm.slides.voiceover_tools import inline_pair_text
+
+    return inline_pair_text(
+        deck, companion.read_text(encoding="utf-8"), comment_token_for_path(path)
+    ).inlined_text
+
+
+def _companion_layout(path: Path) -> str | None:
+    """The layout (``"subdir"`` / ``"sibling"``) of ``path``'s companion, or ``None``.
+
+    ``None`` when the half has no companion yet — the caller then pins the new
+    companion to the twin's layout so a single deck is never split across both.
+    """
+    comp = resolve_companion(path)
+    if comp is None:
+        return None
+    return "subdir" if comp.parent.name == COMPANION_SUBDIR else "sibling"
+
+
+def _flush_companion_writeback(de_state: FileState, en_state: FileState) -> None:
+    """Extract the reconciled inlined decks back into ≤4 files and write atomically (#501).
+
+    The separated-voiceover counterpart of :func:`_flush_states_atomically`. Each
+    half's rendered projection (deck **with** its voiceover inlined) is split back
+    into a voiceover-free deck + a voiceover companion via
+    :func:`extract_pair_text` (voiceover-only — notes stay inline in the deck, per
+    the issue #501 maintainer decision), and only the outputs that differ from disk
+    are committed in one :func:`atomic_write_all` batch (the dirty-diff — a naive
+    re-extract re-derives anchors and could otherwise churn a clean file). An emptied
+    companion is deleted and any stale copy in the other layout is pruned.
+
+    **Nothing changed → nothing written** (the empty-plan short-circuit): if apply
+    mutated neither half the author's on-disk files are left byte-for-byte untouched,
+    even where they are not in the canonical extract form. But once *either* half
+    changed, **both** are re-extracted: ``extract`` canonicalizes a voiceover header
+    (it stamps ``slide_id`` / ``vo_anchor`` that ``inline`` does not strip), so
+    writing only the mutated half would leave the two companions in different
+    representations and the next ``report`` would diff them as drift. Re-extracting
+    both keeps the pair in one representation; the dirty-diff still skips any file
+    already in that form, so a canonical deck sees only the genuinely-changed
+    companion written. The deck on disk stays voiceover-free before *and* after, so a
+    crash between replaces can never leave a mixed / wholly-inline deck.
+    """
+    if not (de_state.dirty or en_state.dirty):
+        return
+    # Pin each half's companion layout to its own, falling back to the twin's, so a
+    # newly-created companion (a one-sided → propagated narration) lands in the same
+    # place (``voiceover/`` subdir vs sibling) as the existing half's — never split
+    # across both layouts (design §5.5).
+    own_layout = {s.path: _companion_layout(s.path) for s in (de_state, en_state)}
+    twin_layout = {
+        de_state.path: own_layout[en_state.path],
+        en_state.path: own_layout[de_state.path],
+    }
+    writes: list[tuple[Path, str]] = []
+    deletions: list[Path] = []
+    for state in (de_state, en_state):
+        layout = own_layout[state.path] or twin_layout[state.path]
+        deck_text, companion_text, companion_path = extract_pair_text(
+            state.render(), state.path, layout=layout
+        )
+        if _read_or_none(state.path) != deck_text:
+            writes.append((state.path, deck_text))
+        existing = resolve_companion(state.path)
+        if companion_text:
+            target = existing if existing is not None else companion_path
+            if _read_or_none(target) != companion_text:
+                writes.append((target, companion_text))
+        elif existing is not None:
+            # The deck lost all its voiceover — remove the now-empty companion.
+            deletions.append(existing)
+    if writes:
+        for path, _text in writes:
+            path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_write_all(writes)
+    for path in deletions:
+        path.unlink(missing_ok=True)
+    # Clear any stale companion left in the other layout (e.g. a sibling shadowed by
+    # a freshly-written subdir copy), mirroring ``extract``'s own prune.
+    for state in (de_state, en_state):
+        kept = resolve_companion(state.path)
+        if kept is not None:
+            _prune_other_companions(state.path, keep=kept)
+        state.dirty = False
+
+
+def content_index(path: Path, lang: str, *, text: str | None = None) -> dict[tuple[str, str], str]:
     """Map ``(slide_id, role) -> parser-stripped content`` for one deck.
 
     Filtered to ``lang`` so the apply-side lookup matches exactly what the
@@ -3317,9 +3467,14 @@ def content_index(path: Path, lang: str) -> dict[tuple[str, str], str]:
     role+language predicate, so the judge can never be fed an
     other-language cell that happens to share a key. Public so the interactive
     walker can render each proposal's current source/target bodies.
+
+    ``text`` (Issue #501) overrides the disk read with the companion-inlined
+    projection so the apply-side lookup matches the plan built over that same text.
     """
+    if text is None:
+        text = path.read_text(encoding="utf-8")
     index: dict[tuple[str, str], str] = {}
-    for cell in parse_cells(path.read_text(encoding="utf-8"), comment_token_for_path(path)):
+    for cell in parse_cells(text, comment_token_for_path(path)):
         role = role_of(cell.metadata)
         if role is None:
             continue
@@ -4122,6 +4277,10 @@ def _record_watermark(
     cache: SyncWatermarkCache,
     de_path: Path,
     en_path: Path,
+    *,
+    de_text: str | None = None,
+    en_text: str | None = None,
+    representation: str | None = None,
 ) -> None:
     """Record both decks' post-apply state as the new baseline.
 
@@ -4131,9 +4290,17 @@ def _record_watermark(
     shared cells. The classifier still reads only the real-role rows
     (``_baseline_from_watermark`` filters the synthetic membership roles), so this
     does not change its behavior.
+
+    ``de_text`` / ``en_text`` (Issue #501) override the disk read with the
+    companion-inlined projection so a separated-voiceover pair records its watermark
+    in the SAME representation the plan diffs against; ``representation`` stamps the
+    marker (``"separated"``) so a later run whose computed representation disagrees
+    demotes to a git-HEAD cold-start rather than diffing across representations.
     """
-    de_text = de_path.read_text(encoding="utf-8")
-    en_text = en_path.read_text(encoding="utf-8")
+    if de_text is None:
+        de_text = de_path.read_text(encoding="utf-8")
+    if en_text is None:
+        en_text = en_path.read_text(encoding="utf-8")
     de_cells = parse_cells(de_text, comment_token_for_path(de_path))
     en_cells = parse_cells(en_text, comment_token_for_path(en_path))
     de_rows = watermark_rows(de_cells)
@@ -4195,6 +4362,10 @@ def _record_watermark(
 
     commit = get_git_info(de_path.parent).get("commit")
     cache.set_synced_commit(str(de_path), str(en_path), commit if isinstance(commit, str) else None)
+    # Issue #501: stamp the representation the rows were recorded in, so a later run
+    # whose computed representation differs demotes to a git-HEAD cold-start. Default
+    # "plain" keeps a non-companion pair's marker explicit (and the pre-#501 behavior).
+    cache.set_representation(str(de_path), str(en_path), representation or "plain")
 
 
 def record_baseline(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> None:

--- a/src/clm/slides/sync_writeback.py
+++ b/src/clm/slides/sync_writeback.py
@@ -454,8 +454,18 @@ class FileState:
     ends_with_newline: bool = True
 
     @classmethod
-    def load(cls, path: Path) -> FileState:
-        text = path.read_text(encoding="utf-8")
+    def load(cls, path: Path, *, text: str | None = None) -> FileState:
+        """Load a deck's :class:`FileState` from ``path`` (or from ``text``).
+
+        ``text`` (Issue #501) overrides the disk read with an in-memory
+        representation — the companion-inlined projection of a separated-voiceover
+        deck — so the apply engine mutates and renders the SAME text the plan's
+        positions index. ``path`` is still used for the comment token and as the
+        write target. When ``text`` is ``None`` (the default) the file is read from
+        disk exactly as before.
+        """
+        if text is None:
+            text = path.read_text(encoding="utf-8")
         preamble, cells = split_cells(text, comment_token_for_path(path))
         return cls(
             path=path,

--- a/tests/slides/test_sync_companion.py
+++ b/tests/slides/test_sync_companion.py
@@ -37,7 +37,9 @@ from clm.slides.sync_apply import apply_plan
 from clm.slides.sync_companion import Representation, project_pair
 from clm.slides.sync_plan import build_sync_plan
 from clm.slides.sync_report import build_report
+from clm.slides.sync_translate import StaticSlideTranslator
 from clm.slides.sync_verify import verify_pair
+from clm.slides.voiceover_tools import resolve_companion
 
 pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git not on PATH")
 
@@ -393,26 +395,25 @@ class TestRepresentationMarker:
 
 
 # ---------------------------------------------------------------------------
-# Apply is guarded (Phase 1 is read-only) and plain pairs are untouched.
+# Apply on an in-sync separated pair is a clean no-op; plain pairs are untouched.
+# (The full write-back is exercised in TestCompanionApplyWriteback below.)
 # ---------------------------------------------------------------------------
 
 
 class TestApplyGuardAndPlainParity:
-    def test_apply_refuses_a_separated_pair(self, tmp_path: Path) -> None:
+    def test_apply_in_sync_separated_pair_writes_nothing(self, tmp_path: Path) -> None:
         pair = _make_pair(
             tmp_path,
             de_comp=_companion("de", ("intro", "Willkommen.")),
             en_comp=_companion("en", ("intro", "Welcome.")),
         )
-        before_de = pair.de.read_text(encoding="utf-8")
-        before_comp = pair.de_comp.read_text(encoding="utf-8")
+        before = {p: p.read_text(encoding="utf-8") for p in (pair.de, pair.en, pair.de_comp)}
         plan = build_sync_plan(pair.de, pair.en)
         result = apply_plan(plan, judge=None)
-        assert result.has_errors
-        assert result.flushed is False
-        # Neither the deck nor the companion was written.
-        assert pair.de.read_text(encoding="utf-8") == before_de
-        assert pair.de_comp.read_text(encoding="utf-8") == before_comp
+        assert not result.has_errors
+        # An in-sync pair changes no files (the empty-plan short-circuit).
+        for path, text in before.items():
+            assert path.read_text(encoding="utf-8") == text
 
     def test_plain_pair_is_not_companion_aware(self, tmp_path: Path) -> None:
         pair = _make_pair(tmp_path)
@@ -498,3 +499,186 @@ class TestCompanionArgResolution:
         orphan.write_text(_companion("de", ("intro", "x")), encoding="utf-8")
         with pytest.raises(click.UsageError, match="voiceover companion"):
             _resolve_single_path(orphan, None)
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — APPLY write-back: reconcile a separated pair into ≤4 files.
+# ---------------------------------------------------------------------------
+
+
+def _errors(result) -> list[str]:
+    return list(result.errors)
+
+
+class TestCompanionApplyWriteback:
+    def test_new_narration_translated_into_the_other_companion(self, tmp_path: Path) -> None:
+        # The headline fix: a narration added on one side is translated and written
+        # into the OTHER language's companion; a second report is clean.
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        pair.de_comp.write_text(
+            _companion("de", ("intro", "Willkommen."), ("ende", "Danke.")),
+            encoding="utf-8",
+        )
+        translator = StaticSlideTranslator(mapping={"#\n# - Danke.": "#\n# - Thanks."})
+        plan = build_sync_plan(pair.de, pair.en)
+        result = apply_plan(plan, judge=None, translator=translator)
+        assert _errors(result) == []
+        assert result.applied_add == 1
+        assert "Thanks." in pair.en_comp.read_text(encoding="utf-8")
+        # Deck stays voiceover-free on disk (the wholly-sidecar invariant).
+        assert "voiceover" not in pair.en.read_text(encoding="utf-8")
+        # A second report against the reconciled tree is clean.
+        assert build_sync_plan(pair.de, pair.en).proposals == []
+
+    def test_deterministic_remove_propagates_without_a_model(self, tmp_path: Path) -> None:
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen."), ("ende", "Danke.")),
+            en_comp=_companion("en", ("intro", "Welcome."), ("ende", "Thanks.")),
+        )
+        # Author removes the ende narration on DE only.
+        pair.de_comp.write_text(_companion("de", ("intro", "Willkommen.")), encoding="utf-8")
+        plan = build_sync_plan(pair.de, pair.en)
+        result = apply_plan(plan, judge=None)  # no translator needed for a remove
+        assert _errors(result) == []
+        assert result.applied_remove == 1
+        assert "Thanks." not in pair.en_comp.read_text(encoding="utf-8")
+        assert build_sync_plan(pair.de, pair.en).proposals == []
+
+    def test_one_sided_companion_created_at_twin_layout(self, tmp_path: Path) -> None:
+        pair = _make_pair(tmp_path, de_comp=_companion("de", ("intro", "Willkommen.")))
+        assert resolve_companion(pair.en) is None
+        translator = StaticSlideTranslator(mapping={"#\n# - Willkommen.": "#\n# - Welcome."})
+        plan = build_sync_plan(pair.de, pair.en)
+        result = apply_plan(plan, judge=None, translator=translator)
+        assert _errors(result) == []
+        created = resolve_companion(pair.en)
+        assert created is not None
+        # Pinned to the DE twin's (sibling) layout, not relocated into a subdir.
+        assert created.parent == pair.en.parent
+        assert "Welcome." in created.read_text(encoding="utf-8")
+        assert build_sync_plan(pair.de, pair.en).proposals == []
+
+    def test_subdir_layout_is_preserved_on_write_back(self, tmp_path: Path) -> None:
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+            subdir=True,
+        )
+        pair.de_comp.write_text(
+            _companion("de", ("intro", "Willkommen."), ("ende", "Danke.")),
+            encoding="utf-8",
+        )
+        translator = StaticSlideTranslator(mapping={"#\n# - Danke.": "#\n# - Thanks."})
+        plan = build_sync_plan(pair.de, pair.en)
+        apply_plan(plan, judge=None, translator=translator)
+        created = resolve_companion(pair.en)
+        assert created is not None
+        assert created.parent.name == "voiceover"  # stayed in the subdir layout
+
+    def test_clean_apply_records_separated_watermark_and_is_idempotent(
+        self, tmp_path: Path
+    ) -> None:
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen."), ("ende", "Danke.")),
+            en_comp=_companion("en", ("intro", "Welcome."), ("ende", "Thanks.")),
+        )
+        pair.de_comp.write_text(_companion("de", ("intro", "Willkommen.")), encoding="utf-8")
+        cache = SyncWatermarkCache(tmp_path / "wm.db")
+        plan = build_sync_plan(pair.de, pair.en, watermark_cache=cache)
+        result = apply_plan(plan, judge=None, watermark_cache=cache)
+        assert result.watermark_recorded
+        assert cache.get_representation(str(pair.de), str(pair.en)) == "separated"
+        # The recorded separated watermark is used next run (not demoted) and is clean.
+        plan2 = build_sync_plan(pair.de, pair.en, watermark_cache=cache)
+        assert plan2.baseline_source == "watermark"
+        assert plan2.proposals == []
+
+    def test_mixed_pair_still_writes_nothing(self, tmp_path: Path) -> None:
+        # A refused (mixed) pair must never be written by apply.
+        de_inline = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n#\n# ## X\n\n'
+            '# %% [markdown] lang="de" tags=["voiceover"]\n#\n# - inline\n\n'
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="ende"\n#\n# ## Y\n'
+        )
+        pair = _make_pair(
+            tmp_path,
+            de_text=de_inline,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+            commit=False,
+        )
+        before = {p: p.read_text(encoding="utf-8") for p in (pair.de, pair.en, pair.de_comp)}
+        plan = build_sync_plan(pair.de, pair.en)
+        assert plan.has_errors  # the refusal rides on the plan's blocking issue
+        result = apply_plan(plan, judge=None)
+        # The plan's blocking issue holds the flush — apply writes nothing.
+        assert result.flushed is False
+        for path, text in before.items():
+            assert path.read_text(encoding="utf-8") == text
+
+    def test_inline_notes_stay_in_the_deck_on_write_back(self, tmp_path: Path) -> None:
+        # Voiceover-only extract: a note inline in the deck stays there; only the
+        # voiceover round-trips to the companion (the post-#387 steady state).
+        de_deck = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n#\n# ## Einführung\n'
+            "\n"
+            '# %% [markdown] lang="de" tags=["notes"]\n#\n# - Eine Sprechernotiz.\n'
+            "\n"
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="ende"\n#\n# ## Ende\n'
+        )
+        en_deck = de_deck.replace('lang="de"', 'lang="en"').replace(
+            "Eine Sprechernotiz.", "A speaker note."
+        )
+        pair = _make_pair(
+            tmp_path,
+            de_text=de_deck,
+            en_text=en_deck,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        pair.de_comp.write_text(
+            _companion("de", ("intro", "Willkommen."), ("ende", "Danke.")),
+            encoding="utf-8",
+        )
+        translator = StaticSlideTranslator(mapping={"#\n# - Danke.": "#\n# - Thanks."})
+        plan = build_sync_plan(pair.de, pair.en)
+        apply_plan(plan, judge=None, translator=translator)
+        de_after = pair.de.read_text(encoding="utf-8")
+        assert 'tags=["notes"]' in de_after  # the note is still inline in the deck
+        assert "Eine Sprechernotiz." in de_after
+        assert "notes" not in pair.de_comp.read_text(encoding="utf-8")
+
+    def test_crash_during_write_back_leaves_files_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        pair.de_comp.write_text(
+            _companion("de", ("intro", "Willkommen."), ("ende", "Danke.")),
+            encoding="utf-8",
+        )
+        before = {
+            p: p.read_text(encoding="utf-8") for p in (pair.de, pair.en, pair.de_comp, pair.en_comp)
+        }
+
+        def _boom(_writes: object) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr("clm.slides.sync_apply.atomic_write_all", _boom)
+        translator = StaticSlideTranslator(mapping={"#\n# - Danke.": "#\n# - Thanks."})
+        plan = build_sync_plan(pair.de, pair.en)
+        with pytest.raises(OSError, match="disk full"):
+            apply_plan(plan, judge=None, translator=translator)
+        # The whole batch failed before any os.replace — every target is untouched.
+        for path, text in before.items():
+            assert path.read_text(encoding="utf-8") == text

--- a/tests/slides/test_sync_tag_drift.py
+++ b/tests/slides/test_sync_tag_drift.py
@@ -500,6 +500,10 @@ class _RecordingCache:
         # Pair-level metadata (Fix D), not a per-cell channel — nothing to record here.
         pass
 
+    def set_representation(self, de_path, en_path, representation):  # noqa: ANN001
+        # Pair-level marker (Issue #501), not a per-cell channel — nothing to record.
+        pass
+
 
 class TestChannelCoverage:
     def test_every_recorded_channel_has_a_named_check(self, tmp_path: Path):


### PR DESCRIPTION
## Summary

Phase 1 (#513) made `clm slides sync`'s **read** modes companion-aware for
separated voiceover companions. **Phase 2** makes the **write** verbs (`apply` /
`accept` / `autopilot`) actually reconcile a separated pair — extracting the
reconciled in-memory projection back into the ≤4 files (both decks + both
companions) in one atomic write. This is the headline #501 fix: a narration added,
edited, moved, or removed in one language's companion now propagates —translated
when needed— to the other language's companion.

## What's in this PR

- **`apply_plan` over the projection.** For a separated pair the FileStates and
  content index are built over `plan.projected_*_text` (the companion-inlined
  projection), so every pass mutates the same text the plan's positions index.
- **`_flush_companion_writeback`.** Renders each half, `extract_pair_text`s it back
  into a voiceover-free deck + a voiceover companion (**notes stay inline** —
  voiceover-only extract), **dirty-diffs** against disk, and commits the survivors
  in one `atomic_write_all` batch. The deck is voiceover-free on disk before *and*
  after, so a crash can never leave a half-inlined deck.
- **Both halves re-extracted when either changed.** `extract` canonicalizes a
  voiceover header that `inline` does not strip, so writing only the mutated half
  would leave the two companions in different representations and re-report as
  drift. The **empty-plan short-circuit** leaves an in-sync pair byte-untouched.
- **One-sided create** pins the new companion to the twin's layout (subdir vs
  sibling); an emptied companion is deleted; stale copies pruned.
- **Watermark** recorded over the **re-projection of the written-back disk state**
  (what the next run reads) with a `separated` marker, only on a clean pass — so a
  reconciled pair is idempotent and doesn't re-surface as drift. Cold-start
  bootstrap (mint/adopt/reconcile) over a separated deck is refused (assign ids
  first).

## Subtlety worth a look

`inline` strips `for_slide`/`vo_anchor` but **not** `slide_id`, while `extract`
*adds* `slide_id`/`vo_anchor` — so `inline∘extract` isn't a byte-identity. Two
coordinated choices keep the system self-consistent: (1) re-extract **both** halves
so both companions land in the same (canonical) representation, and (2) record the
watermark over `inline(disk-after-writeback)` rather than the pre-write render, so
the recorded baseline exactly matches the next run's projection. Both are covered by
the idempotency tests.

## Testing

- `tests/slides/test_sync_companion.py` gains `TestCompanionApplyWriteback` (10
  tests): headline translate-and-write + clean re-report, deterministic remove
  propagation (no model), one-sided create at the twin's layout, subdir layout
  preserved, notes-stay-inline, `separated` watermark recorded + idempotent
  round-trip, crash-safety (failed `atomic_write_all` leaves every target
  untouched), mixed-pair-writes-nothing. The Phase 1 apply-guard test is updated to
  the new no-op contract.
- ~480 existing sync / voiceover / apply / report / info-topic tests pass; `ruff` +
  `mypy` clean; pre-push fast suite green.

Part of #501 (does not close it — Phase 3: ledger/bless/autopilot parity, validator
suggestion fix, and the PythonCourses authoring-doc correction remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
