### PR TITLE
feat(slides): `normalize --stamp-ids` — localized + narrative id stamping (#520 Phase 0)

### DIFF
--- a/changelog.d/520-normalize-stamp-ids.added.md
+++ b/changelog.d/520-normalize-stamp-ids.added.md
@@ -1,0 +1,10 @@
+- `clm slides normalize --stamp-ids` — the one-time sync-v3 id normalization
+  (#520 Phase 0): stamps a `slide_id` onto every id-less localized cell and
+  gives every voiceover/notes narrative its **own unique** content-slug id
+  (re-pointing legacy inherited-owner and placeholder ids). EN-authority and
+  pair-atomic: split decks are stamped through the unified pair so
+  `de_id == en_id`; cells without a directly-adjacent DE/EN twin are refused
+  as review items, never half-stamped. Shared language-neutral cells are
+  never stamped. `clm validate` now accepts both narrative-id conventions —
+  the legacy inherited form and a unique own id — while still flagging a
+  narrative id that duplicates another cell's id (the stale copy-paste case).

--- a/src/clm/cli/commands/slides/normalize.py
+++ b/src/clm/cli/commands/slides/normalize.py
@@ -11,7 +11,9 @@ import click
 from clm.cli.commands.shared import has_deck_scope, resolve_scoped_files
 from clm.slides.normalizer import (
     ALL_OPERATIONS,
+    Change,
     NormalizationResult,
+    ReviewItem,
     normalize_course,
     normalize_directory,
     normalize_file,
@@ -32,6 +34,20 @@ from clm.slides.normalizer import (
         "Comma-separated list of operations: "
         + ", ".join(sorted(ALL_OPERATIONS))
         + ", all. Default: all."
+    ),
+)
+@click.option(
+    "--stamp-ids",
+    "stamp_ids",
+    is_flag=True,
+    help=(
+        "One-time sync-v3 normalization (#520): stamp slide_ids onto id-less "
+        "localized cells and give every voiceover/notes narrative its own "
+        "unique content-slug id (re-pointing inherited-owner ids). "
+        "EN-authority and pair-atomic (split decks are stamped through the "
+        "unified pair; unpairable cells are refused, never half-stamped). "
+        "Shared language-neutral cells are never stamped. Runs INSTEAD of "
+        "the regular operations; combine with --dry-run to preview."
     ),
 )
 @click.option(
@@ -101,6 +117,7 @@ from clm.slides.normalizer import (
 def normalize_slides_cmd(
     path: Path,
     operations: str | None,
+    stamp_ids: bool,
     dry_run: bool,
     canonicalize_start_completed: bool,
     as_json: bool,
@@ -134,7 +151,41 @@ def normalize_slides_cmd(
         clm slides normalize slides/module_100/topic_010/
         clm slides normalize slides/ --operations tag_migration
         clm slides normalize course-specs/python-basics.xml
+        clm slides normalize slides/ --stamp-ids --dry-run
+
+    --stamp-ids is the one-time sync-v3 (#520) id normalization: every
+    localized cell and every narrative gets a slide_id (narratives their
+    OWN unique id, not the owner slide's). It replaces the regular
+    operations for that run.
     """
+    if stamp_ids:
+        if operations is not None:
+            raise click.UsageError(
+                "--stamp-ids replaces the regular operations; drop --operations."
+            )
+        if confirm_pairs is not None:
+            raise click.UsageError(
+                "--confirm-pairs belongs to the interleaving operation, not --stamp-ids."
+            )
+        result = _run_stamp_ids(
+            path,
+            dry_run=dry_run,
+            only=only,
+            exclude=exclude,
+            shipping_only=shipping_only,
+            specs_dir=specs_dir,
+            data_dir=data_dir,
+        )
+        if as_json:
+            click.echo(json.dumps(_result_to_dict(result), indent=2))
+        else:
+            _print_human_readable(result, dry_run)
+        if result.review_items and not result.changes:
+            sys.exit(2)
+        elif result.review_items:
+            sys.exit(1)
+        return
+
     op_list = _parse_operations(operations)
 
     confirmed_pairings = _parse_confirm_pairs(confirm_pairs) if confirm_pairs else None
@@ -179,6 +230,90 @@ def normalize_slides_cmd(
         sys.exit(2)
     elif result.review_items:
         sys.exit(1)
+
+
+def _run_stamp_ids(
+    path: Path,
+    *,
+    dry_run: bool,
+    only: str | None,
+    exclude: tuple[str, ...],
+    shipping_only: bool,
+    specs_dir: Path | None,
+    data_dir: Path | None,
+) -> NormalizationResult:
+    """The ``--stamp-ids`` pass: localized + narrative id stamping (#520 Phase 0).
+
+    Runs the assign-ids engine in stamp mode over the resolved file set —
+    ``assign_ids_in_files`` pairs split halves and stamps each pair through
+    the unified deck, which is what keeps DE/EN ids identical (#162). A
+    single split-half argument is expanded to its on-disk twin for the same
+    reason. Results are folded into the normalize report shape.
+    """
+    from clm.core.topic_resolver import find_slide_files_recursive
+    from clm.slides.assign_ids import AssignOptions, assign_ids_in_files
+    from clm.slides.pairing import split_twin
+
+    if path.is_file() and path.suffix == ".xml":
+        raise click.UsageError(
+            "--stamp-ids runs on a slide file or directory, not a course spec; "
+            "pass the slides/ directory instead."
+        )
+
+    options = AssignOptions(
+        stamp_ids=True,
+        accept_content_derived=True,
+        accept_code_derived=True,
+        report_only=dry_run,
+    )
+    if has_deck_scope(only, exclude, shipping_only):
+        files = resolve_scoped_files(
+            path,
+            only=only,
+            exclude=exclude,
+            shipping_only=shipping_only,
+            specs_dir=specs_dir,
+            data_dir=data_dir,
+        )
+    elif path.is_dir():
+        files = list(find_slide_files_recursive(path))
+    else:
+        files = [path]
+        twin = split_twin(path)
+        if twin is not None:
+            files.append(twin)
+
+    assign_result = assign_ids_in_files(files, options)
+
+    result = NormalizationResult(files_modified=assign_result.files_modified)
+    for a in assign_result.assignments:
+        result.changes.append(
+            Change(
+                file=a.file,
+                operation="stamp_ids",
+                line=a.line,
+                description=f'slide_id="{a.slide_id}" ({a.source})',
+            )
+        )
+    for r in assign_result.refusals:
+        details = {
+            k: v
+            for k, v in {
+                "line": r.line,
+                "proposed_slug": r.proposed_slug,
+                "proposed_title": r.proposed_title,
+            }.items()
+            if v is not None
+        }
+        result.review_items.append(
+            ReviewItem(
+                file=r.file,
+                issue=f"stamp_id_{r.severity}_refusal",
+                suggestion=r.reason,
+                details=details,
+            )
+        )
+    return result
 
 
 def _parse_operations(ops_str: str | None) -> list[str] | None:

--- a/src/clm/cli/commands/slides/normalize.py
+++ b/src/clm/cli/commands/slides/normalize.py
@@ -167,6 +167,11 @@ def normalize_slides_cmd(
             raise click.UsageError(
                 "--confirm-pairs belongs to the interleaving operation, not --stamp-ids."
             )
+        if canonicalize_start_completed:
+            raise click.UsageError(
+                "--canonicalize-start-completed belongs to the interleaving "
+                "operation, not --stamp-ids."
+            )
         result = _run_stamp_ids(
             path,
             dry_run=dry_run,
@@ -249,10 +254,16 @@ def _run_stamp_ids(
     the unified deck, which is what keeps DE/EN ids identical (#162). A
     single split-half argument is expanded to its on-disk twin for the same
     reason. Results are folded into the normalize report shape.
+
+    Discovery is prefix-AGNOSTIC for split decks: the sync surface supports
+    ``apis.de.py`` as well as ``slides_x.de.py``, and this one-time sync-v3
+    migration must reach every deck sync manages — so a directory walk
+    unions the routing-prefixed slide files with every prefix-less split
+    half (voiceover companions are excluded by both walks).
     """
     from clm.core.topic_resolver import find_slide_files_recursive
     from clm.slides.assign_ids import AssignOptions, assign_ids_in_files
-    from clm.slides.pairing import split_twin
+    from clm.slides.pairing import derive_split_twin, find_split_slide_files_recursive
 
     if path.is_file() and path.suffix == ".xml":
         raise click.UsageError(
@@ -276,10 +287,12 @@ def _run_stamp_ids(
             data_dir=data_dir,
         )
     elif path.is_dir():
-        files = list(find_slide_files_recursive(path))
+        files = sorted(
+            set(find_slide_files_recursive(path)) | set(find_split_slide_files_recursive(path))
+        )
     else:
         files = [path]
-        twin = split_twin(path)
+        twin = derive_split_twin(path)
         if twin is not None:
             files.append(twin)
 

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1390,6 +1390,7 @@ clm slides normalize [OPTIONS] PATH
 | Option | Description |
 |--------|-------------|
 | `--operations TEXT` | Comma-separated operations: `preamble_code`, `placeholder_start`, `tag_migration`, `workshop_tags`, `interleaving`, `slide_ids`, `cell_spacing`, `all` (default: `all`) |
+| `--stamp-ids` | (since CLM {version}) The **one-time sync-v3 id normalization** (#520): stamps a `slide_id` onto every id-less **localized** cell (`lang=…`, markdown or code) and gives every voiceover/notes **narrative** its **own unique** content-slug id — re-pointing legacy inherited-owner (and `<deck-stem>-cell-N` placeholder) ids; any other existing id is kept, `!`-preserved ids always win. EN-authority and **pair-atomic**: split decks are stamped through the unified pair so `de_id == en_id`; a cell without a directly-adjacent DE/EN twin is *refused* (review item), never half-stamped. Shared language-neutral cells are never stamped. **Replaces the regular operations for that run** (combining with `--operations` is an error); honors `--dry-run`, `--json`, and the directory scoping options. |
 | `--dry-run` | Preview changes without modifying files |
 | `--canonicalize-start-completed` | Force `start`/`completed` cohesion pairs into the canonical DE/EN interleave, even when DE/EN code differs (e.g. localized identifiers). Run before `clm slides split` so `unify(split(deck)) == deck` holds byte-for-byte. Only affects the `interleaving` operation. |
 | `--confirm-pairs FILE` | (since CLM {version}) Apply an **agent-confirmed interleave** (#236). `FILE` (or `-` for stdin) is a JSON array of `{"de_line": N, "en_line": M}` pairs taken from a `--json` `similarity_failure` worklist; each bypasses the similarity gate and is reordered into adjacency. **Single slide `.py` file only** (the line numbers are per-file). Run on the same, unmodified file the worklist reported — a drifted pairing simply does not match and stays flagged. |
@@ -1428,7 +1429,17 @@ clm slides normalize slides/module_010/topic_100_intro/deck.py --operations inte
 clm slides normalize slides/ --operations slide_ids --only bilingual
 # Scope: only the decks that actually ship
 clm slides normalize slides/ --shipping-only
+# One-time sync-v3 id normalization (#520): preview, then stamp
+clm slides normalize slides/ --stamp-ids --dry-run
+clm slides normalize slides/ --stamp-ids
 ```
+
+Under `--stamp-ids`, narrative ids follow the sync-v3 convention: a
+voiceover/notes cell carries its **own** unique id instead of the owning
+slide's. `clm validate` accepts both conventions — the legacy inherited form
+(narrative id equals the preceding slide/subslide anchor's id) and a unique
+own id; a narrative id that duplicates some *other* cell's id is still an
+error (the stale copy-paste case).
 
 ### `clm slides assign-ids`
 

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1390,7 +1390,7 @@ clm slides normalize [OPTIONS] PATH
 | Option | Description |
 |--------|-------------|
 | `--operations TEXT` | Comma-separated operations: `preamble_code`, `placeholder_start`, `tag_migration`, `workshop_tags`, `interleaving`, `slide_ids`, `cell_spacing`, `all` (default: `all`) |
-| `--stamp-ids` | (since CLM {version}) The **one-time sync-v3 id normalization** (#520): stamps a `slide_id` onto every id-less **localized** cell (`lang=…`, markdown or code) and gives every voiceover/notes **narrative** its **own unique** content-slug id — re-pointing legacy inherited-owner (and `<deck-stem>-cell-N` placeholder) ids; any other existing id is kept, `!`-preserved ids always win. EN-authority and **pair-atomic**: split decks are stamped through the unified pair so `de_id == en_id`; a cell without a directly-adjacent DE/EN twin is *refused* (review item), never half-stamped. Shared language-neutral cells are never stamped. **Replaces the regular operations for that run** (combining with `--operations` is an error); honors `--dry-run`, `--json`, and the directory scoping options. |
+| `--stamp-ids` | (since CLM {version}) The **one-time sync-v3 id normalization** (#520): stamps a `slide_id` onto every id-less **localized** cell (`lang=…`, markdown or code) and gives every voiceover/notes **narrative** its **own unique** content-slug id — re-pointing legacy inherited-owner (and `<deck-stem>-cell-N` placeholder) ids; any other existing id is kept, `!`-preserved ids always win. EN-authority and **pair-atomic**: split decks are stamped through the unified pair so `de_id == en_id`, and a refusal means the deck was left **untouched**. Cells without a directly-adjacent DE/EN twin (including whole block-interleaved runs like `de,de,en,en` — run the `interleaving` operation first), lone split halves, and non-unifiable pairs are refused as review items, never half-stamped. Directory discovery is **prefix-agnostic** for split decks (`apis.de.py` is found alongside `slides_x.de.py`); voiceover companion files are not touched (follow-up). Shared language-neutral cells are never stamped. **Replaces the regular operations for that run** (combining with `--operations`, `--confirm-pairs`, or `--canonicalize-start-completed` is an error); honors `--dry-run`, `--json`, and the directory scoping options. |
 | `--dry-run` | Preview changes without modifying files |
 | `--canonicalize-start-completed` | Force `start`/`completed` cohesion pairs into the canonical DE/EN interleave, even when DE/EN code differs (e.g. localized identifiers). Run before `clm slides split` so `unify(split(deck)) == deck` holds byte-for-byte. Only affects the `interleaving` operation. |
 | `--confirm-pairs FILE` | (since CLM {version}) Apply an **agent-confirmed interleave** (#236). `FILE` (or `-` for stdin) is a JSON array of `{"de_line": N, "en_line": M}` pairs taken from a `--json` `similarity_failure` worklist; each bypasses the similarity gate and is reordered into adjacency. **Single slide `.py` file only** (the line numbers are per-file). Run on the same, unmodified file the worklist reported — a drifted pairing simply does not match and stays flagged. |
@@ -1438,8 +1438,12 @@ Under `--stamp-ids`, narrative ids follow the sync-v3 convention: a
 voiceover/notes cell carries its **own** unique id instead of the owning
 slide's. `clm validate` accepts both conventions — the legacy inherited form
 (narrative id equals the preceding slide/subslide anchor's id) and a unique
-own id; a narrative id that duplicates some *other* cell's id is still an
-error (the stale copy-paste case).
+own id. A narrative id that duplicates another slide's or narrative's id is
+still an **error** (the stale copy-paste case), and divergent ids on an
+adjacent DE/EN narrative twin pair are an error too (they split into
+asymmetric id sets). Duplicates involving **localized** cell ids are
+**warnings** — legacy decks deliberately shadow slide ids on some localized
+cells.
 
 ### `clm slides assign-ids`
 

--- a/src/clm/slides/assign_ids.py
+++ b/src/clm/slides/assign_ids.py
@@ -24,6 +24,19 @@ Rules in one paragraph:
 - Voiceover and notes cells inherit the slide_id of the most recent
   preceding slide/subslide cell (1:N relationship). They are *never*
   written from an extracted heading of their own.
+- **Stamp mode** (``AssignOptions.stamp_ids``, the engine behind
+  ``clm slides normalize --stamp-ids`` — sync-v3 Phase 0, #520): the two
+  rules above are widened for the one-time v3 normalization. Every id-less
+  *localized* cell (``lang=…``, markdown or code, not a slide/subslide)
+  gets a content-slug id, and every localized *narrative* (voiceover/notes)
+  gets its **own unique** id instead of inheriting the owner slide's
+  (design §3.4/§12.1) — an existing inherited-owner or placeholder id is
+  re-pointed, any other existing id is kept (ids stay monotone). Stamping
+  is strictly **pair-atomic**: only directly-adjacent DE/EN twins are
+  stamped (both twins get the exact same id), a cell without an adjacent
+  twin is refused rather than given a one-sided id that would break split
+  id-set symmetry. Shared (language-neutral) cells are never stamped —
+  they pair by byte-parity, not by name.
 """
 
 from __future__ import annotations
@@ -31,12 +44,16 @@ from __future__ import annotations
 import hashlib
 import logging
 import re
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from clm.infrastructure.utils.path_utils import split_lang_suffix
-from clm.notebooks.slide_parser import comment_token_for_path, parse_cell_header
+from clm.notebooks.slide_parser import (
+    CellMetadata,
+    comment_token_for_path,
+    parse_cell_header,
+)
 from clm.slides.code_cell_extract import extract_from_code
 from clm.slides.headingless import (
     Category,
@@ -100,7 +117,10 @@ class AssignedId:
     # "llm" / "paired" / "twin" / "content:<extractor>" (markdown bullet/bold/
     # img_alt/img_src/prose or the code AST extractors
     # code:class/def/assign/import/call/for/expr) /
-    # "code:line" (the opt-in first-code-line fallback, #251).
+    # "code:line" (the opt-in first-code-line fallback, #251) /
+    # "narrative-own" (stamp mode: a fresh own id minted for a narrative) /
+    # "narrative-repoint" (stamp mode: an inherited-owner/placeholder id
+    # replaced by the narrative's own id — sync-v3 §12.1, #520).
     source: str
 
 
@@ -203,6 +223,13 @@ class AssignOptions:
     report_only: bool = False
     llm_suggester: TitleSuggester | None = None
     llm_cache: TitleSuggestionCache | None = None
+    # Stamp mode (sync-v3 Phase 0, #520 — `clm slides normalize --stamp-ids`):
+    # additionally id every localized cell and give narratives their own
+    # unique ids (re-pointing inherited-owner/placeholder ids). Pair-atomic:
+    # only directly-adjacent DE/EN twins are stamped; solo cells are refused.
+    # The caller decides the accept posture (the normalize CLI turns
+    # accept_content_derived + accept_code_derived on).
+    stamp_ids: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -228,6 +255,319 @@ def _classify_for_assignment(cell: _Cell) -> str:
     if meta.is_narrative and meta.lang is not None:
         return "narrative"
     return "skip"
+
+
+# ---------------------------------------------------------------------------
+# Stamp mode (sync-v3 Phase 0, #520): localized + narrative id stamping
+# ---------------------------------------------------------------------------
+
+
+def _narrative_role(meta: CellMetadata) -> str:
+    return "voiceover" if "voiceover" in meta.tags else "notes"
+
+
+def _stamp_class(cell: _Cell) -> str | None:
+    """Stamp-eligibility class of a cell under ``AssignOptions.stamp_ids``.
+
+    ``"narrative"`` — localized voiceover/notes cell (own-id policy, §12.1)
+    ``"localized"`` — any other lang-tagged non-slide cell (markdown or code)
+    ``None`` — everything the stamp pass must not touch: shared/neutral
+    cells (they pair by byte-parity, never by name — design §3.4), j2
+    directives, and slide/subslide cells (the existing machinery owns those).
+    """
+    meta = cell.metadata
+    if meta.is_j2 or meta.lang is None or meta.is_slide_start:
+        return None
+    if meta.is_narrative:
+        return "narrative"
+    return "localized"
+
+
+def _build_stamp_pairs(cells: list[_Cell]) -> dict[int, tuple[int, int]]:
+    """Map each paired stamp-eligible cell index to ``(twin_idx, slug_source_idx)``.
+
+    Twins are **directly adjacent** cells ``(i, i+1)`` of the same stamp
+    class and cell type with differing langs — narratives additionally need
+    the same voiceover/notes role, localized cells identical tags. The
+    bilingual/unified interleave convention keeps DE/EN twins adjacent (the
+    ``interleaving`` normalize operation enforces exactly this), so anything
+    looser risks pairing cells across slides. A cell without an adjacent twin
+    stays out of the map and the stamp pass refuses it: minting a one-sided
+    id would break split id-set symmetry (``sync verify``'s structural gate).
+    """
+    pairs: dict[int, tuple[int, int]] = {}
+    i = 0
+    while i < len(cells) - 1:
+        a, b = cells[i], cells[i + 1]
+        kind = _stamp_class(a)
+        ma, mb = a.metadata, b.metadata
+        if (
+            kind is not None
+            and kind == _stamp_class(b)
+            and ma.cell_type == mb.cell_type
+            and ma.lang != mb.lang
+            and (
+                _narrative_role(ma) == _narrative_role(mb)
+                if kind == "narrative"
+                else list(ma.tags) == list(mb.tags)
+            )
+        ):
+            en_idx = i if ma.lang == "en" else i + 1
+            pairs[i] = (i + 1, en_idx)
+            pairs[i + 1] = (i, en_idx)
+            i += 2
+            continue
+        i += 1
+    return pairs
+
+
+def _is_legacy_narrative_id(existing: str, current_slide_id: str | None, file_path: Path) -> bool:
+    """An inherited owner id or a conversion placeholder — re-pointable in stamp mode.
+
+    Anything else on a narrative counts as its *own* id and is kept (ids are
+    monotone; stamp mode never replaces an id the §12.1 policy already accepts).
+    """
+    bare = strip_preserve_marker(existing)
+    if current_slide_id is not None and bare == current_slide_id:
+        return True
+    return _is_placeholder_narrative_id(existing, file_path)
+
+
+def _stamp_refuse(
+    result: AssignResult,
+    file_str: str,
+    line: int,
+    reason: str,
+    *,
+    severity: str = "soft",
+    proposed_slug: str | None = None,
+    proposed_title: str | None = None,
+) -> None:
+    result.refusals.append(
+        Refusal(
+            file=file_str,
+            line=line,
+            severity=severity,
+            reason=reason,
+            proposed_slug=proposed_slug,
+            proposed_title=proposed_title,
+        )
+    )
+
+
+def _handle_stamp(
+    cell: _Cell,
+    idx: int,
+    kind: str,
+    cells: list[_Cell],
+    stamp_pairs: dict[int, tuple[int, int]],
+    stamp_slug: dict[int, str | None],
+    current_slide_id: str | None,
+    options: AssignOptions,
+    used_ids: set[str],
+    file_path: Path,
+    file_str: str,
+    result: AssignResult,
+    comment_token: str,
+) -> None:
+    """Stamp one localized/narrative cell (``AssignOptions.stamp_ids``).
+
+    Resolution order per adjacent DE/EN twin pair (``stamp_slug`` caches the
+    outcome under the pair's lower index so both twins commit to the same id):
+
+    1. a preserved (``!``) or *own* existing id on either twin wins — the
+       other twin adopts it;
+    2. otherwise mint a content slug from the EN member (DE-sibling fallback),
+       gated by the usual accept knobs, and write it onto both twins —
+       re-pointing inherited-owner/placeholder narrative ids (§12.1);
+    3. cells without an adjacent twin, narratives without a preceding
+       slide/title anchor, and non-extractable bodies are refused, never
+       half-stamped.
+    """
+    existing = cell.metadata.slide_id
+    pair = stamp_pairs.get(idx)
+    group_key = min(idx, pair[0]) if pair is not None else idx
+
+    if existing and is_preserved(existing):
+        # Lock the pair to the preserved bare form so the twin adopts it.
+        stamp_slug.setdefault(group_key, strip_preserve_marker(existing))
+        return
+
+    legacy = (
+        kind == "narrative"
+        and existing is not None
+        and _is_legacy_narrative_id(existing, current_slide_id, file_path)
+    )
+
+    if existing and not legacy:
+        # An own id — monotone: never replaced in stamp mode. Register it so
+        # an id-less twin adopts it; flag twins that committed elsewhere.
+        bare = strip_preserve_marker(existing)
+        prior = stamp_slug.setdefault(group_key, bare)
+        if prior is not None and prior != bare:
+            _stamp_refuse(
+                result,
+                file_str,
+                cell.line_number,
+                f"DE/EN twins carry divergent ids ({prior!r} vs {bare!r}); resolve manually",
+            )
+        return
+
+    if kind == "narrative" and current_slide_id is None:
+        _stamp_refuse(
+            result,
+            file_str,
+            cell.line_number,
+            "narrative has no preceding slide/subslide (or title) anchor; "
+            "fix the deck structure first",
+        )
+        return
+
+    if pair is None:
+        _stamp_refuse(
+            result,
+            file_str,
+            cell.line_number,
+            "no directly-adjacent DE/EN twin; a one-sided id would break split "
+            "id symmetry — normalize the interleaving first",
+        )
+        return
+
+    twin_idx, slug_source_idx = pair
+
+    if group_key in stamp_slug:
+        # Second member of the pair: mirror the twin's resolution.
+        resolved = stamp_slug[group_key]
+        if resolved is None:
+            _stamp_refuse(
+                result,
+                file_str,
+                cell.line_number,
+                "twin cell refused; both cells in the pair need a manual id",
+            )
+            return
+        if existing and strip_preserve_marker(existing) == resolved:
+            return  # idempotent
+        if not options.report_only:
+            _write_slide_id(cell, resolved)
+        used_ids.add(resolved)
+        result.assignments.append(
+            AssignedId(
+                file=file_str,
+                line=cell.line_number,
+                slide_id=resolved,
+                source="narrative-repoint" if legacy else "paired",
+            )
+        )
+        return
+
+    # First member of the pair to resolve. Adoption first: the twin's own
+    # (or preserved) id wins over a fresh mint — ids stay monotone.
+    twin = cells[twin_idx]
+    twin_existing = twin.metadata.slide_id
+    if twin_existing:
+        twin_own = is_preserved(twin_existing) or not (
+            kind == "narrative"
+            and _is_legacy_narrative_id(twin_existing, current_slide_id, file_path)
+        )
+        if twin_own:
+            twin_bare = strip_preserve_marker(twin_existing)
+            stamp_slug[group_key] = twin_bare
+            if existing and strip_preserve_marker(existing) == twin_bare:
+                return
+            if not options.report_only:
+                _write_slide_id(cell, twin_bare)
+            used_ids.add(twin_bare)
+            result.assignments.append(
+                AssignedId(
+                    file=file_str,
+                    line=cell.line_number,
+                    slide_id=twin_bare,
+                    source="twin",
+                )
+            )
+            return
+
+    # Mint a fresh id from the EN member; fall back to the other sibling
+    # when the EN body has nothing extractable (transliteration keeps the
+    # resulting slug ASCII).
+    slug_source = cells[slug_source_idx]
+    extraction = _extract_from_cell(slug_source, comment_token, options.accept_code_derived)
+    if extraction.category == Category.NON_EXTRACTABLE:
+        alt_idx = twin_idx if slug_source_idx == idx else idx
+        alt_extraction = _extract_from_cell(
+            cells[alt_idx], comment_token, options.accept_code_derived
+        )
+        if alt_extraction.category != Category.NON_EXTRACTABLE:
+            extraction = Extraction(
+                alt_extraction.category,
+                alt_extraction.text,
+                f"sibling-{alt_extraction.source}",
+            )
+    if extraction.category == Category.NON_EXTRACTABLE:
+        _stamp_refuse(
+            result,
+            file_str,
+            cell.line_number,
+            "cell has no heading and no extractable content",
+            severity="hard",
+        )
+        stamp_slug[group_key] = None
+        return
+
+    is_code_line = extraction.source in _CODE_LINE_SOURCES
+    if extraction.category == Category.HEADED:
+        write = True
+        source_label = extraction.source
+    elif is_code_line:
+        write = options.accept_code_derived
+        source_label = extraction.source
+    else:
+        write = options.accept_content_derived
+        source_label = f"content:{extraction.source}"
+
+    proposed = _proposed_slug_from_extraction(extraction, used_ids)
+
+    if not write:
+        accept_flag = "--accept-code-derived" if is_code_line else "--accept-content-derived"
+        _stamp_refuse(
+            result,
+            file_str,
+            cell.line_number,
+            f"headingless cell; pass {accept_flag} to accept",
+            proposed_slug=proposed or None,
+            proposed_title=extraction.text,
+        )
+        stamp_slug[group_key] = None
+        return
+
+    if not proposed:
+        _stamp_refuse(
+            result,
+            file_str,
+            cell.line_number,
+            "could not derive a usable slug from content",
+            proposed_title=extraction.text,
+        )
+        stamp_slug[group_key] = None
+        return
+
+    stamp_slug[group_key] = proposed
+    if existing and strip_preserve_marker(existing) == proposed:
+        return  # idempotent
+    if not options.report_only:
+        _write_slide_id(cell, proposed)
+    used_ids.add(proposed)
+    if kind == "narrative":
+        source_label = "narrative-repoint" if legacy else "narrative-own"
+    result.assignments.append(
+        AssignedId(
+            file=file_str,
+            line=cell.line_number,
+            slide_id=proposed,
+            source=source_label,
+        )
+    )
 
 
 def _proposed_slug_from_extraction(
@@ -328,6 +668,11 @@ def assign_ids_for_cells(
     # sibling's id already in used_ids and bump the counter.
     group_slug: dict[int, str | None] = {}
 
+    # Stamp mode (#520): the adjacent-twin map and the per-pair slug cache
+    # for localized/narrative cells (the stamp-mode analogue of group_slug).
+    stamp_pairs: dict[int, tuple[int, int]] = _build_stamp_pairs(cells) if options.stamp_ids else {}
+    stamp_slug: dict[int, str | None] = {}
+
     # Track the most recent slide_id (bare form) by source order so that
     # narrative cells (voiceover/notes) inherit from the preceding
     # slide/subslide.
@@ -402,10 +747,46 @@ def assign_ids_for_cells(
             continue
 
         if role == "narrative":
-            _handle_narrative(cell, current_slide_id, options, file_path, file_str, result)
+            if options.stamp_ids:
+                # §12.1 (sync-v3, #520): narratives get their OWN unique id
+                # instead of inheriting the owner slide's.
+                _handle_stamp(
+                    cell,
+                    idx,
+                    "narrative",
+                    cells,
+                    stamp_pairs,
+                    stamp_slug,
+                    current_slide_id,
+                    options,
+                    used_ids,
+                    file_path,
+                    file_str,
+                    result,
+                    comment_token,
+                )
+            else:
+                _handle_narrative(cell, current_slide_id, options, file_path, file_str, result)
             continue
 
-        # role == "skip": unchanged.
+        # role == "skip": unchanged — except stamp mode, which additionally
+        # ids the id-less localized (non-slide, non-narrative) cells.
+        if options.stamp_ids and _stamp_class(cell) == "localized":
+            _handle_stamp(
+                cell,
+                idx,
+                "localized",
+                cells,
+                stamp_pairs,
+                stamp_slug,
+                current_slide_id,
+                options,
+                used_ids,
+                file_path,
+                file_str,
+                result,
+                comment_token,
+            )
 
     return result
 
@@ -901,6 +1282,25 @@ def assign_ids_in_file(path: Path, options: AssignOptions) -> AssignResult:
     (#162 defensive). Run order decides which half's slug wins when *both* are
     id-less, but the two halves always end up in slide_id parity.
     """
+    if options.stamp_ids and split_lang_suffix(path) is not None:
+        # Stamp mode is strictly pair-atomic: minting localized/narrative ids
+        # on ONE half would derive divergent slugs per language (#162). The
+        # only safe stamp route for split decks is the unified pair path
+        # (assign_ids_in_split_pair); a lone half falls back to the normal
+        # slide-only behavior plus one loud refusal.
+        result = assign_ids_in_file(path, replace(options, stamp_ids=False))
+        result.refusals.append(
+            Refusal(
+                file=str(path),
+                line=1,
+                severity="soft",
+                reason=(
+                    "split half processed alone; --stamp-ids needs both halves "
+                    "(pair-atomic minting) — run it on the deck pair or directory"
+                ),
+            )
+        )
+        return result
     text = path.read_text(encoding="utf-8")
     twin_ids = _twin_ids_for(path, text)
     new_text, result = assign_ids_for_text(text, path, options, twin_ids=twin_ids)
@@ -1015,8 +1415,26 @@ def assign_ids_in_files(files: list[Path], options: AssignOptions) -> AssignResu
                 _merge_result(combined, pair_result)
             else:
                 # Not unifiable — fall back to the per-file defensive on each.
-                _merge_result(combined, assign_ids_in_file(de_path, options))
-                _merge_result(combined, assign_ids_in_file(en_path, options))
+                # Stamp mode never runs per-half (pair-atomicity, #162): the
+                # deck gets ONE loud refusal instead of a per-cell flood, and
+                # the halves still get the normal slide-only pass.
+                per_file_options = options
+                if options.stamp_ids:
+                    per_file_options = replace(options, stamp_ids=False)
+                    combined.refusals.append(
+                        Refusal(
+                            file=str(de_path),
+                            line=1,
+                            severity="soft",
+                            reason=(
+                                "split pair is not unifiable; --stamp-ids skipped this "
+                                "deck — fix the DE/EN alignment first (e.g. `clm slides "
+                                "normalize --operations interleaving` or `clm slides sync`)"
+                            ),
+                        )
+                    )
+                _merge_result(combined, assign_ids_in_file(de_path, per_file_options))
+                _merge_result(combined, assign_ids_in_file(en_path, per_file_options))
             handled.add(de_path)
             handled.add(en_path)
         else:

--- a/src/clm/slides/assign_ids.py
+++ b/src/clm/slides/assign_ids.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import re
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -65,7 +65,9 @@ from clm.slides.pairing import (
     TITLE_SLIDE_ID,
     build_slide_groups,
     build_slide_pairs,
+    derive_split_twin,
     is_title_macro_cell,
+    split_lang_tag,
     split_twin,
 )
 from clm.slides.raw_cells import RawCell as _Cell
@@ -283,41 +285,61 @@ def _stamp_class(cell: _Cell) -> str | None:
     return "localized"
 
 
+def _stamp_run_key(cell: _Cell) -> tuple | None:
+    """The same-class run key for the stamp pairing walk (None = not eligible).
+
+    Cells with equal keys form one contiguous *run*; DE/EN twins can only
+    pair inside a run. Narratives key on their voiceover/notes role,
+    localized cells on their exact tag list; both include the cell type, so
+    a markdown narrative never runs together with a code narrative.
+    """
+    kind = _stamp_class(cell)
+    if kind is None:
+        return None
+    meta = cell.metadata
+    if kind == "narrative":
+        return ("narrative", meta.cell_type, _narrative_role(meta))
+    return ("localized", meta.cell_type, tuple(meta.tags))
+
+
 def _build_stamp_pairs(cells: list[_Cell]) -> dict[int, tuple[int, int]]:
     """Map each paired stamp-eligible cell index to ``(twin_idx, slug_source_idx)``.
 
-    Twins are **directly adjacent** cells ``(i, i+1)`` of the same stamp
-    class and cell type with differing langs — narratives additionally need
-    the same voiceover/notes role, localized cells identical tags. The
-    bilingual/unified interleave convention keeps DE/EN twins adjacent (the
-    ``interleaving`` normalize operation enforces exactly this), so anything
-    looser risks pairing cells across slides. A cell without an adjacent twin
-    stays out of the map and the stamp pass refuses it: minting a one-sided
-    id would break split id-set symmetry (``sync verify``'s structural gate).
+    Pairing is per contiguous *run* of same-key stamp-eligible cells (see
+    :func:`_stamp_run_key`) and strict: a run pairs only when it decomposes
+    cleanly into consecutive ``(i, i+1)`` twins with differing langs — the
+    bilingual/unified interleave convention (which the ``interleaving``
+    normalize operation enforces). An irregular run — odd length, or a
+    block layout like ``[de1, de2, en1, en2]`` — yields NO pairs at all:
+    greedily pairing its interior (``de2``/``en1``, two cells that are not
+    translations of each other) would stamp one identity onto two different
+    logical cells, and the mis-minted id would then spread via twin
+    adoption once the author fixes the ordering. Unpaired cells are refused
+    by the stamp pass; minting a one-sided id would break split id-set
+    symmetry (``sync verify``'s structural gate).
     """
     pairs: dict[int, tuple[int, int]] = {}
+    n = len(cells)
     i = 0
-    while i < len(cells) - 1:
-        a, b = cells[i], cells[i + 1]
-        kind = _stamp_class(a)
-        ma, mb = a.metadata, b.metadata
-        if (
-            kind is not None
-            and kind == _stamp_class(b)
-            and ma.cell_type == mb.cell_type
-            and ma.lang != mb.lang
-            and (
-                _narrative_role(ma) == _narrative_role(mb)
-                if kind == "narrative"
-                else list(ma.tags) == list(mb.tags)
-            )
-        ):
-            en_idx = i if ma.lang == "en" else i + 1
-            pairs[i] = (i + 1, en_idx)
-            pairs[i + 1] = (i, en_idx)
-            i += 2
+    while i < n:
+        key = _stamp_run_key(cells[i])
+        if key is None:
+            i += 1
             continue
-        i += 1
+        j = i
+        while j < n and _stamp_run_key(cells[j]) == key:
+            j += 1
+        run = range(i, j)
+        clean = len(run) % 2 == 0 and all(
+            cells[a].metadata.lang != cells[a + 1].metadata.lang for a in run[::2]
+        )
+        if clean:
+            for a in run[::2]:
+                b = a + 1
+                en_idx = a if cells[a].metadata.lang == "en" else b
+                pairs[a] = (b, en_idx)
+                pairs[b] = (a, en_idx)
+        i = j
     return pairs
 
 
@@ -388,20 +410,19 @@ def _handle_stamp(
     pair = stamp_pairs.get(idx)
     group_key = min(idx, pair[0]) if pair is not None else idx
 
-    if existing and is_preserved(existing):
-        # Lock the pair to the preserved bare form so the twin adopts it.
-        stamp_slug.setdefault(group_key, strip_preserve_marker(existing))
-        return
-
     legacy = (
         kind == "narrative"
         and existing is not None
+        and not is_preserved(existing)
         and _is_legacy_narrative_id(existing, current_slide_id, file_path)
     )
 
     if existing and not legacy:
-        # An own id — monotone: never replaced in stamp mode. Register it so
-        # an id-less twin adopts it; flag twins that committed elsewhere.
+        # A preserved (`!`) or own id — monotone: never replaced in stamp
+        # mode. Register it so an id-less twin adopts the bare form, and
+        # flag a twin pair that committed to a DIFFERENT id (divergent twin
+        # ids split into asymmetric DE/EN id sets; both visitation orders
+        # must detect this, so the check lives on the register itself).
         bare = strip_preserve_marker(existing)
         prior = stamp_slug.setdefault(group_key, bare)
         if prior is not None and prior != bare:
@@ -483,7 +504,9 @@ def _handle_stamp(
                     file=file_str,
                     line=cell.line_number,
                     slide_id=twin_bare,
-                    source="twin",
+                    # Replacing an inherited-owner/placeholder id is a §12.1
+                    # re-point even when the new id comes from the twin.
+                    source="narrative-repoint" if legacy else "twin",
                 )
             )
             return
@@ -1282,13 +1305,15 @@ def assign_ids_in_file(path: Path, options: AssignOptions) -> AssignResult:
     (#162 defensive). Run order decides which half's slug wins when *both* are
     id-less, but the two halves always end up in slide_id parity.
     """
-    if options.stamp_ids and split_lang_suffix(path) is not None:
+    if options.stamp_ids and split_lang_tag(path) is not None:
         # Stamp mode is strictly pair-atomic: minting localized/narrative ids
-        # on ONE half would derive divergent slugs per language (#162). The
-        # only safe stamp route for split decks is the unified pair path
-        # (assign_ids_in_split_pair); a lone half falls back to the normal
-        # slide-only behavior plus one loud refusal.
-        result = assign_ids_in_file(path, replace(options, stamp_ids=False))
+        # on ONE half would derive divergent slugs per language (#162), and
+        # writing ANYTHING on a refused deck would smuggle non-EN-authority
+        # ids in through the back door. So a lone split half is refused
+        # outright — no fallback pass, the deck stays untouched. The gate is
+        # the prefix-AGNOSTIC lang tag (``apis.de.py`` is a split half too;
+        # the sync surface supports prefix-less decks by design).
+        result = AssignResult(files_visited=1)
         result.refusals.append(
             Refusal(
                 file=str(path),
@@ -1351,6 +1376,7 @@ def assign_ids_in_split_pair(
     unified_new, result = assign_ids_for_text(unified, en_path, options)
     result.files_visited = 2
     result.files_modified = 0
+    _reattribute_pair_records(result, unified, de_path, en_path, comment_token)
     if options.report_only or unified_new == unified:
         return result
 
@@ -1366,6 +1392,62 @@ def assign_ids_in_split_pair(
         en_path.write_text(en_new, encoding="utf-8", newline="\n")
         result.files_modified += 1
     return result
+
+
+def _reattribute_pair_records(
+    result: AssignResult,
+    unified: str,
+    de_path: Path,
+    en_path: Path,
+    comment_token: str,
+) -> None:
+    """Point pair-run assignments/refusals at the real half file and line.
+
+    :func:`assign_ids_in_split_pair` runs the engine over the reconstructed
+    *unified* text with ``file_path=en_path``, so raw records name the EN
+    file at unified-deck line numbers — lines that exist in neither half.
+    This maps each record back through the split distribution (a cell goes
+    to the DE half unless ``lang="en"``, to the EN half unless ``lang="de"``;
+    shared cells appear in both and stay attributed to EN): the n-th
+    DE-bound unified cell IS the n-th cell of the split DE half, because the
+    byte-faithful round-trip guard above already proved the distribution.
+    Line numbers come from the *pre-assign* halves — id stamping rewrites
+    headers in place and never adds or removes lines. Any structural
+    surprise leaves the record untouched rather than guessing.
+    """
+    _preamble, ucells = _split_cells(unified, comment_token)
+    from clm.slides.split import SplitError, split_text
+
+    try:
+        de_half, en_half = split_text(unified, comment_token)
+    except SplitError:  # pragma: no cover - caller already split this text
+        return
+    _pre_de, de_cells = _split_cells(de_half, comment_token)
+    _pre_en, en_cells = _split_cells(en_half, comment_token)
+
+    locate: dict[int, tuple[str, int]] = {}
+    de_seen = en_seen = 0
+    for cell in ucells:
+        lang = cell.metadata.lang
+        if lang != "en":
+            if lang == "de" and de_seen < len(de_cells):
+                locate[cell.line_number] = ("de", de_cells[de_seen].line_number)
+            de_seen += 1
+        if lang != "de":
+            if lang == "en" and en_seen < len(en_cells):
+                locate[cell.line_number] = ("en", en_cells[en_seen].line_number)
+            en_seen += 1
+    if de_seen != len(de_cells) or en_seen != len(en_cells):
+        return  # distribution mismatch — keep the raw attribution
+
+    records: list[AssignedId | Refusal] = [*result.assignments, *result.refusals]
+    for record in records:
+        found = locate.get(record.line)
+        if found is None:
+            continue
+        side, line = found
+        record.file = str(de_path if side == "de" else en_path)
+        record.line = line
 
 
 def _merge_result(combined: AssignResult, result: AssignResult) -> None:
@@ -1405,36 +1487,39 @@ def assign_ids_in_files(files: list[Path], options: AssignOptions) -> AssignResu
     for slide_file in files:
         if slide_file in handled:
             continue
-        twin = split_twin(slide_file)
+        # Stamp mode pairs prefix-AGNOSTICALLY (``apis.de.py`` is a split
+        # half the sync surface supports by design); the normal pass keeps
+        # the historical prefix-gated pairing.
+        twin = derive_split_twin(slide_file) if options.stamp_ids else split_twin(slide_file)
         if twin is not None and twin in fileset:
-            de_path, en_path = (
-                (slide_file, twin) if split_lang_suffix(slide_file) == "de" else (twin, slide_file)
+            lang_tag = (
+                split_lang_tag(slide_file) if options.stamp_ids else (split_lang_suffix(slide_file))
             )
+            de_path, en_path = (slide_file, twin) if lang_tag == "de" else (twin, slide_file)
             pair_result = assign_ids_in_split_pair(de_path, en_path, options)
             if pair_result is not None:
                 _merge_result(combined, pair_result)
+            elif options.stamp_ids:
+                # Not unifiable — stamp mode refuses the WHOLE deck, writes
+                # nothing (pair-atomicity, #162): one loud refusal instead of
+                # a per-cell flood or a half-processed deck.
+                combined.files_visited += 2
+                combined.refusals.append(
+                    Refusal(
+                        file=str(de_path),
+                        line=1,
+                        severity="soft",
+                        reason=(
+                            "split pair is not unifiable; --stamp-ids skipped this "
+                            "deck — fix the DE/EN alignment first (e.g. `clm slides "
+                            "normalize --operations interleaving` or `clm slides sync`)"
+                        ),
+                    )
+                )
             else:
                 # Not unifiable — fall back to the per-file defensive on each.
-                # Stamp mode never runs per-half (pair-atomicity, #162): the
-                # deck gets ONE loud refusal instead of a per-cell flood, and
-                # the halves still get the normal slide-only pass.
-                per_file_options = options
-                if options.stamp_ids:
-                    per_file_options = replace(options, stamp_ids=False)
-                    combined.refusals.append(
-                        Refusal(
-                            file=str(de_path),
-                            line=1,
-                            severity="soft",
-                            reason=(
-                                "split pair is not unifiable; --stamp-ids skipped this "
-                                "deck — fix the DE/EN alignment first (e.g. `clm slides "
-                                "normalize --operations interleaving` or `clm slides sync`)"
-                            ),
-                        )
-                    )
-                _merge_result(combined, assign_ids_in_file(de_path, per_file_options))
-                _merge_result(combined, assign_ids_in_file(en_path, per_file_options))
+                _merge_result(combined, assign_ids_in_file(de_path, options))
+                _merge_result(combined, assign_ids_in_file(en_path, options))
             handled.add(de_path)
             handled.add(en_path)
         else:

--- a/src/clm/slides/normalizer.py
+++ b/src/clm/slides/normalizer.py
@@ -95,7 +95,10 @@ class NormalizationResult:
         for c in self.changes:
             op_counts[c.operation] = op_counts.get(c.operation, 0) + 1
         for op, count in sorted(op_counts.items()):
-            parts.append(f"{count} {op.replace('_', ' ')}{'s' if count != 1 else ''}")
+            label = op.replace("_", " ")
+            # "slide ids"/"stamp ids" are already plural — no naive extra "s".
+            plural = "s" if count != 1 and not label.endswith("s") else ""
+            parts.append(f"{count} {label}{plural}")
         if self.review_items:
             ri = len(self.review_items)
             parts.append(f"{ri} item{'s' if ri != 1 else ''} for review")

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -946,9 +946,18 @@ def _check_slide_ids(cells: list[Cell], file_path: str) -> list[Finding]:
     A *missing* slide_id on a ``slide``/``subslide`` cell is an
     ``error`` as of CLM 1.8 (it was a warning through 1.7, during the
     PythonCourses migration sweep). All other rules — duplicate ids,
-    narrative-cell adjacency mismatch, slug-format violations, DE/EN
-    pair mismatch — fire at the severity their semantics warrant
+    narrative-cell id rules, slug-format violations, DE/EN pair
+    mismatch — fire at the severity their semantics warrant
     (errors for content bugs, warnings for style/format drift).
+
+    Narrative (voiceover/notes) ids accept **two** conventions: the legacy
+    inherited form (id equals the preceding slide/subslide anchor's id) and
+    the sync-v3 *own-id* form (§12.1 / #520 — a unique id of the
+    narrative's own, minted by ``clm slides normalize --stamp-ids``). An
+    own id participates in the duplicate check — keyed on the adjacent
+    DE/EN narrative twin group, exactly like slide pairs — so the stale
+    copy-paste id this rule has always guarded against (an id that equals
+    some *other* cell's id) still errors, as a duplicate.
 
     The ``!`` preserve marker is stripped before every comparison except
     the slug-format check, where it's permitted as a single leading
@@ -964,15 +973,35 @@ def _check_slide_ids(cells: list[Cell], file_path: str) -> list[Finding]:
     # treat both members as one occurrence — keying on group identity
     # avoids flagging the EN sibling as a duplicate of the DE cell.
     slide_groups = build_slide_groups(cells)
-    cell_to_group: dict[int, int] = {}
+    cell_to_group: dict[int, str] = {}
     for gi, group in enumerate(slide_groups):
         for ci in group:
-            cell_to_group[ci] = gi
+            cell_to_group[ci] = f"slide:{gi}"
 
-    # Bare slide_id -> (group index, line) of first sighting. A second
+    # Narrative twin groups: directly-adjacent voiceover/notes cells with
+    # differing langs and the same role are one logical narrative (the
+    # DE/EN pair shares its own id, like slide pairs). Direct adjacency is
+    # the interleave convention `normalize --stamp-ids` stamps under.
+    for i in range(len(cells) - 1):
+        ma, mb = cells[i].metadata, cells[i + 1].metadata
+        if (
+            ma.is_narrative
+            and mb.is_narrative
+            and not ma.is_j2
+            and not mb.is_j2
+            and ma.lang
+            and mb.lang
+            and ma.lang != mb.lang
+            and ("voiceover" in ma.tags) == ("voiceover" in mb.tags)
+            and i not in cell_to_group
+            and i + 1 not in cell_to_group
+        ):
+            cell_to_group[i] = cell_to_group[i + 1] = f"narr:{i}"
+
+    # Bare slide_id -> (group key, line) of first sighting. A second
     # occurrence in the *same* group is the pair sharing the id and is
     # fine; in a *different* group it's a real duplicate.
-    bare_first_seen: dict[str, tuple[int, int]] = {}
+    bare_first_seen: dict[str, tuple[str, int]] = {}
 
     # Most recent slide_id (bare) seen in source order. Updated by
     # ``slide``/``subslide`` cells and by the j2 ``header()`` macro
@@ -1019,11 +1048,11 @@ def _check_slide_ids(cells: list[Cell], file_path: str) -> list[Finding]:
             bare = strip_preserve_marker(sid)
             findings.extend(_check_slug_format(sid, cell, file_path))
 
-            gi = cell_to_group[idx]
+            group_key = cell_to_group[idx]
             prev = bare_first_seen.get(bare)
             if prev is None:
-                bare_first_seen[bare] = (gi, cell.line_number)
-            elif prev[0] != gi:
+                bare_first_seen[bare] = (group_key, cell.line_number)
+            elif prev[0] != group_key:
                 findings.append(
                     Finding(
                         severity="error",
@@ -1067,23 +1096,35 @@ def _check_slide_ids(cells: list[Cell], file_path: str) -> list[Finding]:
                     )
                 )
             elif bare != current_slide_id:
-                findings.append(
-                    Finding(
-                        severity="error",
-                        category="pairing",
-                        file=file_path,
-                        line=cell.line_number,
-                        message=(
-                            f"voiceover/notes slide_id={bare!r} does not match "
-                            f"preceding slide {current_slide_id!r}"
-                        ),
-                        suggestion=(
-                            "Voiceover/notes slide_id must match the immediately "
-                            "preceding slide/subslide (likely a stale id left by "
-                            "copy-paste)."
-                        ),
+                # The sync-v3 own-id convention (§12.1 / #520): a narrative id
+                # of the cell's own is legal iff it is unique. Register it in
+                # the duplicate map keyed on the narrative twin group — a
+                # stale copy-paste id (one that equals some other slide's or
+                # narrative's id) still errors, now as a duplicate.
+                group_key = cell_to_group.get(idx, f"narr-solo:{idx}")
+                prev = bare_first_seen.get(bare)
+                if prev is None:
+                    bare_first_seen[bare] = (group_key, cell.line_number)
+                elif prev[0] != group_key:
+                    findings.append(
+                        Finding(
+                            severity="error",
+                            category="pairing",
+                            file=file_path,
+                            line=cell.line_number,
+                            message=(
+                                f"voiceover/notes slide_id={bare!r} duplicates an id "
+                                f"first seen at line {prev[1]} (and does not match the "
+                                f"preceding slide {current_slide_id!r})"
+                            ),
+                            suggestion=(
+                                "A narrative id is either the preceding slide's id "
+                                "(legacy inherit) or a unique id of its own "
+                                "(`clm slides normalize --stamp-ids`); this one is "
+                                "neither — likely a stale id left by copy-paste."
+                            ),
+                        )
                     )
-                )
             continue
 
     # Pair-mismatch check: when a DE slide cell sits next to an EN slide

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -978,30 +978,47 @@ def _check_slide_ids(cells: list[Cell], file_path: str) -> list[Finding]:
         for ci in group:
             cell_to_group[ci] = f"slide:{gi}"
 
-    # Narrative twin groups: directly-adjacent voiceover/notes cells with
-    # differing langs and the same role are one logical narrative (the
-    # DE/EN pair shares its own id, like slide pairs). Direct adjacency is
-    # the interleave convention `normalize --stamp-ids` stamps under.
+    # Narrative and localized twin groups: directly-adjacent lang-tagged
+    # cells with differing langs, the same cell type, and the same
+    # role/tags are one logical cell (the DE/EN pair shares its own id,
+    # like slide pairs). Direct adjacency + these equality conditions
+    # mirror the stamp engine's pairing (`_build_stamp_pairs`) — the
+    # interleave convention `normalize --stamp-ids` stamps under.
+    narrative_pairs: list[tuple[int, int]] = []
+    localized_pairs: list[tuple[int, int]] = []
     for i in range(len(cells) - 1):
         ma, mb = cells[i].metadata, cells[i + 1].metadata
         if (
-            ma.is_narrative
-            and mb.is_narrative
-            and not ma.is_j2
-            and not mb.is_j2
-            and ma.lang
-            and mb.lang
-            and ma.lang != mb.lang
-            and ("voiceover" in ma.tags) == ("voiceover" in mb.tags)
-            and i not in cell_to_group
-            and i + 1 not in cell_to_group
+            ma.is_j2
+            or mb.is_j2
+            or not ma.lang
+            or not mb.lang
+            or ma.lang == mb.lang
+            or ma.cell_type != mb.cell_type
+            or ma.is_slide_start
+            or mb.is_slide_start
+            or i in cell_to_group
+            or i + 1 in cell_to_group
         ):
-            cell_to_group[i] = cell_to_group[i + 1] = f"narr:{i}"
+            continue
+        if ma.is_narrative and mb.is_narrative:
+            if ("voiceover" in ma.tags) == ("voiceover" in mb.tags):
+                cell_to_group[i] = cell_to_group[i + 1] = f"narr:{i}"
+                narrative_pairs.append((i, i + 1))
+        elif not ma.is_narrative and not mb.is_narrative and list(ma.tags) == list(mb.tags):
+            cell_to_group[i] = cell_to_group[i + 1] = f"loc:{i}"
+            localized_pairs.append((i, i + 1))
 
     # Bare slide_id -> (group key, line) of first sighting. A second
     # occurrence in the *same* group is the pair sharing the id and is
     # fine; in a *different* group it's a real duplicate.
     bare_first_seen: dict[str, tuple[str, int]] = {}
+
+    # Localized (non-slide, non-narrative) cell ids live in a SEPARATE map:
+    # the corpus carries legacy localized ids that deliberately shadow their
+    # slide's id, so cross-kind collisions involving localized cells are
+    # warnings and must never make a slide/narrative error retroactively.
+    localized_first_seen: dict[str, tuple[str, int]] = {}
 
     # Most recent slide_id (bare) seen in source order. Updated by
     # ``slide``/``subslide`` cells and by the j2 ``header()`` macro
@@ -1103,9 +1120,8 @@ def _check_slide_ids(cells: list[Cell], file_path: str) -> list[Finding]:
                 # narrative's id) still errors, now as a duplicate.
                 group_key = cell_to_group.get(idx, f"narr-solo:{idx}")
                 prev = bare_first_seen.get(bare)
-                if prev is None:
-                    bare_first_seen[bare] = (group_key, cell.line_number)
-                elif prev[0] != group_key:
+                loc_prev = localized_first_seen.get(bare)
+                if prev is not None and prev[0] != group_key:
                     findings.append(
                         Finding(
                             severity="error",
@@ -1125,7 +1141,111 @@ def _check_slide_ids(cells: list[Cell], file_path: str) -> list[Finding]:
                             ),
                         )
                     )
+                elif loc_prev is not None and loc_prev[0] != group_key:
+                    findings.append(
+                        Finding(
+                            severity="warning",
+                            category="pairing",
+                            file=file_path,
+                            line=cell.line_number,
+                            message=(
+                                f"voiceover/notes slide_id={bare!r} duplicates a "
+                                f"localized cell's id first seen at line {loc_prev[1]}"
+                            ),
+                            suggestion="Own narrative ids should be unique in the file.",
+                        )
+                    )
+                elif prev is None:
+                    bare_first_seen[bare] = (group_key, cell.line_number)
             continue
+
+        if meta.lang is not None and meta.slide_id is not None:
+            # A localized (non-slide, non-narrative) cell id — the population
+            # `normalize --stamp-ids` (#520) creates. Registered separately;
+            # duplicates involving localized ids are WARNINGS (see the map's
+            # comment — legacy decks shadow slide ids on purpose).
+            bare = strip_preserve_marker(meta.slide_id)
+            group_key = cell_to_group.get(idx, f"loc-solo:{idx}")
+            prev = bare_first_seen.get(bare)
+            loc_prev = localized_first_seen.get(bare)
+            duplicate = (prev is not None and prev[0] != group_key) or (
+                loc_prev is not None and loc_prev[0] != group_key
+            )
+            if duplicate:
+                first_line = prev[1] if prev is not None else loc_prev[1]  # type: ignore[index]
+                findings.append(
+                    Finding(
+                        severity="warning",
+                        category="pairing",
+                        file=file_path,
+                        line=cell.line_number,
+                        message=(
+                            f"localized cell slide_id={bare!r} duplicates an id "
+                            f"first seen at line {first_line}"
+                        ),
+                        suggestion=(
+                            "Stamped localized ids should be unique in the file "
+                            "(`clm slides normalize --stamp-ids` mints unique slugs)."
+                        ),
+                    )
+                )
+            elif loc_prev is None:
+                localized_first_seen[bare] = (group_key, cell.line_number)
+            continue
+
+    # Twin-mismatch checks for narrative and localized DE/EN pairs: twins
+    # must share one id (a divergence splits into asymmetric DE/EN id sets,
+    # which `sync verify`'s structural gate rejects). Narrative divergence
+    # is an error — the severity the pre-#520 adjacency rule gave this
+    # state; localized divergence warns, matching the other localized-id
+    # checks above. Pairs where either side is id-less are fine (stamping
+    # adopts the twin's id).
+    for na, nb in narrative_pairs:
+        sid_a = cells[na].metadata.slide_id
+        sid_b = cells[nb].metadata.slide_id
+        if sid_a is None or sid_b is None:
+            continue
+        if strip_preserve_marker(sid_a) == strip_preserve_marker(sid_b):
+            continue
+        findings.append(
+            Finding(
+                severity="error",
+                category="pairing",
+                file=file_path,
+                line=cells[na].line_number,
+                message=(
+                    f"DE/EN narrative twins carry mismatched slide_id: "
+                    f"{strip_preserve_marker(sid_a)!r} (line {cells[na].line_number}) vs "
+                    f"{strip_preserve_marker(sid_b)!r} (line {cells[nb].line_number})"
+                ),
+                suggestion=(
+                    "Adjacent DE/EN voiceover/notes twins share one id; "
+                    "resolve the divergence manually or re-run "
+                    "`clm slides normalize --stamp-ids` after fixing it."
+                ),
+            )
+        )
+    for la, lb in localized_pairs:
+        sid_a = cells[la].metadata.slide_id
+        sid_b = cells[lb].metadata.slide_id
+        if sid_a is None or sid_b is None:
+            continue
+        if strip_preserve_marker(sid_a) == strip_preserve_marker(sid_b):
+            continue
+        findings.append(
+            Finding(
+                severity="warning",
+                category="pairing",
+                file=file_path,
+                line=cells[la].line_number,
+                message=(
+                    f"DE/EN localized twins carry mismatched slide_id: "
+                    f"{strip_preserve_marker(sid_a)!r} (line {cells[la].line_number}) vs "
+                    f"{strip_preserve_marker(sid_b)!r} (line {cells[lb].line_number})"
+                ),
+                suggestion="Adjacent DE/EN localized twins share one id.",
+            )
+        )
 
     # Pair-mismatch check: when a DE slide cell sits next to an EN slide
     # cell in source order, the EN-derived slug policy (handover §2.3)

--- a/tests/cli/test_normalize_slides.py
+++ b/tests/cli/test_normalize_slides.py
@@ -304,6 +304,45 @@ class TestNormalizeStampIds:
         assert result.exit_code != 0
         assert "replaces the regular operations" in result.output
 
+    def test_rejects_canonicalize_combination(self, tmp_path):
+        de, _en = self._pair(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            normalize_slides_cmd,
+            [str(de.parent), "--stamp-ids", "--canonicalize-start-completed"],
+        )
+        assert result.exit_code != 0
+        assert "interleaving operation" in result.output
+
+    def test_prefixless_deck_discovered_and_stamped(self, tmp_path):
+        # The sync surface supports prefix-less split decks (apis.de.py);
+        # the one-time Phase-0 migration must reach them too.
+        topic = tmp_path / "topic_030_apis"
+        de = _write_slide(topic / "apis.de.py", _STAMP_DE)
+        en = _write_slide(topic / "apis.en.py", _STAMP_EN)
+        runner = CliRunner()
+        result = runner.invoke(normalize_slides_cmd, [str(topic), "--stamp-ids"])
+        assert result.exit_code == 0, result.output
+        assert de.read_text(encoding="utf-8") != _STAMP_DE
+        assert en.read_text(encoding="utf-8") != _STAMP_EN
+
+    def test_changes_name_both_half_files(self, tmp_path):
+        de, en = self._pair(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(normalize_slides_cmd, [str(de.parent), "--stamp-ids", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output[result.output.index("{") :])
+        files = {Path(c["file"]).name for c in payload["changes"]}
+        assert files == {de.name, en.name}
+
+    def test_summary_grammar(self, tmp_path):
+        de, _en = self._pair(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(normalize_slides_cmd, [str(de.parent), "--stamp-ids"])
+        assert result.exit_code == 0, result.output
+        assert "stamp ids." in result.output
+        assert "stamp idss" not in result.output
+
     def test_rejects_spec_input(self, tmp_path):
         spec = tmp_path / "course.xml"
         spec.write_text("<course/>", encoding="utf-8")

--- a/tests/cli/test_normalize_slides.py
+++ b/tests/cli/test_normalize_slides.py
@@ -222,3 +222,110 @@ class TestNormalizeSlidesCmd:
         result = runner.invoke(normalize_slides_cmd, [str(topic)])
         assert result.exit_code == 0
         assert "tag_migration" in result.output
+
+
+_STAMP_DE = (
+    '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
+    "# ## Einführung\n"
+    "\n"
+    '# %% [markdown] lang="de" tags=["voiceover"] slide_id="intro"\n'
+    "# Willkommen zur Einführung in dieses Thema.\n"
+    "\n"
+    '# %% [markdown] lang="de"\n'
+    "# Ein lokalisierter Hinweis ohne Bezeichner.\n"
+)
+_STAMP_EN = (
+    '# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n'
+    "# ## Introduction\n"
+    "\n"
+    '# %% [markdown] lang="en" tags=["voiceover"] slide_id="intro"\n'
+    "# Welcome to the introduction of this topic.\n"
+    "\n"
+    '# %% [markdown] lang="en"\n'
+    "# A localized note without an identifier.\n"
+)
+
+
+class TestNormalizeStampIds:
+    """`normalize --stamp-ids` — sync-v3 Phase 0 (#520)."""
+
+    def _pair(self, tmp_path: Path) -> tuple[Path, Path]:
+        topic = tmp_path / "topic_010_test"
+        de = _write_slide(topic / "slides_test.de.py", _STAMP_DE)
+        en = _write_slide(topic / "slides_test.en.py", _STAMP_EN)
+        return de, en
+
+    def test_stamps_split_pair_in_directory(self, tmp_path):
+        de, en = self._pair(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(normalize_slides_cmd, [str(de.parent), "--stamp-ids"])
+        assert result.exit_code == 0, result.output
+        assert "stamp_ids" in result.output
+        de_text = de.read_text(encoding="utf-8")
+        en_text = en.read_text(encoding="utf-8")
+        # The voiceover no longer shares the slide's id; both halves agree.
+        assert de_text.count('slide_id="intro"') == 1
+        assert de_text.splitlines()[3] == en_text.splitlines()[3].replace('lang="en"', 'lang="de"')
+
+    def test_dry_run_writes_nothing(self, tmp_path):
+        de, en = self._pair(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(normalize_slides_cmd, [str(de.parent), "--stamp-ids", "--dry-run"])
+        assert result.exit_code == 0, result.output
+        assert de.read_text(encoding="utf-8") == _STAMP_DE
+        assert en.read_text(encoding="utf-8") == _STAMP_EN
+
+    def test_json_report_shape(self, tmp_path):
+        de, _en = self._pair(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(normalize_slides_cmd, [str(de.parent), "--stamp-ids", "--json"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output[result.output.index("{") :])
+        assert payload["files_modified"] == 2
+        assert all(c["operation"] == "stamp_ids" for c in payload["changes"])
+        assert any("narrative" in c["description"] for c in payload["changes"])
+
+    def test_single_split_half_expands_to_pair(self, tmp_path):
+        de, en = self._pair(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(normalize_slides_cmd, [str(de), "--stamp-ids"])
+        assert result.exit_code == 0, result.output
+        # Both halves were stamped even though only one was named.
+        assert de.read_text(encoding="utf-8") != _STAMP_DE
+        assert en.read_text(encoding="utf-8") != _STAMP_EN
+
+    def test_rejects_operations_combination(self, tmp_path):
+        de, _en = self._pair(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(
+            normalize_slides_cmd,
+            [str(de.parent), "--stamp-ids", "--operations", "cell_spacing"],
+        )
+        assert result.exit_code != 0
+        assert "replaces the regular operations" in result.output
+
+    def test_rejects_spec_input(self, tmp_path):
+        spec = tmp_path / "course.xml"
+        spec.write_text("<course/>", encoding="utf-8")
+        runner = CliRunner()
+        result = runner.invoke(normalize_slides_cmd, [str(spec), "--stamp-ids"])
+        assert result.exit_code != 0
+        assert "not a course spec" in result.output
+
+    def test_refusals_surface_as_review_items(self, tmp_path):
+        topic = tmp_path / "topic_020_solo"
+        # A bilingual deck whose only stamp candidate has no adjacent twin.
+        bilingual = _write_slide(
+            topic / "slides_solo.py",
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
+            "# ## Einführung\n"
+            "\n"
+            '# %% [markdown] lang="de"\n'
+            "# Ein Hinweis nur auf Deutsch.\n",
+        )
+        runner = CliRunner()
+        result = runner.invoke(normalize_slides_cmd, [str(bilingual), "--stamp-ids", "--json"])
+        assert result.exit_code == 2, result.output  # review items, no changes
+        payload = json.loads(result.output[result.output.index("{") :])
+        assert payload["review_items"]
+        assert payload["review_items"][0]["issue"] == "stamp_id_soft_refusal"

--- a/tests/slides/test_assign_ids.py
+++ b/tests/slides/test_assign_ids.py
@@ -1117,3 +1117,247 @@ class TestSkippedCells:
         assert result.assignments == []
         assert result.refusals == []
         assert new_text == text
+
+
+# ---------------------------------------------------------------------------
+# Stamp mode (sync-v3 Phase 0, #520): localized + narrative id stamping
+# ---------------------------------------------------------------------------
+
+_STAMP = {"stamp_ids": True, "accept_content_derived": True, "accept_code_derived": True}
+
+_STAMP_BILINGUAL = (
+    '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
+    "# ## Einführung\n"
+    "\n"
+    '# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n'
+    "# ## Introduction\n"
+    "\n"
+    '# %% [markdown] lang="de" tags=["voiceover"] slide_id="intro"\n'
+    "# Willkommen zur Einführung in dieses Thema.\n"
+    "\n"
+    '# %% [markdown] lang="en" tags=["voiceover"] slide_id="intro"\n'
+    "# Welcome to the introduction of this topic.\n"
+    "\n"
+    '# %% [markdown] lang="de"\n'
+    "# Ein lokalisierter Hinweis ohne Bezeichner.\n"
+    "\n"
+    '# %% [markdown] lang="en"\n'
+    "# A localized note without an identifier.\n"
+    "\n"
+    '# %% tags=["keep"]\n'
+    "x = 1\n"
+)
+
+
+class TestStampIds:
+    def test_owner_inherited_narrative_repointed_to_own_id(self):
+        new_text, result = _run(_STAMP_BILINGUAL, **_STAMP)
+        narrative = [a for a in result.assignments if a.source == "narrative-repoint"]
+        assert len(narrative) == 2  # both twins of the voiceover pair
+        own = narrative[0].slide_id
+        assert own != "intro"
+        assert narrative[1].slide_id == own
+        # The slide pair keeps its id untouched.
+        assert new_text.count('slide_id="intro"') == 2
+
+    def test_idless_localized_pair_shares_one_content_slug(self):
+        new_text, result = _run(_STAMP_BILINGUAL, **_STAMP)
+        localized = [
+            a
+            for a in result.assignments
+            if a.source in ("content:prose", "paired") and "note" in a.slide_id
+        ]
+        assert len(localized) == 2
+        assert localized[0].slide_id == localized[1].slide_id
+        # EN-authority: the shared slug comes from the EN body.
+        assert localized[0].slide_id.startswith("a-localized-note")
+
+    def test_shared_and_j2_cells_never_stamped(self):
+        new_text, result = _run(_STAMP_BILINGUAL, **_STAMP)
+        # The neutral code cell is untouched: exactly 2 narrative re-points
+        # plus 2 localized stamps.
+        assert '# %% tags=["keep"]\nx = 1' in new_text
+        assert len(result.assignments) == 4
+
+    def test_idempotent_second_run(self):
+        first, result1 = _run(_STAMP_BILINGUAL, **_STAMP)
+        assert result1.assignments
+        second, result2 = _run(first, **_STAMP)
+        assert result2.assignments == []
+        assert result2.refusals == []
+        assert second == first
+
+    def test_stamp_off_keeps_legacy_behavior(self):
+        new_text, result = _run(_STAMP_BILINGUAL, accept_content_derived=True)
+        # Without stamp_ids the voiceover keeps the inherited owner id and
+        # localized content cells stay id-less.
+        assert new_text == _STAMP_BILINGUAL
+        assert result.assignments == []
+
+    def test_own_id_narrative_kept(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
+            "# ## Einführung\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["voiceover"] slide_id="my-own-story"\n'
+            "# Sprechertext\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["voiceover"] slide_id="my-own-story"\n'
+            "# Voiceover text\n"
+        )
+        new_text, result = _run(text, **_STAMP)
+        assert result.assignments == []
+        assert new_text == text
+
+    def test_preserved_narrative_id_wins_and_twin_adopts(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
+            "# ## Einführung\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["voiceover"] slide_id="!keep-me"\n'
+            "# Sprechertext\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["voiceover"]\n'
+            "# Voiceover text\n"
+        )
+        new_text, result = _run(text, **_STAMP)
+        assert 'slide_id="!keep-me"' in new_text  # marker untouched
+        # The id-less EN twin adopts the preserved bare form (resolved via
+        # the pair cache, hence "paired" — the same label the slide
+        # machinery uses for a sibling applying a cached resolution).
+        assert len(result.assignments) == 1
+        adopted = result.assignments[0]
+        assert adopted.slide_id == "keep-me"
+        assert adopted.source == "paired"
+
+    def test_solo_localized_cell_refused_not_half_stamped(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
+            "# ## Einführung\n"
+            "\n"
+            '# %% [markdown] lang="de"\n'
+            "# Ein Hinweis nur auf Deutsch.\n"
+        )
+        new_text, result = _run(text, **_STAMP)
+        assert result.assignments == []
+        assert len(result.refusals) == 1
+        assert "no directly-adjacent DE/EN twin" in result.refusals[0].reason
+        assert new_text == text
+
+    def test_narrative_without_anchor_refused(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["voiceover"]\n'
+            "# Sprechertext ohne Slide davor\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["voiceover"]\n'
+            "# Voiceover without a preceding slide\n"
+        )
+        new_text, result = _run(text, **_STAMP)
+        assert result.assignments == []
+        assert all("no preceding slide" in r.reason for r in result.refusals)
+        assert new_text == text
+
+    def test_collision_gets_suffix(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="a"\n'
+            "# ## A\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["voiceover"]\n'
+            "# Der gleiche Text.\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["voiceover"]\n'
+            "# The same narration text.\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["subslide"] slide_id="b"\n'
+            "# ## B\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["voiceover"]\n'
+            "# Der gleiche Text nochmal.\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["voiceover"]\n'
+            "# The same narration text.\n"
+        )
+        new_text, result = _run(text, **_STAMP)
+        slugs = sorted({a.slide_id for a in result.assignments})
+        assert len(slugs) == 2
+        assert slugs[1] == f"{slugs[0]}-2"
+
+    def test_content_not_accepted_refuses_with_proposal(self):
+        new_text, result = _run(_STAMP_BILINGUAL, stamp_ids=True)
+        # Without the accept knobs the prose-derived stamps refuse softly,
+        # carrying the proposed slug for the worklist.
+        soft = [r for r in result.refusals if r.severity == "soft" and r.proposed_slug]
+        assert soft
+        assert result.assignments == []
+
+    def test_localized_code_pair_stamped_via_code_extractor(self):
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
+            "# ## Einführung\n"
+            "\n"
+            '# %% lang="de"\n'
+            "zahl = 1\n"
+            "\n"
+            '# %% lang="en"\n'
+            "number = 1\n"
+        )
+        new_text, result = _run(text, **_STAMP)
+        assert [a.slide_id for a in result.assignments] == ["number", "number"]
+
+    def test_split_pair_stamped_identically(self, tmp_path):
+        from clm.slides.assign_ids import assign_ids_in_files
+
+        de = _write(
+            tmp_path,
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
+            "# ## Einführung\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["voiceover"] slide_id="intro"\n'
+            "# Willkommen zur Einführung in dieses Thema.\n"
+            "\n"
+            '# %% [markdown] lang="de"\n'
+            "# Ein lokalisierter Hinweis ohne Bezeichner.\n",
+            name="slides_stamp.de.py",
+        )
+        en = _write(
+            tmp_path,
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n'
+            "# ## Introduction\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["voiceover"] slide_id="intro"\n'
+            "# Welcome to the introduction of this topic.\n"
+            "\n"
+            '# %% [markdown] lang="en"\n'
+            "# A localized note without an identifier.\n",
+            name="slides_stamp.en.py",
+        )
+
+        result = assign_ids_in_files([de, en], AssignOptions(**_STAMP))
+        assert result.files_modified == 2
+        assert not result.refusals
+
+        def ids_of(path: Path) -> list[str]:
+            cells = parse_cells(path.read_text(encoding="utf-8"), "#")
+            return [c.metadata.slide_id for c in cells if c.metadata.slide_id]
+
+        de_ids = ids_of(de)
+        en_ids = ids_of(en)
+        assert de_ids == en_ids  # identical ids, identical order
+        assert len(de_ids) == 3
+        assert len(set(de_ids)) == 3  # the narrative no longer shares "intro"
+
+    def test_split_half_alone_downgraded_with_refusal(self, tmp_path):
+        de = _write(
+            tmp_path,
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
+            "# ## Einführung\n"
+            "\n"
+            '# %% [markdown] lang="de"\n'
+            "# Ein Hinweis.\n",
+            name="slides_solo.de.py",
+        )
+        result = assign_ids_in_file(de, AssignOptions(**_STAMP))
+        assert result.assignments == []
+        assert any("--stamp-ids needs both halves" in r.reason for r in result.refusals)
+        # The localized cell was NOT half-stamped.
+        assert "slide_id" not in de.read_text(encoding="utf-8").splitlines()[3]

--- a/tests/slides/test_assign_ids.py
+++ b/tests/slides/test_assign_ids.py
@@ -1346,18 +1346,162 @@ class TestStampIds:
         assert len(de_ids) == 3
         assert len(set(de_ids)) == 3  # the narrative no longer shares "intro"
 
-    def test_split_half_alone_downgraded_with_refusal(self, tmp_path):
+    def test_split_half_alone_refused_untouched(self, tmp_path):
+        # A refused deck stays byte-identical — no fallback pass smuggles
+        # DE-derived (non-EN-authority) ids in through the back door.
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "# ## Einführung\n"
+            "\n"
+            '# %% [markdown] lang="de"\n'
+            "# Ein Hinweis.\n"
+        )
+        de = _write(tmp_path, text, name="slides_solo.de.py")
+        result = assign_ids_in_file(de, AssignOptions(**_STAMP))
+        assert result.assignments == []
+        assert any("--stamp-ids needs both halves" in r.reason for r in result.refusals)
+        assert de.read_text(encoding="utf-8") == text
+
+    def test_prefixless_lone_half_refused_untouched(self, tmp_path):
+        # The pair-atomic guard is prefix-AGNOSTIC: apis.de.py is a split
+        # half too (the sync surface supports prefix-less decks by design).
+        text = '# %% [markdown] lang="de" tags=["slide"]\n# ## Datenbanken\n'
+        de = _write(tmp_path, text, name="apis.de.py")
+        result = assign_ids_in_file(de, AssignOptions(**_STAMP))
+        assert result.assignments == []
+        assert any("--stamp-ids needs both halves" in r.reason for r in result.refusals)
+        assert de.read_text(encoding="utf-8") == text
+
+    def test_prefixless_split_pair_stamped(self, tmp_path):
+        from clm.slides.assign_ids import assign_ids_in_files
+
         de = _write(
             tmp_path,
             '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
             "# ## Einführung\n"
             "\n"
             '# %% [markdown] lang="de"\n'
-            "# Ein Hinweis.\n",
-            name="slides_solo.de.py",
+            "# Ein lokalisierter Hinweis ohne Bezeichner.\n",
+            name="apis.de.py",
         )
-        result = assign_ids_in_file(de, AssignOptions(**_STAMP))
+        en = _write(
+            tmp_path,
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n'
+            "# ## Introduction\n"
+            "\n"
+            '# %% [markdown] lang="en"\n'
+            "# A localized note without an identifier.\n",
+            name="apis.en.py",
+        )
+        result = assign_ids_in_files([de, en], AssignOptions(**_STAMP))
+        assert result.files_modified == 2
+        assert not result.refusals
+        de_ids = [
+            c.metadata.slide_id
+            for c in parse_cells(de.read_text(encoding="utf-8"), "#")
+            if c.metadata.slide_id
+        ]
+        en_ids = [
+            c.metadata.slide_id
+            for c in parse_cells(en.read_text(encoding="utf-8"), "#")
+            if c.metadata.slide_id
+        ]
+        assert de_ids == en_ids
+        assert len(de_ids) == 2
+
+    def test_preserved_divergent_twin_detected_in_both_orders(self):
+        # A twin pair committed to two different ids must refuse regardless
+        # of which member carries the preserve marker / is visited first.
+        def deck(first: str, second: str) -> str:
+            return (
+                '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
+                "# ## Einführung\n"
+                "\n"
+                f'# %% [markdown] lang="de" tags=["voiceover"] slide_id="{first}"\n'
+                "# Sprechertext\n"
+                "\n"
+                f'# %% [markdown] lang="en" tags=["voiceover"] slide_id="{second}"\n'
+                "# Voiceover text\n"
+            )
+
+        for first, second in (("id-a", "!id-b"), ("!id-b", "id-a"), ("!id-a", "!id-b")):
+            new_text, result = _run(deck(first, second), **_STAMP)
+            assert any("divergent ids" in r.reason for r in result.refusals), (
+                f"divergence not detected for order ({first}, {second})"
+            )
+            assert new_text == deck(first, second)  # nothing overwritten
+
+    def test_block_layout_run_refused_entirely(self):
+        # [de1, de2, en1, en2]: greedily pairing the adjacent interior
+        # (de2, en1) would stamp one identity onto two cells that are not
+        # translations of each other, and the mis-minted id would then
+        # spread via twin adoption after the author fixes the ordering.
+        # The whole irregular run must be refused instead.
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
+            "# ## Einführung\n"
+            "\n"
+            '# %% [markdown] lang="de"\n'
+            "# Erster deutscher Absatz über Variablen.\n"
+            "\n"
+            '# %% [markdown] lang="de"\n'
+            "# Zweiter deutscher Absatz über Schleifen.\n"
+            "\n"
+            '# %% [markdown] lang="en"\n'
+            "# First English paragraph about variables.\n"
+            "\n"
+            '# %% [markdown] lang="en"\n'
+            "# Second English paragraph about loops.\n"
+        )
+        new_text, result = _run(text, **_STAMP)
         assert result.assignments == []
-        assert any("--stamp-ids needs both halves" in r.reason for r in result.refusals)
-        # The localized cell was NOT half-stamped.
-        assert "slide_id" not in de.read_text(encoding="utf-8").splitlines()[3]
+        assert len(result.refusals) == 4
+        assert new_text == text
+
+    def test_legacy_repoint_via_twin_adoption_labeled_repoint(self):
+        # DE narrative carries the inherited owner id (legacy), EN twin an
+        # own id: the DE re-point adopts the twin's id but is still a §12.1
+        # re-point in the audit trail, not a plain twin adoption.
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
+            "# ## Einführung\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["voiceover"] slide_id="intro"\n'
+            "# Sprechertext\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["voiceover"] slide_id="my-own"\n'
+            "# Voiceover text\n"
+        )
+        new_text, result = _run(text, **_STAMP)
+        assert [(a.slide_id, a.source) for a in result.assignments] == [
+            ("my-own", "narrative-repoint")
+        ]
+
+    def test_pair_records_attributed_to_half_files(self, tmp_path):
+        from clm.slides.assign_ids import assign_ids_in_files
+
+        de = _write(
+            tmp_path,
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="intro"\n'
+            "# ## Einführung\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["voiceover"] slide_id="intro"\n'
+            "# Willkommen zur Einführung in dieses Thema.\n",
+            name="slides_attr.de.py",
+        )
+        en = _write(
+            tmp_path,
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="intro"\n'
+            "# ## Introduction\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["voiceover"] slide_id="intro"\n'
+            "# Welcome to the introduction of this topic.\n",
+            name="slides_attr.en.py",
+        )
+        result = assign_ids_in_files([de, en], AssignOptions(**_STAMP))
+        assert len(result.assignments) == 2
+        by_file = {Path(a.file).name: a for a in result.assignments}
+        # One record per half, each at that half's real line number (the
+        # narrative header is line 4 in both 5-line files).
+        assert set(by_file) == {"slides_attr.de.py", "slides_attr.en.py"}
+        assert all(a.line == 4 for a in result.assignments)

--- a/tests/slides/test_validator.py
+++ b/tests/slides/test_validator.py
@@ -2011,6 +2011,129 @@ class TestCheckSlideIds:
         result = validate_file(p, checks=["pairing"])
         assert result.findings == []
 
+    def test_narrative_twins_with_divergent_own_ids_error(self, tmp_path):
+        # Divergent twin ids split into asymmetric DE/EN id sets (a sync
+        # verify failure); the pre-#520 adjacency rule errored here too.
+        p = _write_slide(
+            tmp_path,
+            "slides_divergent_twins.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Titel
+
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Title
+
+            # %% [markdown] lang="de" tags=["voiceover"] slide_id="own-de"
+            # Sprechertext
+
+            # %% [markdown] lang="en" tags=["voiceover"] slide_id="own-en"
+            # Voiceover text
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        mismatch = [f for f in result.findings if "narrative twins carry mismatched" in f.message]
+        assert len(mismatch) == 1
+        assert mismatch[0].severity == "error"
+
+    def test_narrative_legacy_plus_own_twin_errors_as_mismatch(self, tmp_path):
+        # Mixed form: DE still inherits the owner id, EN carries an own id —
+        # the twins diverge, which splits asymmetrically.
+        p = _write_slide(
+            tmp_path,
+            "slides_mixed_twins.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Titel
+
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Title
+
+            # %% [markdown] lang="de" tags=["voiceover"] slide_id="intro"
+            # Sprechertext
+
+            # %% [markdown] lang="en" tags=["voiceover"] slide_id="own-en"
+            # Voiceover text
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        mismatch = [f for f in result.findings if "narrative twins carry mismatched" in f.message]
+        assert len(mismatch) == 1
+
+    def test_narrative_twin_grouping_respects_cell_type(self, tmp_path):
+        # A markdown voiceover next to a code voiceover is NOT a twin pair
+        # (the stamp engine requires equal cell types); the code pair behind
+        # them is. Their shared own id must not be flagged as a duplicate.
+        p = _write_slide(
+            tmp_path,
+            "slides_cell_type.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="demo"
+            # ## Demo
+
+            # %% [markdown] lang="en" tags=["slide"] slide_id="demo"
+            # ## Demo
+
+            # %% lang="en" tags=["voiceover"] slide_id="demo-en"
+            print("en narration")
+
+            # %% lang="de" tags=["voiceover"] slide_id="demo-en"
+            print("de narration")
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        dup = [f for f in result.findings if "duplicates an id" in f.message]
+        assert dup == []
+
+    def test_localized_duplicate_ids_warn_not_error(self, tmp_path):
+        # Stamped localized ids participate in duplicate detection — but as
+        # warnings: the corpus carries legacy localized ids that shadow
+        # their slide's id on purpose.
+        p = _write_slide(
+            tmp_path,
+            "slides_loc_dup.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Titel
+
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Title
+
+            # %% [markdown] lang="de" slide_id="body-x"
+            # Absatz eins
+
+            # %% [markdown] lang="en" slide_id="body-x"
+            # Paragraph one
+
+            # %% [markdown] lang="de" slide_id="body-x"
+            # Absatz zwei
+
+            # %% [markdown] lang="en" slide_id="body-x"
+            # Paragraph two
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        dup = [f for f in result.findings if "localized cell slide_id" in f.message]
+        assert len(dup) == 2  # the second pair's two cells
+        assert all(f.severity == "warning" for f in dup)
+
+    def test_localized_id_shadowing_slide_id_warns(self, tmp_path):
+        p = _write_slide(
+            tmp_path,
+            "slides_loc_shadow.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Titel
+
+            # %% [markdown] lang="de" slide_id="intro"
+            # Absatz
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        dup = [f for f in result.findings if "localized cell slide_id" in f.message]
+        assert len(dup) == 1
+        assert dup[0].severity == "warning"
+
     def test_narrative_without_preceding_anchor_errors(self, tmp_path):
         p = _write_slide(
             tmp_path,

--- a/tests/slides/test_validator.py
+++ b/tests/slides/test_validator.py
@@ -1931,11 +1931,45 @@ class TestCheckSlideIds:
         result = validate_file(p, checks=["pairing"])
         assert result.findings == []
 
-    def test_narrative_with_stale_slide_id_errors(self, tmp_path):
+    def test_narrative_with_unique_own_id_passes(self, tmp_path):
+        # The sync-v3 own-id convention (§12.1 / #520, `normalize
+        # --stamp-ids`): a narrative id of the cell's own — unique in the
+        # file, not the anchor's id — is legal. (Through CLM 1.18 this was
+        # an unconditional adjacency error.)
+        p = _write_slide(
+            tmp_path,
+            "slides_own_id.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="second"
+            # ## Zweites
+
+            # %% [markdown] lang="en" tags=["slide"] slide_id="second"
+            # ## Second
+
+            # %% [markdown] lang="de" tags=["voiceover"] slide_id="own-narration"
+            # Sprechertext mit eigener Kennung
+
+            # %% [markdown] lang="en" tags=["voiceover"] slide_id="own-narration"
+            # Voiceover with its own id
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        assert result.findings == []
+
+    def test_narrative_with_stale_duplicate_slide_id_errors(self, tmp_path):
+        # The stale copy-paste id this rule has always guarded against: an
+        # id that equals some OTHER slide's id. Under the own-id convention
+        # it is flagged as a duplicate rather than an adjacency mismatch.
         p = _write_slide(
             tmp_path,
             "slides_stale.py",
             """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="first"
+            # ## Erstes
+
+            # %% [markdown] lang="en" tags=["slide"] slide_id="first"
+            # ## First
+
             # %% [markdown] lang="de" tags=["slide"] slide_id="second"
             # ## Zweites
 
@@ -1947,11 +1981,35 @@ class TestCheckSlideIds:
             """,
         )
         result = validate_file(p, checks=["pairing"])
-        mismatch = [f for f in result.findings if "does not match preceding slide" in f.message]
+        mismatch = [f for f in result.findings if "duplicates an id" in f.message]
         assert len(mismatch) == 1
         assert mismatch[0].severity == "error"
         assert "'first'" in mismatch[0].message
         assert "'second'" in mismatch[0].message
+
+    def test_narrative_twins_share_their_own_id_without_duplicate_error(self, tmp_path):
+        # Adjacent DE/EN narrative twins share one own id, exactly like a
+        # DE/EN slide pair — the duplicate check must treat them as one
+        # logical narrative.
+        p = _write_slide(
+            tmp_path,
+            "slides_own_twins.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Titel
+
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Title
+
+            # %% [markdown] lang="de" tags=["notes"] slide_id="speaker-notes-intro"
+            # Notizen
+
+            # %% [markdown] lang="en" tags=["notes"] slide_id="speaker-notes-intro"
+            # Notes
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        assert result.findings == []
 
     def test_narrative_without_preceding_anchor_errors(self, tmp_path):
         p = _write_slide(
@@ -2033,10 +2091,12 @@ class TestCheckSlideIds:
         result = validate_file(p, checks=["pairing"])
         assert result.findings == []
 
-    def test_title_macro_followed_by_mismatched_narrative_errors(self, tmp_path):
+    def test_title_macro_narrative_with_own_id_passes(self, tmp_path):
+        # Under the own-id convention a unique narrative id below the title
+        # macro is legal (formerly an adjacency error against "title").
         p = _write_slide(
             tmp_path,
-            "slides_title_mismatch.py",
+            "slides_title_own_id.py",
             """\
             # j2 from 'macros.j2' import header
             # {{ header("Einfuehrung", "Introduction") }}
@@ -2046,9 +2106,7 @@ class TestCheckSlideIds:
             """,
         )
         result = validate_file(p, checks=["pairing"])
-        mismatch = [f for f in result.findings if "does not match preceding slide" in f.message]
-        assert len(mismatch) == 1
-        assert "'title'" in mismatch[0].message
+        assert result.findings == []
 
     # -- Pair-mismatch warning --
 
@@ -2174,7 +2232,10 @@ class TestCheckSlideIds:
         warnings = [f for f in result.findings if "missing slide_id" in f.message]
         assert len(warnings) == 1
 
-    def test_quick_mode_flags_narrative_mismatch(self, tmp_path):
+    def test_quick_mode_flags_narrative_duplicate(self, tmp_path):
+        # Quick mode reuses _check_slide_ids, so the own-id duplicate rule
+        # fires there too: a narrative id equal to another slide's id is a
+        # stale copy-paste, not an own id.
         p = _write_slide(
             tmp_path,
             "slides_quick_stale.py",
@@ -2182,12 +2243,15 @@ class TestCheckSlideIds:
             # %% [markdown] lang="de" tags=["slide"] slide_id="real"
             # ## Titel
 
-            # %% [markdown] lang="de" tags=["voiceover"] slide_id="stale"
+            # %% [markdown] lang="de" tags=["slide"] slide_id="other"
+            # ## Anderes
+
+            # %% [markdown] lang="de" tags=["voiceover"] slide_id="real"
             # Sprechertext
             """,
         )
         result = validate_quick(p)
-        mismatch = [f for f in result.findings if "does not match preceding slide" in f.message]
+        mismatch = [f for f in result.findings if "duplicates an id" in f.message]
         assert len(mismatch) == 1
         assert mismatch[0].severity == "error"
 


### PR DESCRIPTION
## Summary

Second slice of **Phase 0** of the sync-v3 umbrella (#520): the one-time id normalization `clm slides normalize --stamp-ids` (design §3.4 + settled decision §12.1), plus the validator support the own-id convention requires. Deck files only — voiceover companion files follow in a separate PR before the PythonCourses normalize commit.

### What `--stamp-ids` does
- Every id-less **localized** cell (`lang=…`, markdown or code, non-slide) gets a content-slug id.
- Every voiceover/notes **narrative** gets its **own unique** id (§12.1) — legacy inherited-owner and `<deck-stem>-cell-N` placeholder ids are re-pointed (`narrative-own` / `narrative-repoint` sources); any other existing id is kept (ids stay monotone); `!`-preserved ids always win and their bare form is adopted by the twin.
- **Pair-atomic by construction**: twins pair only inside clean alternating DE/EN runs (block layouts like `de,de,en,en` are refused whole — greedy pairing would stamp one identity onto non-twins and the mis-mint would spread via twin adoption); split decks stamp through the unified pair (EN-authority, byte-faithful round-trip gate); lone halves and non-unifiable pairs are refused **untouched**; prefix-less decks (`apis.de.py`) are discovered and guarded the same as prefixed ones.
- Shared language-neutral cells are never stamped (byte-parity, not names).
- Replaces the regular operations for that run; honors `--dry-run`/`--json`/scoping; refusals become `stamp_id_{soft,hard}_refusal` review items with proposed slugs; pair-run records are attributed to the real half file/line.

### Validator
`_check_slide_ids` accepts both narrative-id conventions (legacy inherit / unique own id). Own ids join the duplicate check keyed on adjacent DE/EN twin groups, so stale copy-paste ids still error — now as duplicates. Divergent ids on a narrative twin pair are an error (they split into asymmetric id sets); duplicates involving localized ids are **warnings** (the corpus deliberately shadows slide ids on a few localized cells — verified against PythonCourses: 410 localized-with-id cells, 4 legit shadows).

### Adversarial review
A 4-dimension review with per-finding adversarial verification ran before this PR; all 14 confirmed findings are fixed in the second commit (order-dependent divergence detection, block-layout mis-stamping, prefix-gated guard bypass, EN-attributed unified line numbers, refusal-still-writes fallback, label/plural/flag-policy polish).

## Test plan

- [x] 402 tests across assign-ids / validator / normalize CLI / normalizer suites (36 new)
- [x] 834 sync-related fast tests unchanged and green
- [x] Real-corpus rehearsal on a copied PythonCourses module: 94 stamps (47 DE / 47 EN, real line numbers), zero refusals, zero `sync verify` structural violations, all 19 pairs post-sync-clean (`build_sync_plan` no-op after seed), zero validate errors/warnings, idempotent second run
- [x] Info topic (`commands.md`) updated per the Info Topics Maintenance Rule; changelog fragment added
- [x] Fast suite via pre-push hook

Part of #520. Exit criteria remaining for Phase 0: companion-file stamping (next PR), then the reviewed one-time normalize commit in PythonCourses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xju9N384PqCWxiaBtMx9Uj
