### PR TITLE
feat(workers): run Direct notebook kernel in a separate interpreter (Wave 2b-1)

### DIFF
--- a/changelog.d/516-notebook-kernel-python-direct.added.md
+++ b/changelog.d/516-notebook-kernel-python-direct.added.md
@@ -1,0 +1,13 @@
+- **Direct-mode notebook execution can now run its Python kernel in a separate
+  interpreter (Wave 2b).** Point clm at a course venv and the notebook kernel
+  runs there — so course-runtime packages (`[ml]`: torch/pandas/…) live in a
+  separate environment from clm's own, while clm keeps driving nbconvert
+  (mirroring what the Docker notebook image already does). Register a course
+  interpreter with the new `clm provision kernel-env --python <path>`, then
+  select it via the `CLM_NOTEBOOK_KERNEL_PYTHON` env var, a course-spec
+  `<kernel-python>` element, or `clm.toml` `[jupyter] kernel_python` (that is the
+  precedence, most specific first). Unset ⇒ the kernel runs in clm's own
+  environment, exactly as before — this is fully opt-in. Only the `python3`
+  kernel is affected; C++/C#/Java/TS kernels and Docker mode are unchanged. See
+  `clm info commands` / `clm info spec-files` and
+  `docs/claude/design/dependency-environment-isolation.md`.

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -1853,12 +1853,23 @@ async def main_build(
     # Direct mode it stays the legacy primary ``output_root``.
     worker_workspace_path = _resolve_worker_workspace_path(course, worker_config)
 
+    # Resolve the Direct-mode notebook-kernel interpreter (Wave 2b): env
+    # CLM_NOTEBOOK_KERNEL_PYTHON > course spec <kernel-python> > clm.toml
+    # [jupyter].kernel_python > "" (clm's own env). "" leaves today's behaviour
+    # untouched. Docker mode ignores it (a host interpreter is meaningless in a
+    # container). Resolved here where the spec is in scope; the executor just
+    # provisions + injects JUPYTER_PATH.
+    from clm.infrastructure.workers.kernel_env import resolve_notebook_kernel_python
+
+    notebook_kernel_python = resolve_notebook_kernel_python(course.spec.kernel_python)
+
     lifecycle_manager = WorkerLifecycleManager(
         config=worker_config,
         db_path=config.jobs_db_path,
         workspace_path=worker_workspace_path,
         cache_db_path=config.cache_db_path,
         data_dir=data_dir,
+        notebook_kernel_python=notebook_kernel_python,
     )
 
     # Out-of-process HTTP-replay proxy (issue #165). Must run BEFORE workers

--- a/src/clm/cli/commands/provision.py
+++ b/src/clm/cli/commands/provision.py
@@ -1,0 +1,67 @@
+"""``clm provision`` command group.
+
+Prepares environments clm runs *against* (as opposed to clm's own venv). Today
+it registers a course-runtime kernel environment for Direct-mode notebook
+execution (Wave 2b); the group is intentionally open-ended so other
+environment-provisioning commands (e.g. a future ``docker-image`` that folds in
+the current ``clm docker`` build) can live alongside it.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import click
+
+logger = logging.getLogger(__name__)
+
+
+@click.group("provision")
+def provision_group() -> None:
+    """Provision environments clm runs against (kernels, tools)."""
+
+
+@provision_group.command("kernel-env")
+@click.option(
+    "--python",
+    "python_exe",
+    required=True,
+    type=click.Path(path_type=Path),
+    help="Path to the Python interpreter (course venv) that should host the "
+    "Direct-mode notebook kernel. Must have 'ipykernel' installed.",
+)
+@click.option(
+    "--no-validate",
+    is_flag=True,
+    default=False,
+    help="Skip the interpreter/ipykernel validation (write the kernelspec anyway).",
+)
+def kernel_env(python_exe: Path, no_validate: bool) -> None:
+    """Register a course-runtime kernel environment for Direct mode.
+
+    Writes a ``python3`` kernelspec pointing at the given interpreter and prints
+    the ways to activate it. clm then runs the notebook kernel in that
+    environment (course-runtime packages like ``[ml]`` live there, not in clm's
+    own venv) while clm keeps driving nbconvert.
+
+    This registers an interpreter you already have; it does not create the venv.
+    """
+    from clm.infrastructure.workers.kernel_env import (
+        KERNEL_PYTHON_ENV_VAR,
+        provision_course_kernel,
+    )
+
+    try:
+        root = provision_course_kernel(python_exe, validate=not no_validate)
+    except RuntimeError as e:
+        raise click.ClickException(str(e)) from e
+
+    resolved = python_exe.expanduser()
+    click.echo(f"Registered course kernel for: {resolved}")
+    click.echo(f"Kernelspec root: {root}")
+    click.echo("")
+    click.echo("Activate it for a build in any of these ways (most specific wins):")
+    click.echo(f"  - Env var:     {KERNEL_PYTHON_ENV_VAR}={resolved}")
+    click.echo(f"  - Course spec: <kernel-python>{resolved}</kernel-python>")
+    click.echo(f'  - clm.toml:    [jupyter] kernel_python = "{resolved}"')

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -3357,6 +3357,33 @@ Build and push CLM Docker images.
 | `docker pull` | Pull images from Docker Hub |
 | `docker push` | Push images to Docker Hub |
 
+### `clm provision`
+
+Provision environments clm runs *against* (as opposed to clm's own venv).
+
+| Subcommand | Description |
+|------------|-------------|
+| `provision kernel-env --python PATH` | Register a course venv as the Direct-mode Python notebook kernel (Wave 2b) |
+
+`provision kernel-env` writes a `python3` kernelspec pointing at the given
+interpreter and prints how to activate it. clm then runs the notebook kernel in
+that environment — so course-runtime packages (`[ml]`: torch/pandas/…) live in a
+**separate** venv from clm, while clm keeps driving nbconvert. It registers an
+interpreter you already have; it does not create the venv. The interpreter must
+have `ipykernel` installed (pass `--no-validate` to skip that check).
+
+Selection precedence for the kernel interpreter (most specific wins):
+
+1. `CLM_NOTEBOOK_KERNEL_PYTHON` environment variable.
+2. Course-spec `<kernel-python>` element (see `clm info spec-files`).
+3. `clm.toml` `[jupyter] kernel_python`.
+4. Unset ⇒ the kernel runs in clm's own environment (default).
+
+Only the Python (`python3`) kernel is affected; C++/C#/Java/TS kernels are
+external toolchains and resolve as before. Applies to **Direct** execution only
+— the Docker notebook image already isolates the course-runtime stack. See
+`docs/claude/design/dependency-environment-isolation.md`.
+
 ### `clm git`
 
 Manage git repositories for course output directories.

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -329,6 +329,30 @@ Defaults to `Coding-Akademie München` (de) / `Coding-Academy Munich` (en).
 
 ## Optional Elements
 
+### `<kernel-python>` (Optional, CLM {version}+)
+
+Course-level interpreter that runs the **Python notebook kernel in Direct
+execution mode**. Point it at a course venv so course-runtime packages
+(`[ml]`: torch/pandas/…) run in a separate environment from clm's own, while
+clm keeps driving the build. Empty/absent (the default) runs the kernel in
+clm's environment, exactly as before.
+
+```xml
+<kernel-python>/opt/course-venvs/ml/bin/python</kernel-python>
+```
+
+The interpreter must have `ipykernel` installed. Register it once with
+`clm provision kernel-env --python <path>` (writes the kernelspec clm points the
+build at). This is the key lever for keeping a **plain-Python** course on a light
+venv while an ML-heavy course uses a fat one — no global reconfiguration.
+
+Precedence (highest first): the `CLM_NOTEBOOK_KERNEL_PYTHON` environment
+variable, then this `<kernel-python>`, then `clm.toml` `[jupyter] kernel_python`;
+unset ⇒ clm's own environment. Only the Python kernel is affected (C++/C#/Java/TS
+kernels are external toolchains). Direct mode only — the Docker notebook image
+already isolates the course-runtime stack. See `clm info commands` (`clm
+provision`) and `docs/claude/design/dependency-environment-isolation.md`.
+
 ### `<sidecar-layout>` (Optional, CLM {version}+)
 
 Per-course override for where a build records a topic's **first** HTTP-replay

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -73,6 +73,7 @@ _COMMANDS = "clm.cli.commands"
         "config": f"{_COMMANDS}.config:config",
         "db": f"{_COMMANDS}.db:db",
         "docker": f"{_COMMANDS}.docker:docker_group",
+        "provision": f"{_COMMANDS}.provision:provision_group",
         "jobs": f"{_COMMANDS}.jobs:jobs_group",
         "git": f"{_COMMANDS}.git:git_group",
         "release": f"{_COMMANDS}.release:release_group",

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -1498,6 +1498,14 @@ class CourseSpec:
     # *write* location of new files (e.g. a first-recorded cassette during a
     # build); reads always auto-detect both layouts. From ``<sidecar-layout>``.
     sidecar_layout: str | None = None
+    # Course-level interpreter for the Python notebook kernel in Direct mode
+    # (Wave 2b, issue #516 follow-up). Empty = clm's own environment. Set to a
+    # course venv path so course-runtime packages ([ml] etc.) run in a separate
+    # environment from clm. Overridden by the CLM_NOTEBOOK_KERNEL_PYTHON env
+    # var; overrides the project-level clm.toml [jupyter].kernel_python. Path is
+    # used verbatim (absolute or resolved by the shell/user); relative paths are
+    # taken as-is. From ``<kernel-python>``.
+    kernel_python: str = ""
     author: str = "Dr. Matthias Hölzl"
     organization: Text = field(
         factory=lambda: Text(de="Coding-Akademie München", en="Coding-Academy Munich")
@@ -2584,6 +2592,7 @@ class CourseSpec:
             image_options=ImageOptionsSpec.from_element(root.find("image-options")),
             jupyterlite=JupyterLiteConfig.from_element(root.find("jupyterlite")),
             sidecar_layout=sidecar_layout,
+            kernel_python=element_text(root, "kernel-python").strip(),
             author=author,
             organization=organization,
         )

--- a/src/clm/infrastructure/config.py
+++ b/src/clm/infrastructure/config.py
@@ -249,6 +249,19 @@ class JupyterConfig(BaseModel):
         description="Log cell processing in notebook processor",
     )
 
+    kernel_python: str = Field(
+        default="",
+        description=(
+            "Path to the interpreter that runs the Python notebook kernel in "
+            "Direct mode. Empty = use clm's own environment (default). Set to a "
+            "course venv to isolate course-runtime packages ([ml] etc.) from "
+            "clm's environment. This is the project-level (clm.toml) tier; the "
+            "env var CLM_NOTEBOOK_KERNEL_PYTHON and a course-spec <kernel-python> "
+            "element override it. See docs/claude/design/"
+            "dependency-environment-isolation.md."
+        ),
+    )
+
 
 class WorkersConfig(BaseModel):
     """Worker configuration."""

--- a/src/clm/infrastructure/workers/kernel_env.py
+++ b/src/clm/infrastructure/workers/kernel_env.py
@@ -1,0 +1,187 @@
+"""Course-runtime kernel environment for Direct-mode notebook execution.
+
+Wave 2b (issue #516 follow-up) lets the Direct notebook worker launch its
+Python kernel from a **separate interpreter** — a course venv holding the
+course-runtime stack (``[ml]`` etc.) — while clm's own venv keeps driving
+nbconvert. This isolates course dependencies from clm's environment, mirroring
+what the Docker notebook image already does.
+
+The mechanism is pure Jupyter plumbing and needs no change to the execution
+hot path:
+
+- ``TrackingExecutePreprocessor`` is created with **no ``kernel_name``**, so
+  nbconvert resolves the kernel from the notebook's ``metadata.kernelspec.name``
+  — the literal ``python3`` for Python decks
+  (``clm.workers.notebook.utils.prog_lang_utils.kernelspec_for``).
+- ``jupyter_client`` resolves ``python3`` by scanning kernelspec directories,
+  and the dirs named by ``JUPYTER_PATH`` are searched **before** the user /
+  system data dirs.
+
+So provisioning a ``kernels/python3/kernel.json`` whose ``argv[0]`` is the
+course interpreter and prepending its root to the worker's ``JUPYTER_PATH``
+makes the kernel subprocess run in the course venv. Only the ``python3``
+kernelspec is written; C++/C#/Java/TS kernels are external toolchains and are
+left untouched.
+
+This module owns two things: :func:`resolve_notebook_kernel_python` (the
+env > course-spec > ``clm.toml`` precedence) and :func:`provision_course_kernel`
+(writes the kernelspec, returns the ``JUPYTER_PATH`` root).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+import platformdirs
+
+logger = logging.getLogger(__name__)
+
+#: Env var that overrides every other tier (operator escape hatch for one
+#: invocation — debugging, CI). Documented canonical name.
+KERNEL_PYTHON_ENV_VAR = "CLM_NOTEBOOK_KERNEL_PYTHON"
+
+
+def resolve_notebook_kernel_python(spec_value: str = "") -> str:
+    """Resolve the interpreter for the Python notebook kernel (Direct mode).
+
+    Precedence, most specific first (first non-empty wins):
+
+    1. ``CLM_NOTEBOOK_KERNEL_PYTHON`` env var — operator escape hatch.
+    2. ``spec_value`` — the course spec's ``<kernel-python>`` element.
+    3. ``clm.toml [jupyter].kernel_python`` — the project-level default.
+    4. ``""`` — use clm's own environment (today's behaviour).
+
+    Args:
+        spec_value: The course-spec ``<kernel-python>`` value (tier 2). Callers
+            that have no spec in scope pass ``""``.
+
+    Returns:
+        The resolved interpreter path, or ``""`` to mean "use clm's env".
+    """
+    env_value = os.environ.get(KERNEL_PYTHON_ENV_VAR, "").strip()
+    if env_value:
+        return env_value
+    if spec_value and spec_value.strip():
+        return spec_value.strip()
+
+    # Project (clm.toml) tier. Read lazily so importing this module never
+    # forces config resolution.
+    from clm.infrastructure.config import get_config
+
+    return (get_config().jupyter.kernel_python or "").strip()
+
+
+def _kernel_envs_root() -> Path:
+    """Return the base dir under which per-interpreter kernelspecs are written.
+
+    Uses ``platformdirs.user_data_dir("clm")`` — a persistent, per-user,
+    cross-platform location (distinct from config/logs/cache). Each interpreter
+    gets its own subdir so multiple course venvs coexist.
+    """
+    return Path(platformdirs.user_data_dir("clm", appauthor=False)) / "kernel-envs"
+
+
+def _validate_ipykernel(python_exe: Path) -> None:
+    """Fail early (with an actionable message) if ``ipykernel`` is missing.
+
+    The kernel launcher (``python -m ipykernel_launcher``) lives in the course
+    venv, so ``ipykernel`` must be installed there.
+    """
+    try:
+        result = subprocess.run(
+            [str(python_exe), "-c", "import ipykernel"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        raise RuntimeError(
+            f"Could not run the interpreter {python_exe!r} to validate it: {e}"
+        ) from e
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"The interpreter {python_exe!r} cannot import 'ipykernel'. Install "
+            f'it into that environment (e.g. `"{python_exe}" -m pip install '
+            f"ipykernel`) so it can host the notebook kernel, then retry."
+        )
+
+
+def provision_course_kernel(python_exe: Path, *, validate: bool = True) -> Path:
+    """Write a ``python3`` kernelspec for ``python_exe`` and return its root.
+
+    The returned directory is the one to place on ``JUPYTER_PATH`` (it *contains*
+    ``kernels/python3/kernel.json``, which is the layout jupyter_client expects).
+    The location is derived from a hash of the resolved interpreter path so
+    re-provisioning the same interpreter is idempotent and distinct interpreters
+    never collide.
+
+    Args:
+        python_exe: Interpreter that should host the Python notebook kernel.
+        validate: When True (default), verify the interpreter exists and can
+            import ``ipykernel`` before writing the kernelspec.
+
+    Returns:
+        The ``JUPYTER_PATH`` root directory containing ``kernels/python3/``.
+
+    Raises:
+        RuntimeError: The interpreter does not exist, or (when ``validate``)
+            cannot import ``ipykernel``.
+    """
+    resolved = python_exe.expanduser()
+    if validate:
+        if not resolved.is_file():
+            raise RuntimeError(
+                f"kernel-python interpreter not found: {resolved!r}. Point "
+                f"CLM_NOTEBOOK_KERNEL_PYTHON / <kernel-python> / clm.toml "
+                f"[jupyter].kernel_python at an existing Python executable."
+            )
+        _validate_ipykernel(resolved)
+
+    key = hashlib.sha256(str(resolved).encode("utf-8")).hexdigest()[:16]
+    root = _kernel_envs_root() / key
+    kernel_dir = root / "kernels" / "python3"
+    kernel_dir.mkdir(parents=True, exist_ok=True)
+
+    kernel_json = {
+        "argv": [
+            str(resolved),
+            "-m",
+            "ipykernel_launcher",
+            "-f",
+            "{connection_file}",
+        ],
+        "display_name": "Python 3 (clm course venv)",
+        "language": "python",
+    }
+    (kernel_dir / "kernel.json").write_text(
+        json.dumps(kernel_json, indent=2),
+        encoding="utf-8",
+    )
+    logger.debug("Provisioned course kernelspec for %s at %s", resolved, kernel_dir)
+    return root
+
+
+def jupyter_path_with_kernel(root: Path, existing: str | None) -> str:
+    """Prepend ``root`` to an existing ``JUPYTER_PATH`` value.
+
+    Prepending (not appending) is load-bearing: jupyter_client returns the first
+    ``python3`` kernelspec it finds across the search path, so our course kernel
+    must sit ahead of clm's own.
+    """
+    root_str = str(root)
+    if existing:
+        return root_str + os.pathsep + existing
+    return root_str
+
+
+__all__ = [
+    "KERNEL_PYTHON_ENV_VAR",
+    "resolve_notebook_kernel_python",
+    "provision_course_kernel",
+    "jupyter_path_with_kernel",
+]

--- a/src/clm/infrastructure/workers/lifecycle_manager.py
+++ b/src/clm/infrastructure/workers/lifecycle_manager.py
@@ -50,6 +50,7 @@ class WorkerLifecycleManager:
         session_id: str | None = None,
         cache_db_path: Path | None = None,
         data_dir: Path | None = None,
+        notebook_kernel_python: str = "",
     ):
         """Initialize lifecycle manager.
 
@@ -60,12 +61,16 @@ class WorkerLifecycleManager:
             session_id: Optional session ID for event logging
             cache_db_path: Path to executed notebook cache database
             data_dir: Path to source data directory (for Docker workers to mount)
+            notebook_kernel_python: Resolved interpreter for the Direct notebook
+                kernel (Wave 2b); "" = clm's own env. Forwarded to the pool
+                manager / direct executor.
         """
         self.config = config
         self.db_path = db_path
         self.workspace_path = workspace_path
         self.cache_db_path = cache_db_path
         self.data_dir = data_dir
+        self.notebook_kernel_python = notebook_kernel_python
         self.session_id = session_id or f"session-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
 
         # Worker pool manager (used for actual worker start/stop)
@@ -197,6 +202,7 @@ class WorkerLifecycleManager:
             network_name=self.config.network_name,
             log_level=logging.getLevelName(logger.getEffectiveLevel()),
             cache_db_path=self.cache_db_path,
+            notebook_kernel_python=self.notebook_kernel_python,
         )
 
         # Update discovery to use pool_manager's executors for accurate health checks

--- a/src/clm/infrastructure/workers/pool_manager.py
+++ b/src/clm/infrastructure/workers/pool_manager.py
@@ -119,6 +119,7 @@ class WorkerPoolManager:
         max_startup_concurrency: int | None = None,
         cache_db_path: Path | None = None,
         data_dir: Path | None = None,
+        notebook_kernel_python: str = "",
     ):
         """Initialize worker pool manager.
 
@@ -133,6 +134,9 @@ class WorkerPoolManager:
                 Defaults to CLM_MAX_WORKER_STARTUP_CONCURRENCY env var or 10.
             cache_db_path: Path to executed notebook cache database
             data_dir: Path to source data directory (for Docker workers to mount)
+            notebook_kernel_python: Resolved interpreter for the Direct notebook
+                kernel (Wave 2b); "" = clm's own env. Forwarded to the direct
+                executor; Docker mode ignores it.
         """
         self.db_path = db_path
         self.workspace_path = workspace_path
