### PR TITLE
fix(sync): alert on id-less-half edits of asymmetric companions; recalibrate corpus oracles (#520 Phase 0)

### DIFF
--- a/src/clm/slides/sync_plan.py
+++ b/src/clm/slides/sync_plan.py
@@ -2787,6 +2787,29 @@ def _idd_narrative_baseline_hashes(
     return out
 
 
+def _idless_narrative_baseline_hashes(
+    baseline: list[BaselineCell] | None,
+) -> dict[tuple[str, str], Counter[str]]:
+    """Map ``(owning_slide_id, role) -> hash multiset`` for ID-LESS baseline narratives.
+
+    The mirror of :func:`_idd_narrative_baseline_hashes` for the other half of
+    the #443 asymmetry: detecting a one-sided edit of the **id-less** half
+    needs its recorded bodies, keyed the way the reconcile keys the current
+    cells. Rows without Phase-B owning info (pre-#403 watermarks) are skipped —
+    a ``None`` owner would aggregate every id-less narrative of a role into one
+    bucket and produce spurious drift.
+    """
+    out: dict[tuple[str, str], Counter[str]] = {}
+    for cell in baseline or []:
+        if (
+            cell.role in NARRATIVE_ROLES
+            and cell.slide_id is None
+            and cell.owning_slide_id is not None
+        ):
+            out.setdefault((cell.owning_slide_id, cell.role), Counter())[cell.content_hash] += 1
+    return out
+
+
 def _alert_asymmetric_companion_drift(
     plan: SyncPlan,
     de_idless: list[CurrentCell],
@@ -2820,18 +2843,25 @@ def _alert_asymmetric_companion_drift(
     Detects per ``(owning_slide_id, role)`` against the recorded baseline:
     - **edit** — the id'd half is present now and its body differs from its baseline;
     - **removal** — the id'd half was in the baseline but is gone now, while the
-      id-less twin on the other half survives.
+      id-less twin on the other half survives;
+    - **id-less edit** — the id-less half's recorded bodies (hash multiset per
+      key) no longer match the working tree while the id'd twin exists. Found
+      by the #520 corpus rehearsal: the id-less half's edit rides only on its
+      anchor ``add``, which the reconcile cancels — the mirror image of the
+      id'd-half drop above.
     """
     if de_baseline is None or en_baseline is None:
         return  # cold start: no baseline to detect drift against
     de_idd_base = _idd_narrative_baseline_hashes(de_baseline)
     en_idd_base = _idd_narrative_baseline_hashes(en_baseline)
+    de_idless_base = _idless_narrative_baseline_hashes(de_baseline)
+    en_idless_base = _idless_narrative_baseline_hashes(en_baseline)
     drop: set[int] = set()
     # Each direction: the id-less half (whose anchor add we may drop) is on one side, the
     # id'd half (the keyed companion that drifted) on the other.
-    for idless_cells, idd_cells, idd_base, idless_dir, idd_dir in (
-        (de_idless, en_idd, en_idd_base, "de->en", "en->de"),
-        (en_idless, de_idd, de_idd_base, "en->de", "de->en"),
+    for idless_cells, idd_cells, idd_base, idless_base, idless_dir, idd_dir in (
+        (de_idless, en_idd, en_idd_base, de_idless_base, "de->en", "en->de"),
+        (en_idless, de_idd, de_idd_base, en_idless_base, "en->de", "de->en"),
     ):
         idd_now = {(c.owning_slide_id, c.role): c for c in idd_cells}
         idless_by_key: dict[tuple[str | None, str], list[CurrentCell]] = {}
@@ -2846,9 +2876,15 @@ def _alert_asymmetric_companion_drift(
             base_hash = idd_base.get(key)
             edited = now is not None and base_hash is not None and now.content_hash != base_hash
             removed = now is None and base_hash is not None
-            if not (edited or removed):
+            idless_edited = False
+            if not (edited or removed) and owning is not None:
+                base_counts = idless_base.get((owning, role))
+                if base_counts is not None and (now is not None or base_hash is not None):
+                    now_counts: Counter[str] = Counter(c.content_hash for c in idless_by_key[key])
+                    idless_edited = now_counts != base_counts
+            if not (edited or removed or idless_edited):
                 continue
-            what, noun = ("edited", "edit") if edited else ("removed", "removal")
+            what, noun = ("removed", "removal") if removed else ("edited", "edit")
             plan.issues.append(
                 PlanIssue(
                     severity="error",

--- a/tests/slides/test_sync_corpus_mutation.py
+++ b/tests/slides/test_sync_corpus_mutation.py
@@ -451,25 +451,27 @@ def _half_has_key(text: str, side: str, sid: str, role: str) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _run_mutation(pairs, tmp_path, mutate, check, side: str = "en"):
+def _run_mutation(pairs, tmp_path, mutate, check, side: str = "en", require_propagation=True):
     """Apply ``mutate`` to each selected pair's ``side`` half; assert propagate-or-alert.
 
     ``mutate(text)`` receives the mutated half's text and returns
-    ``(mutated_text, judge)`` or None. ``check(plan, result, twin_after)``
-    returns True when the change demonstrably reached the OTHER half. The pairs
-    were selected for carrying the mutation's target cell class, so the
-    mutation must find a target in every one.
+    ``(mutated_text, judge)`` or None — None skips the pair: selection counts
+    cell classes on the DE half only, and on a normalized corpus (#520) the
+    residual carriers of a class can be one-sided asymmetric decks where the
+    mutated half has no target (e.g. an id-less narrative surviving only on
+    DE because the stamp refused the asymmetric pair). The bundled corpus is
+    symmetric, so CI always exercises every mutation.
     """
     if not pairs:
         pytest.skip("no clean corpus pair carries this mutation's cell class")
     propagated_somewhere = False
+    exercised = 0
     for i, (name, de_text, en_text) in enumerate(pairs):
         source_text = en_text if side == "en" else de_text
         prepared = mutate(source_text)
-        assert prepared is not None, (
-            f"{name}: selected for this cell class but the mutation found no target — "
-            "selection and mutation disagree (test bug)"
-        )
+        if prepared is None:
+            continue
+        exercised += 1
         mutated, judge = prepared
         tmp = tmp_path / f"m{i}"
         tmp.mkdir()
@@ -491,9 +493,16 @@ def _run_mutation(pairs, tmp_path, mutate, check, side: str = "en"):
         if propagated:
             propagated_somewhere = True
             assert result.watermark_recorded, f"{name} [{side}-side]: propagated but watermark held"
+    if not exercised:
+        pytest.skip("no selected pair carries this mutation's target on the mutated half")
     # The clean common case on real decks is propagation, not an alert; if every
     # single pair only alerted, the engine has regressed into refuse-everything.
-    assert propagated_somewhere, "mutation alerted on every pair — nothing propagated"
+    # Classes whose only residual carriers are asymmetric decks (the ones
+    # --stamp-ids refused, #520) legitimately alert on every pair and opt out
+    # via require_propagation=False — the falsely-consistent and
+    # propagate-or-alert asserts above still hold for them.
+    if require_propagation:
+        assert propagated_somewhere, "mutation alerted on every pair — nothing propagated"
 
 
 @pytest.mark.parametrize("side", ["en", "de"])
@@ -535,7 +544,11 @@ def test_idless_narrative_edit_is_judge_reconciled(corpus_pairs, tmp_path, side)
     # (#199/#403), not the keyed diff — the arm of the engine where one-sided
     # edits have historically gone missing (#443 was next door). Narrative
     # edits are judge-reconciled (without a judge the engine alerts instead);
-    # a silent drop never satisfies #269.
+    # a silent drop never satisfies #269. On the normalized corpus (#520)
+    # the only residual id-less narratives live on asymmetric decks whose
+    # edits correctly ALERT (the #471 asymmetric-companion error), so
+    # propagation is not required there; the bundled corpus still proves
+    # the judge-reconcile path in CI.
     _run_mutation(
         corpus_pairs["idless_narr"],
         tmp_path,
@@ -544,6 +557,7 @@ def test_idless_narrative_edit_is_judge_reconciled(corpus_pairs, tmp_path, side)
         ),
         lambda plan, result, twin_after: _JUDGED in twin_after,
         side=side,
+        require_propagation=_BUNDLED,
     )
 
 

--- a/tests/slides/test_sync_corpus_noop.py
+++ b/tests/slides/test_sync_corpus_noop.py
@@ -140,18 +140,17 @@ def test_noop_pairs_do_not_catastrophically_regress(report):
 
 @_real_corpus_only
 def test_churn_baseline_populations_present(report):
-    # The measurement half: the item-2 (neutral, silent-drop) and item-3 (id-less
-    # localized, re-translated) exposure populations are what Phases 2-3 must
-    # drive to zero. Guard that the harness still measures them (a non-zero,
-    # plausible magnitude), so a refactor can't silently zero the baseline out.
+    # The measurement half. Item-2 (neutral, silent-drop exposure) is still a
+    # live population — shared cells are never stamped (#520 §3.4) — so guard
+    # that the harness keeps measuring it (a non-zero, plausible magnitude).
     c = report.census
     assert c.item2_population > 1000, report.render()  # Phase-0: ~8,014
-    assert c.item3_population > 100, report.render()  # Phase-0: ~1,702
-    # The per-group blast radius pins the GROUPING (not just the predicate): a
-    # broken _split_groups would collapse cells into too few groups (inflating
-    # max_in_one_group) or shatter them (deflating it). `blast_total ==
-    # item3_population` is true by construction (same predicate, same cells), so
-    # assert the grouping-shaped quantities instead.
-    assert report.blast_groups_with_idless > 100, report.render()  # Phase-0: ~948
-    assert 1 <= report.blast_max_in_one_group <= 50, report.render()  # Phase-0: ~10
-    assert report.blast_max_in_one_group <= report.census.item3_population
+    # Item-3 (id-less localized, re-translated) was ~1,702 before the sync-v3
+    # Phase 0 normalize commit (`clm slides normalize --stamp-ids`, #520)
+    # stamped ids on the whole population. Post-normalize this is a CEILING:
+    # only the handful of cells on refused asymmetric decks may remain
+    # id-less (~5 measured), and the number regressing upward means id-less
+    # localized cells are being (re)introduced — the exposure the one-time
+    # normalization exists to keep closed.
+    assert c.item3_population < 100, report.render()  # normalized: ~5
+    assert report.blast_max_in_one_group <= max(report.census.item3_population, 1)

--- a/tests/slides/test_sync_limitations.py
+++ b/tests/slides/test_sync_limitations.py
@@ -1448,6 +1448,30 @@ def test_issue443_one_sided_edit_of_keyed_companion_is_alerted(tmp_path: Path):
     assert "id-less" in issue.reason and "#443" in issue.reason
 
 
+def test_issue443_one_sided_edit_of_idless_half_is_alerted(tmp_path: Path):
+    # The mirror image, found by the #520 corpus rehearsal on the normalized
+    # corpus (slides_pe_02a_fundamentals): editing the DE (id-LESS) half of
+    # the asymmetric companion reported "decks already consistent" — the
+    # edit's only carrier is the id-less anchor add, which the reconcile
+    # cancels. It must alert exactly like the id'd-half edit.
+    de_path, en_path, cache = _asymmetric_companion_pair(tmp_path)
+    try:
+        de_path.write_text(
+            _slide("de", "s1", "# ## Folie eins") + _voiceover_idless("de", "Hallo Welt, neu"),
+            encoding="utf-8",
+        )
+        plan = build_sync_plan(de_path, en_path, watermark_cache=cache, allow_git_fallback=False)
+    finally:
+        cache.close()
+
+    assert not plan.is_noop  # NOT a silent "already consistent"
+    assert plan.has_errors  # alerted (#269 propagate-or-alert)
+    assert plan.count("add") == 0  # the edit is not masked as a fresh narrative add
+    issue = next(i for i in plan.issues if i.severity == "error")
+    assert issue.slide_id == "s1"
+    assert "id-less" in issue.reason and "#443" in issue.reason
+
+
 def test_issue443_one_sided_removal_of_keyed_companion_is_alerted(tmp_path: Path):
     # The corpus ``test_keyed_companion_remove_propagates`` shape: deleting the EN
     # (id'd) half used to leave the surviving DE id-less half's add masquerading as a

--- a/tests/slides/test_sync_narrative_anchor.py
+++ b/tests/slides/test_sync_narrative_anchor.py
@@ -223,7 +223,12 @@ class TestMassAddGuard:
             ]
         )
         plan, result, _de, en_after = _sync(tmp_path, de0, en0, de1, en0)
-        assert any(p.kind == "refuse" for p in plan.proposals)
+        # The #443 asymmetric-drift alert (id-less half's multiset changed
+        # while an id'd twin exists) catches this shape before the mass-add
+        # guard since the #520 corpus rehearsal — an error-severity issue
+        # instead of refuse proposals. Either mechanism satisfies the
+        # invariant: loud, watermark held, nothing written.
+        assert plan.has_errors or any(p.kind == "refuse" for p in plan.proposals)
         assert result.watermark_recorded is False
         assert "# extra" not in en_after  # nothing written — duplicates avoided
 


### PR DESCRIPTION
## Summary

The #520 full-corpus rehearsal (stamping PythonCourses, 8,278 changes) surfaced one latent engine bug and recalibrated two oracle assumptions:

### Engine: the mirror of the #471 fix
Editing the **id-less** half of an asymmetric (id-less ↔ id'd) voiceover companion was silently dropped — the edit's only carrier is the id-less anchor `add`, which the report-#10 reconcile cancels; #471's alert only watched the **id'd** half. `_alert_asymmetric_companion_drift` now also compares the id-less half's recorded bodies (hash multiset per `(owning_slide_id, role)`, pre-#403 baselines skipped) and raises the same error alert. This is pre-existing on real decks (`slides_pe_02a_fundamentals`) — the extended mutation oracle caught it the moment the normalized corpus made asymmetric decks the only remaining id-less-narrative carriers. The mass-add guard test now accepts the alert mechanism (it catches that shape earlier; same invariant: loud, watermark held, nothing written).

### Oracles: post-normalize recalibration
- `_run_mutation` skips pairs whose mutated half has no target (mirror-assumption breaks only on residual asymmetric decks); `idless_narr` requires propagation only on the bundled corpus — the residual real carriers correctly alert.
- `test_churn_baseline_populations_present`: `item3_population` flips from a >100 floor to a **<100 ceiling** (measured ~5 post-normalize, was ~1,702) — the guard now protects the normalized state. `item2` keeps its floor (shared cells are never stamped).

## Test plan
- [x] New fast regression test `test_issue443_one_sided_edit_of_idless_half_is_alerted` (bundled, runs in CI)
- [x] All 25 corpus oracle tests green on the stamped PythonCourses corpus (~3:45)
- [x] Bundled-corpus CI arm unchanged (22 passed)
- [x] 835 fast sync tests green; fast suite via pre-push hook

Companion PR: the PythonCourses one-time normalize commit (its release-gate oracle run needs this recalibration).

Part of #520, Phase 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xju9N384PqCWxiaBtMx9Uj
