### PR TITLE
feat(sync): companion-aware bless + consistency ledger (#501 Phase 3)

### DIFF
--- a/changelog.d/501-sync-companion-ledger-bless.added.md
+++ b/changelog.d/501-sync-companion-ledger-bless.added.md
@@ -1,0 +1,10 @@
+- **`clm slides sync baseline bless` and the consistency ledger are now
+  companion-aware.** Blessing a separated-voiceover pair records its watermark over
+  the companion-inlined projection with the `separated` marker (so the bless is not
+  demoted on the next run), and the consistency-ledger recorders (`accept --record`,
+  `bless`, and the semantic-judge pass) fingerprint the same projection — so a
+  narration confirmed in-sync is stored and later suppressed like any other cell
+  instead of being invisible to the ledger (issue #501). A drift *after* a
+  confirmation still surfaces (the recorded hashes no longer match). The `clm
+  validate` companion-parity suggestion now points authors at `clm slides sync`,
+  which reconciles the divergence.

--- a/docs/claude/design/sync-separated-voiceover-companions.md
+++ b/docs/claude/design/sync-separated-voiceover-companions.md
@@ -1,6 +1,7 @@
 # Reconciling separated voiceover companions in `clm slides sync`
 
-**Status:** proposed · **Issue:** [#501](https://github.com/hoelzl/clm/issues/501) ·
+**Status:** implemented (Phases 0–3; PRs #510 / #513 / #515 / this one) ·
+**Issue:** [#501](https://github.com/hoelzl/clm/issues/501) ·
 **Date:** 2026-07-01 · **Supersedes:** the "N-file atomicity — design not started"
 deferral in `split-voiceover-hardening.md` §3 #6 / §12 #7.
 

--- a/src/clm/slides/sync_apply.py
+++ b/src/clm/slides/sync_apply.py
@@ -68,6 +68,7 @@ from clm.slides.pairing import TITLE_SLIDE_ID, is_title_macro_cell
 from clm.slides.raw_cells import RawCell, split_cells
 from clm.slides.slug import resolve_collision, slugify
 from clm.slides.sync_code import TranslationOutcome, apply_code_structure
+from clm.slides.sync_companion import project_pair
 from clm.slides.sync_plan import (
     LOCALIZED_CODE_ROLE,
     LOCALIZED_MARKDOWN_ROLE,
@@ -4378,8 +4379,26 @@ def record_baseline(cache: SyncWatermarkCache, de_path: Path, en_path: Path) -> 
     throwaway commit** (#430). The caller must first assert the pair is a
     structurally valid split (``clm slides sync verify``); ``bless`` trusts the
     author's assertion that the localized halves are semantically in sync.
+
+    Issue #501: a separated-voiceover pair is blessed over its companion-inlined
+    projection with the ``separated`` marker, so the blessed watermark is in the same
+    representation the next run diffs against (blessing the voiceover-free deck would
+    demote on the very next run and make the bless a no-op).
     """
-    _record_watermark(cache, de_path, en_path)
+    de_text = de_path.read_text(encoding="utf-8")
+    en_text = en_path.read_text(encoding="utf-8")
+    projection = project_pair(de_path, en_path, de_text, en_text)
+    if projection.is_separated:
+        _record_watermark(
+            cache,
+            de_path,
+            en_path,
+            de_text=projection.de_text,
+            en_text=projection.en_text,
+            representation="separated",
+        )
+    else:
+        _record_watermark(cache, de_path, en_path)
 
 
 def _eligible_for_partial_advance(plan: SyncPlan, result: ApplyResult) -> bool:

--- a/src/clm/slides/sync_ledger.py
+++ b/src/clm/slides/sync_ledger.py
@@ -281,6 +281,28 @@ def save(ledger: SyncLedger, path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _inlined_deck_text(path: Path) -> str:
+    """A deck's text with its separated voiceover companion inlined (issue #501).
+
+    The ledger records and reads its per-cell fingerprints over this projection —
+    the SAME companion-inlined representation ``build_sync_plan``'s trust overlay
+    compares against (``de_current`` is built from the projected text). Without it a
+    separated deck's voiceover lives only in the companion, so ``record_pair`` /
+    ``record_edit`` would fingerprint a voiceover-free deck, never record the
+    narration, and the overlay's suppression would silently never fire for it. A
+    plain deck (no companion) returns its text unchanged, so nothing else moves.
+    """
+    from clm.slides.voiceover_tools import inline_pair_text, resolve_companion
+
+    text = path.read_text(encoding="utf-8")
+    companion = resolve_companion(path)
+    if companion is None:
+        return text
+    return inline_pair_text(
+        text, companion.read_text(encoding="utf-8"), comment_token_for_path(path)
+    ).inlined_text
+
+
 def _localized_idd_hashes(
     cells: list[Cell], lang: str
 ) -> dict[tuple[str, str], tuple[str, str | None]]:
@@ -313,10 +335,12 @@ def current_pairs(
     """``{(slide_id, role): (de_hash, en_hash, construct)}`` for the pair's localized id'd cells.
 
     Only keys present (id'd, localized) in **both** halves are returned — a
-    one-sided cell has no twin to certify in-sync.
+    one-sided cell has no twin to certify in-sync. Fingerprints the companion-inlined
+    projection (issue #501) so a separated deck's voiceover narratives — id'd once
+    ``extract`` has canonicalized them — are recorded like any other localized cell.
     """
-    de_cells = parse_cells(de_path.read_text(encoding="utf-8"), comment_token_for_path(de_path))
-    en_cells = parse_cells(en_path.read_text(encoding="utf-8"), comment_token_for_path(en_path))
+    de_cells = parse_cells(_inlined_deck_text(de_path), comment_token_for_path(de_path))
+    en_cells = parse_cells(_inlined_deck_text(en_path), comment_token_for_path(en_path))
     de_map = _localized_idd_hashes(de_cells, "de")
     en_map = _localized_idd_hashes(en_cells, "en")
     pairs: dict[tuple[str, str], tuple[str, str, str | None]] = {}
@@ -346,7 +370,7 @@ def _idless_narrative_hashes(path: Path, lang: str) -> dict[IdlessKey, str]:
         ordered_sync_cells,
     )
 
-    text = path.read_text(encoding="utf-8")
+    text = _inlined_deck_text(path)  # issue #501: fingerprint over the companion-inlined projection
     token = comment_token_for_path(path)
     identity = narrative_identity_map(split_cells(text, token)[1])
     cells = ordered_sync_cells(parse_cells(text, token), lang, identity)
@@ -711,7 +735,7 @@ def _idless_narrative_full(path: Path, lang: str) -> dict[IdlessKey, tuple[str, 
         ordered_sync_cells,
     )
 
-    text = path.read_text(encoding="utf-8")
+    text = _inlined_deck_text(path)  # issue #501: fingerprint over the companion-inlined projection
     token = comment_token_for_path(path)
     raw_cells = split_cells(text, token)[1]
     identity = narrative_identity_map(raw_cells)

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -1450,8 +1450,9 @@ def _check_split_companion_for_slide_parity(de_path: Path, en_path: Path) -> lis
             suggestion=(
                 "Each narration cell's for_slide is the slide_id of the slide it "
                 "narrates; the DE/EN companions must cover the same set of slides, "
-                "or one language ships with missing voiceover. Add the missing "
-                "narration, or route the change through `clm slides sync`."
+                "or one language ships with missing voiceover. Run `clm slides sync` "
+                "to propagate the missing narration to the other language (it now "
+                "reconciles separated voiceover companions), or add it by hand."
             ),
         )
     ]

--- a/tests/slides/test_sync_companion.py
+++ b/tests/slides/test_sync_companion.py
@@ -1,26 +1,25 @@
-"""Companion-aware ``clm slides sync`` — Phase 1 (issue #501).
+"""Companion-aware ``clm slides sync`` (issue #501).
 
 ``clm slides sync`` was structurally blind to **separated voiceover companion
 files** (``voiceover_*.de.py`` / ``voiceover_*.en.py``): editing one companion was
-never propagated to the other language and no ``sync`` subcommand reported it.
-Phase 1 makes the read modes companion-aware by inlining each half's companion in
-memory (design ``sync-separated-voiceover-companions.md``) so the existing plan
-engine sees the narration like any other cell — while writing nothing (apply is
-guarded; the ≤4-file write-back is Phase 2).
+never propagated to the other language and no ``sync`` subcommand reported it. The
+feature inlines each half's companion in memory (design
+``sync-separated-voiceover-companions.md``) so the existing plan engine sees the
+narration like any other cell, and extracts the reconciled projection back into the
+companions on write-back. These tests pin the whole contract, grouped by phase:
 
-These tests pin the Phase 1 contract:
-
-* a **standing** separated pair reports **0 changes** — the keystone: the git-HEAD
-  baseline is projected identically to the working tree, so a companion present on
-  both sides now and at HEAD reads as in-sync, *not* a spurious add (§5.3);
-* a **drifted** companion surfaces as ``add …/voiceover [translation pending]`` in
-  ``report`` — exactly as inline voiceover already does (the headline fix);
-* **mixed** / **cross-language** representations, and an **unplaceable** companion
-  cell, **refuse** and write nothing;
-* a legacy voiceover-free **watermark** on a now-separated deck **demotes** to a
-  projected git-HEAD baseline (the automatic re-baseline);
-* ``apply`` on a separated pair **refuses** (Phase 1 is read-only);
-* pointing ``sync`` at a ``voiceover_*`` file reconciles its **deck pair**.
+* **Read** (Phase 1) — a standing separated pair reports **0 changes** (the §5.3
+  keystone: the baseline is projected identically), a drifted companion surfaces as
+  ``add …/voiceover [translation pending]``, mixed / cross-language / unplaceable
+  cells **refuse**, a legacy watermark **demotes**, and a ``voiceover_*`` argument
+  resolves to its deck pair.
+* **Apply** (Phase 2) — a narration added / edited / removed on one side is
+  reconciled into the other companion in one atomic ≤4-file write; an in-sync pair
+  writes nothing; a one-sided companion is created at the twin's layout; notes stay
+  inline; the deck stays voiceover-free on disk.
+* **Bless + ledger** (Phase 3) — ``bless`` records a ``separated`` watermark and the
+  consistency ledger fingerprints the projection, so a confirmed narration is
+  suppressed while a later drift still surfaces.
 """
 
 from __future__ import annotations
@@ -682,3 +681,74 @@ class TestCompanionApplyWriteback:
         # The whole batch failed before any os.replace — every target is untouched.
         for path, text in before.items():
             assert path.read_text(encoding="utf-8") == text
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — bless + consistency-ledger parity over the projection.
+# ---------------------------------------------------------------------------
+
+
+class TestCompanionBlessAndLedger:
+    def test_bless_records_a_separated_watermark(self, tmp_path: Path) -> None:
+        from clm.slides.sync_apply import record_baseline
+
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        # Hand-reconcile a fresh state and bless it as the baseline.
+        pair.de_comp.write_text(_companion("de", ("intro", "Hallo.")), encoding="utf-8")
+        pair.en_comp.write_text(_companion("en", ("intro", "Hi.")), encoding="utf-8")
+        cache = SyncWatermarkCache(tmp_path / "wm.db")
+        record_baseline(cache, pair.de, pair.en)
+        assert cache.get_representation(str(pair.de), str(pair.en)) == "separated"
+        # The blessed (separated) watermark is trusted next run — not demoted — and clean.
+        plan = build_sync_plan(pair.de, pair.en, watermark_cache=cache)
+        assert plan.baseline_source == "watermark"
+        assert plan.proposals == []
+
+    def test_bless_plain_pair_records_plain_representation(self, tmp_path: Path) -> None:
+        from clm.slides.sync_apply import record_baseline
+
+        pair = _make_pair(tmp_path)
+        cache = SyncWatermarkCache(tmp_path / "wm.db")
+        record_baseline(cache, pair.de, pair.en)
+        assert cache.get_representation(str(pair.de), str(pair.en)) == "plain"
+
+    def test_ledger_suppresses_a_separated_voiceover(self, tmp_path: Path) -> None:
+        from clm.slides import sync_ledger
+
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        # A one-sided voiceover edit would normally propose an edit against git HEAD.
+        pair.de_comp.write_text(
+            _companion("de", ("intro", "Hallo und willkommen.")), encoding="utf-8"
+        )
+        assert any(p.role == "voiceover" for p in build_sync_plan(pair.de, pair.en).proposals)
+        # Record the current state as trusted-in-sync (the voiceover lives in the
+        # companion, so this only works because the ledger fingerprints the projection).
+        rec = sync_ledger.record_pair(pair.de, pair.en, confirmed_by="test")
+        assert not rec.refused
+        ledger = sync_ledger.load(sync_ledger.ledger_path_for(pair.de))
+        plan = build_sync_plan(pair.de, pair.en, ledger=ledger)
+        assert [p for p in plan.proposals if p.role == "voiceover"] == []
+        assert plan.ledger_skipped >= 1
+
+    def test_ledger_does_not_suppress_a_drifted_voiceover(self, tmp_path: Path) -> None:
+        from clm.slides import sync_ledger
+
+        pair = _make_pair(
+            tmp_path,
+            de_comp=_companion("de", ("intro", "Willkommen.")),
+            en_comp=_companion("en", ("intro", "Welcome.")),
+        )
+        sync_ledger.record_pair(pair.de, pair.en, confirmed_by="test")
+        # Drift AFTER recording: the ledger must not mask it.
+        pair.de_comp.write_text(_companion("de", ("intro", "Etwas anderes.")), encoding="utf-8")
+        ledger = sync_ledger.load(sync_ledger.ledger_path_for(pair.de))
+        plan = build_sync_plan(pair.de, pair.en, ledger=ledger)
+        assert any(p.role == "voiceover" for p in plan.proposals)


### PR DESCRIPTION
## Summary

The final phase of #501 brings the remaining `clm slides sync` trust surfaces —
`baseline bless` and the consistency ledger — into the separated-voiceover
projection, so they work for companion decks just like the read (#513) and write
(#515) paths already do.

## What's in this PR

- **`bless` (`record_baseline`)** projects the pair and, for a separated deck,
  records the watermark over the companion-inlined text with the `separated`
  marker — so a blessed separated pair is *trusted* next run instead of demoting to
  git-HEAD (which silently made the bless a no-op).
- **Consistency ledger recorders fingerprint the projection.** A shared
  `_inlined_deck_text(path)` feeds `current_pairs` / `_idless_narrative_hashes`, so
  `record_pair` / `record_edit` / the semantic-judge pass see a separated deck's
  voiceover narration (which lives in the companion, not the deck) and record it
  under the **same identity the overlay compares against**. A canonical
  (extract-stamped `slide_id`) voiceover records via the id'd `(slide_id, role)`
  path — which is exactly how the classifier keys its edit proposal — so the
  overlay's suppression fires. A one-sided narrative is skipped by the existing
  both-halves filter, so a drift is never blessed as in-sync.
- **`clm validate`** companion-parity suggestion now points at `clm slides sync`
  (accurate since it reconciles the divergence).

## Why the ledger keying is subtle (verified, not assumed)

A separated companion, once `extract` has canonicalized it, carries `slide_id` on
its voiceover cell — so the inlined cell is a *narrative* that nonetheless has a
`slide_id`. The overlay routes such an edit through its **id'd** bucket
(`de_by_key`), not the narrative bucket (which requires `slide_id is None`). I
probed the actual proposal keying (`slide_id='intro'`, id'd path) and confirmed
`_localized_idd_hashes` includes it, so recording via `current_pairs` lands it in
the matching bucket. End-to-end tests assert suppression fires and that a drift
*after* recording is not masked.

`autopilot` already routes through `build_sync_plan` + `apply_plan` (both
companion-aware), so it needs no separate seam.

## Testing

- `tests/slides/test_sync_companion.py` gains `TestCompanionBlessAndLedger`: bless
  records a `separated` watermark (trusted + idempotent next run), a plain pair
  records `plain`, the ledger suppresses a confirmed separated voiceover, and a
  drift after the confirmation still surfaces.
- ~500 existing sync / ledger / validate / watermark / info-topic tests pass;
  `ruff` + `mypy` clean; pre-push fast suite green.

Completes the #501 implementation (Phases 0–3). Design doc marked implemented.

Note: the downstream PythonCourses authoring docs (`.claude/docs/voiceover-authoring.md`,
`.github/copilot-instructions.md`) still describe the pre-#501 behavior and should be
updated in that repo to note that `clm slides sync` now propagates companion voiceover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