@@ -141,6 +145,7 @@ class WorkerPoolManager:
         self.network_name = network_name
         self.log_level = log_level
         self.cache_db_path = cache_db_path
+        self.notebook_kernel_python = notebook_kernel_python
 
         # Determine max startup concurrency
         if max_startup_concurrency is None:
@@ -206,6 +211,7 @@ class WorkerPoolManager:
                     workspace_path=self.workspace_path,
                     log_level=self.log_level,
                     cache_db_path=self.cache_db_path,
+                    notebook_kernel_python=self.notebook_kernel_python,
                 )
             else:
                 raise ValueError(f"Unknown execution mode: {mode}")

--- a/src/clm/infrastructure/workers/worker_executor.py
+++ b/src/clm/infrastructure/workers/worker_executor.py
@@ -583,6 +583,7 @@ class DirectWorkerExecutor(WorkerExecutor):
         workspace_path: Path,
         log_level: str = "INFO",
         cache_db_path: Path | None = None,
+        notebook_kernel_python: str = "",
     ):
         """Initialize direct process executor.
 
@@ -591,13 +592,30 @@ class DirectWorkerExecutor(WorkerExecutor):
             workspace_path: Path to workspace directory
             log_level: Logging level for workers
             cache_db_path: Path to executed notebook cache database
+            notebook_kernel_python: Resolved interpreter for the Python notebook
+                kernel (Wave 2b). Empty = run the kernel in clm's own env
+                (default). When set, a ``python3`` kernelspec pointing at it is
+                provisioned once here and prepended to each Direct notebook
+                worker's ``JUPYTER_PATH`` so the kernel subprocess runs in that
+                (course) environment. Docker mode ignores this — a host
+                interpreter path is meaningless inside a container.
         """
         self.db_path = db_path
         self.workspace_path = workspace_path
         self.log_level = log_level
         self.cache_db_path = cache_db_path
