### PR TITLE
build(deps): move JupyterLite build to an isolated `uvx` tool env (Wave 2a)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,13 +46,14 @@ pip install -e ".[all]"           # everything clm needs for dev (or: uv sync)
 ```
 
 `[all]` deliberately **excludes** `[ml]` (course-runtime PyTorch/pandas stack,
-not imported by clm) and `[jupyterlite]` (a shell-out build tool whose `empack`
-pins `click<8.2`, incompatible with clm's CLI). Add ML with
-`pip install -e ".[all,ml]"`; build JupyterLite output in isolation with
-`uv sync --extra jupyterlite --no-default-groups`. For the full list of optional
-extras (`[notebook]`, `[plantuml]`, `[drawio]`, `[all-workers]`, `[recordings]`,
-`[summarize]`, `[voiceover]`, `[slides]`, `[gcal]`, `[mcp]`, `[ml]`, `[dev]`,
-`[tui]`, `[web]`) see `docs/user-guide/installation.md`.
+not imported by clm; add it with `pip install -e ".[all,ml]"`). JupyterLite is
+**not a clm extra** — clm only shells out to `jupyter lite build`, which now
+runs in an isolated `uvx` tool env (pinned in
+`src/clm/workers/jupyterlite/builder.py`), so it needs no install step beyond
+having `uv` on PATH. For the full list of optional extras (`[notebook]`,
+`[plantuml]`, `[drawio]`, `[all-workers]`, `[recordings]`, `[summarize]`,
+`[voiceover]`, `[slides]`, `[gcal]`, `[mcp]`, `[ml]`, `[dev]`, `[tui]`, `[web]`)
+see `docs/user-guide/installation.md`.
 
 ## Testing
 

--- a/changelog.d/516-jupyterlite-uvx-tool-env.changed.md
+++ b/changelog.d/516-jupyterlite-uvx-tool-env.changed.md
@@ -1,0 +1,12 @@
+- **The JupyterLite site build now runs in an isolated `uvx` tool environment,
+  and the `[jupyterlite]` extra has been removed.** clm never imported
+  `jupyterlite-core` — it only shells out to `jupyter lite build` — so the build
+  now invokes `uvx --from jupyterlite-core==<pin> --with … jupyter-lite build`
+  with pinned versions of jupyterlite-core, both kernel addons, and
+  jupyter-server (pins live in `src/clm/workers/jupyterlite/builder.py`). Because
+  jupyterlite-core/`empack` (which caps `click<8.2`) can no longer enter clm's
+  dependency graph, the `[tool.uv] conflicts` Click fork added in the previous
+  release is gone too. Building the JupyterLite output format now needs only
+  [`uv`](https://docs.astral.sh/uv/) on your PATH — nothing added to clm's own
+  environment. See `docs/claude/design/dependency-environment-isolation.md`
+  (Wave 2a) and issue #516.

--- a/docs/claude/design/dependency-environment-isolation.md
+++ b/docs/claude/design/dependency-environment-isolation.md
@@ -1,7 +1,8 @@
 # Design: dependency-environment isolation (three roles, three environments)
 
-Status: proposed (2026-07-02). Wave 1 (packaging) has shipped; this document
-specifies Wave 2 (the structural split). Context: issue #516 follow-up.
+Status: in progress (2026-07-02). Wave 1 (packaging) and Wave 2a (JupyterLite
+tool env) have shipped; Wave 2b (course-runtime kernel env) is still proposed.
+Context: issue #516 follow-up.
 
 ## Problem
 
@@ -124,8 +125,10 @@ mitmproxy transport) and confirm none leak constraints into clm's resolution.
   default `uv sync` group; fork jupyterlite via `[tool.uv] conflicts` so clm's
   CLI gets modern Click; CI installs from the lock. Removes the immediate
   landmine without any worker-code change. (This PR.)
-- **Wave 2a:** Role C — move the JupyterLite build to a `uvx` tool env; drop the
-  `[jupyterlite]` extra + conflict.
+- **Wave 2a (shipped):** Role C — the JupyterLite build now shells out to a
+  pinned `uvx` tool env (`src/clm/workers/jupyterlite/builder.py`); the
+  `[jupyterlite]` extra and the `[tool.uv] conflicts` fork are deleted. clm's
+  env only needs `uv` on PATH.
 - **Wave 2b:** Role B — kernelspec/`JUPYTER_PATH` course-venv wiring (route 1),
   then the interpreter knob (route 2). Remove `[ml]` as a clm extra.
 

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -444,8 +444,10 @@ clm build --watch               # Watch for changes and auto-rebuild
 - Apply optional branding via `overrides.json` (theme, logo, site name)
 - Write a deterministic `jupyterlite-manifest.json` for content-addressed caching
 
-**Dependencies** (optional, install with `[jupyterlite]`):
-- jupyterlite-core, jupyterlite-pyodide-kernel, jupyterlite-xeus, jupyter-server
+**Dependencies** (not a clm extra): the build shells out to `jupyter lite build`
+in an isolated `uvx` tool env pinned in `builder.py` (jupyterlite-core,
+jupyterlite-pyodide-kernel, jupyterlite-xeus, jupyter-server). clm's env only
+needs `uv` on PATH — see `docs/claude/design/dependency-environment-isolation.md`.
 
 **Location**: `src/clm/workers/jupyterlite/`
 
@@ -1171,10 +1173,12 @@ distributed repo.
 
 Site-level bundler that consumes already-built notebook output and produces
 a deployable JupyterLite static site. Opt-in only via `<jupyterlite>` config
-block + `<format>jupyterlite</format>` per target. Requires `[jupyterlite]`.
+block + `<format>jupyterlite</format>` per target. Not a clm extra — the build
+runs in an isolated `uvx` tool env (needs only `uv` on PATH).
 
 - `builder` — `build_site(BuildArgs)` orchestrator: assembles lite-dir,
-  shells out to `jupyter lite build`, emits launcher + README + manifest.
+  shells out to `jupyter lite build` in a pinned `uvx` tool env, emits launcher
+  + README + manifest.
 - `lite_dir` — pure-IO assembler: `assemble_lite_dir()`, `write_overrides()`,
   `hash_manifest()`.
 - `miniserve` — download/cache/verify prebuilt binaries, emit per-OS launcher

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -97,7 +97,7 @@ pip install -e ".[web]"      # Web dashboard
 
 # Install for development
 pip install -e ".[dev]"      # Development tools
-pip install -e ".[all]"      # Everything clm needs (excludes [ml] + [jupyterlite]; see below)
+pip install -e ".[all]"      # Everything clm needs (excludes [ml]; see below)
 ```
 
 ### Python Optional Dependencies
