### PR TITLE
docs(decks): describe course decks --json as flat topics[], not section-grouped (#516)

### DIFF
--- a/changelog.d/516-decks-json-flat-shape-docs.fixed.md
+++ b/changelog.d/516-decks-json-flat-shape-docs.fixed.md
@@ -1,0 +1,11 @@
+- **`clm course decks --json` help now says its output is a *flat* `topics[]`,
+  not a section grouping (#516).** The old wording ("a per-topic `topics` array
+  **keyed by `section`**") read as a `{section: [...]}` mapping, so agents wrote
+  filters against a non-existent `sections[]` shape, got `[]`, and reported a
+  silent no-output failure (exit 0, nothing printed) even though the command
+  emitted valid JSON. The `--json` help, command docstring, and `clm info
+  commands` entry now state the shape is a **flat** `topics` array whose
+  `section` is a plain string field, list the real top-level keys (`spec`,
+  `slides_dir`, `lang`, `deck_count`, `decks`, `topics`, `unresolved` — no
+  `sections` key), and point at `clm export outline --format json` for the
+  section-grouped (`sections[].topics[]`) shape. Docs only — no behavior change.

--- a/src/clm/cli/commands/course/decks.py
+++ b/src/clm/cli/commands/course/decks.py
@@ -79,10 +79,13 @@ def _rel(path: Path, base: Path) -> str:
     "--json",
     "as_json",
     is_flag=True,
-    help="Output as JSON. Adds a per-topic ``topics`` array — each entry "
-    "carries its ``section``, ``resolved_module`` and ``slide_files`` (the "
-    "source ``.py`` decks), plus first-occurrence-shadowed duplicates and "
-    "unresolved topics. This is the section -> source-file mapping in one call.",
+    help="Output as JSON. Emits a FLAT ``topics`` array (NOT grouped by "
+    "section): each entry is ``{topic_id, section, resolved_module, "
+    "slide_files, shadowed, …}`` where ``section`` is a plain string field. "
+    "Top-level keys: ``spec``, ``slides_dir``, ``lang``, ``deck_count``, "
+    "``decks``, ``topics``, ``unresolved`` — there is no ``sections`` key. For "
+    "the section-grouped shape (``sections[].topics[]`` with deck titles) use "
+    "``clm export outline --format json``.",
 )
 def spec_decks_cmd(
     spec_file: Path | None,
@@ -99,11 +102,16 @@ def spec_decks_cmd(
     This is the reliable way to compute a spec's "shipping set" — do not guess
     from deck filenames.
 
-    Plain output is one deck path per line. ``--json`` additionally emits a
-    per-topic ``topics`` array keyed by ``section`` with each topic's
-    ``slide_files`` — i.e. the **section -> source-``.py``-deck mapping**, with
-    no need to parse the spec XML by hand. (``clm export outline --format json``
-    gives the same mapping grouped by section and annotated with deck titles.)
+    Plain output is one deck path per line. ``--json`` emits a **flat**
+    ``topics`` array (**not** grouped by section): each entry carries a
+    ``section`` *string field* alongside that topic's ``resolved_module`` and
+    ``slide_files`` (the source ``.py`` decks) — the **section ->
+    source-``.py``-deck mapping** in one call, with no need to parse the spec
+    XML by hand. Top-level keys are ``spec``, ``slides_dir``, ``lang``,
+    ``deck_count``, ``decks``, ``topics``, ``unresolved`` (there is **no**
+    ``sections`` key). For the same mapping already nested as
+    ``sections[].topics[]`` and annotated with deck titles, use
+    ``clm export outline <spec> --format json``.
 
     \b
     Examples:

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -855,19 +855,23 @@ decks. Module-bound `<topic>`/`<section>` references resolve in their module;
 unbound topic IDs that match multiple modules are first-occurrence-wins (matching
 the build), and the shadowed matches are reported in `--json` output.
 
-Plain output is one deck path per line. `--json` adds a per-topic `topics`
-array that pairs each topic's `section` with its `slide_files` — the
+Plain output is one deck path per line. `--json` emits a **flat** `topics`
+array (**not** grouped by section): each entry pairs a `section` *string field*
+with that topic's `resolved_module` and `slide_files` — the
 **section → source-`.py`-deck mapping** in one call, so there is no need to
 parse the spec XML or grep `slides/` to learn which files back each section.
-(`clm export outline <spec> --format json` returns the same mapping grouped by
-section and annotated with deck titles.)
+Top-level keys are `spec`, `slides_dir`, `lang`, `deck_count`, `decks`,
+`topics`, `unresolved` — there is **no** `sections` key, and `section` is a
+string field on each topic, not a grouping key. For the same mapping already
+nested as `sections[].topics[]` and annotated with deck titles, use
+`clm export outline <spec> --format json`.
 
 | Option | Description |
 |--------|-------------|
 | `--all-specs DIR` | Resolve the union shipping set across every `*.xml` spec in `DIR`, annotating each deck with the spec(s) that reference it. Mutually exclusive with `SPEC_FILE`. |
 | `--lang de\|en\|both` | Keep only decks serving this language. Bilingual decks (no `.de`/`.en` tag) serve both, so they always survive the filter; split halves are kept only for their own language. Default: `both`. |
 | `--data-dir DIR` | Course data directory (contains `slides/`). Default: inferred from the spec file (its grandparent). |
-| `--json` | Output as JSON: a per-topic `topics` array (each with `section`, `resolved_module`, `slide_files`), plus unresolved topics and first-occurrence-shadowed duplicates. |
+| `--json` | Output as JSON: a **flat** `topics` array (not grouped by section) — each entry is `{topic_id, section, resolved_module, slide_files, shadowed, …}` with `section` as a plain string field. Top-level keys: `spec`, `slides_dir`, `lang`, `deck_count`, `decks`, `topics`, `unresolved` (no `sections` key). For the section-grouped shape use `clm export outline --format json`. |
 
 Topic references that resolve to no directory on disk are reported as a warning
 (stderr) but do not fail the command.

--- a/tests/cli/test_spec_decks.py
+++ b/tests/cli/test_spec_decks.py
@@ -86,6 +86,38 @@ class TestSpecDecksCommand:
         assert data["lang"] == "both"
         assert any("slides_intro.py" in d for d in data["decks"])
 
+    def test_json_shape_is_flat_not_grouped_by_section(self, tmp_path):
+        """The JSON is a flat ``topics[]`` (each with a ``section`` string
+        field), NOT a ``sections[]`` grouping. This contract is documented in
+        the ``--json`` help and ``clm info commands``; an agent that filters
+        against an assumed nested schema gets silent no-output (issue #516)."""
+        _topic(tmp_path, "module_100_basics", "topic_010_intro", "slides_intro.py")
+        spec_file = _write_spec(tmp_path, f"<sections>{_section('S', 'intro')}</sections>")
+
+        result = CliRunner().invoke(
+            cli, ["course", "decks", str(spec_file), "--data-dir", str(tmp_path), "--json"]
+        )
+
+        assert result.exit_code == 0
+        data = _json_from_output(result.output)
+        # Exactly the documented top-level keys — no ``sections`` key.
+        assert set(data) == {
+            "spec",
+            "slides_dir",
+            "lang",
+            "deck_count",
+            "decks",
+            "topics",
+            "unresolved",
+        }
+        assert "sections" not in data
+        # ``topics`` is a flat list; ``section`` is a plain string field on each.
+        assert isinstance(data["topics"], list)
+        assert data["topics"], "expected at least one resolved topic"
+        for topic in data["topics"]:
+            assert isinstance(topic["section"], str)
+            assert isinstance(topic["slide_files"], list)
+
     def test_lang_filter_excludes_other_split_half(self, tmp_path):
         _topic(
             tmp_path,


### PR DESCRIPTION
## Summary

Fixes #516. The `clm course decks --json` help described its output as a
`topics` array **"keyed by `section`"**, which reads as a `{section: [...]}`
mapping or nesting. The actual JSON is a **flat `topics[]` array** where each
entry has a `section` *string field* — top-level keys are `spec`, `slides_dir`,
`lang`, `deck_count`, `decks`, `topics`, `unresolved` (no `sections` key at all).

This caused a real silent agent failure: an LLM wrote `data.get('sections', [])`,
got `[]`, and the command exited 0 with no output even though it emitted valid
200 KB+ JSON — hard to debug because the tool itself is healthy.

## Changes

Reworded all three surfaces seeded from the same prose:

1. **`clm course decks --help`** — description paragraph now says **flat** (not
   grouped by section), names the real top-level keys, and points at
   `clm export outline --format json` for the section-grouped shape.
2. **`clm course decks --help`** — `--json` option line: same, with an inline
   schema sketch (`{topic_id, section, resolved_module, slide_files, shadowed, …}`)
   as a "show, don't tell" guard.
3. **`clm info commands`** — `clm course decks` description paragraph + `--json`
   table row, matching the above.

Plus:
- A regression test (`test_json_shape_is_flat_not_grouped_by_section`) asserting
  the exact top-level key set, absence of a `sections` key, and that `section`
  is a string field on each topic.
- A `changelog.d/` fragment.

**Docs only — no behavior change.** The JSON shape is unchanged; only the prose
describing it is corrected.

## Testing

- `pytest tests/cli/test_spec_decks.py` — 12 passed (incl. new test)
- `ruff check` / `ruff format --check` — clean
- Rendered `clm course decks --help` and `clm info commands` verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)