+        self.notebook_kernel_python = notebook_kernel_python
         self.processes: dict[str, subprocess.Popen] = {}
         self.worker_info: dict[str, dict] = {}  # worker_id -> {type, index, etc.}
+
+        # Provision the course kernelspec once (idempotent) so every notebook
+        # worker this executor starts shares one JUPYTER_PATH root. Fails fast
+        # at construction with an actionable error if the interpreter is bad.
+        self._kernel_jupyter_path_root: Path | None = None
+        if notebook_kernel_python:
+            from clm.infrastructure.workers.kernel_env import provision_course_kernel
+
+            self._kernel_jupyter_path_root = provision_course_kernel(Path(notebook_kernel_python))
 
         # Windows-only: kill-on-close JobObject that owns every worker
         # subprocess we start. On Windows, Popen.terminate() calls
@@ -699,6 +717,23 @@ class DirectWorkerExecutor(WorkerExecutor):
 
             # Config-resolved Jupyter settings for the notebook worker (Phase 4).
             env.update(_notebook_worker_jupyter_env())
+
+            # Course-runtime kernel isolation (Wave 2b): point the notebook
+            # kernel at a separate interpreter by prepending our provisioned
+            # `python3` kernelspec root to JUPYTER_PATH. Notebook workers only —
+            # other worker types don't launch a Jupyter kernel.
+            if worker_type == "notebook" and self._kernel_jupyter_path_root is not None:
+                from clm.infrastructure.workers.kernel_env import jupyter_path_with_kernel
+
+                env["JUPYTER_PATH"] = jupyter_path_with_kernel(
+                    self._kernel_jupyter_path_root, env.get("JUPYTER_PATH")
+                )
+                logger.debug(
+                    "Notebook worker %s: JUPYTER_PATH=%s (course kernel %s)",
+                    worker_id,
+                    env["JUPYTER_PATH"],
+                    self.notebook_kernel_python,
+                )
 
             # Build command
             cmd = [sys.executable, "-m", module]