@@ -160,15 +160,16 @@ CLM has several optional dependency groups for different features:
   - Required for: `clm calendar push` (mirror a cohort's viewing calendar into Google Calendar)
   - Install: `pip install -e ".[gcal]"`
 
-**Output Bundling**:
-- **[jupyterlite]**: jupyterlite-core, jupyterlite-pyodide-kernel, jupyterlite-xeus, jupyter-server
-  - Required for: the `jupyterlite` output format (browser-based notebook site bundler)
-  - **Not in `[all]` and not in the default `uv sync` groups.** Its `empack`
-    dependency pins `click<8.2`, which conflicts with clm's CLI (`click>=8.2`);
-    `[tool.uv] conflicts` keeps the two in separate resolution forks. Install it
-    on its own so it can't hold your Click back:
-    `uv sync --extra jupyterlite --no-default-groups`
-  - Install (isolated env): `pip install -e ".[jupyterlite]"`
+**Output Bundling (JupyterLite)**:
+- The `jupyterlite` output format (browser-based notebook site bundler) needs
+  **no clm extra**. clm never imports jupyterlite-core — it only shells out to
+  `jupyter lite build`, which runs in an **isolated `uvx` tool environment**
+  pinned in `src/clm/workers/jupyterlite/builder.py`. The only requirement is
+  that [`uv`](https://docs.astral.sh/uv/) is installed and `uvx` is on PATH; the
+  first build provisions the tool env automatically. Keeping jupyterlite-core
+  and its `empack` dependency (which caps `click<8.2`) out of clm's environment
+  is deliberate — it makes the old Click collision structurally impossible. See
+  `docs/claude/design/dependency-environment-isolation.md`.
 
 **HTTP Replay**:
 - **[replay]**: mitmproxy, pyyaml, filelock
@@ -186,24 +187,22 @@ CLM has several optional dependency groups for different features:
   replay, dev, tui, web
   - Required for: Full clm development and testing
   - Install: `pip install -e ".[all]"`
-  - **Deliberately excludes `[ml]` and `[jupyterlite]`.** Neither is imported by
-    clm itself: `[ml]` (PyTorch/pandas/transformers/…) is *course-runtime* — it
-    exists only so Direct-mode notebook kernels can import it — and `[jupyterlite]`
-    is a standalone build tool clm shells out to whose `empack` dependency pins
-    `click<8.2` (incompatible with clm's CLI). Bundling them made every install
-    multi-GB and, in jupyterlite's case, held the whole environment back to an old
-    Click. Install them explicitly when a course needs them (see below), or run
+  - **Deliberately excludes `[ml]`.** It is not imported by clm itself:
+    `[ml]` (PyTorch/pandas/transformers/…) is *course-runtime* — it exists only
+    so Direct-mode notebook kernels can import it. Bundling it made every install
+    multi-GB. Install it explicitly when a course needs it (see below), or run
     the workers in Docker mode (the notebook image bakes the ML stack in).
+    (JupyterLite is likewise absent, but it is not a clm extra at all — its
+    build runs in an isolated `uvx` tool env.)
 
 **Notes**:
 - Core package works without worker dependencies (can use Docker mode)
 - For direct execution mode, install worker-specific dependencies
 - For clm development and testing, install with `[all]` (or just `uv sync`)
 - To run **ML course decks** in Direct mode: `pip install -e ".[all,ml]"`
-- To build the **JupyterLite** output format, install it in isolation so its
-  `click<8.2` cap can't drag the rest of your env down:
-  `uv sync --extra jupyterlite --no-default-groups` (or a separate venv /
-  `pip install -e ".[jupyterlite]"` in its own environment)
+- To build the **JupyterLite** output format, just make sure `uv` is installed
+  (`uvx` on PATH); clm runs `jupyter lite build` in an isolated tool env — there
+  is nothing to add to clm's own environment.
 - External tools (PlantUML JAR, Draw.io app) still required for those workers
 
 ## External Tool Dependencies

--- a/docs/user-guide/jupyterlite.md
+++ b/docs/user-guide/jupyterlite.md
@@ -10,15 +10,18 @@ exactly as they do today.
 
 ## Installation
 
-Install CLM with the JupyterLite extra:
+There is **nothing to install into CLM's environment** for JupyterLite. CLM
+never imports `jupyterlite-core`; it shells out to `jupyter lite build`, which
+runs in an **isolated `uvx` tool environment** that CLM provisions on demand
+with pinned versions of `jupyterlite-core`, the Pyodide and xeus-python kernel
+addons, and `jupyter-server`.
 
-```bash
-pip install "coding-academy-lecture-manager[jupyterlite]"
-```
-
-This is also included in the `[all]` extra. The extra brings in
-`jupyterlite-core`, the Pyodide and xeus-python kernel addons, and
-`jupyter-server`.
+The only requirement is that [`uv`](https://docs.astral.sh/uv/) is installed and
+`uvx` is on your PATH (uv ships `uvx`). The first build provisions the tool env
+(a few seconds); later builds reuse uv's cached tool environment. Keeping the
+JupyterLite toolchain out of CLM's own environment avoids a dependency
+collision (`empack`, pulled in by `jupyterlite-xeus`, caps `click<8.2` while
+CLM's CLI needs `click>=8.2`).
 
 ## Quick Start
 
@@ -242,7 +245,9 @@ For most courses, `xeus-python` with pre-staged wheels is recommended.
 
 ## Troubleshooting
 
-**"jupyterlite-core is not installed"**: Run `pip install -e ".[jupyterlite]"`.
+**"uv is not installed (or `uvx` is not on PATH)"**: The site build runs in an
+isolated `uvx` tool env. Install [`uv`](https://docs.astral.sh/uv/) and make
+sure `uvx` is on your PATH, then retry.
 
 **Build fails with kernel addon errors**: CLM automatically disables the
 inactive kernel addon during builds. If you see errors from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,21 +172,12 @@ voiceover-granite = [
     "torch>=2.0.0",
     "soundfile>=0.12.0",
 ]
-# JupyterLite: browser-based notebook site bundler
-# Heavy/optional — only install if a course opts into the `jupyterlite`
-# output format. `jupyterlite-core` ships the `jupyter lite build` CLI;
-# the kernel extras provide the two supported kernels (xeus-python for
-# reproducible preinstalled wheels, pyodide for runtime %pip install).
-jupyterlite = [
-    "jupyterlite-core>=0.7,<0.9",
-    "jupyterlite-pyodide-kernel>=0.7,<0.9",
-    "jupyterlite-xeus>=4.0,<5.0",
-    # jupyterlite-core's `contents` addon shells out to jupyter-server to
-    # enumerate the notebook tree; without it the build fails with
-    # "jupyter-server is not installed". The dependency is not declared
-    # by jupyterlite-core itself so we list it here.
-    "jupyter-server>=2.12",
-]
+# NOTE: JupyterLite is intentionally NOT a clm extra. clm only shells out to
+# the `jupyter lite build` CLI, which now runs in an isolated `uvx` tool
+# environment pinned in `src/clm/workers/jupyterlite/builder.py` (Wave 2a).
+# Keeping jupyterlite-core/empack out of clm's dependency graph makes the old
+# `empack` → `click<8.2` collision structurally impossible. See
+# docs/claude/design/dependency-environment-isolation.md.
 # Slide authoring tools (search, validation, normalization)
 slides = [
     "rapidfuzz>=3.0.0",
@@ -228,10 +219,10 @@ mcp = [
 dev = [
     # The CLI test suite drives Click's CliRunner via the 8.2+ API (no
     # `mix_stderr`); on Click 8.1 ~30 tests fail with "I/O operation on closed
-    # file". The base requirement stays `click>=8.1.0` so the opt-in
-    # `[jupyterlite]` extra (whose `empack` caps `click<8.2`) can still resolve
-    # in its own fork; pinning the floor here forces the dev/test/`all` fork to a
-    # modern Click. Paired with `[tool.uv] conflicts` (jupyterlite ⟂ dev).
+    # file". Pinning the floor here keeps the dev/test/`all` environment on a
+    # modern Click. (JupyterLite's `empack` — which caps `click<8.2` — no longer
+    # enters clm's resolution: its build moved to an isolated `uvx` tool env in
+    # Wave 2a, so the old `[tool.uv] conflicts` fork is gone.)
     "click>=8.2",
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
@@ -258,18 +249,15 @@ web = [
     "segno>=1.6.0",  # Pure-Python QR codes for Mobile Deck Studio pairing
 ]
 # Everything
-# NOTE: `all` intentionally excludes `ml` and `jupyterlite`.
-#   - `ml` (torch/pandas/transformers/…) is course-*runtime*: clm never imports
-#     it; it exists only so Direct-mode notebook kernels can import it. Bundling
-#     it made every `clm` install carry a multi-GB ML stack for no clm-side
-#     benefit. Install it explicitly (`[ml]`) on a box that runs ML course decks
-#     in Direct mode — or use the Docker notebook image, which bakes it in.
-#   - `jupyterlite` pulls `empack`, which caps `click<8.2` and collides with
-#     clm's own CLI (needs `click>=8.2`); it is also a pure out-of-process build
-#     tool clm only shells out to. It is a conflicting extra (see
-#     `[tool.uv] conflicts` below) and is installed on demand (`[jupyterlite]`).
-# Wave 2 moves the JupyterLite build into an isolated `uvx` tool env and drops
-# the extra entirely. See docs/claude/design/dependency-environment-isolation.md.
+# NOTE: `all` intentionally excludes `ml`. `ml` (torch/pandas/transformers/…)
+# is course-*runtime*: clm never imports it; it exists only so Direct-mode
+# notebook kernels can import it. Bundling it made every `clm` install carry a
+# multi-GB ML stack for no clm-side benefit. Install it explicitly (`[ml]`) on
+# a box that runs ML course decks in Direct mode — or use the Docker notebook
+# image, which bakes it in.
+# (JupyterLite is not a clm extra at all — its build runs in an isolated `uvx`
+# tool env; see the note above the `slides` extra and
+# docs/claude/design/dependency-environment-isolation.md.)
 all = [
     "coding-academy-lecture-manager[all-workers,summarize,voiceover,recordings,slides,gcal,mcp,replay,dev,tui,web]",
 ]
@@ -552,15 +540,12 @@ version = "{new_version}\""""
 # See docs/proposals/PRE_COMMIT_HOOK_HARDENING.md (Fix 1) for rationale.
 dev = [
     # This is the group `uv sync` installs by default (local dev / worktree
-    # setup / pre-push gate). `jupyterlite` is intentionally NOT here: its
-    # `empack` dependency caps `click<8.2`, which collides with the CLI test
-    # suite's need for `click>=8.2` and used to silently pin a freshly-synced
-    # worktree to click 8.1.8 (issue #516 follow-up). Install JupyterLite on
-    # demand with `uv sync --extra jupyterlite --no-default-groups`. `ml` is
-    # likewise excluded (huge, course-runtime-only, py3.14-blocked).
+    # setup / pre-push gate). `ml` is excluded (huge, course-runtime-only,
+    # py3.14-blocked) and JupyterLite is not a clm extra at all — its build runs
+    # in an isolated `uvx` tool env (Wave 2a), so nothing here pulls
+    # jupyterlite-core/empack into clm's resolution.
     "coding-academy-lecture-manager[notebook,plantuml,drawio,recordings,slides,mcp,summarize,voiceover,replay,tui,web]",
-    # Force this fork to a modern Click (the CliRunner 8.2+ API); paired with
-    # the jupyterlite conflict in `[tool.uv]` so the two resolve separately.
+    # Keep this environment on a modern Click (the CliRunner 8.2+ API).
     "click>=8.2",
     "pytest>=7.0",
     "pytest-asyncio>=0.21",
@@ -582,36 +567,11 @@ dev = [
 # (also refreshes uv.lock; see scripts/check_exclude_newer.py for drift check)
 exclude-newer = "2026-05-28"
 
-# `jupyterlite` transitively depends on `empack`, which pins `click<8.2`, while
-# clm's own CLI + its test suite (the `dev` extra) require `click>=8.2`. Left in
-# one resolution these are unsatisfiable together and uv pins the whole graph to
-# click 8.1.8, silently breaking ~30 CLI tests on a freshly-synced worktree
-# (issue #516 follow-up). Declaring the two extras as conflicting makes uv
-# resolve them in separate forks: the default / `dev` / `all` environment gets a
-# modern click, while an opt-in `[jupyterlite]` build env keeps its
-# empack-compatible click<8.2. Wave 2 removes the jupyterlite extra (the build
-# moves to an isolated `uvx` tool env) and this conflict goes with it.
-conflicts = [
-    [
-        { extra = "jupyterlite" },
-        { extra = "dev" },
-    ],
-    # `all` bundles the `dev` extra (and thus `click>=8.2`), so it is likewise
-    # incompatible with jupyterlite's empack cap. Declared as its own pair
-    # because `all` and `dev` are not mutually exclusive with each other.
-    [
-        { extra = "jupyterlite" },
-        { extra = "all" },
-    ],
-    # The default-installed `dev` dependency-group also pins `click>=8.2`, so a
-    # `uv sync --extra jupyterlite` (which keeps default groups) would clash.
-    # This pairing makes uv fork them; install jupyterlite with
-    # `--no-default-groups` to activate the empack-compatible fork.
-    [
-        { extra = "jupyterlite" },
-        { group = "dev" },
-    ],
-]
+# NOTE: there is deliberately no `[tool.uv] conflicts` block. It previously
+# forked the `jupyterlite` extra (whose `empack` caps `click<8.2`) away from
+# clm's own `click>=8.2` CLI. Wave 2a removed the `[jupyterlite]` extra entirely
+# — the site build runs in an isolated `uvx` tool env — so jupyterlite-core /
+# empack never enter clm's resolution and no conflict fork is needed.
 
 # Exempt PyTorch packages from exclude-newer: the cu130 index doesn't
 # provide upload dates on its wheels, so they must opt out entirely.

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -971,8 +971,8 @@ def enable_jupyterlite_workers_if_needed(course, worker_config) -> None:
     the operator already set a higher count via CLI/config) so the build's
     lifecycle manager spins up one jupyterlite worker alongside the
     notebook/plantuml/drawio workers. This keeps the opt-in contract tight:
-    installing the ``[jupyterlite]`` extra has no effect until a course
-    actually uses the format.
+    the jupyterlite worker (which shells out to an isolated ``uvx`` tool env)
+    never starts until a course actually uses the format.
     """
     wants_jl = any(t.includes_format("jupyterlite") for t in course.output_targets)
     if not wants_jl:

--- a/src/clm/cli/commands/jupyterlite.py
+++ b/src/clm/cli/commands/jupyterlite.py
@@ -1,8 +1,9 @@
 """``clm jupyterlite`` command group.
 
 Provides ``clm jupyterlite preview <target>`` for locally serving
-a previously built JupyterLite site. Requires the ``[jupyterlite]``
-extra only for the actual build — preview itself is pure stdlib.
+a previously built JupyterLite site. Preview itself is pure stdlib; the
+actual build shells out to an isolated ``uvx`` tool env (needs ``uv`` on
+PATH), not any clm extra.
 """
 
 from __future__ import annotations

--- a/src/clm/cli/info_topics/jupyterlite.md
+++ b/src/clm/cli/info_topics/jupyterlite.md
@@ -128,6 +128,16 @@ and miniserve launcher:
 - `clm jupyterlite preview --target <name> <spec.xml>` — serves a previously
   built JupyterLite site locally.
 
+## Build requirements
+
+CLM does **not** install the JupyterLite toolchain into its own environment.
+`clm build` shells out to `jupyter lite build` inside an isolated `uvx`
+(`uv tool run`) environment with pinned versions of `jupyterlite-core`, both
+kernel addons, and `jupyter-server`. The only requirement is that
+[`uv`](https://docs.astral.sh/uv/) is installed and `uvx` is on your PATH; the
+first build provisions the tool env automatically and later builds reuse uv's
+cache. This keeps `jupyterlite-core`/`empack` out of CLM's dependency graph.
+
 ## Validation
 
 At spec-parse time:

--- a/src/clm/core/operations/build_jupyterlite_site.py
+++ b/src/clm/core/operations/build_jupyterlite_site.py
@@ -29,16 +29,16 @@ logger = logging.getLogger(__name__)
 
 
 def _get_jupyterlite_core_version() -> str:
-    """Return the installed ``jupyterlite-core`` version, or ``""`` if missing."""
-    try:
-        from importlib.metadata import PackageNotFoundError, version
+    """Return the ``jupyterlite-core`` version used for the build cache key.
 
-        try:
-            return version("jupyterlite-core")
-        except PackageNotFoundError:
-            return ""
-    except Exception:
-        return ""
+    The site build runs in an isolated ``uvx`` tool env (Wave 2a), not clm's
+    own venv, so jupyterlite-core is no longer importable here — the version is
+    the pin the tool env is built from (``builder.JUPYTERLITE_CORE_VERSION``).
+    Bumping that pin invalidates previously-cached sites, which is what we want.
+    """
+    from clm.workers.jupyterlite.builder import JUPYTERLITE_CORE_VERSION
+
+    return JUPYTERLITE_CORE_VERSION
 
 
 @frozen

--- a/src/clm/workers/jupyterlite/builder.py
+++ b/src/clm/workers/jupyterlite/builder.py
@@ -12,7 +12,6 @@ import json
 import logging
 import shutil
 import subprocess
-import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -20,6 +19,44 @@ from pathlib import Path
 from clm.workers.jupyterlite.lite_dir import assemble_lite_dir, hash_manifest
 
 logger = logging.getLogger(__name__)
+
+# Pinned versions for the isolated JupyterLite tool environment.
+#
+# The site build no longer runs in clm's own venv: clm shells out to an
+# isolated ``uvx`` (``uv tool run``) environment so that jupyterlite-core's
+# transitive constraints — notably ``empack``'s ``click<8.2`` cap — can never
+# enter clm's dependency graph (issue #516 / Wave 2a). Because that tool env is
+# created on demand from these pins, they ARE the version truth: they define
+# both what ``uvx`` installs and the ``jupyterlite_core_version`` that feeds the
+# build cache key, so a bump here correctly invalidates previously-cached sites.
+JUPYTERLITE_CORE_VERSION = "0.7.6"
+_JUPYTERLITE_PYODIDE_KERNEL_VERSION = "0.7.2"
+_JUPYTERLITE_XEUS_VERSION = "4.5.2"
+_JUPYTER_SERVER_SPEC = "jupyter-server>=2.12"
+
+
+def _jupyter_lite_tool_command() -> list[str]:
+    """Return the ``uvx`` prefix that runs ``jupyter-lite`` from a tool env.
+
+    Both kernel addons are ``--with``-installed so the tool env always has
+    them present; ``_run_jupyter_lite_build`` then disables whichever kernel
+    the course did not pick via ``--disable-addons``. ``jupyter-server`` is
+    required by jupyterlite-core's ``contents`` addon (it is not declared as a
+    dependency by jupyterlite-core itself).
+    """
+    uvx = shutil.which("uvx") or "uvx"
+    return [
+        uvx,
+        "--from",
+        f"jupyterlite-core=={JUPYTERLITE_CORE_VERSION}",
+        "--with",
+        f"jupyterlite-pyodide-kernel=={_JUPYTERLITE_PYODIDE_KERNEL_VERSION}",
+        "--with",
+        f"jupyterlite-xeus=={_JUPYTERLITE_XEUS_VERSION}",
+        "--with",
+        _JUPYTER_SERVER_SPEC,
+        "jupyter-lite",
+    ]
 
 
 @dataclass
@@ -51,26 +88,24 @@ class BuildResult:
 
 
 def _run_jupyter_lite_build(lite_dir: Path, site_dir: Path, kernel: str) -> None:
-    """Invoke ``jupyter lite build`` as a subprocess.
+    """Invoke ``jupyter lite build`` in an isolated ``uvx`` tool environment.
 
-    We call the CLI directly (instead of importing ``jupyterlite_core``)
-    because the CLI is the supported entry point and it shells out
-    further to its own tasks — keeping this boundary explicit also makes
-    the build reproducible from a developer's terminal by copy-pasting
-    the command we log.
+    clm never installs or imports ``jupyterlite-core``; it shells out to the
+    CLI from a dedicated, pinned ``uvx`` (``uv tool run``) environment (see
+    ``_jupyter_lite_tool_command``). Running the build out-of-process this way
+    keeps jupyterlite-core's transitive constraints (``empack`` caps
+    ``click<8.2``) entirely out of clm's dependency graph. The exact command we
+    run is logged so it can be reproduced from a developer's terminal.
 
-    The ``--disable-addons`` flag is load-bearing: ``jupyterlite-xeus``
-    and ``jupyterlite-pyodide-kernel`` are both installed by the
-    ``[jupyterlite]`` extra, but each one's ``post_build`` hook assumes
-    its kernel is the active one. Leaving both enabled causes the
-    non-active addon to raise (xeus demands an environment file;
-    pyodide-kernel demands a wheelhouse). We turn off whichever kernel
-    the course did not pick.
+    The ``--disable-addons`` flag is load-bearing: ``jupyterlite-xeus`` and
+    ``jupyterlite-pyodide-kernel`` are both installed into the tool env (both
+    ``--with``), but each one's ``post_build`` hook assumes its kernel is the
+    active one. Leaving both enabled causes the non-active addon to raise (xeus
+    demands an environment file; pyodide-kernel demands a wheelhouse). We turn
+    off whichever kernel the course did not pick.
     """
     cmd = [
-        sys.executable,
-        "-m",
-        "jupyterlite_core",
+        *_jupyter_lite_tool_command(),
         "build",
         "--lite-dir",
         str(lite_dir),
@@ -86,8 +121,9 @@ def _run_jupyter_lite_build(lite_dir: Path, site_dir: Path, kernel: str) -> None
         subprocess.run(cmd, check=True, capture_output=True, text=True)
     except FileNotFoundError as e:
         raise RuntimeError(
-            "jupyterlite-core is not installed. Install with "
-            "`pip install -e '.[jupyterlite]'` and retry."
+            "uv is not installed (or `uvx` is not on PATH). The JupyterLite "
+            "site build runs in an isolated `uvx` tool environment; install uv "
+            "(https://docs.astral.sh/uv/) and retry."
         ) from e
     except subprocess.CalledProcessError as e:
         stderr = e.stderr or ""
@@ -358,6 +394,7 @@ def build_result_to_summary(result: BuildResult) -> str:
 
 
 __all__ = [
+    "JUPYTERLITE_CORE_VERSION",
     "BuildArgs",
     "BuildResult",
     "build_site",

--- a/src/clm/workers/jupyterlite/jupyterlite_worker.py
+++ b/src/clm/workers/jupyterlite/jupyterlite_worker.py
@@ -2,11 +2,11 @@
 
 Pulls ``jupyterlite`` jobs off the shared queue, reconstructs a
 ``BuildArgs`` bundle from the payload, and shells out to
-``jupyter lite build``. The heavy ``jupyterlite-core`` dependency is
-imported lazily (inside ``build_site``) so that the worker module
-itself is safe to import even when the ``[jupyterlite]`` extra is
-absent — that way discovery/registration code paths don't explode on
-installs that never opt into the format.
+``jupyter lite build`` in an isolated ``uvx`` tool environment. clm never
+installs or imports ``jupyterlite-core`` — the tool env is provisioned on
+demand (needs only ``uv`` on PATH) — so the worker module is always safe to
+import; discovery/registration code paths never depend on the JupyterLite
+toolchain being present.
 """
 
 from __future__ import annotations

--- a/tests/workers/jupyterlite/test_builder.py
+++ b/tests/workers/jupyterlite/test_builder.py
@@ -17,6 +17,7 @@ import pytest
 
 from clm.workers.jupyterlite import builder as builder_module
 from clm.workers.jupyterlite.builder import (
+    JUPYTERLITE_CORE_VERSION,
     BuildArgs,
     build_result_to_summary,
     build_site,
@@ -212,6 +213,54 @@ def test_build_site_normalizes_backslash_paths_in_contents(
                     _no_backslash_in_path(item)
 
         _no_backslash_in_path(data)
+
+
+def test_run_build_shells_out_to_uvx_tool_env(tmp_path: Path) -> None:
+    """The build invokes ``jupyter-lite`` from an isolated ``uvx`` tool env.
+
+    Wave 2a moved the build out of clm's own venv: clm shells out to
+    ``uvx --from jupyterlite-core==<pin> --with … jupyter-lite build`` so
+    jupyterlite-core/empack never enter clm's dependency graph. We assert the
+    command shape (pinned ``--from``, both kernel addons ``--with``-installed)
+    and that the correct addon is disabled for the chosen kernel.
+    """
+    with patch.object(builder_module.subprocess, "run") as run:
+        builder_module._run_jupyter_lite_build(
+            tmp_path / "lite", tmp_path / "site", kernel="pyodide"
+        )
+
+    cmd = run.call_args.args[0]
+    assert Path(cmd[0]).name.startswith("uvx")
+    assert "--from" in cmd
+    assert f"jupyterlite-core=={JUPYTERLITE_CORE_VERSION}" in cmd
+    # Both kernel addons are provisioned into the tool env...
+    assert any("jupyterlite-pyodide-kernel==" in part for part in cmd)
+    assert any("jupyterlite-xeus==" in part for part in cmd)
+    # ...and jupyter-server (the contents addon needs it).
+    assert any(part.startswith("jupyter-server") for part in cmd)
+    assert "jupyter-lite" in cmd and "build" in cmd
+    # pyodide kernel → xeus addon disabled.
+    disable_idx = cmd.index("--disable-addons")
+    assert cmd[disable_idx + 1] == "jupyterlite-xeus"
+
+
+def test_run_build_disables_pyodide_addon_for_xeus(tmp_path: Path) -> None:
+    with patch.object(builder_module.subprocess, "run") as run:
+        builder_module._run_jupyter_lite_build(
+            tmp_path / "lite", tmp_path / "site", kernel="xeus-python"
+        )
+    cmd = run.call_args.args[0]
+    disable_idx = cmd.index("--disable-addons")
+    assert cmd[disable_idx + 1] == "jupyterlite-pyodide-kernel"
+
+
+def test_run_build_missing_uv_raises_actionable_error(tmp_path: Path) -> None:
+    """A missing ``uvx`` surfaces as an install-uv hint, not a raw OSError."""
+    with patch.object(builder_module.subprocess, "run", side_effect=FileNotFoundError):
+        with pytest.raises(RuntimeError, match="uv is not installed"):
+            builder_module._run_jupyter_lite_build(
+                tmp_path / "lite", tmp_path / "site", kernel="pyodide"
+            )
 
 
 def test_build_result_summary_is_valid_json(

--- a/tests/workers/jupyterlite/test_jupyterlite_integration.py
+++ b/tests/workers/jupyterlite/test_jupyterlite_integration.py
@@ -1,10 +1,11 @@
 """End-to-end integration test for the JupyterLite builder.
 
-Runs the real ``jupyter lite build`` CLI on a synthetic 2-notebook tree
-and asserts the site's ``index.html`` is produced. Skipped when
-``jupyterlite-core`` is not importable (i.e., the ``[jupyterlite]``
-extra is not installed) so the fast-suite dev box doesn't need to pull
-the extra.
+Runs the real ``jupyter lite build`` CLI on a synthetic 1-notebook tree
+and asserts the site's ``index.html`` is produced. The build shells out
+to an isolated ``uvx`` tool env (Wave 2a) — clm no longer installs
+jupyterlite-core — so this test is skipped when ``uvx`` is not on PATH.
+The first run provisions the tool env (a few seconds); subsequent runs
+reuse the cached uv tool env.
 
 Marked ``integration`` — excluded from the default fast suite and
 Docker suite; runs via ``pytest -m integration``.
@@ -12,20 +13,20 @@ Docker suite; runs via ``pytest -m integration``.
 
 from __future__ import annotations
 
-import importlib.util
 import json
+import shutil
 from pathlib import Path
 
 import pytest
 
 pytestmark = pytest.mark.integration
 
-HAS_JUPYTERLITE = importlib.util.find_spec("jupyterlite_core") is not None
+HAS_UVX = shutil.which("uvx") is not None
 
 
 @pytest.mark.skipif(
-    not HAS_JUPYTERLITE,
-    reason="jupyterlite-core not installed (pip install -e '.[jupyterlite]')",
+    not HAS_UVX,
+    reason="uvx not on PATH (JupyterLite builds run in an isolated uvx tool env)",
 )
 def test_jupyter_lite_build_produces_index_html(tmp_path: Path) -> None:
     from clm.workers.jupyterlite.builder import BuildArgs, build_site

--- a/uv.lock
+++ b/uv.lock
@@ -2,39 +2,15 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "(python_full_version >= '3.14' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev') or (python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev')",
-    "(python_full_version == '3.13.*' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev') or (python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev')",
-    "(python_full_version < '3.13' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev') or (python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev')",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev'",
-    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev'",
-    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev'",
-    "(python_full_version >= '3.15' and sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version >= '3.15' and sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version == '3.14.*' and sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version == '3.14.*' and sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version == '3.13.*' and sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version == '3.13.*' and sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version < '3.13' and sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version < '3.13' and sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "python_full_version >= '3.15' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version == '3.14.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "(python_full_version >= '3.15' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version >= '3.15' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version == '3.14.*' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version == '3.14.*' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version == '3.13.*' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version < '3.13' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "python_full_version >= '3.15' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version == '3.14.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
+    "(python_full_version >= '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform == 'win32')",
+    "(python_full_version == '3.14.*' and sys_platform == 'linux') or (python_full_version == '3.14.*' and sys_platform == 'win32')",
+    "(python_full_version == '3.13.*' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
+    "(python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform == 'win32')",
+    "python_full_version >= '3.15' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
-conflicts = [[
-    { package = "coding-academy-lecture-manager", extra = "dev" },
-    { package = "coding-academy-lecture-manager", extra = "jupyterlite" },
-], [
-    { package = "coding-academy-lecture-manager", extra = "all" },
-    { package = "coding-academy-lecture-manager", extra = "jupyterlite" },
-], [
-    { package = "coding-academy-lecture-manager", extra = "jupyterlite" },
-    { package = "coding-academy-lecture-manager", group = "dev" },
-]]
 
 [options]
 exclude-newer = "2026-05-28T22:00:00Z"
@@ -55,8 +31,8 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/14/787e5498cd062640f0f3d92ef4ae4063174f76f9afd29d13fc52a319daae/accelerate-1.13.0.tar.gz", hash = "sha256:d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236", size = 402835, upload-time = "2026-03-04T19:34:12.359Z" }
 wheels = [
@@ -194,7 +170,7 @@ version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "frozenlist" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -244,7 +220,7 @@ version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
@@ -799,7 +775,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -948,40 +924,10 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "(python_full_version >= '3.14' and sys_platform == 'linux') or (python_full_version >= '3.14' and sys_platform == 'win32')",
-    "(python_full_version == '3.13.*' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
-    "(python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform == 'win32')",
-    "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-]
-dependencies = [
-    { name = "colorama", marker = "(sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
-]
-
-[[package]]
-name = "click"
 version = "8.4.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "(python_full_version >= '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform == 'win32')",
-    "(python_full_version == '3.14.*' and sys_platform == 'linux') or (python_full_version == '3.14.*' and sys_platform == 'win32')",
-    "(python_full_version == '3.13.*' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
-    "(python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform == 'win32')",
-    "python_full_version >= '3.15' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.14.*' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-]
 dependencies = [
-    { name = "colorama", marker = "(sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
@@ -1012,8 +958,7 @@ version = "1.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-30-coding-academy-lecture-manager-jupyterlite'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-30-coding-academy-lecture-manager-all' or extra == 'extra-30-coding-academy-lecture-manager-dev' or extra != 'extra-30-coding-academy-lecture-manager-jupyterlite' or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "click" },
     { name = "docker" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -1032,7 +977,7 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "aiofiles" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "click" },
     { name = "faster-whisper" },
     { name = "filelock" },
     { name = "google-api-python-client" },
@@ -1091,7 +1036,7 @@ all-workers = [
     { name = "tenacity" },
 ]
 dev = [
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "click" },
     { name = "hypothesis" },
     { name = "mypy" },
     { name = "pytest" },
@@ -1112,12 +1057,6 @@ gcal = [
     { name = "google-api-python-client" },
     { name = "google-auth" },
     { name = "google-auth-oauthlib" },
-]
-jupyterlite = [
-    { name = "jupyter-server" },
-    { name = "jupyterlite-core" },
-    { name = "jupyterlite-pyodide-kernel" },
-    { name = "jupyterlite-xeus" },
 ]
 mcp = [
     { name = "mcp" },
@@ -1174,11 +1113,11 @@ ml = [
     { name = "tiktoken" },
     { name = "timm" },
     { name = "toolz" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "torchaudio" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "tqdm" },
     { name = "trafilatura" },
     { name = "transformers" },
@@ -1231,14 +1170,14 @@ voiceover = [
 voiceover-cohere = [
     { name = "sentencepiece" },
     { name = "soundfile" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "transformers" },
 ]
 voiceover-granite = [
     { name = "soundfile" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "transformers" },
 ]
 web = [
@@ -1250,8 +1189,8 @@ web = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "coding-academy-lecture-manager", extra = ["drawio", "mcp", "notebook", "plantuml", "recordings", "replay", "slides", "summarize", "tui", "voiceover", "web"], marker = "extra == 'extra-30-coding-academy-lecture-manager-all' or extra == 'extra-30-coding-academy-lecture-manager-dev' or extra != 'extra-30-coding-academy-lecture-manager-jupyterlite' or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "click" },
+    { name = "coding-academy-lecture-manager", extra = ["drawio", "mcp", "notebook", "plantuml", "recordings", "replay", "slides", "summarize", "tui", "voiceover", "web"] },
     { name = "hypothesis" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -1306,10 +1245,6 @@ requires-dist = [
     { name = "ipywidgets", marker = "extra == 'notebook'", specifier = ">=8.1.0" },
     { name = "jinja2", marker = "extra == 'notebook'", specifier = "~=3.1.4" },
     { name = "jinja2", marker = "extra == 'recordings'", specifier = ">=3.1" },
-    { name = "jupyter-server", marker = "extra == 'jupyterlite'", specifier = ">=2.12" },
-    { name = "jupyterlite-core", marker = "extra == 'jupyterlite'", specifier = ">=0.7,<0.9" },
-    { name = "jupyterlite-pyodide-kernel", marker = "extra == 'jupyterlite'", specifier = ">=0.7,<0.9" },
-    { name = "jupyterlite-xeus", marker = "extra == 'jupyterlite'", specifier = ">=4.0,<5.0" },
     { name = "jupytext", marker = "extra == 'notebook'", specifier = ">=1.16.4" },
     { name = "langchain", marker = "extra == 'ml'", specifier = ">=1.2.7" },
     { name = "langchain-anthropic", marker = "extra == 'ml'" },
@@ -1409,7 +1344,7 @@ requires-dist = [
     { name = "watchfiles", marker = "extra == 'web'", specifier = ">=0.18.0" },
     { name = "wsproto", marker = "extra == 'web'", specifier = ">=1.2.0" },
 ]
-provides-extras = ["notebook", "plantuml", "drawio", "all-workers", "ml", "summarize", "recordings", "voiceover", "voiceover-cohere", "voiceover-granite", "jupyterlite", "slides", "gcal", "replay", "mcp", "dev", "tui", "web", "all"]
+provides-extras = ["notebook", "plantuml", "drawio", "all-workers", "ml", "summarize", "recordings", "voiceover", "voiceover-cohere", "voiceover-granite", "slides", "gcal", "replay", "mcp", "dev", "tui", "web", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1529,8 +1464,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "arrow" },
     { name = "binaryornot" },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-30-coding-academy-lecture-manager-jupyterlite'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-30-coding-academy-lecture-manager-all' or extra == 'extra-30-coding-academy-lecture-manager-dev' or extra != 'extra-30-coding-academy-lecture-manager-jupyterlite' or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "click" },
     { name = "jinja2" },
     { name = "python-slugify" },
     { name = "pyyaml" },
@@ -1645,7 +1579,7 @@ name = "cryptography"
 version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
 wheels = [
@@ -1730,21 +1664,17 @@ name = "cuda-bindings"
 version = "13.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "cuda-pathfinder", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/e0/4b3fdba08ff177e9451f376a4ba2df18d76f9158e6a16cdc062bd83db9fa/cuda_bindings-13.3.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f72f67f5790e7fa51e3f893e007e49567573ccdf4ed1ca988fbbbd36cd77847c", size = 6020531, upload-time = "2026-05-27T03:59:07.942Z" },
     { url = "https://files.pythonhosted.org/packages/04/40/a2ea4d8f032bfd6c220d50b6f92cd61f33d48f31959da39ed1b178cfee54/cuda_bindings-13.3.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a99c3b8d584f266c616bd0f30c7cd83e33553e3ef2abad41ff5a74fbc033a69a", size = 6653764, upload-time = "2026-05-27T03:59:09.981Z" },
-    { url = "https://files.pythonhosted.org/packages/45/d0/a4a05a88a89396adfcc7a1a751270a669774c18426c4fd7f6a3c0a528336/cuda_bindings-13.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:851e138181b3a6edf6f29ba30ce7481df9a0dbfffc655b603dd1bb31032707ca", size = 5874053, upload-time = "2026-05-27T03:59:12.08Z" },
     { url = "https://files.pythonhosted.org/packages/ae/a0/156efe7816699c2de1ea2395031db7d010b7af23c243563a3ee6f0ecc1de/cuda_bindings-13.3.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7698fcc4577aa96372866f4d0c9a6cf686cd5c90eab94581c29d37fe6600542", size = 5914803, upload-time = "2026-05-27T03:59:14.011Z" },
     { url = "https://files.pythonhosted.org/packages/51/91/510aae64d53227b5b36db6bfaea41514b66d92cd65ddc43aa49566f18313/cuda_bindings-13.3.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:abd908f651160d12c45c5714a38ee102a1173a55433c0d1509ec0e8293beb4a6", size = 6472506, upload-time = "2026-05-27T03:59:16.551Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/69/22fdc157e8fb2af3cc8f759481392795f1d046ebc202fb8c660cc87d7644/cuda_bindings-13.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:97afb1ebe2f60b538d88a902a952749e97f999505cd8aca78d491ea7e8b038c8", size = 5826328, upload-time = "2026-05-27T03:59:18.812Z" },
     { url = "https://files.pythonhosted.org/packages/01/53/2ef49e5b3734a5531b2ba5d726cba724d9cbb262404e586ed61070604826/cuda_bindings-13.3.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a801fa30e75d25b74252123aefc746b6c4275624d2b8640632dd1dfeeaa1f88", size = 6008814, upload-time = "2026-05-27T03:59:20.921Z" },
     { url = "https://files.pythonhosted.org/packages/2f/cb/3a9fcf0651e0a49b4d0f1955837ce079245b27086c22fb2f253039bdf324/cuda_bindings-13.3.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:94d40ef7b4bdd9dce0244a1baa132e0e538f1eb2c0d162fb3648a15e48515365", size = 6531477, upload-time = "2026-05-27T03:59:23.391Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/e8/b99e7475badedc960a20b10e5734e371d724197db8761569882ac1ef494b/cuda_bindings-13.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:e17a46d711233a8a8e4c33aaa773e13810abe5fe686e08ca3e3df52449e6d7eb", size = 5959970, upload-time = "2026-05-27T03:59:25.935Z" },
     { url = "https://files.pythonhosted.org/packages/2b/0f/6987c5ee98f117317a85650ddc79480a3fa59a573ae1c923d0722b56ae71/cuda_bindings-13.3.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e5911bea15810b749a8077f8c45423ed785d51618b8e8664dea1fc8f5a2a76c8", size = 5807073, upload-time = "2026-05-27T03:59:28.218Z" },
     { url = "https://files.pythonhosted.org/packages/f6/ab/46ceee07dc19f18a5d1c28d592750ed9dbdc803077eb083576a442c9938c/cuda_bindings-13.3.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2870fed7707a37f8af0c02364b05f355ebe8921604e8c68eb56cf66867e0798", size = 6354325, upload-time = "2026-05-27T03:59:30.715Z" },
-    { url = "https://files.pythonhosted.org/packages/93/12/24b54244e7ce677daae1ff81b47af900544c94745f934c9ed94e71ef1d87/cuda_bindings-13.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2ddb3b5c9b013f42b1304ba39c0fe4277f4c228987e62d850aff66353aeb0ee2", size = 6737000, upload-time = "2026-05-27T03:59:33.093Z" },
 ]
 
 [[package]]
@@ -1765,34 +1695,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -1966,7 +1896,7 @@ name = "docker"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
     { name = "urllib3" },
 ]
@@ -1985,38 +1915,12 @@ wheels = [
 ]
 
 [[package]]
-name = "doit"
-version = "0.37.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/35/f6/3a817d438799bda4d4e5fd136175cf7c328c074fadc1422dec3b374907e7/doit-0.37.0.tar.gz", hash = "sha256:d3c72e0e46a8fa1ddabea8f830762402dee090caf33c30c2295ac7010db8f09c", size = 1450967, upload-time = "2026-02-09T07:02:15.578Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/38/3d6dcbf8379cb86d71a2325210ca3469a33767d8254b74d8c343db26ce87/doit-0.37.0-py3-none-any.whl", hash = "sha256:a9f181566aa90faac515e276f85e6526019554ed7e13c12cf9dc094ffecf3e1b", size = 85780, upload-time = "2026-02-09T07:02:10.155Z" },
-]
-
-[[package]]
 name = "emoji"
 version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/78/0d2db9382c92a163d7095fc08efff7800880f830a152cfced40161e7638d/emoji-2.15.0.tar.gz", hash = "sha256:eae4ab7d86456a70a00a985125a03263a5eac54cd55e51d7e184b1ed3b6757e4", size = 615483, upload-time = "2025-09-21T12:13:02.755Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/5e/4b5aaaabddfacfe36ba7768817bd1f71a7a810a43705e531f3ae4c690767/emoji-2.15.0-py3-none-any.whl", hash = "sha256:205296793d66a89d88af4688fa57fd6496732eb48917a87175a023c8138995eb", size = 608433, upload-time = "2025-09-21T12:13:01.197Z" },
-]
-
-[[package]]
-name = "empack"
-version = "6.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" } },
-    { name = "networkx" },
-    { name = "platformdirs" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "typer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/0c/39e11d3eed34490c31bf9655d7957eabf75c2dc50724060abb6f1cab4df2/empack-6.0.0.tar.gz", hash = "sha256:4ab0ae6187e9c7c7d83301c09c7847bffa2e76382d16bb7e7edd72784bcd4669", size = 19421, upload-time = "2025-06-30T08:27:50.671Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/c5/2ce2c05279b215bbafc2c4bb9024f33cf4389891400b96f539c174505fa7/empack-6.0.0-py2.py3-none-any.whl", hash = "sha256:be9508e3e4ecabeddbc353cbc764d0be12140103613db8c988a6cf54f782d43e", size = 15980, upload-time = "2025-06-30T08:27:48.917Z" },
 ]
 
 [[package]]
@@ -2057,10 +1961,10 @@ dependencies = [
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "spacy" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f9/08/d54365d18d797c583599387af0b21b5e50d377a357a0d871195fbb84d271/fastai-2.8.7.tar.gz", hash = "sha256:93be109daab077a73279bb2aba27fa72a206bbf055b0f1921475afde69b7705f", size = 221121, upload-time = "2026-02-14T02:00:55.745Z" }
 wheels = [
@@ -2226,8 +2130,7 @@ version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "blinker" },
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-30-coding-academy-lecture-manager-jupyterlite'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-30-coding-academy-lecture-manager-all' or extra == 'extra-30-coding-academy-lecture-manager-dev' or extra != 'extra-30-coding-academy-lecture-manager-jupyterlite' or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "click" },
     { name = "itsdangerous" },
     { name = "jinja2" },
     { name = "markupsafe" },
@@ -2285,15 +2188,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/34/3b/214dcc19ee31d3d38fb5ad2755c11ef0514e5dc300bbaf41c0b69f393799/fonttools-4.63.0-cp314-cp314t-win32.whl", hash = "sha256:948428a275741f0b64b113c955425a953314f4b9ab9997f73a72c83e68e569c8", size = 2359326, upload-time = "2026-05-14T12:04:24.22Z" },
     { url = "https://files.pythonhosted.org/packages/dd/1e/3ff1a9b523058c2eeb6a9d50f5574e2a738200d0d94107d5bc4105e8da3f/fonttools-4.63.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6d4741eb179121cab9eea4cb2393d24492373a260d7945006358c08cfbf45419", size = 2425829, upload-time = "2026-05-14T12:04:26.829Z" },
     { url = "https://files.pythonhosted.org/packages/2c/47/c99d5268f354002ce80f8d029cd9d7d872969da1de8b93d32de4dc56d6f4/fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d", size = 1164562, upload-time = "2026-05-14T12:04:29.092Z" },
-]
-
-[[package]]
-name = "fqdn"
-version = "1.5.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015, upload-time = "2021-03-11T07:16:29.08Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121, upload-time = "2021-03-11T07:16:28.351Z" },
 ]
 
 [[package]]
@@ -2521,7 +2415,7 @@ version = "6.15.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "audioop-lts", marker = "python_full_version >= '3.13' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
     { name = "brotli" },
     { name = "fastapi" },
     { name = "gradio-client" },
@@ -2579,9 +2473,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/37/4549f149c9797c21b32c2683c33522af22522099de128b2406672526d005/greenlet-3.5.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:fa4f98af3a528f0c3fd592a26df7f376f93329c8f4d987f6bb979057af8bf5e2", size = 286220, upload-time = "2026-05-20T13:07:28.463Z" },
     { url = "https://files.pythonhosted.org/packages/38/ff/a4f436709716965eaab9f36ea7b906c8a927fbe32fb1372a2071d964f6b1/greenlet-3.5.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffea73584b216150eab159b6d12348fb253e68757974de1e2c40d8a318ac89ed", size = 601585, upload-time = "2026-05-20T14:00:06.141Z" },
     { url = "https://files.pythonhosted.org/packages/65/ad/54bc3fcee3ad368a61b19b67d88117f7a8c29727bf71fffdeda81fbd946e/greenlet-3.5.1-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1072b4f9edcc1e192d9283a66a3e68d6b84c561de33a83d7858beb9ba1effe10", size = 614215, upload-time = "2026-05-20T14:05:42.675Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/6c/de5b1b388cd2d9fbdfeab324863daba37d54e6e233ddbefd70b385a8c591/greenlet-3.5.1-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:89101bfd5011e069be974903cb3a4e4523845e4ece2d62dcd8d358933c0ef249", size = 620094, upload-time = "2026-05-20T14:09:09.18Z" },
     { url = "https://files.pythonhosted.org/packages/40/69/b91cda0647df839483201545913514c2827ebea5e5ccdf931842763bc127/greenlet-3.5.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:add5217d68b31130f0beca584d7fef4878327d2e31642b66618a14eef312b63b", size = 611358, upload-time = "2026-05-20T13:14:26.37Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/43/1204baffab8a6476464795a7ccf394a3248d4f22c9f87173a15b36b6d971/greenlet-3.5.1-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:e6cd99ea59dd5d89f0c956606571d79bfe6f68c9eb7f4a4083a41a7f1587edee", size = 422782, upload-time = "2026-05-20T14:01:39.597Z" },
     { url = "https://files.pythonhosted.org/packages/59/90/3cf77e080350cd02fa307bb2abf05df48f4482c240275bbd2c203ba8bb1c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a5ea42a752d47a145eae922b605cd1634665ac3d5ec1e72402d5048e8d60d207", size = 1570475, upload-time = "2026-05-20T14:02:25.29Z" },
     { url = "https://files.pythonhosted.org/packages/65/2c/18cece62045e74598c3c393f70dce4a63f56222015ba29a5d4eeb04f764c/greenlet-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c5551170cf4f5ff5623e9af81323751979fee2c731e2287b61f73cd27257b823", size = 1635625, upload-time = "2026-05-20T13:14:34.027Z" },
     { url = "https://files.pythonhosted.org/packages/30/f5/310d104ddf41eb5a70f4c268d22508dfb0c3c8e86fec152be34d0d2ed819/greenlet-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c8bb982ad117d29478ef8f5533e97df21f1e2befd17a299257b0c96d1371c0b", size = 238791, upload-time = "2026-05-20T13:10:39.018Z" },
@@ -2589,9 +2481,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/27/69/7f7e5372d998b81001899b1c0823c957aa413ba0f2662e65821611cc31e4/greenlet-3.5.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:51518ff74664078fc51bffcc6fc529b0df5ae58da192691cee765d45ce944a2b", size = 285060, upload-time = "2026-05-20T13:08:51.899Z" },
     { url = "https://files.pythonhosted.org/packages/b1/bf/387f9b6b865fd2ae0d0be09e0004827295a01b71be76ed350dd1e28a91a4/greenlet-3.5.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ffdb3c0bb002c99cd8f298957e046c3dbf6006b5b7cdf11a4e19194624a0a0a", size = 604370, upload-time = "2026-05-20T14:00:07.492Z" },
     { url = "https://files.pythonhosted.org/packages/32/f5/169ce3d4e4c67291bd18f8cbe0299c9f3e45102c7f1fb3c14780c93e4532/greenlet-3.5.1-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7715a5a2c3378ba602c3a440558261e13a820bb53a82693aacd7b7f6d964e283", size = 616987, upload-time = "2026-05-20T14:05:44.237Z" },
-    { url = "https://files.pythonhosted.org/packages/19/ba/c24110c55dffa55aa6e1d98b45310da33801aeba7686ff0190fe5d46fd32/greenlet-3.5.1-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d40a890035c0058cadbdc4af7569800fd28a0e527a0fdbb7b5f9418f176846ce", size = 622911, upload-time = "2026-05-20T14:09:10.598Z" },
     { url = "https://files.pythonhosted.org/packages/ee/e5/7f2e41d5273be07e77560d61ea4e56485b4d6c316d2a84518c62d1364061/greenlet-3.5.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc71ff466927a201b08305acac451ebe1aedfcea002f62f1f2f2ac2ac1e6a135", size = 613911, upload-time = "2026-05-20T13:14:27.539Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/7b/d20db2e8a5ad6c038702f3179b136f93f0a3d1a21a0c0777f3e470cdf4b2/greenlet-3.5.1-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:67821bb03e4e98664490edb787ff6af501194c29bbee0f5c1dfdcf1dc3d9d436", size = 425228, upload-time = "2026-05-20T14:01:40.837Z" },
     { url = "https://files.pythonhosted.org/packages/c5/a4/fbdc67579b73615a1f91615e814303cc71e06128f7baaba87be79b8fb90c/greenlet-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cd443683db272ebaaca03af98c0b063ab30db70ea8a31a1559f35e3f7b744ccd", size = 1570689, upload-time = "2026-05-20T14:02:27.225Z" },
     { url = "https://files.pythonhosted.org/packages/e6/b4/77abbe35078be39718a46cd49caf16bceb35662f97a34101dca28aa98e47/greenlet-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:089fff7a6ce8d9316d1f65ebc00273a56be258c1725b32b94de90a3a979557e1", size = 1635602, upload-time = "2026-05-20T13:14:36.344Z" },
     { url = "https://files.pythonhosted.org/packages/37/f7/129f27ca700845b8ee8ca88ce7f43435a1239c2eddb7677fc938822762cf/greenlet-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:110a1ca7b49b014b097f6078272c3f4ed31af45b254de5228b79adba879f6af9", size = 238683, upload-time = "2026-05-20T13:11:50.57Z" },
@@ -2599,9 +2489,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/cb/c62454606daf5640369c94d8a9dd540599b1bfc090e2d2180cb77f4038d2/greenlet-3.5.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8ab31c9de8651a2facdd5c5bb0011f2380dd1a7af78ce2adf4b56095294fc07", size = 285579, upload-time = "2026-05-20T13:08:56.396Z" },
     { url = "https://files.pythonhosted.org/packages/ec/71/c4270398c2eba968a6071af1dfbdcaeee6ec1c24bc8b435b8cc452700da6/greenlet-3.5.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e300185139abc337ade480c327183adf42a875ac7181bfe66d7d4efea31fbea", size = 651106, upload-time = "2026-05-20T14:00:09.448Z" },
     { url = "https://files.pythonhosted.org/packages/1a/ab/71e34b78a44ec271fb5f550c17bc46d301ddc5953890d935f270b0dcdb5a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7ffdb990dcaa0234cf9845aead5df2e3c3a8b6507d409274dd87e0d5ab05ffc2", size = 663478, upload-time = "2026-05-20T14:05:45.88Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/2d/2d80842910da44f78c286532d084b8a5c3717c844ae80ceb3858738ae89a/greenlet-3.5.1-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c09df69dc1712d131332054a858a3e5cca400967fa3a672e2324fbb0971448c", size = 667767, upload-time = "2026-05-20T14:09:12.15Z" },
     { url = "https://files.pythonhosted.org/packages/77/96/4efd6fa5c62c85426a0c19077a586258ebc3a2a146ff2493e4312a697a22/greenlet-3.5.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f82b3597e9d83b63408affed0b48fd0f54935edac4302237b9a837be0dae33c", size = 660800, upload-time = "2026-05-20T13:14:29.129Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/d3/dad2eecedfbb1ed7050a20dcfae40c1442b74bc7423608be2c7e03ee7133/greenlet-3.5.1-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:a4764e0bfc6a4d114c865b32520805c16a990ef5f286a514413b05d5ecd6a23d", size = 470786, upload-time = "2026-05-20T14:01:42.064Z" },
     { url = "https://files.pythonhosted.org/packages/7a/e0/6c71401a25cac7000261304e866a2f2cc04dc74810d40e2f118aa4799495/greenlet-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c0141e37414c10164e702b8fb1473304221ad98f71600850c6ef7ff4880feba0", size = 1617518, upload-time = "2026-05-20T14:02:28.662Z" },
     { url = "https://files.pythonhosted.org/packages/41/26/c5c06643e8c0af9e7bf18e16cb51d0ab7625155f0392e1c9015d66d556cd/greenlet-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:50ae25a67bea74ea41fb14b960bc532df73eb713417b2d61892dced82fe8d3bc", size = 1681593, upload-time = "2026-05-20T13:14:39.417Z" },
     { url = "https://files.pythonhosted.org/packages/8a/bd/e11a108317485075e68af9d23039619b86b28130c3b50d227d42edece64b/greenlet-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:8a17c42330e261299766b75ac1ea32caa437a9453c8f65d16a13140db378ecd3", size = 239800, upload-time = "2026-05-20T13:09:30.128Z" },
@@ -2609,18 +2497,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/90/12/41bf27fde4d3605d3773ae57751eda182b8be2f5398011c041173b1d9534/greenlet-3.5.1-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:ea8da1e900d758d078810d4255d8c6aa572181896a31ec79d779eb79c3adc9ad", size = 293637, upload-time = "2026-05-20T13:12:35.529Z" },
     { url = "https://files.pythonhosted.org/packages/44/44/ba14b23e9757707050c2f397d305bbcae62e5d7cad122f8b6baec5ae4a1f/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a19570c52a21420dcbc94e661994bc325c0b5b11304540fed514586da5dc8f2e", size = 650840, upload-time = "2026-05-20T14:00:11.079Z" },
     { url = "https://files.pythonhosted.org/packages/a8/37/5ddc2b686a6844f91abecef43411842426da2e1573f60b49ecf2547f4ae1/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3d955c89b75eeca4723d7cc14135f393cd47c32e2a6cb4a8e4c6e760a26b0986", size = 656416, upload-time = "2026-05-20T14:05:47.118Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/46/5987dcd1a2570ba84f3b187536b2ca3ae97613387e57f5cfa99df068fe5e/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ea37d5a157eb9493820d3792ac4ece28619a394391d2b9f2f78057d396ff0f0f", size = 656607, upload-time = "2026-05-20T14:09:13.949Z" },
     { url = "https://files.pythonhosted.org/packages/e1/f0/d17510297c35a2992712f0bf84de3779749999f7d3d63aa1f09db7c62dbe/greenlet-3.5.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2daaaebd1a5aa88c49045b6baf9310b3263796bd88db713edf37cf53e7bb4e", size = 654397, upload-time = "2026-05-20T13:14:30.696Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/c1/6da0a9ddcc29d7e51ef14883fa3dc1e53b3f4ffba00582106c7bf55da1d8/greenlet-3.5.1-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:8d8a23250ea3ec7b36de8fa4b541e9e2db3ee82915cc060ab0631609ad8b28de", size = 488287, upload-time = "2026-05-20T14:01:43.143Z" },
     { url = "https://files.pythonhosted.org/packages/37/eb/147387705bb89092645b012586e7273cb5ed3c90ef7eaf3a69173eaf0209/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3bfbd69cc349e43bf3a8ae1c85548ff0718efc887615c2db16c3833d7b0b072d", size = 1614469, upload-time = "2026-05-20T14:02:30.192Z" },
     { url = "https://files.pythonhosted.org/packages/a6/4e/37ee0da7732b7aa9896f17e15579a9df34b9fcb9dd494f0adfa749af6623/greenlet-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4378720dd888136c27215a0214d32a4d37c3852765d45bc37aad0623423cfd78", size = 1675115, upload-time = "2026-05-20T13:14:40.972Z" },
     { url = "https://files.pythonhosted.org/packages/57/f3/97dfcf4a6eb5077f8a672234216fb5923eb89f2cab7081cb10b2cf75b605/greenlet-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:45718441607f9325d948db98cbc691276059316d0358c188c246da4e1d4d23d2", size = 245246, upload-time = "2026-05-20T13:12:22.646Z" },
     { url = "https://files.pythonhosted.org/packages/5d/73/d7f72e34b582f694f4a9b248162db7b09cc458a259ba8f0c0bfa1a34ea7d/greenlet-3.5.1-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:2baee5ca02031757ffe8cc3d69f0cc0aec7065ce362622da74f32d3bcab1c541", size = 285575, upload-time = "2026-05-20T13:12:07.043Z" },
     { url = "https://files.pythonhosted.org/packages/df/59/fa9c6e87dc8ad27a95dabe2f29f372b733d05a8a67470f6c901ed9975655/greenlet-3.5.1-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b1ec3274918a81d3ea778b9e75b56b72b33f300edb6cf7f3a7fe1dae56683de", size = 656428, upload-time = "2026-05-20T14:00:12.556Z" },
     { url = "https://files.pythonhosted.org/packages/f6/f9/e753408871eaa61dfe35e619cfc67512b036fde99893685d50eea9e07146/greenlet-3.5.1-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:111e2390ffffc47d5840b01711dd7fac07d4c09283d0283e7f3264b14e284c64", size = 667064, upload-time = "2026-05-20T14:05:48.662Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/74/807a047255bf1e09303627c46dc043dca596b6958a354d904f32ab382005/greenlet-3.5.1-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:10a9a1c0bfbc93d41156ffcb90c75fbc05544054faf15dcc1fdf9765f8b607f0", size = 672962, upload-time = "2026-05-20T14:09:15.532Z" },
     { url = "https://files.pythonhosted.org/packages/96/27/5565b5b40389f1c7753003a07e21892fda8660926787036d5bc0308b8113/greenlet-3.5.1-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e630136e905fe5ff43e86945ae41220b6d1470956a39220e708110ac48d01ea5", size = 665697, upload-time = "2026-05-20T13:14:32.943Z" },
-    { url = "https://files.pythonhosted.org/packages/76/32/19d4e13225193c29b13e308015223f7d75fd3d8623d49dd19040d2ce8ec1/greenlet-3.5.1-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:ef08c1567c78074b22d1a200183d52d04a14df447bf70bcbb6a3507a48e776fc", size = 476047, upload-time = "2026-05-20T14:01:44.39Z" },
     { url = "https://files.pythonhosted.org/packages/cf/82/e7de4178c0c2d1c9a5a3be3cc0b33e46a85b3ee4a77c071bf7ad8600e079/greenlet-3.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:975eac34b44a7077ca4d421348455b94f0f518246a7f14bc6d2fdcfe5b584368", size = 1621256, upload-time = "2026-05-20T14:02:31.91Z" },
     { url = "https://files.pythonhosted.org/packages/00/10/f2dddcf7dacac17dfc68691809589adad06135eb28930429cf58a6467a2f/greenlet-3.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9ab3c3a0b2ae6198e67c898dad5215a49f9ae0d0081b3c3ec59f333e39eeca26", size = 1685956, upload-time = "2026-05-20T13:14:42.55Z" },
     { url = "https://files.pythonhosted.org/packages/22/17/4a232b32133230ada52f70e9d7f5b65b0caef8772f01849bd8d149e7e4ca/greenlet-3.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:cbfc69be86e10dcfef5b1e6269d1d6926552aa89ee39e1de3353360c1b6989ab", size = 239802, upload-time = "2026-05-20T13:13:15.481Z" },
@@ -2628,9 +2512,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7a/57/816d9cff29119da3505b3d6a5e14a8af89006ac36f47f891ff293ee05af1/greenlet-3.5.1-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:a6fdf2433a5441ef9a95464f7c3e674775da1c8c1177fff311cee1acad4626ed", size = 293877, upload-time = "2026-05-20T13:10:19.078Z" },
     { url = "https://files.pythonhosted.org/packages/23/a1/59b0a7c7d140ff1a75626680b9a9899b79a9176cab298b394968fb023295/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7546556f0d649f99f6a361098a55f761181bb2ea12ff150bb16d26092ad88244", size = 655333, upload-time = "2026-05-20T14:00:14.758Z" },
     { url = "https://files.pythonhosted.org/packages/72/1b/5efe127597625042218939d01855109f352779050768b670b52edcc16a6c/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d5ee3ea898009fa898f85f9982255d35278c477bebe185beca249cab42d4526c", size = 659443, upload-time = "2026-05-20T14:05:50.159Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/9d/1dcdf7b95ab3cf8c7b6d7277c18a5e167312f2b362ddfcc5d5e6d8d84b43/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a57b0d05a0448eed231d59c0ceb287dde984551e54cbc51ac2d4865712838e9c", size = 659998, upload-time = "2026-05-20T14:09:16.912Z" },
     { url = "https://files.pythonhosted.org/packages/6c/6d/c404246ea4d22d097a7426d0efb5b781bd7eb67715f09e79001bd552ab18/greenlet-3.5.1-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a5c81f74d204d3edd136ebfd50dce53acbb776995d721a0fe801626cfc93b8cd", size = 658356, upload-time = "2026-05-20T13:14:35.091Z" },
-    { url = "https://files.pythonhosted.org/packages/05/7e/c4959664fc231d587d66d8e81f2095e98056ba1954beafdcbe635e251052/greenlet-3.5.1-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:b0703c2cef53e01baec47f7a3868009913ad71ec678bbecb42a6f40895e4ce62", size = 494470, upload-time = "2026-05-20T14:01:45.611Z" },
     { url = "https://files.pythonhosted.org/packages/51/02/f8ee37fb6d2219329f350af241c27fcf12df57e723d11f6fc6d3bacdadaa/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:2c18ef16bf6d4dd410e4dd52996888ea1497be26892fe5bbc73580aba4287b8e", size = 1619216, upload-time = "2026-05-20T14:02:33.403Z" },
     { url = "https://files.pythonhosted.org/packages/93/c5/3dc9475ace2c7a3680da12372cddd7f1ac874eb410a1ac48d3e9dab83782/greenlet-3.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:17d86354f0ae6b61bf9be5148d0dd34e06c3cb7c602c671f79f29ac3b150e659", size = 1678427, upload-time = "2026-05-20T13:14:43.71Z" },
     { url = "https://files.pythonhosted.org/packages/df/4e/750c15c317a41ffb36f0bf40b933e3d744a7dede61889f74443ea69690cf/greenlet-3.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:e7516cf6ae6b8a582c2770a0caed47b8a48373ed732c33d69a72913ae6ac923e", size = 245225, upload-time = "2026-05-20T13:13:59.366Z" },
@@ -2876,7 +2758,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
     { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
@@ -2982,7 +2864,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -3020,11 +2902,11 @@ name = "ipython"
 version = "8.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "decorator" },
     { name = "jedi" },
     { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "(sys_platform != 'emscripten' and sys_platform != 'win32') or (sys_platform == 'emscripten' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'emscripten' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'emscripten' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
     { name = "prompt-toolkit" },
     { name = "pygments" },
     { name = "stack-data" },
@@ -3049,18 +2931,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl", hash = "sha256:ecaca67aed704a338f88f67b1181b58f821ab5dc89c1f0f5ef99db43c1c2921e", size = 139808, upload-time = "2025-11-01T21:18:10.956Z" },
-]
-
-[[package]]
-name = "isoduration"
-version = "20.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "arrow" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
 ]
 
 [[package]]
@@ -3222,19 +3092,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
 ]
 
-[package.optional-dependencies]
-format-nongpl = [
-    { name = "fqdn" },
-    { name = "idna" },
-    { name = "isoduration" },
-    { name = "jsonpointer" },
-    { name = "rfc3339-validator" },
-    { name = "rfc3986-validator" },
-    { name = "rfc3987-syntax" },
-    { name = "uri-template" },
-    { name = "webcolors" },
-]
-
 [[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
@@ -3277,67 +3134,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jupyter-events"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jsonschema", extra = ["format-nongpl"], marker = "extra == 'extra-30-coding-academy-lecture-manager-jupyterlite'" },
-    { name = "packaging" },
-    { name = "python-json-logger" },
-    { name = "pyyaml" },
-    { name = "referencing" },
-    { name = "rfc3339-validator" },
-    { name = "rfc3986-validator" },
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/18/f8/475c4241b2b75af0deaae453ed003c6c851766dbc44d332d8baf245dc931/jupyter_events-0.12.1.tar.gz", hash = "sha256:faff25f77218335752f35f23c5fe6e4a392a7bd99a5939ccb9b8fbf594636cf3", size = 62854, upload-time = "2026-04-20T23:17:50.66Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/6c/6fcde0c8f616ed360ffd3587f7db9e225a7e62b583a04494d2f069cf64ea/jupyter_events-0.12.1-py3-none-any.whl", hash = "sha256:c366585253f537a627da52fa7ca7410c5b5301fe893f511e7b077c2d93ec8bcf", size = 19512, upload-time = "2026-04-20T23:17:48.927Z" },
-]
-
-[[package]]
-name = "jupyter-server"
-version = "2.18.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "argon2-cffi" },
-    { name = "jinja2" },
-    { name = "jupyter-client" },
-    { name = "jupyter-core" },
-    { name = "jupyter-events" },
-    { name = "jupyter-server-terminals" },
-    { name = "nbconvert" },
-    { name = "nbformat" },
-    { name = "packaging" },
-    { name = "prometheus-client" },
-    { name = "pywinpty", marker = "os_name == 'nt'" },
-    { name = "pyzmq" },
-    { name = "send2trash" },
-    { name = "terminado" },
-    { name = "tornado" },
-    { name = "traitlets" },
-    { name = "websocket-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/15/1eacb0fcb79ef86e8a0a79a708e6ad7435f6f223097dd29a4ce861fabc44/jupyter_server-2.18.2.tar.gz", hash = "sha256:06b4f40d8a7a00bb39d5216859c81374a0e7cfefe6d8a5a7facc5a5c37c679a7", size = 753177, upload-time = "2026-05-06T07:04:36.274Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/50/ecf4f70d65bdb7519b28a33d1b2fee8a4b4ba1ae1a92f15d97e877c5de21/jupyter_server-2.18.2-py3-none-any.whl", hash = "sha256:fa5e46539ded65791838035a2b6001f13e54d5f64b8b3752eb1e91fdd641a5b8", size = 391907, upload-time = "2026-05-06T07:04:34.014Z" },
-]
-
-[[package]]
-name = "jupyter-server-terminals"
-version = "0.5.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pywinpty", marker = "os_name == 'nt'" },
-    { name = "terminado" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/2d/6674563f71c6320841fc300911a55143925112a72a883e2ca71fba4c618d/jupyter_server_terminals-0.5.4-py3-none-any.whl", hash = "sha256:55be353fc74a80bc7f3b20e6be50a55a61cd525626f578dcb66a5708e2007d14", size = 13704, upload-time = "2026-01-14T16:53:18.738Z" },
-]
-
-[[package]]
 name = "jupyterlab-pygments"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3353,49 +3149,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/26/2d/ef58fed122b268c69c0aa099da20bc67657cdfb2e222688d5731bd5b971d/jupyterlab_widgets-3.0.16.tar.gz", hash = "sha256:423da05071d55cf27a9e602216d35a3a65a3e41cdf9c5d3b643b814ce38c19e0", size = 897423, upload-time = "2025-11-01T21:11:29.724Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl", hash = "sha256:45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8", size = 914926, upload-time = "2025-11-01T21:11:28.008Z" },
-]
-
-[[package]]
-name = "jupyterlite-core"
-version = "0.7.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "doit" },
-    { name = "jupyter-core" },
-    { name = "pycparser", marker = "platform_python_implementation == 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/6f/42d15a20bf89ba1b07e835f2c4aa2d6d2b6d55f2b39c379b4a303d1abe5b/jupyterlite_core-0.7.6.tar.gz", hash = "sha256:bc2393d2218dbd666a2854c669b59503de207110511baa80b0025facb7f0c9e0", size = 16320112, upload-time = "2026-05-07T06:10:21.808Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/61/4a04631711b050e9e912dd5076122f2b85914fb4f2dba75751f757efe496/jupyterlite_core-0.7.6-py3-none-any.whl", hash = "sha256:549071b6d037b5545bfc8a3733a7bfc1faa4d0c42dbe87faed0f49d29591f58f", size = 16332653, upload-time = "2026-05-07T06:10:18.366Z" },
-]
-
-[[package]]
-name = "jupyterlite-pyodide-kernel"
-version = "0.7.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jupyterlite-core" },
-    { name = "pkginfo" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/87/af85e6bfc7cc725ef66b346a4c28b83c6cd74d506f30bd83c066ab459fdc/jupyterlite_pyodide_kernel-0.7.2.tar.gz", hash = "sha256:4a3466c5e18adc9ac4db7a8386fc63da2fc9e6b6df8a23cb65a81e8343f1baae", size = 546139, upload-time = "2026-05-04T14:43:18.139Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/96/3e03edc7a13a61e930b8d01b43b76e5613beb3bc6d231396286287b51e5d/jupyterlite_pyodide_kernel-0.7.2-py3-none-any.whl", hash = "sha256:b03de062804b2b70cfaccd2918b78a20a4a874e9adde2fe02ee8cb7db79ccbf7", size = 560441, upload-time = "2026-05-04T14:43:16.118Z" },
-]
-
-[[package]]
-name = "jupyterlite-xeus"
-version = "4.5.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "empack" },
-    { name = "jupyterlite-core" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "traitlets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/53/67/3725af296be05be97b42db589682ee25c86212d029685e997039ec1ec438/jupyterlite_xeus-4.5.2.tar.gz", hash = "sha256:294cacb7430f6f063c12857d8d5bc56e05823b670fcb03ce6a2ff0e64e2a68c8", size = 10412193, upload-time = "2026-04-15T14:05:53.356Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5b/cb/cec13106869acb49e17163cf872088a38f7f80b36b38f74426f894f689ef/jupyterlite_xeus-4.5.2-py3-none-any.whl", hash = "sha256:3a3978744e692eaff21bff8332628dbabaf3c06d6df40c083183e77aeb53c952", size = 9601765, upload-time = "2026-04-15T14:05:50.073Z" },
 ]
 
 [[package]]
@@ -3770,7 +3523,7 @@ version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
-    { name = "orjson", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
     { name = "packaging" },
     { name = "pydantic" },
     { name = "requests" },
@@ -3783,15 +3536,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7a/61/d269b8bd3376031de7be6ac2de8ba94fafff67635195d97aa0e842027ac7/langsmith-0.8.6.tar.gz", hash = "sha256:a46fd3403c2de3a9c34f72ebb7b2e45872627671adcc67c6a4c571520b6931cc", size = 4463093, upload-time = "2026-05-27T22:51:52.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/c5/28f99eccd79ce89ec93de9a5039a74ddf4740f2d9671b0a06c5d2e200914/langsmith-0.8.6-py3-none-any.whl", hash = "sha256:b304888ea5ec5fe397db24f0bf474b0c8e472fb23ee36a2007e9837f6ff29cc1", size = 399954, upload-time = "2026-05-27T22:51:50.847Z" },
-]
-
-[[package]]
-name = "lark"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
 ]
 
 [[package]]
@@ -3907,8 +3651,8 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "win32-setctime", marker = "sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
@@ -4171,12 +3915,12 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
-    { name = "pywin32", marker = "sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "sse-starlette" },
     { name = "starlette" },
     { name = "typing-extensions" },
     { name = "typing-inspection" },
-    { name = "uvicorn", marker = "sys_platform != 'emscripten' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
 wheels = [
@@ -4234,14 +3978,14 @@ dependencies = [
     { name = "mitmproxy-rs" },
     { name = "msgpack" },
     { name = "publicsuffix2" },
-    { name = "pydivert", marker = "sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "pydivert", marker = "sys_platform == 'win32'" },
     { name = "pyopenssl" },
     { name = "pyparsing" },
     { name = "pyperclip" },
     { name = "ruamel-yaml" },
     { name = "sortedcontainers" },
     { name = "tornado" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
     { name = "urwid" },
     { name = "wsproto" },
     { name = "zstandard" },
@@ -4273,9 +4017,9 @@ name = "mitmproxy-rs"
 version = "0.12.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mitmproxy-linux", marker = "sys_platform == 'linux' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "mitmproxy-macos", marker = "sys_platform == 'darwin' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "mitmproxy-windows", marker = "os_name == 'nt' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "mitmproxy-linux", marker = "sys_platform == 'linux'" },
+    { name = "mitmproxy-macos", marker = "sys_platform == 'darwin'" },
+    { name = "mitmproxy-windows", marker = "os_name == 'nt'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5d/5c/16a61303da76cd34aa6ddbd7ef6ac66d9ef8514c4d3a5b71831169d63236/mitmproxy_rs-0.12.9.tar.gz", hash = "sha256:c6ffc35c002c675cac534442d92d1cdebd66fafd63754ad33b92ae968ea6e449", size = 1334424, upload-time = "2026-01-30T14:54:15.043Z" }
 wheels = [
@@ -4737,8 +4481,7 @@ name = "nltk"
 version = "3.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-30-coding-academy-lecture-manager-jupyterlite'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-30-coding-academy-lecture-manager-all' or extra == 'extra-30-coding-academy-lecture-manager-dev' or extra != 'extra-30-coding-academy-lecture-manager-jupyterlite' or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "click" },
     { name = "joblib" },
     { name = "regex" },
     { name = "tqdm" },
@@ -4851,12 +4594,11 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
     { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
-    { url = "https://files.pythonhosted.org/packages/45/9e/2f562daf80eb8f7a685fb7bea4fda71f6048e4f359d6fdd1b6e70206cb2f/nvidia_cublas-13.1.1.3-py3-none-win_amd64.whl", hash = "sha256:b6cdce694e47ff6aadf0a69df1cab6628d696f5ff56e8d16af50309d855fa20f", size = 404358158, upload-time = "2026-04-08T18:47:26.987Z" },
 ]
 
 [[package]]
@@ -4866,7 +4608,6 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
     { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/df/b74b10025c1205695c5676373f2edd3e87a7202cc62ead0dfbc373b0f6ea/nvidia_cuda_cupti-13.0.85-py3-none-win_amd64.whl", hash = "sha256:683f58d301548deeefcb8f6fac1b8d907691b9d8b18eccab417f51e362102f00", size = 7736776, upload-time = "2025-09-04T08:38:08.38Z" },
 ]
 
 [[package]]
@@ -4876,7 +4617,6 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
     { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/af/345fedb9f4c76c84ab4fa445b36bd4048a4d9db60e6bc76b4f913ff4b852/nvidia_cuda_nvrtc-13.0.88-py3-none-win_amd64.whl", hash = "sha256:6bcd4e7f8e205cbe644f5a98f2f799bef9556fefc89dd786e79a16312ce49872", size = 76807835, upload-time = "2025-09-04T08:39:15.274Z" },
 ]
 
 [[package]]
@@ -4886,7 +4626,6 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
     { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/94/6b867483bec07da24ffa32736c79fabb94ef3a7af4d787a9d4a974868576/nvidia_cuda_runtime-13.0.96-py3-none-win_amd64.whl", hash = "sha256:f79298c8a098cec150a597c8eba58ecdab96e3bdc4b9bc4f9983635031740492", size = 2927037, upload-time = "2025-10-09T09:04:23.782Z" },
 ]
 
 [[package]]
@@ -4894,12 +4633,11 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
     { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
-    { url = "https://files.pythonhosted.org/packages/78/39/21507455b1bca8b5702a9e9fc6ce73735f216f558dac2c9ede58e4d456b8/nvidia_cudnn_cu13-9.20.0.48-py3-none-win_amd64.whl", hash = "sha256:af8139732b99c0118be65ea5aac97f0d46018f8c552889e49d2fb0c6261a4a24", size = 350712614, upload-time = "2026-03-09T19:31:11.398Z" },
 ]
 
 [[package]]
@@ -4907,12 +4645,11 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
     { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
-    { url = "https://files.pythonhosted.org/packages/85/b2/f8af21a2ed1beed337a6a02c5a28aeb85441f4d578ec3d529543c775ea4b/nvidia_cufft-12.0.0.61-py3-none-win_amd64.whl", hash = "sha256:2abce5b39d2f5ae12730fb7e5db6696533e36c26e2d3e8fd1750bdd2853364eb", size = 213342123, upload-time = "2025-09-04T08:40:51.145Z" },
 ]
 
 [[package]]
@@ -4931,7 +4668,6 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
     { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
-    { url = "https://files.pythonhosted.org/packages/99/27/72103153b1ffc00e09fdc40ac970235343dcd1ea8bd762e84d2d73219ffa/nvidia_curand-10.4.0.35-py3-none-win_amd64.whl", hash = "sha256:65b1710aa6961d326b411e314b374290904c5ddf41dc3f766ebc3f1d7d4ca69f", size = 55242481, upload-time = "2025-08-04T10:30:41.831Z" },
 ]
 
 [[package]]
@@ -4939,14 +4675,13 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
     { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
-    { url = "https://files.pythonhosted.org/packages/99/ef/332a0101260ca78a1daef046bf0b06199e8ed4dac1d2aa698289c358169c/nvidia_cusolver-12.0.4.66-py3-none-win_amd64.whl", hash = "sha256:16515bd33a8e76bb54d024cfa068fa68d30e80fc34b9e1090813ea9362e0cb65", size = 193551444, upload-time = "2025-09-04T08:41:46.813Z" },
 ]
 
 [[package]]
@@ -4954,12 +4689,11 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
     { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
-    { url = "https://files.pythonhosted.org/packages/02/b0/b043d6f3480f102f885cf87fc3ffd3edcb5e23b855025a50e2ef4d059185/nvidia_cusparse-12.6.3.3-py3-none-win_amd64.whl", hash = "sha256:cbcf42feb737bd7ec15b4c0a63e62351886bd3f975027b8815d7f720a2b5ea79", size = 143783033, upload-time = "2025-09-04T08:42:12.391Z" },
 ]
 
 [[package]]
@@ -4969,7 +4703,6 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
     { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
-    { url = "https://files.pythonhosted.org/packages/31/83/f3647ce26916c94a6ca4ff1810623e2c405cff2dea6e78d29516b2514df9/nvidia_cusparselt_cu13-0.8.1-py3-none-win_amd64.whl", hash = "sha256:dccbd362f91a7b9024d1f55ee9f548ac065027ff15d8c8b0db889ab3a8f31215", size = 156885108, upload-time = "2025-09-05T18:51:35.958Z" },
 ]
 
 [[package]]
@@ -4988,7 +4721,6 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
     { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/01/07530b0e37546231052e30234540289c42eaffa486f1a34a87fed340157b/nvidia_nvjitlink-13.0.88-py3-none-win_amd64.whl", hash = "sha256:634e96e3da9ef845ae744097a1f289238ecf946ce0b82e93cdce14b9782e682f", size = 36035115, upload-time = "2025-09-04T08:43:03.001Z" },
 ]
 
 [[package]]
@@ -5007,7 +4739,6 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/50/0e2220f8620a177de994211186ffc5bfa9f2ce1e1282797f8f90096f9f88/nvidia_nvtx-13.0.85-py3-none-win_amd64.whl", hash = "sha256:d66ea44254dd3c6eacc300047af6e1288d2269dd072b417e0adffbf479e18519", size = 137066, upload-time = "2025-09-04T08:39:25.649Z" },
 ]
 
 [[package]]
@@ -5304,7 +5035,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -5458,15 +5189,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pkginfo"
-version = "1.12.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/03/e26bf3d6453b7fda5bd2b84029a426553bb373d6277ef6b5ac8863421f87/pkginfo-1.12.1.2.tar.gz", hash = "sha256:5cd957824ac36f140260964eba3c6be6442a8359b8c48f4adf90210f33a04b7b", size = 451828, upload-time = "2025-02-19T15:27:37.188Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/3d/f4f2ba829efb54b6cd2d91349c7463316a9cc55a43fc980447416c88540f/pkginfo-1.12.1.2-py3-none-any.whl", hash = "sha256:c783ac885519cab2c34927ccfa6bf64b5a704d7c69afaea583dd9b7afe969343", size = 32717, upload-time = "2025-02-19T15:27:33.071Z" },
-]
-
-[[package]]
 name = "platformdirs"
 version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5522,7 +5244,7 @@ name = "portalocker"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/77/65b857a69ed876e1951e88aaba60f5ce6120c33703f7cb61a3c894b8c1b6/portalocker-3.2.0.tar.gz", hash = "sha256:1f3002956a54a8c3730586c5c77bf18fae4149e07eaf1c29fc3faf4d5a3f89ac", size = 95644, upload-time = "2025-06-14T13:20:40.03Z" }
 wheels = [
@@ -5587,15 +5309,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/37/aa/51e5b4109a4cdfae28c3613eeeb10764a3794ebef8de93ffbb109465bea3/preshed-3.0.13-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:670db59a52e1823b5f088c764df474e65b686592d4093adbeef14581c95ee2cb", size = 1959473, upload-time = "2026-03-23T08:57:15.706Z" },
     { url = "https://files.pythonhosted.org/packages/0e/6a/1d966f367a14c703dde629d150d996c1b727d442f620300b21c9ec1a24d1/preshed-3.0.13-cp314-cp314t-win_amd64.whl", hash = "sha256:b03e21b0bf95eb56e23973f32cabb930e94f352228652f81c0955dbd6967d904", size = 146229, upload-time = "2026-03-23T08:57:17.457Z" },
     { url = "https://files.pythonhosted.org/packages/22/80/368139067603e590a000122355f9c8576c8ebed4fb0b8849feaa2698489d/preshed-3.0.13-cp314-cp314t-win_arm64.whl", hash = "sha256:b980f3ea9bb74b7f94464bc3d6eb3c9162b6b79b531febd14c6465c24344d2cc", size = 119339, upload-time = "2026-03-23T08:57:18.882Z" },
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]
@@ -5764,8 +5477,8 @@ name = "psycopg"
 version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "tzdata", marker = "sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/db/2f/cb91e5502ec9de1de6f1b76cfbf69531932725361168bb06963620c77e2e/psycopg-3.3.4.tar.gz", hash = "sha256:e21207764952cff81b6b8bdacad9a3939f2793367fdac2987b3aac36a651b5bc", size = 165799, upload-time = "2026-05-01T23:31:55.179Z" }
 wheels = [
@@ -5774,7 +5487,7 @@ wheels = [
 
 [package.optional-dependencies]
 binary = [
-    { name = "psycopg-binary", marker = "implementation_name != 'pypy' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
 ]
 
 [[package]]
@@ -6077,7 +5790,7 @@ name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
 wheels = [
@@ -6113,7 +5826,7 @@ version = "26.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
 wheels = [
@@ -6209,7 +5922,7 @@ name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
@@ -6238,7 +5951,7 @@ name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coverage", marker = "extra == 'extra-30-coding-academy-lecture-manager-all' or extra == 'extra-30-coding-academy-lecture-manager-dev' or extra != 'extra-30-coding-academy-lecture-manager-jupyterlite' or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "coverage" },
     { name = "pluggy" },
     { name = "pytest" },
 ]
@@ -6353,15 +6066,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-json-logger"
-version = "4.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
-]
-
-[[package]]
 name = "python-multipart"
 version = "0.0.29"
 source = { registry = "https://pypi.org/simple" }
@@ -6405,24 +6109,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
-]
-
-[[package]]
-name = "pywinpty"
-version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/54/37c7370ba91f579235049dc26cd2c5e657d2a943e01820844ffc81f32176/pywinpty-3.0.3.tar.gz", hash = "sha256:523441dc34d231fb361b4b00f8c99d3f16de02f5005fd544a0183112bcc22412", size = 31309, upload-time = "2026-02-04T21:51:09.524Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/d4/aeb5e1784d2c5bff6e189138a9ca91a090117459cea0c30378e1f2db3d54/pywinpty-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c9081df0e49ffa86d15db4a6ba61530630e48707f987df42c9d3313537e81fc0", size = 2113098, upload-time = "2026-02-04T21:54:37.711Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/53/7278223c493ccfe4883239cf06c823c56460a8010e0fc778eef67858dc14/pywinpty-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:15e79d870e18b678fb8a5a6105fd38496b55697c66e6fc0378236026bc4d59e9", size = 234901, upload-time = "2026-02-04T21:53:31.35Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/cb/58d6ed3fd429c96a90ef01ac9a617af10a6d41469219c25e7dc162abbb71/pywinpty-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9c91dbb026050c77bdcef964e63a4f10f01a639113c4d3658332614544c467ab", size = 2112686, upload-time = "2026-02-04T21:52:03.035Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/50/724ed5c38c504d4e58a88a072776a1e880d970789deaeb2b9f7bd9a5141a/pywinpty-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:fe1f7911805127c94cf51f89ab14096c6f91ffdcacf993d2da6082b2142a2523", size = 234591, upload-time = "2026-02-04T21:52:29.821Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/ad/90a110538696b12b39fd8758a06d70ded899308198ad2305ac68e361126e/pywinpty-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:3f07a6cf1c1d470d284e614733c3d0f726d2c85e78508ea10a403140c3c0c18a", size = 2112360, upload-time = "2026-02-04T21:55:33.397Z" },
-    { url = "https://files.pythonhosted.org/packages/44/0f/7ffa221757a220402bc79fda44044c3f2cc57338d878ab7d622add6f4581/pywinpty-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:15c7c0b6f8e9d87aabbaff76468dabf6e6121332c40fc1d83548d02a9d6a3759", size = 233107, upload-time = "2026-02-04T21:51:45.455Z" },
-    { url = "https://files.pythonhosted.org/packages/28/88/2ff917caff61e55f38bcdb27de06ee30597881b2cae44fbba7627be015c4/pywinpty-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:d4b6b7b0fe0cdcd02e956bd57cfe9f4e5a06514eecf3b5ae174da4f951b58be9", size = 2113282, upload-time = "2026-02-04T21:52:08.188Z" },
-    { url = "https://files.pythonhosted.org/packages/63/32/40a775343ace542cc43ece3f1d1fce454021521ecac41c4c4573081c2336/pywinpty-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:34789d685fc0d547ce0c8a65e5a70e56f77d732fa6e03c8f74fefb8cbb252019", size = 234207, upload-time = "2026-02-04T21:51:58.687Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/54/5d5e52f4cb75028104ca6faf36c10f9692389b1986d34471663b4ebebd6d/pywinpty-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:0c37e224a47a971d1a6e08649a1714dac4f63c11920780977829ed5c8cadead1", size = 2112910, upload-time = "2026-02-04T21:52:30.976Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/44/dcd184824e21d4620b06c7db9fbb15c3ad0a0f1fa2e6de79969fb82647ec/pywinpty-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:c4e9c3dff7d86ba81937438d5819f19f385a39d8f592d4e8af67148ceb4f6ab5", size = 233425, upload-time = "2026-02-04T21:51:56.754Z" },
 ]
 
 [[package]]
@@ -6476,7 +6162,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [
@@ -6602,7 +6288,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
     { name = "rpds-py" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -6759,39 +6445,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
-]
-
-[[package]]
-name = "rfc3339-validator"
-version = "0.1.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
-]
-
-[[package]]
-name = "rfc3986-validator"
-version = "0.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/da/88/f270de456dd7d11dcc808abfa291ecdd3f45ff44e3b549ffa01b126464d0/rfc3986_validator-0.1.1.tar.gz", hash = "sha256:3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055", size = 6760, upload-time = "2019-10-28T16:00:19.144Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl", hash = "sha256:2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9", size = 4242, upload-time = "2019-10-28T16:00:13.976Z" },
-]
-
-[[package]]
-name = "rfc3987-syntax"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "lark" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
 ]
 
 [[package]]
@@ -7123,15 +6776,6 @@ wheels = [
 ]
 
 [[package]]
-name = "send2trash"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
-]
-
-[[package]]
 name = "sentencepiece"
 version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -7363,7 +7007,7 @@ name = "sqlalchemy"
 version = "2.0.50"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/da/6fbf010c8ebb347679d0d100b22fe9ba5e13fd04046c5df7280d2f0bf706/sqlalchemy-2.0.50.tar.gz", hash = "sha256:af5607d11ef90fd6a5c0549fe0045dce1663d427426bcfb506dcb5346a85a3b9", size = 9907424, upload-time = "2026-05-24T19:20:04.018Z" }
@@ -7475,7 +7119,7 @@ version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", hash = "sha256:3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553", size = 2668923, upload-time = "2026-05-28T11:42:50.568Z" }
 wheels = [
@@ -7510,20 +7154,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/94/91fccdb4b8110642462e653d5dcb27e7b674742ad68efd146367da7bdb10/tenacity-9.0.0.tar.gz", hash = "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b", size = 47421, upload-time = "2024-07-29T12:12:27.547Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b6/cb/b86984bed139586d01532a587464b5805f12e397594f19f931c4c2fbfa61/tenacity-9.0.0-py3-none-any.whl", hash = "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539", size = 28169, upload-time = "2024-07-29T12:12:25.825Z" },
-]
-
-[[package]]
-name = "terminado"
-version = "0.18.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ptyprocess", marker = "os_name != 'nt'" },
-    { name = "pywinpty", marker = "os_name == 'nt'" },
-    { name = "tornado" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
 ]
 
 [[package]]
