### PR TITLE
fix(slides): gate deck-side twin adoption on the document id namespace (#520 Phase 0)

### DIFF
--- a/src/clm/slides/assign_ids.py
+++ b/src/clm/slides/assign_ids.py
@@ -385,6 +385,7 @@ def _handle_stamp(
     cells: list[_Cell],
     stamp_pairs: dict[int, tuple[int, int]],
     stamp_slug: dict[int, str | None],
+    stamp_claims: dict[str, int],
     current_slide_id: str | None,
     options: AssignOptions,
     used_ids: set[str],
@@ -494,6 +495,27 @@ def _handle_stamp(
         )
         if twin_own:
             twin_bare = strip_preserve_marker(twin_existing)
+            # Adoption gate: writing the twin's id onto this cell must not
+            # CREATE a duplicate. The twin's id can be claimed elsewhere in
+            # the document — e.g. a stale narrative id equal to some OTHER
+            # slide's id on a structurally divergent deck — and adopting it
+            # would stamp that foreign identity onto this cell (found by the
+            # #520 corpus rehearsal on slides_pe_02a_fundamentals).
+            pair_claims = sum(
+                1
+                for sid in (existing, twin_existing)
+                if sid and strip_preserve_marker(sid) == twin_bare
+            )
+            if stamp_claims.get(twin_bare, 0) > pair_claims:
+                _stamp_refuse(
+                    result,
+                    file_str,
+                    cell.line_number,
+                    f"twin id {twin_bare!r} duplicates an id used elsewhere in "
+                    "this document; resolve manually",
+                )
+                stamp_slug[group_key] = None
+                return
             stamp_slug[group_key] = twin_bare
             if existing and strip_preserve_marker(existing) == twin_bare:
                 return
@@ -697,10 +719,21 @@ def assign_ids_for_cells(
     # sibling's id already in used_ids and bump the counter.
     group_slug: dict[int, str | None] = {}
 
-    # Stamp mode (#520): the adjacent-twin map and the per-pair slug cache
-    # for localized/narrative cells (the stamp-mode analogue of group_slug).
+    # Stamp mode (#520): the adjacent-twin map, the per-pair slug cache
+    # (the stamp-mode analogue of group_slug), and the claim counts backing
+    # the twin-adoption uniqueness gate (a set cannot tell "claimed by a
+    # cell OUTSIDE the pair" from "claimed by the twin itself").
     stamp_pairs: dict[int, tuple[int, int]] = _build_stamp_pairs(cells) if options.stamp_ids else {}
     stamp_slug: dict[int, str | None] = {}
+    stamp_claims: dict[str, int] = {}
+    if options.stamp_ids:
+        for rid in reserved_ids or ():
+            stamp_claims[rid] = stamp_claims.get(rid, 0) + 1
+        for claim_cell in cells:
+            claim_sid = claim_cell.metadata.slide_id
+            if claim_sid:
+                claim_bare = strip_preserve_marker(claim_sid)
+                stamp_claims[claim_bare] = stamp_claims.get(claim_bare, 0) + 1
 
     # Track the most recent slide_id (bare form) by source order so that
     # narrative cells (voiceover/notes) inherit from the preceding
@@ -786,6 +819,7 @@ def assign_ids_for_cells(
                     cells,
                     stamp_pairs,
                     stamp_slug,
+                    stamp_claims,
                     current_slide_id,
                     options,
                     used_ids,
@@ -808,6 +842,7 @@ def assign_ids_for_cells(
                 cells,
                 stamp_pairs,
                 stamp_slug,
+                stamp_claims,
                 current_slide_id,
                 options,
                 used_ids,

--- a/tests/slides/test_assign_ids.py
+++ b/tests/slides/test_assign_ids.py
@@ -1545,6 +1545,38 @@ class TestStampIds:
         assert any("only one deck half" in r.reason for r in result.refusals)
         assert comp_de.read_text(encoding="utf-8") == comp_text
 
+    def test_deck_adoption_refuses_id_claimed_by_another_cell(self):
+        # The slides_pe_02a_fundamentals shape from the #520 corpus
+        # rehearsal: an id-less DE narrative adjacent to an EN narrative
+        # carrying a stale id equal to some OTHER slide's id ("recap").
+        # Adopting it would stamp that foreign identity onto the DE cell
+        # (and create a bare-id duplicate); the twin-adoption gate must
+        # refuse instead.
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="recap"\n'
+            "# ## Rückblick\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["slide"] slide_id="recap"\n'
+            "# ## Recap\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["subslide"] slide_id="other"\n'
+            "# ## Anderes\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["subslide"] slide_id="other"\n'
+            "# ## Other\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["voiceover"]\n'
+            "# Sprechertext.\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["voiceover"] slide_id="recap"\n'
+            "# Narration text.\n"
+        )
+        new_text, result = _run(text, **_STAMP)
+        assert result.assignments == []
+        assert any("duplicates an id used elsewhere" in r.reason for r in result.refusals)
+        # The DE narrative was NOT stamped with the foreign id.
+        assert new_text == text
+
     def test_companion_pre242_title_shape_refused_untouched(self, tmp_path):
         # Pre-#242 extract wrote title cells as slide_id="title" with NO
         # for_slide — a documented on-disk population (_is_title_intent).


### PR DESCRIPTION
## Summary

The full-corpus `--stamp-ids` rehearsal on PythonCourses (8,280 stamps) surfaced exactly one new validate error — the deck-path variant of the adoption hole the companion review had flagged: on `slides_pe_02a_fundamentals`, an id-less DE narrative sat adjacent (in the unified deck) to an EN narrative carrying a stale id equal to a **different** slide's id. Relative to its positional anchor that id isn't "legacy", so it classified as an own id and twin adoption stamped the foreign identity onto the DE cell — a new duplicate.

`_handle_stamp`'s twin-adoption branch now refuses when the twin's id is claimed by any cell **outside** the pair (or by reserved companion ids), mirroring the companion-side adoption gate from #527. New `stamp_claims` counting backs the check.

## Test plan
- [x] Regression test reproducing the pe_02a shape (foreign-id adoption refused, file untouched)
- [x] 141 assign-ids + normalize CLI tests green
- [x] Full-corpus rehearsal after the fix: 8,278 stamps, **zero** new validate errors (down 36 vs master), idempotent — see the PythonCourses PR
- [x] Fast suite via pre-push hook

Part of #520 (sync v3 umbrella), Phase 0 — last engine change before the one-time PythonCourses normalize commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xju9N384PqCWxiaBtMx9Uj