--- a/tests/cli/test_provision_command.py
+++ b/tests/cli/test_provision_command.py
@@ -1,0 +1,64 @@
+"""Tests for the ``clm provision`` command group (Wave 2b)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from clm.cli.commands.provision import provision_group
+from clm.infrastructure.workers import kernel_env
+
+
+def test_group_help():
+    result = CliRunner().invoke(provision_group, ["--help"])
+    assert result.exit_code == 0
+    assert "kernel-env" in result.output
+
+
+def test_kernel_env_help():
+    result = CliRunner().invoke(provision_group, ["kernel-env", "--help"])
+    assert result.exit_code == 0
+    assert "--python" in result.output
+
+
+def test_kernel_env_registers_and_prints_activation(tmp_path, monkeypatch):
+    root = tmp_path / "kernel-envs"
+    monkeypatch.setattr(kernel_env, "_kernel_envs_root", lambda: root)
+    fake_python = tmp_path / "venv" / "python"
+
+    result = CliRunner().invoke(
+        provision_group,
+        ["kernel-env", "--python", str(fake_python), "--no-validate"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "CLM_NOTEBOOK_KERNEL_PYTHON" in result.output
+    assert "<kernel-python>" in result.output
+
+    # It actually wrote a python3 kernelspec pointing at the interpreter.
+    written = list(root.rglob("kernel.json"))
+    assert len(written) == 1
+    data = json.loads(written[0].read_text(encoding="utf-8"))
+    assert data["argv"][0] == str(fake_python)
+
+
+def test_kernel_env_missing_interpreter_is_clickexception(tmp_path):
+    missing = tmp_path / "nope" / "python"
+    result = CliRunner().invoke(provision_group, ["kernel-env", "--python", str(missing)])
+    # Validation failure surfaces as a clean CLI error, not a traceback.
+    assert result.exit_code != 0
+    assert "not found" in result.output
+
+
+def test_kernel_env_bad_ipykernel_is_clickexception(tmp_path, monkeypatch):
+    monkeypatch.setattr(kernel_env, "_kernel_envs_root", lambda: tmp_path / "ke")
+    real_file = tmp_path / "python"
+    real_file.write_text("", encoding="utf-8")
+    with patch.object(
+        kernel_env.subprocess, "run", return_value=MagicMock(returncode=1, stderr="")
+    ):
+        result = CliRunner().invoke(provision_group, ["kernel-env", "--python", str(real_file)])
+    assert result.exit_code != 0
+    assert "ipykernel" in result.output

--- a/tests/core/course_spec_test.py
+++ b/tests/core/course_spec_test.py
@@ -1353,6 +1353,22 @@ def test_from_file():
     assert course.dictionaries[2].name == Text(de="", en="")
 
 
+def test_kernel_python_defaults_empty():
+    """A spec without <kernel-python> leaves kernel_python empty (Wave 2b)."""
+    spec = CourseSpec.from_file(io.StringIO(COURSE_1_XML))
+    assert spec.kernel_python == ""
+
+
+def test_kernel_python_parsed_from_element():
+    """<kernel-python> at course level populates CourseSpec.kernel_python."""
+    xml = COURSE_1_XML.replace(
+        "</course>",
+        "    <kernel-python>/opt/course-venv/bin/python</kernel-python>\n</course>",
+    )
+    spec = CourseSpec.from_file(io.StringIO(xml))
+    assert spec.kernel_python == "/opt/course-venv/bin/python"
+
+
 class TestGitHubSpecDeriveDirName:
     """Tests for GitHubSpec.derive_dir_name."""
 

--- a/tests/infrastructure/workers/test_kernel_env.py
+++ b/tests/infrastructure/workers/test_kernel_env.py
@@ -1,0 +1,246 @@
+"""Tests for Wave 2b course-runtime kernel isolation (Direct mode).
+
+Covers the resolver precedence, kernelspec provisioning, JUPYTER_PATH
+assembly, and the DirectWorkerExecutor injection. No real kernel is launched;
+the ipykernel validation subprocess is patched or bypassed.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from clm.infrastructure.workers import kernel_env
+from clm.infrastructure.workers.kernel_env import (
+    KERNEL_PYTHON_ENV_VAR,
+    jupyter_path_with_kernel,
+    provision_course_kernel,
+    resolve_notebook_kernel_python,
+)
+from clm.infrastructure.workers.worker_executor import DirectWorkerExecutor, WorkerConfig
+
+# --------------------------------------------------------------------------- #
+# resolve_notebook_kernel_python — env > spec > clm.toml > empty
+# --------------------------------------------------------------------------- #
+
+
+def test_resolve_env_wins_over_spec_and_toml(monkeypatch):
+    monkeypatch.setenv(KERNEL_PYTHON_ENV_VAR, "/env/python")
+    fake_cfg = MagicMock()
+    fake_cfg.jupyter.kernel_python = "/toml/python"
+    with patch("clm.infrastructure.config.get_config", return_value=fake_cfg):
+        assert resolve_notebook_kernel_python("/spec/python") == "/env/python"
+
+
+def test_resolve_spec_wins_over_toml(monkeypatch):
+    monkeypatch.delenv(KERNEL_PYTHON_ENV_VAR, raising=False)
+    fake_cfg = MagicMock()
+    fake_cfg.jupyter.kernel_python = "/toml/python"
+    with patch("clm.infrastructure.config.get_config", return_value=fake_cfg):
+        assert resolve_notebook_kernel_python("/spec/python") == "/spec/python"
+
+
+def test_resolve_falls_back_to_toml(monkeypatch):
+    monkeypatch.delenv(KERNEL_PYTHON_ENV_VAR, raising=False)
+    fake_cfg = MagicMock()
+    fake_cfg.jupyter.kernel_python = "/toml/python"
+    with patch("clm.infrastructure.config.get_config", return_value=fake_cfg):
+        assert resolve_notebook_kernel_python("") == "/toml/python"
+
+
+def test_resolve_empty_default(monkeypatch):
+    monkeypatch.delenv(KERNEL_PYTHON_ENV_VAR, raising=False)
+    fake_cfg = MagicMock()
+    fake_cfg.jupyter.kernel_python = ""
+    with patch("clm.infrastructure.config.get_config", return_value=fake_cfg):
+        assert resolve_notebook_kernel_python("") == ""
+
+
+def test_resolve_env_whitespace_is_ignored(monkeypatch):
+    monkeypatch.setenv(KERNEL_PYTHON_ENV_VAR, "   ")
+    fake_cfg = MagicMock()
+    fake_cfg.jupyter.kernel_python = ""
+    with patch("clm.infrastructure.config.get_config", return_value=fake_cfg):
+        # Blank env falls through to the spec value.
+        assert resolve_notebook_kernel_python("/spec/python") == "/spec/python"
+
+
+# --------------------------------------------------------------------------- #
+# provision_course_kernel
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def kernel_root(tmp_path, monkeypatch):
+    """Redirect provisioning output into tmp_path instead of the user data dir."""
+    root = tmp_path / "kernel-envs"
+    monkeypatch.setattr(kernel_env, "_kernel_envs_root", lambda: root)
+    return root
+
+
+def test_provision_writes_python3_kernelspec(kernel_root, tmp_path):
+    fake_python = tmp_path / "venv" / "python"
+    # validate=False so we don't need a real interpreter with ipykernel.
+    root = provision_course_kernel(fake_python, validate=False)
+
+    kernel_json_path = root / "kernels" / "python3" / "kernel.json"
+    assert kernel_json_path.is_file()
+    data = json.loads(kernel_json_path.read_text(encoding="utf-8"))
+    assert data["argv"][0] == str(fake_python)
+    assert data["argv"][1:] == ["-m", "ipykernel_launcher", "-f", "{connection_file}"]
+    assert data["language"] == "python"
+    # The returned root is the JUPYTER_PATH entry (contains kernels/).
+    assert (root / "kernels").is_dir()
+
+
+def test_provision_is_idempotent_per_interpreter(kernel_root, tmp_path):
+    fake_python = tmp_path / "python"
+    root_a = provision_course_kernel(fake_python, validate=False)
+    root_b = provision_course_kernel(fake_python, validate=False)
+    assert root_a == root_b
+
+
+def test_provision_distinct_interpreters_distinct_roots(kernel_root, tmp_path):
+    root_a = provision_course_kernel(tmp_path / "a" / "python", validate=False)
+    root_b = provision_course_kernel(tmp_path / "b" / "python", validate=False)
+    assert root_a != root_b
+
+
+def test_provision_missing_interpreter_raises(kernel_root, tmp_path):
+    missing = tmp_path / "does-not-exist" / "python"
+    with pytest.raises(RuntimeError, match="not found"):
+        provision_course_kernel(missing, validate=True)
+
+
+def test_validate_ipykernel_failure_raises(kernel_root, tmp_path):
+    real_file = tmp_path / "python"
+    real_file.write_text("", encoding="utf-8")
+    failed = MagicMock(returncode=1, stderr="ModuleNotFoundError: ipykernel")
+    with patch.object(kernel_env.subprocess, "run", return_value=failed):
+        with pytest.raises(RuntimeError, match="ipykernel"):
+            provision_course_kernel(real_file, validate=True)
+
+
+def test_validate_ipykernel_success_writes_spec(kernel_root, tmp_path):
+    real_file = tmp_path / "python"
+    real_file.write_text("", encoding="utf-8")
+    ok = MagicMock(returncode=0, stderr="")
+    with patch.object(kernel_env.subprocess, "run", return_value=ok):
+        root = provision_course_kernel(real_file, validate=True)
+    assert (root / "kernels" / "python3" / "kernel.json").is_file()
+
+
+# --------------------------------------------------------------------------- #
+# jupyter_path_with_kernel
+# --------------------------------------------------------------------------- #
+
+
+def test_jupyter_path_prepends_when_existing():
+    import os
+
+    root = Path("/course/root")
+    result = jupyter_path_with_kernel(root, f"/prior{os.pathsep}/more")
+    assert result == f"{root}{os.pathsep}/prior{os.pathsep}/more"
+    # Course root sits first so its python3 kernelspec shadows clm's own.
+    assert result.split(os.pathsep)[0] == str(root)
+
+
+def test_jupyter_path_no_existing():
+    root = Path("/course/root")
+    assert jupyter_path_with_kernel(root, None) == str(root)
+    assert jupyter_path_with_kernel(root, "") == str(root)
+
+
+# --------------------------------------------------------------------------- #
+# DirectWorkerExecutor injection
+# --------------------------------------------------------------------------- #
+
+
+@patch("subprocess.Popen")
+def test_executor_injects_jupyter_path_for_notebook(mock_popen, tmp_path):
+    mock_popen.return_value = MagicMock(pid=4321)
+    fake_root = tmp_path / "kernel-root"
+
+    with patch(
+        "clm.infrastructure.workers.kernel_env.provision_course_kernel",
+        return_value=fake_root,
+    ) as prov:
+        executor = DirectWorkerExecutor(
+            db_path=tmp_path / "jobs.db",
+            workspace_path=tmp_path / "ws",
+            notebook_kernel_python="/course/venv/python",
+        )
+    prov.assert_called_once()
+
+    config = WorkerConfig(worker_type="notebook", count=1, execution_mode="direct")
+    executor.start_worker("notebook", 0, config)
+
+    env = mock_popen.call_args[1]["env"]
+    import os
+
+    assert env["JUPYTER_PATH"].split(os.pathsep)[0] == str(fake_root)
+
+
+@patch("subprocess.Popen")
+def test_executor_skips_jupyter_path_for_non_notebook(mock_popen, tmp_path):
+    mock_popen.return_value = MagicMock(pid=4321)
+    fake_root = tmp_path / "kernel-root"
+    with patch(
+        "clm.infrastructure.workers.kernel_env.provision_course_kernel",
+        return_value=fake_root,
+    ):
+        executor = DirectWorkerExecutor(
+            db_path=tmp_path / "jobs.db",
+            workspace_path=tmp_path / "ws",
+            notebook_kernel_python="/course/venv/python",
+        )
+    config = WorkerConfig(worker_type="plantuml", count=1, execution_mode="direct")
+    executor.start_worker("plantuml", 0, config)
+
+    env = mock_popen.call_args[1]["env"]
+    # A plantuml worker launches no Jupyter kernel — no course JUPYTER_PATH.
+    assert str(fake_root) not in env.get("JUPYTER_PATH", "")
+
+
+def test_jupyter_client_resolves_python3_to_provisioned_kernel(kernel_root, tmp_path, monkeypatch):
+    """End-to-end mechanism check: JUPYTER_PATH → our python3 kernelspec wins.
+
+    Proves the load-bearing assumption without launching a kernel: with our
+    provisioned root on JUPYTER_PATH, jupyter_client's KernelSpecManager resolves
+    the ``python3`` name to the interpreter we pointed at (shadowing clm's own).
+    """
+    import os
+
+    pytest.importorskip("jupyter_client")
+    from jupyter_client.kernelspec import KernelSpecManager
+
+    fake_python = tmp_path / "course-venv" / "python"
+    root = provision_course_kernel(fake_python, validate=False)
+
+    monkeypatch.setenv("JUPYTER_PATH", str(root))
+    spec = KernelSpecManager().get_kernel_spec("python3")
+
+    assert spec.argv[0] == str(fake_python)
+    assert os.path.commonpath([spec.resource_dir, str(root)]) == str(root)
+
+
+@patch("subprocess.Popen")
+def test_executor_no_provisioning_when_unset(mock_popen, tmp_path):
+    mock_popen.return_value = MagicMock(pid=4321)
+    with patch("clm.infrastructure.workers.kernel_env.provision_course_kernel") as prov:
+        executor = DirectWorkerExecutor(
+            db_path=tmp_path / "jobs.db",
+            workspace_path=tmp_path / "ws",
+        )
+    # Empty (default) → no provisioning at all, today's behaviour untouched.
+    prov.assert_not_called()
+    assert executor._kernel_jupyter_path_root is None
+
+    config = WorkerConfig(worker_type="notebook", count=1, execution_mode="direct")
+    executor.start_worker("notebook", 0, config)
+    env = mock_popen.call_args[1]["env"]
+    # We didn't add a course kernel; JUPYTER_PATH is whatever the host had (if any).
+    assert executor.notebook_kernel_python == ""