@@ -7662,10 +7292,10 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "torchvision", version = "0.27.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/08/54/ece85b0eef3700c90db8271a43669b05a0ebbe2edb1962329c34374a297e/timm-1.0.27.tar.gz", hash = "sha256:315dfe63186ca9fb7ff941268941231fd5be259f2b4bb4afa28560ae1015cb9a", size = 2439861, upload-time = "2026-05-08T19:38:36.844Z" }
 wheels = [
@@ -7757,48 +7387,26 @@ name = "torch"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev'",
-    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev'",
-    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev'",
-    "python_full_version >= '3.15' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version == '3.14.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version >= '3.15' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version == '3.14.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
+    "python_full_version >= '3.15' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "fsspec", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "jinja2", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "networkx", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "setuptools", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "sympy", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "typing-extensions", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "filelock", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "fsspec", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "jinja2", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "networkx", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "setuptools", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "sympy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/bb/285d643f254731294c9b595a007eac39db4600a98682d7bca688f42ca164/torch-2.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b41339df93d491435e790ff8bcbae1c0ce777175889bfd1281d119862793e6a2", size = 88010197, upload-time = "2026-05-13T14:55:35.414Z" },
-    { url = "https://files.pythonhosted.org/packages/79/81/76debf1db1343bd929bbb5d74c89fb437c2ed88eb144712557e7bd3eea45/torch-2.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8fbef9f108a863e7722a73740998967e3b074742a834fc5be3a535a2befa7057", size = 426376751, upload-time = "2026-05-13T14:55:03.353Z" },
-    { url = "https://files.pythonhosted.org/packages/de/f0/80026028b603c4650ff270fc3785bdef4bd6738765a9cc5a0f5a637d65a2/torch-2.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4b4f64c2c2b11f7510d93dd6412b87025ff6eddd6bb61c3b5a3d892ea20c4756", size = 532261691, upload-time = "2026-05-13T14:52:54.453Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/c2/64b06cbb7830fb3cd9be13e1158b31a3f36b68e6a209105ee3c9d9480be0/torch-2.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:8b958caff4a14d3a3b0b2dfc6a378f64dda9728a9dad28c08a0db9ce4dafb549", size = 122988114, upload-time = "2026-05-13T14:54:42.153Z" },
     { url = "https://files.pythonhosted.org/packages/86/ca/01896c80ba921676aa45886b2c5b8d774912de2a1f719de48169c6f755cd/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:90dd587a5f61bfe1307148b581e2084fc5bc4a06e2b90a20e9a36b81087ff16b", size = 88009511, upload-time = "2026-05-13T14:54:47.411Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/04/52bdaf4787eab6ac7d7f5851dff934e4def0bc8ead9c8fd2b69b3e529699/torch-2.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:864392c73b7654f4d2b3ae712f607937d0dbb1101c4555fbb41848106b297f39", size = 426383231, upload-time = "2026-05-13T14:53:32.129Z" },
-    { url = "https://files.pythonhosted.org/packages/49/8a/94bdecd13f5aaa90d45920b89789d9fe7c6f4af8c3cdd7ce01fcb59908fc/torch-2.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5d6b560dfa7d56291c07d615c3bb73e8d9943d9b6d87f76cd0d9d570c4797fa6", size = 532269288, upload-time = "2026-05-13T14:53:49.423Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/2f/bdbaaa267de519ef1b73054bf590d8c93c37a266c9a4e24a01bd38b6918f/torch-2.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:3fee918902090ade827643e758e98363278815de583c75d111fdd665ebffde9f", size = 122987706, upload-time = "2026-05-13T14:54:00.335Z" },
     { url = "https://files.pythonhosted.org/packages/9b/ad/e95e822f3538171e22640a7fbe839a1fdb666600bf6487025de2ff03b11a/torch-2.12.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:10ee1448a9f304d3b987eb4656f664ba6e4d7b410ca7a5a7c642199777a2cf88", size = 88319556, upload-time = "2026-05-13T14:54:05.574Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/07/055d06d985b445d67422d25b033c11cf55bbb81785d4c4e68e28bca5820e/torch-2.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:af68dbf403439cae9ceaeaaf92f8352b460787dcd27b92aa05c40dd4a19c0f1e", size = 426397656, upload-time = "2026-05-13T14:52:38.84Z" },
-    { url = "https://files.pythonhosted.org/packages/43/94/b0b4fdc3014122e0a7302fb90086d352aa48f2576f0b252561ebb38c01a8/torch-2.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:a6a2eebb237d3b1d9ad3b378e86d9b9e0782afdea8b1e0eba6a13646b9b49c07", size = 532183124, upload-time = "2026-05-13T14:53:16.178Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/c8/052405e6ad05d3237bfe5a4df78f917773956f8e17813a2d44c059068b74/torch-2.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2140e373e9a51a3e22ef62e8d14366d0b470d18f0adf19fdc757368077133a34", size = 123232462, upload-time = "2026-05-13T14:52:27.26Z" },
     { url = "https://files.pythonhosted.org/packages/67/dc/ac069f8d6e8be701535921141055293b0d4819d3d7f224a4612cf157c7f9/torch-2.12.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f7dfae4a519197dfa050e98d8e36378a0fb5899625a875c2b54445005a2e404e", size = 88027282, upload-time = "2026-05-13T14:53:05.258Z" },
-    { url = "https://files.pythonhosted.org/packages/33/c3/1c1eb00e34555b536dddf792676026a988d710ed36981aa00499b36b0620/torch-2.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:891c769072637c74e9a5a77a3bc782894696d8ffec83b938df8536dee7f0ba78", size = 426386961, upload-time = "2026-05-13T14:51:28.406Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/d4/7e730dba0c7032a4154dc9056b76cf9625515e030e269cfbf8098fcfee7d/torch-2.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e2ad3eb85d39c3cab62dfa93ed5a73516e6a53c6713cb97d004004fe089f0f1f", size = 532272265, upload-time = "2026-05-13T14:51:59.308Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/b4/92c80d1bbfee1c0036c06d1d2155a3065bd2423134c83bf8a47e65cd6b9b/torch-2.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:c66696857e987efb8bc1777a37357ec4f60ab5e8af6250b83d6034437fa2d8f3", size = 122987138, upload-time = "2026-05-13T14:51:45.942Z" },
     { url = "https://files.pythonhosted.org/packages/7b/78/2e12b37ce50a19a037d7bc62d652a5a8f27385a7b05859d6bc9204f20cfe/torch-2.12.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:b4556715c8572758625d62b6e0ae3b1f76c440221913a6fb5e100f321fb4fb02", size = 88320100, upload-time = "2026-05-13T14:51:39.955Z" },
-    { url = "https://files.pythonhosted.org/packages/56/5e/83c450ec7b0bb40a7b74611c1b5440f9260e33c54c90d556fd4a1f0fd955/torch-2.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a43ac605a5e13116c72b64c359644cce0229f213dde48d2ae0ae5eb5becf7feb", size = 426391871, upload-time = "2026-05-13T14:52:14.989Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/e9/1a0b575d98d0afedd8f157d23fa3d2759421483660448e60d0a4b10b6daa/torch-2.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6a7512adfdd7f6732e40de1c620831e3c75b39b98cef60b11d0c5f0a76473ec5", size = 532192241, upload-time = "2026-05-13T14:51:07.795Z" },
-    { url = "https://files.pythonhosted.org/packages/88/21/afadd25ecd81b3cea1e11c73cf1ab41a983a50271548c3ec7ec3b9efc3e9/torch-2.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5f96b63f8287f66a005dd1b5a6abba2920f11156c5e5c4d815f3e2050fd1aa16", size = 123231092, upload-time = "2026-05-13T14:51:18.854Z" },
 ]
 
 [[package]]