### PR DESCRIPTION
## Wave 2b-1 — course-runtime kernel isolation (Direct mode)

Implements the design landed in #530. Direct-mode notebook execution can now
launch its **Python kernel from a course venv**, so course-runtime packages
(`[ml]`: torch/pandas/…) live in a separate environment from clm's own while clm
keeps driving nbconvert — mirroring what the Docker notebook image already does.
**Fully opt-in and inert until configured.**

### Mechanism (no execution-hot-path change)
nbconvert resolves the `python3` kernel from the notebook's `kernelspec.name`,
and `jupyter_client` searches `JUPYTER_PATH` dirs **first**. So we provision a
`python3/kernel.json` whose `argv[0]` is the course interpreter and prepend its
root to the Direct notebook worker's `JUPYTER_PATH`. A **hermetic test** drives
`jupyter_client`'s `KernelSpecManager` to prove `python3` really resolves to the
provisioned interpreter.

### What's included
- **`clm.infrastructure.workers.kernel_env`** — `resolve_notebook_kernel_python`
  (precedence: env `CLM_NOTEBOOK_KERNEL_PYTHON` > course-spec `<kernel-python>` >
  `clm.toml [jupyter].kernel_python` > `""` = clm's env), `provision_course_kernel`
  (writes the kernelspec under `platformdirs.user_data_dir`, validates `ipykernel`),
  `jupyter_path_with_kernel`.
- **Config** — `JupyterConfig.kernel_python` (the `clm.toml` tier).
- **Spec** — course-level `<kernel-python>` → `CourseSpec.kernel_python`.
- **Wiring** — `build.py` resolves once (spec in scope) and threads
  `notebook_kernel_python` through `WorkerLifecycleManager` → `WorkerPoolManager`
  → `DirectWorkerExecutor`, which provisions once and injects `JUPYTER_PATH` for
  **notebook workers only**. Docker mode ignores it; other worker types launch no
  kernel.
- **`clm provision` group** — `clm provision kernel-env --python <path>` registers
  an existing interpreter (does not create the venv; `--no-validate` to skip the
  ipykernel check).
- **Scope** — only the `python3` kernel; C++/C#/Java/TS kernels untouched.
- **Docs** — `clm info commands` + `clm info spec-files`; changelog fragment.

`[ml]` stays a clm extra in 2b-1; **2b-2** repositions it as a *course* extra and
updates installation docs.

### Validation
- New unit tests: resolver precedence, provisioning (idempotent, missing-interp,
  ipykernel validation), `JUPYTER_PATH` assembly, executor injection
  (notebook-only, unset = no-op), and the `clm provision` command.
- Hermetic end-to-end: `jupyter_client` resolves `python3` to the provisioned kernel.
- 145 worker-infra + 181 build/config + 15 info-topic tests pass; ruff/mypy clean;
  pre-push fast suite passed.

Design: `docs/claude/design/dependency-environment-isolation.md` (Wave 2b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