@@ -7806,34 +7414,27 @@ name = "torch"
 version = "2.12.0+cu130"
 source = { registry = "https://download.pytorch.org/whl/cu130" }
 resolution-markers = [
-    "(python_full_version >= '3.14' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev') or (python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev')",
-    "(python_full_version == '3.13.*' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev') or (python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev')",
-    "(python_full_version < '3.13' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev') or (python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev')",
-    "(python_full_version >= '3.15' and sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version >= '3.15' and sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version == '3.14.*' and sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version == '3.14.*' and sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version == '3.13.*' and sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version == '3.13.*' and sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version < '3.13' and sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version < '3.13' and sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version >= '3.15' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version >= '3.15' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version == '3.14.*' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version == '3.14.*' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version == '3.13.*' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version < '3.13' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
+    "(python_full_version >= '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform == 'win32')",
+    "(python_full_version == '3.14.*' and sys_platform == 'linux') or (python_full_version == '3.14.*' and sys_platform == 'win32')",
+    "(python_full_version == '3.13.*' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
+    "(python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform == 'win32')",
 ]
 dependencies = [
-    { name = "cuda-bindings", marker = "sys_platform == 'linux' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "filelock", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "fsspec", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "jinja2", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "networkx", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "setuptools", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "sympy", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "triton", marker = "sys_platform == 'linux' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "fsspec", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "jinja2", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "networkx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "sympy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.12.0%2Bcu130-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:cb95bd4626150e41aeea2b60e4635a878ebe01e63f3344409f4b7353fdb7998c", upload-time = "2026-05-12T23:49:12Z" },
@@ -7885,44 +7486,22 @@ name = "torchvision"
 version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev'",
-    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev'",
-    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev'",
-    "python_full_version >= '3.15' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version == '3.14.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version >= '3.15' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version == '3.14.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
-    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite'",
+    "python_full_version >= '3.15' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "pillow", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "numpy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "pillow", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c8/5cd91932f7f3671b0743dc4ae1a4c16b1d0b45bf4087976277d325bda718/torchvision-0.27.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:1a6dd742a150645126df9e0b2e449874c1d635897c773b322c2e067e98382dfe", size = 1758824, upload-time = "2026-05-13T14:57:15.227Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/36/7fb7d19477b3d93283b52fea11fa8ee30ab9064a08c97b4a6b91445e26cb/torchvision-0.27.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65772ff3ec4f4f5d680e30019835555dd239e7fefee4b0a846375fe1cb1592ef", size = 7831034, upload-time = "2026-05-13T14:57:06.483Z" },
-    { url = "https://files.pythonhosted.org/packages/62/43/dfd894c3f8b01b5b33fde990f0159c1926ebc7b6e2c4193e2efb7da3c4cb/torchvision-0.27.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7a9966a088d06b4cf6c610e03be62de469efa6f2cd2e7c7eed8e925ed6af59ac", size = 7579774, upload-time = "2026-05-13T14:56:59.337Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0c/722e989f9cf026e97ef7cb24a9bb1859e099f72d247ae35388fb89729f73/torchvision-0.27.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c037709072ca9b19750c0cbe9e8bb6f91c9a1be1befa26df33e281deccbd8c7", size = 4021073, upload-time = "2026-05-13T14:57:00.848Z" },
     { url = "https://files.pythonhosted.org/packages/d8/ae/36547812e6e047c1d80bcacd1b17a340612b08a6e876e0aabf3d0b9228b0/torchvision-0.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:41d6dae73e1af09fa82ded597ae57f2a2314285acde54b25890a8f8e51b999d7", size = 1758826, upload-time = "2026-05-13T14:57:05.262Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/30/32c4ea842738728a14e3df8c576c62dedcf5ae5cb6a5c984c6429ebe7524/torchvision-0.27.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:70f071c6f74b60d5fe8851636d8d4cd5f4fa29d57fd9348a87a6f17b990b95ba", size = 7789501, upload-time = "2026-05-13T14:56:57.786Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/24/4d0d48684251bd0673f87d633d5d88ab00227983b00591156eed2f86c8d5/torchvision-0.27.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:aaafa6962c9d91f42503de1957d6fa349907d028c06f335bd95da7a5bc57147d", size = 7579868, upload-time = "2026-05-13T14:56:41.618Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/da/e6edd051d2ba25adf23b120fa97f458dff888d098c51e84724f17d2d1470/torchvision-0.27.0-cp313-cp313-win_amd64.whl", hash = "sha256:aee384a2782c89517c4ab9061d2720ba59fd2ffe5ef89d0a149cc2d43abdf521", size = 4092700, upload-time = "2026-05-13T14:57:09.729Z" },
     { url = "https://files.pythonhosted.org/packages/fa/23/95dfa40431360f42ca949bf861434bed51164adfa8fb9801e05bf3194f50/torchvision-0.27.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:c5121f1b9ab09a7f73e837871deb8321551f7eaeb19d87aa00de9191968eae44", size = 1845008, upload-time = "2026-05-13T14:57:03.768Z" },
-    { url = "https://files.pythonhosted.org/packages/23/b9/9dbdf76b2b49a75ba8088df6f7c755bdb520afb6c6dbac0102b46cde5e99/torchvision-0.27.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:1c01f0d1091ae22b9dfc082b0a0fe5faaf053686a29b4fb082ba7691375c73cf", size = 7791430, upload-time = "2026-05-13T14:56:56.206Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/6a/e4a16cf2f3310c2ea7760dc5d9054496844391e0f4c1fae87fefac2f3d9e/torchvision-0.27.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:dadea3c5ecfd05bbb2a3312ab0374f213c58bf6459cb059122e2f4dfe13d10ed", size = 7668441, upload-time = "2026-05-13T14:57:02.127Z" },
-    { url = "https://files.pythonhosted.org/packages/00/70/01b6461117a6a94b5af3f8ee166bb0f045056f3cf187750c110dabfdfffa/torchvision-0.27.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a49e55055a39a8506fe7e59850522cab004efb2c3839f6057658889c1d69c815", size = 4141602, upload-time = "2026-05-13T14:56:53.449Z" },
     { url = "https://files.pythonhosted.org/packages/92/22/c0633677b3b3f3e69554a21ac087bf705f829c40cd5e3783507b8c006681/torchvision-0.27.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:c1fac0fc2a7adf29481fc1938a0e7845c57ba1147a986784109c4d98f434ea8c", size = 1758818, upload-time = "2026-05-13T14:56:54.988Z" },
-    { url = "https://files.pythonhosted.org/packages/48/e8/55f9d9667b56dae470e69e31beac9b00d458ea393feec1aae95cc4f3f1c9/torchvision-0.27.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:cbf89764fc76f3f17fbf80c12d5a89c691e91cb9d82c38412aaf0568655ffb19", size = 7789667, upload-time = "2026-05-13T14:56:48.858Z" },
-    { url = "https://files.pythonhosted.org/packages/00/bc/6f8681daf3bbc4c315bb0005110f99d28e3ecd675bf9c8f2c0d393fbac7a/torchvision-0.27.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:91f61b9865423037c327eb56afa207cc72de874e458c361840db9dcf5ce0c0eb", size = 7579848, upload-time = "2026-05-13T14:56:38.209Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6c/8d8020e6bd1e46c53e487c9c4e9457a07f2ee28931028fb5d71e2da40adc/torchvision-0.27.0-cp314-cp314-win_amd64.whl", hash = "sha256:5bb82fc3c55daf1788621e504310b0a286f1069627a8742f692aebb075ef25a7", size = 4119284, upload-time = "2026-05-13T14:56:46.625Z" },
     { url = "https://files.pythonhosted.org/packages/8d/7e/e78c48662a8d551606efdbe11c6b9c1d6d2391b92cd0e4591b9e6a2412b8/torchvision-0.27.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:2c4099a15150143b9b034730b404a56d572efe0b79489b4c765d929cb4eac7f3", size = 1758828, upload-time = "2026-05-13T14:56:52.293Z" },
-    { url = "https://files.pythonhosted.org/packages/21/dd/d03ee9f9ee7bf11a8c7c776fb8e7fd6102f59c013791a2a4e5175bd6cba7/torchvision-0.27.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b4c6bb0a670dcba017b3643e21902c9b8a1cc1c127d602f1488fa29ec3c6e865", size = 7790618, upload-time = "2026-05-13T14:56:44.721Z" },
-    { url = "https://files.pythonhosted.org/packages/39/08/4002336a74742be70728603ec1769feb2b55e0d19c532c9ec9f92008de76/torchvision-0.27.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1c2db4bde82bc48ebff73436a6adf34d4f809448268a70d9a1285f5c8f92313d", size = 7580217, upload-time = "2026-05-13T14:56:43.274Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/cb/4dd4783eb3565f526ba6e64b6f6ca26c00eacc924cdfe60455db9d91b84b/torchvision-0.27.0-cp314-cp314t-win_amd64.whl", hash = "sha256:72bf547e58ddb948689734eed6f4b6a2031f979dba4fb08e3690688b392e929f", size = 4226392, upload-time = "2026-05-13T14:56:40.235Z" },
 ]
 
 [[package]]
@@ -7930,22 +7509,15 @@ name = "torchvision"
 version = "0.27.0+cu130"
 source = { registry = "https://download.pytorch.org/whl/cu130" }
 resolution-markers = [
-    "(python_full_version >= '3.14' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev') or (python_full_version >= '3.14' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev')",
-    "(python_full_version == '3.13.*' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev') or (python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev')",
-    "(python_full_version < '3.13' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev') or (python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-all' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra != 'group-30-coding-academy-lecture-manager-dev')",
-    "(python_full_version >= '3.15' and sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version >= '3.15' and sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version == '3.14.*' and sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version == '3.14.*' and sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version == '3.13.*' and sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version == '3.13.*' and sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version < '3.13' and sys_platform == 'linux' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version < '3.13' and sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version >= '3.15' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version >= '3.15' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version == '3.14.*' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version == '3.14.*' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version == '3.13.*' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version == '3.13.*' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
-    "(python_full_version < '3.13' and sys_platform == 'linux' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite') or (python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-30-coding-academy-lecture-manager-dev' and extra != 'extra-30-coding-academy-lecture-manager-jupyterlite')",
+    "(python_full_version >= '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform == 'win32')",
+    "(python_full_version == '3.14.*' and sys_platform == 'linux') or (python_full_version == '3.14.*' and sys_platform == 'win32')",
+    "(python_full_version == '3.13.*' and sys_platform == 'linux') or (python_full_version == '3.13.*' and sys_platform == 'win32')",
+    "(python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform == 'win32')",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "pillow", marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
-    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pillow", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "torch", version = "2.12.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torchvision-0.27.0%2Bcu130-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:0a839a2921410b1135add4c3d90f784c9d1e9e9f3c7b401b216d356ddca23ab2", upload-time = "2026-05-12T16:20:44Z" },
@@ -7987,7 +7559,7 @@ name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
@@ -8064,7 +7636,7 @@ version = "0.26.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "rich" },
     { name = "shellingham" },
 ]
@@ -8108,7 +7680,7 @@ name = "tzlocal"
 version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
 wheels = [
@@ -8122,15 +7694,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
-]
-
-[[package]]
-name = "uri-template"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/c7/0336f2bd0bcbada6ccef7aaa25e443c118a704f828a0620c6fa0207c1b64/uri-template-1.3.0.tar.gz", hash = "sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7", size = 21678, upload-time = "2023-06-21T01:49:05.374Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl", hash = "sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363", size = 11140, upload-time = "2023-06-21T01:49:03.467Z" },
 ]
 
 [[package]]
@@ -8246,8 +7809,7 @@ name = "uvicorn"
 version = "0.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-30-coding-academy-lecture-manager-jupyterlite'" },
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'extra-30-coding-academy-lecture-manager-all' or extra == 'extra-30-coding-academy-lecture-manager-dev' or extra != 'extra-30-coding-academy-lecture-manager-jupyterlite' or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "click" },
     { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
@@ -8257,11 +7819,11 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "httptools" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
-    { name = "uvloop", marker = "(platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32') or (platform_python_implementation == 'PyPy' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (platform_python_implementation == 'PyPy' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (platform_python_implementation == 'PyPy' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'cygwin' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'cygwin' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'cygwin' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (sys_platform == 'win32' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
     { name = "watchfiles" },
     { name = "websockets" },
 ]
@@ -8318,7 +7880,7 @@ name = "wasabi"
 version = "1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-30-coding-academy-lecture-manager-all' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-dev' and extra == 'extra-30-coding-academy-lecture-manager-jupyterlite') or (extra == 'extra-30-coding-academy-lecture-manager-jupyterlite' and extra == 'group-30-coding-academy-lecture-manager-dev')" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/f9/054e6e2f1071e963b5e746b48d1e3727470b2a490834d18ad92364929db3/wasabi-1.1.3.tar.gz", hash = "sha256:4bb3008f003809db0c3e28b4daf20906ea871a2bb43f9914197d540f4f2e0878", size = 30391, upload-time = "2024-05-31T16:56:18.99Z" }
 wheels = [
@@ -8474,15 +8036,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ce/e5/e272bb9a045105a1fdf4b798d8086f5932a178f4d738f17a74f5c9e0ae9a/weasel-1.0.0.tar.gz", hash = "sha256:7b129b44c90cc543b760532974ca1e4eb30dad2aa2026f57bdce66354ae610fc", size = 38682, upload-time = "2026-03-20T08:10:25.266Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/07/57ebf7a6798b016c064bd0ca81b4c6a99daa4dc377b898bc7b41eb6b5af0/weasel-1.0.0-py3-none-any.whl", hash = "sha256:89518acee027f49d743126c3502d35e6dd14f5768be5c37c9af47c171b6005cc", size = 50713, upload-time = "2026-03-20T08:10:23.637Z" },
-]
-
-[[package]]
-name = "webcolors"
-version = "25.10.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1d/7a/eb316761ec35664ea5174709a68bbd3389de60d4a1ebab8808bfc264ed67/webcolors-25.10.0.tar.gz", hash = "sha256:62abae86504f66d0f6364c2a8520de4a0c47b80c03fc3a5f1815fedbef7c19bf", size = 53491, upload-time = "2025-10-31T07:51:03.977Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl", hash = "sha256:032c727334856fc0b968f63daa252a1ac93d33db2f5267756623c210e57a4f1d", size = 14905, upload-time = "2025-10-31T07:51:01.778Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Wave 2a of dependency-environment isolation

clm never imported `jupyterlite-core` — it only shells out to `jupyter lite
build`. This moves that build out of clm's own venv into a dedicated, pinned
`uvx` (`uv tool run`) environment, making `jupyterlite-core` / `empack` (which
caps `click<8.2`) **structurally incapable** of entering clm's dependency graph.
The `[jupyterlite]` extra and the `[tool.uv] conflicts` Click fork added in Wave 1
(#522) are therefore deleted.

Design: `docs/claude/design/dependency-environment-isolation.md` (Wave 2a).
Follows up on #516 / #522.

### Changes
- **`builder.py`** — invoke `uvx --from jupyterlite-core==<pin> --with
  jupyterlite-pyodide-kernel --with jupyterlite-xeus --with jupyter-server
  jupyter-lite build …`. Both kernel addons are provisioned so the existing
  `--disable-addons` kernel selection still works. Version pins live here and are
  the single version truth (they also feed the build cache key). `FileNotFoundError`
  now tells the user to install `uv`.
- **`build_jupyterlite_site.py`** — derive `jupyterlite_core_version` from the
  builder pin instead of `importlib.metadata` (jupyterlite-core is no longer in
  clm's env; that lookup would return `""` and weaken the cache key).
- **`pyproject.toml`** — delete the `[jupyterlite]` extra and the entire
  `[tool.uv] conflicts` block; clean the jupyterlite-conflict comments in `all` /
  `dev` extra / `dev` group (keep `click>=8.2` on `dev`). `uv.lock` regenerated;
  `uv sync` now resolves **Click 8.4.1** with no conflict machinery.
- **Docs** — installation, JupyterLite user guide, `clm info jupyterlite` topic,
  architecture, and the design doc updated to the tool-env story (build needs only
  `uv` on PATH). Changelog fragment added.
- **Tests** — new fast-suite tests assert the `uvx` command shape (pinned `--from`,
  both addons `--with`, jupyter-server) and the missing-`uv` error message; the
  integration test now gates on `uvx` availability instead of importing
  jupyterlite-core.

### Validation
- `uv lock` + `uv sync --extra all` → Click 8.4.1; no jupyterlite/empack in the lock.
- Full `tests/workers/jupyterlite/` suite (85 passed, 1 skipped) + operation tests.
- Real end-to-end build through the `uvx` tool env via the integration test (passed).
- ruff / mypy clean; pre-push fast suite passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
