### PR TITLE
feat(sync): v3 BilingualDeck model + doc lenses with round-trip law suite (#520 Phase 1)

### DIFF
--- a/changelog.d/520-bilingual-doc-lenses.added.md
+++ b/changelog.d/520-bilingual-doc-lenses.added.md
@@ -1,0 +1,16 @@
+- **Sync v3 Phase 1 — canonical bilingual document model + lens projections** (#520):
+  new `clm.slides.bilingual_doc` (the `BilingualDeck` model with total `MemberKey`
+  identity per design §3.3) and `clm.slides.doc_lenses` (`parse_bundle` reads the
+  ≤4-file deck+companion bundle into one document; `project` renders each file back
+  byte-identically). Projection mismatches (one-sided members, shared divergence,
+  the #443 id'd-on-one-half shape, layout mixtures) are recorded as first-class
+  observations; input failing the §3.4 normalize precondition (duplicate ids,
+  id-less anchors, id-less localized/narrative cells) yields a framed
+  "normalize first" refusal with every reason enumerated. Round-trip laws are
+  pinned by golden + Hypothesis property tests plus a corpus gate
+  (`tests/data/doc_corpus` bundled fixtures in CI; the full-corpus
+  `project ∘ parse` byte-identity run verified locally over PythonCourses:
+  644/706 pairs parse — the 62 refusals are the standing normalize worklist —
+  with zero byte divergences). Internal-only for now: no CLI surface change; the
+  v2 engine is untouched (an import-cleanliness test pins that the v3 modules
+  never import `sync_plan`/`sync_apply`/`sync_code`, per the §12.5 cutover design).

--- a/src/clm/slides/bilingual_doc.py
+++ b/src/clm/slides/bilingual_doc.py
@@ -202,11 +202,13 @@ class SlideGroup:
 #   one_sided_group        whole group present on one side only
 #   id_stamp_pending_twin  id'd on one half, id-less positional twin (#443)
 #   lang_attr_mismatch     paired sides disagree about lang-ness
+#   member_kind_mismatch   paired sides disagree about the cell kind
 #   wrong_language_cell    a cell whose lang attr contradicts its file side
 #   preamble_divergence    DE/EN deck preambles differ
 #   layout_mixed           one half has inline voiceover AND a companion
 #   layout_cross_language  the halves use different voiceover layouts
 #   owner_missing          companion member's for_slide matches no anchor
+#   owner_mismatch         paired companion sides name different owners
 #   group_order_divergence paired groups appear in different order per side
 #   unexpected_companion_cell  non-narrative cell in a companion file
 ObservationKind = str
@@ -226,7 +228,9 @@ class Observation:
 class RefusalReason:
     """One reason a bundle failed the §3.4 normalize precondition."""
 
-    code: str  # duplicate_id | idless_anchor | idless_localized | idless_narrative
+    # duplicate_id | idless_anchor | idless_localized | idless_narrative
+    # | legacy_title_companion
+    code: str
     detail: str
     member: MemberKey | None = None
 

--- a/src/clm/slides/bilingual_doc.py
+++ b/src/clm/slides/bilingual_doc.py
@@ -1,0 +1,309 @@
+"""The canonical bilingual document model for sync v3 (#520 Phase 1).
+
+One deck is *one* :class:`BilingualDeck`, and the up-to-four on-disk files
+(``slides_x.de.py`` / ``slides_x.en.py`` plus the optional
+``voiceover_x.de.py`` / ``voiceover_x.en.py`` companions) are lens
+projections of it — the ``split``/``unify`` discipline lifted from the text
+layer to a parsed model, per
+``docs/claude/design/sync-total-identity-document-model.md`` §3–§4.
+
+The load-bearing rules (design §2):
+
+* **P1 — identity is total.** Every logical cell has exactly one
+  :class:`MemberKey`, computed once at parse time by the §3.3 rule:
+  ``id:<slide_id>`` when the cell carries a slide id, else
+  ``pos:<group>/<kind>/<i>`` (owning group's anchor id, kind-class, ordinal
+  among the group's id-less members of that kind-class).
+* **P2 — identity is invariant under every mutable attribute.** Lang-ness,
+  tags, content, and layout (inline/companion) are member *state*, never
+  identity-regime selectors.
+* **P4 — one document, N projections.** A member stores its verbatim
+  per-side cells (:class:`SideCell`); projection re-emits those bytes and
+  never regenerates headers, so ``project ∘ parse`` is byte-identity by
+  construction wherever parsing assigned every input cell to exactly one
+  member.
+
+The model deliberately stores *per-side* content even for ``shared``
+members: a shared member whose two projections have diverged (an in-flight
+edit) is recorded as an :class:`Observation` — first-class evidence for the
+Phase 2 differ — while the bytes of both sides remain reproducible.
+
+This module is a pure data model: no I/O, no imports from the v2 sync core
+(``sync_plan`` / ``sync_apply`` / ``sync_code`` — enforced by the
+import-cleanliness test, design §12.5). Parsing and projection live in
+:mod:`clm.slides.doc_lenses`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Literal
+
+from attrs import define, field, frozen
+
+__all__ = [
+    "HEADER_GROUP",
+    "ORPHAN_GROUP",
+    "PREFACE_GROUP",
+    "BilingualDeck",
+    "Member",
+    "MemberKey",
+    "NormalizeRefusal",
+    "Observation",
+    "ParseOutcome",
+    "RefusalReason",
+    "SideCell",
+    "SlideGroup",
+]
+
+Lang = Literal["de", "en"]
+Part = Literal["deck", "companion"]
+
+# Group tokens for positional keys outside anchored slide groups. ``~`` is not
+# a valid slug character, so these can never collide with a real slide id.
+HEADER_GROUP = "~header"
+PREFACE_GROUP = "~preface"
+ORPHAN_GROUP = "~orphan"
+
+
+# ---------------------------------------------------------------------------
+# Identity
+# ---------------------------------------------------------------------------
+
+
+@frozen
+class MemberKey:
+    """The one identity of a logical cell (design §3.3).
+
+    ``scheme == "id"``: ``value`` is the bare slide id (preserve marker ``!``
+    stripped). ``scheme == "pos"``: ``value`` is
+    ``<group>/<kind>/<ordinal>`` where ``group`` is the owning group's bare
+    anchor id (or :data:`HEADER_GROUP` / :data:`PREFACE_GROUP`), ``kind`` the
+    cell kind-class (``markdown`` / ``code`` / ``j2``), and ``ordinal`` the
+    0-based position among the group's id-less members of that kind-class in
+    merged document order.
+    """
+
+    scheme: Literal["id", "pos"]
+    value: str
+
+    @classmethod
+    def for_id(cls, slide_id: str) -> MemberKey:
+        return cls(scheme="id", value=slide_id)
+
+    @classmethod
+    def positional(cls, group: str, kind: str, ordinal: int) -> MemberKey:
+        return cls(scheme="pos", value=f"{group}/{kind}/{ordinal}")
+
+    def render(self) -> str:
+        """The canonical string handle (``id:intro`` / ``pos:title/j2/0``)."""
+        return f"{self.scheme}:{self.value}"
+
+    @classmethod
+    def parse(cls, text: str) -> MemberKey:
+        scheme, sep, value = text.partition(":")
+        if not sep or scheme not in ("id", "pos") or not value:
+            raise ValueError(f"not a MemberKey: {text!r}")
+        return cls(scheme=scheme, value=value)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Members
+# ---------------------------------------------------------------------------
+
+
+@frozen
+class SideCell:
+    """One side's verbatim cell — the byte-identity carrier.
+
+    ``lines`` is the raw line list of the percent-format cell (header line
+    first, trailing blank separator lines included), exactly as split from
+    the source file. ``index`` is the cell's 0-based ordinal within its
+    source file's cell stream; projection re-emits cells sorted by it.
+    """
+
+    lines: tuple[str, ...]
+    index: int
+    line_number: int  # 1-based line of the header in the source file
+    part: Part
+    lang_attr: str | None  # the cell's lang="…" attribute, verbatim
+    tags: tuple[str, ...]
+    slide_id: str | None  # verbatim, may carry the ``!`` preserve marker
+    for_slide: str | None
+    vo_anchor: str | None
+    cell_type: str  # markdown | code | j2
+
+    @property
+    def header(self) -> str:
+        return self.lines[0]
+
+    @property
+    def body(self) -> str:
+        return "\n".join(self.lines[1:])
+
+
+@define
+class Member:
+    """One logical cell of the bilingual document (design §3.1).
+
+    A shared member normally appears byte-identically on both sides; a
+    localized member appears as its ``lang="de"`` variant in the DE
+    projection and its ``lang="en"`` variant in the EN projection; a
+    ``layout == "companion"`` member appears in the ``voiceover_*`` files.
+    A missing side (``de``/``en`` is ``None``) is a pending state, recorded
+    as an observation, never an error.
+    """
+
+    key: MemberKey
+    kind: str  # markdown | code | j2
+    role: str  # header | slide | subslide | voiceover | notes | code | aux
+    langness: str  # shared | localized
+    layout: str  # inline | companion
+    owner: MemberKey | None  # owning slide anchor; serialized as for_slide
+    de: SideCell | None
+    en: SideCell | None
+
+    @property
+    def is_one_sided(self) -> bool:
+        return (self.de is None) != (self.en is None)
+
+    def side(self, lang: Lang) -> SideCell | None:
+        return self.de if lang == "de" else self.en
+
+
+@define
+class SlideGroup:
+    """An anchored slide group: the id'd anchor member plus everything until
+    the next anchor (design §3.1).
+
+    ``anchor`` is ``None`` only for the synthetic preface group (content
+    before the first slide in a deck without a title macro). ``anchor_id``
+    is the bare anchor id (``"title"`` for the title-macro group,
+    :data:`PREFACE_GROUP` for the preface group).
+    """
+
+    anchor_id: str
+    anchor: Member | None
+    members: list[Member] = field(factory=list)
+
+    def all_members(self) -> Iterator[Member]:
+        if self.anchor is not None:
+            yield self.anchor
+        yield from self.members
+
+
+# ---------------------------------------------------------------------------
+# Observations and refusals
+# ---------------------------------------------------------------------------
+
+# Observation kinds (design §3.2 — recorded mismatches, never errors):
+#   shared_divergence      shared member whose two sides differ byte-wise
+#   one_sided_member       member present on one side only
+#   one_sided_group        whole group present on one side only
+#   id_stamp_pending_twin  id'd on one half, id-less positional twin (#443)
+#   lang_attr_mismatch     paired sides disagree about lang-ness
+#   wrong_language_cell    a cell whose lang attr contradicts its file side
+#   preamble_divergence    DE/EN deck preambles differ
+#   layout_mixed           one half has inline voiceover AND a companion
+#   layout_cross_language  the halves use different voiceover layouts
+#   owner_missing          companion member's for_slide matches no anchor
+#   group_order_divergence paired groups appear in different order per side
+#   unexpected_companion_cell  non-narrative cell in a companion file
+ObservationKind = str
+
+
+@frozen
+class Observation:
+    """A first-class recorded mismatch on the document (design §3.2)."""
+
+    kind: ObservationKind
+    member: MemberKey | None = None
+    side: Lang | None = None
+    detail: str = ""
+
+
+@frozen
+class RefusalReason:
+    """One reason a bundle failed the §3.4 normalize precondition."""
+
+    code: str  # duplicate_id | idless_anchor | idless_localized | idless_narrative
+    detail: str
+    member: MemberKey | None = None
+
+
+@define
+class NormalizeRefusal:
+    """A framed "run normalize first" refusal for a whole deck (design §3.2).
+
+    Every offending condition is enumerated (never first-error-only), so one
+    normalize pass can fix them all.
+    """
+
+    reasons: list[RefusalReason] = field(factory=list)
+
+    def render(self) -> str:
+        lines = ["deck is not normalized — run `clm slides normalize --stamp-ids` first:"]
+        lines += [f"  - [{r.code}] {r.detail}" for r in self.reasons]
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# The document
+# ---------------------------------------------------------------------------
+
+
+@define
+class BilingualDeck:
+    """The canonical parsed document over the ≤4-file bundle (design §3.1).
+
+    ``*_preamble`` fields hold the verbatim lines before the first cell
+    boundary of each source file; a ``None`` companion preamble means that
+    companion file was absent from the bundle (an empty present file is an
+    empty tuple). ``header`` holds the per-language j2/header members that
+    precede the title group. ``orphans`` holds companion members whose
+    ``for_slide`` matched no anchor — kept so projection never drops them.
+    """
+
+    comment_token: str
+    de_deck_preamble: tuple[str, ...]
+    en_deck_preamble: tuple[str, ...]
+    de_companion_preamble: tuple[str, ...] | None
+    en_companion_preamble: tuple[str, ...] | None
+    header: list[Member] = field(factory=list)
+    groups: list[SlideGroup] = field(factory=list)
+    orphans: list[Member] = field(factory=list)
+    observations: list[Observation] = field(factory=list)
+
+    def members(self) -> Iterator[Member]:
+        """Every member in document order (header, groups, orphans)."""
+        yield from self.header
+        for group in self.groups:
+            yield from group.all_members()
+        yield from self.orphans
+
+    def member_by_key(self, key: MemberKey) -> Member | None:
+        for member in self.members():
+            if member.key == key:
+                return member
+        return None
+
+    def has_companion(self, lang: Lang) -> bool:
+        preamble = self.de_companion_preamble if lang == "de" else self.en_companion_preamble
+        return preamble is not None
+
+
+@define
+class ParseOutcome:
+    """Result of :func:`clm.slides.doc_lenses.parse_bundle`.
+
+    Exactly one of ``deck`` / ``refusal`` is set. A refusal is the framed
+    §3.4 "normalize first" outcome — never an exception, never a degraded
+    heuristic parse.
+    """
+
+    deck: BilingualDeck | None = None
+    refusal: NormalizeRefusal | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.deck is not None

--- a/src/clm/slides/doc_lenses.py
+++ b/src/clm/slides/doc_lenses.py
@@ -42,6 +42,7 @@ This module must not import from the v2 sync core (``sync_plan`` /
 from __future__ import annotations
 
 import logging
+import re
 from collections import Counter
 from collections.abc import Callable
 from pathlib import Path
@@ -171,8 +172,31 @@ class _DeckSeg:
     groups: list[_GroupSeg] = field(factory=list)
 
 
+# The slide_id attribute, for parity checks that must ignore it (the same
+# strip form assign_ids._SLIDE_ID_RE uses when rewriting ids).
+_SLIDE_ID_ATTR_RE = re.compile(r'\s*slide_id="[^"]*"')
+
+
+def _lines_sans_id(cell: SideCell) -> tuple[str, ...]:
+    """The cell's verbatim lines with the header's slide_id attribute removed.
+
+    Shared-member byte parity is judged modulo the id attribute: a shared
+    pair differing *only* by a one-sided id stamp is the #443 transition
+    (observed as ``id_stamp_pending_twin``), not a content divergence —
+    reporting both would be noise.
+    """
+    return (_SLIDE_ID_ATTR_RE.sub("", cell.lines[0]), *cell.lines[1:])
+
+
 def _bare(slide_id: str | None) -> str | None:
-    return strip_preserve_marker(slide_id) if slide_id else None
+    """The bare id, or ``None`` for absent, empty, or marker-only ids.
+
+    ``slide_id=""`` and ``slide_id="!"`` carry no usable identity — treating
+    them as id'd would bypass the id-less refusals and mint empty keys.
+    """
+    if not slide_id:
+        return None
+    return strip_preserve_marker(slide_id) or None
 
 
 def _segment_deck(source: _Source) -> _DeckSeg:
@@ -308,6 +332,11 @@ class _Parser:
         # DE cell -> EN cell pairing, across parts (one map per bundle).
         self.pairs: dict[_Ref, _Ref] = {}
         self.paired_en: set[_Ref] = set()
+        # Member-keyed observations are recorded against the Member OBJECT and
+        # materialized only after positional ordinals are assigned — otherwise
+        # a frozen Observation would carry the pre-ordinal sentinel key and
+        # never resolve via member_by_key (P1: identity carried unchanged).
+        self._member_obs: list[tuple[str, Member, Lang | None, str]] = []
 
     # -- plumbing -------------------------------------------------------------
 
@@ -334,6 +363,21 @@ class _Parser:
     def refuse(self, code: str, detail: str, member: MemberKey | None = None) -> None:
         self.refusals.append(RefusalReason(code=code, detail=detail, member=member))
 
+    def observe_member(
+        self,
+        kind: str,
+        member: Member,
+        side: Lang | None = None,
+        detail: str = "",
+    ) -> None:
+        """Record an observation about ``member``, keyed once keys are final."""
+        self._member_obs.append((kind, member, side, detail))
+
+    def _materialize_member_observations(self) -> None:
+        for kind, member, side, detail in self._member_obs:
+            self.observe(kind, member=member.key, side=side, detail=detail)
+        self._member_obs.clear()
+
     # -- phase 1: keying preconditions ------------------------------------------
 
     def check_keying(self) -> None:
@@ -344,6 +388,12 @@ class _Parser:
         DE and EN sides are the only sanctioned repetition. The legacy
         inherited-id narrative (``slide_id`` equal to the owning slide's) is
         exactly such a duplicate — a normalize-first refusal, per §12.1.
+
+        Keying refusals return *before* pairing, so the §3.4 conditions that
+        need pairing to judge (id-less localized/narrative vs the #443
+        transition) are not enumerated alongside them — rule-2 resolution is
+        meaningless without unique keys. That costs no extra author round
+        trip: ``normalize --stamp-ids`` repairs both classes in one pass.
         """
         for lang in LANGS:
             counts: Counter[str] = Counter()
@@ -368,10 +418,13 @@ class _Parser:
                     )
         for lang, deck in (("de", self.de_deck), ("en", self.en_deck)):
             for cell in deck.cells:
-                if ("slide" in cell.tags or "subslide" in cell.tags) and cell.slide_id is None:
+                if ("slide" in cell.tags or "subslide" in cell.tags) and _bare(
+                    cell.slide_id
+                ) is None:
                     self.refuse(
                         "idless_anchor",
-                        f"slide-start cell without slide_id (deck.{lang} line {cell.line_number})",
+                        f"slide-start cell without a usable slide_id "
+                        f"(deck.{lang} line {cell.line_number})",
                     )
 
     # -- phase 2: pairing --------------------------------------------------------
@@ -414,40 +467,64 @@ class _Parser:
     def pair_positionally(self, de_idxs: list[int], en_idxs: list[int], part: Part) -> None:
         """Rule-2 pairing of one kind-class pool of leftover cells.
 
-        First id-less × id-less by ordinal (the steady-state shared members),
-        then id'd × id-less (the #443 id-stamp-pending shape); whatever
-        remains stays one-sided.
+        Two cursors walk the pools slot by slot, so an id'd-on-one-half cell
+        *occupies its positional slot* rather than being pushed behind the
+        id-less residue (which would shift every later sibling onto the
+        wrong twin — the interleaved-#443 mis-adoption):
+
+        - id-less × id-less: the steady-state positional pair.
+        - exactly one side id'd: the #443 id-stamp-pending shape — adopted
+          when the id-less twin is localized (lang-tagged, where cross-side
+          bodies differ by nature) or, for shared cells, when the bodies are
+          byte-equal (an id stamped onto one half of an unchanged cell). A
+          shared-class id'd cell with a *different* body is a genuinely new
+          one-sided member: only its own side's cursor advances, so the
+          remaining id-less cells still align.
+        - both sides id'd (necessarily different ids, or the global by-id
+          pass would have paired them): two one-sided members.
+
+        Whatever remains past either pool's end stays one-sided.
         """
         de_pool = self._unpaired("de", part, de_idxs)
         en_pool = self._unpaired("en", part, en_idxs)
-        de_idless = [i for i in de_pool if self._cell("de", (part, i)).slide_id is None]
-        en_idless = [i for i in en_pool if self._cell("en", (part, i)).slide_id is None]
-        for de_i, en_i in zip(de_idless, en_idless, strict=False):
-            self.pairs[(part, de_i)] = (part, en_i)
-        # The #443 pass: an id'd cell on one half adopts the positional
-        # id-less residue on the other; the id'd side's key wins.
-        de_idd = [i for i in de_pool if self._cell("de", (part, i)).slide_id is not None]
-        en_idd = [i for i in en_pool if self._cell("en", (part, i)).slide_id is not None]
-        de_idless_rest = de_idless[len(en_idless) :]
-        en_idless_rest = en_idless[len(de_idless) :]
-        for de_i, en_i in zip(de_idd, en_idless_rest, strict=False):
-            self.pairs[(part, de_i)] = (part, en_i)
-            key = _bare(self._cell("de", (part, de_i)).slide_id)
-            self.observe(
-                "id_stamp_pending_twin",
-                member=MemberKey.for_id(key or "?"),
-                side="en",
-                detail="id'd on the de half only; the en twin pairs positionally (#443)",
-            )
-        for de_i, en_i in zip(de_idless_rest, en_idd, strict=False):
-            self.pairs[(part, de_i)] = (part, en_i)
-            key = _bare(self._cell("en", (part, en_i)).slide_id)
-            self.observe(
-                "id_stamp_pending_twin",
-                member=MemberKey.for_id(key or "?"),
-                side="de",
-                detail="id'd on the en half only; the de twin pairs positionally (#443)",
-            )
+        i = j = 0
+        while i < len(de_pool) and j < len(en_pool):
+            de_cell = self._cell("de", (part, de_pool[i]))
+            en_cell = self._cell("en", (part, en_pool[j]))
+            de_id = _bare(de_cell.slide_id)
+            en_id = _bare(en_cell.slide_id)
+            if de_id is None and en_id is None:
+                self.pairs[(part, de_pool[i])] = (part, en_pool[j])
+                i += 1
+                j += 1
+                continue
+            if de_id is not None and en_id is not None:
+                i += 1
+                j += 1
+                continue
+            idd_cell, idless_cell = (de_cell, en_cell) if de_id else (en_cell, de_cell)
+            adopt = idless_cell.lang_attr is not None or idd_cell.lines[1:] == idless_cell.lines[1:]
+            if adopt:
+                self.pairs[(part, de_pool[i])] = (part, en_pool[j])
+                idless_side: Lang = "en" if de_id else "de"
+                idd_side = "de" if de_id else "en"
+                self.observe(
+                    "id_stamp_pending_twin",
+                    member=MemberKey.for_id(de_id or en_id or "?"),
+                    side=idless_side,
+                    detail=(
+                        f"id'd on the {idd_side} half only; the {idless_side} twin "
+                        f"pairs positionally (#443)"
+                    ),
+                )
+                i += 1
+                j += 1
+                continue
+            # Unrelated one-sided id'd shared cell: skip it, keep alignment.
+            if de_id is not None:
+                i += 1
+            else:
+                j += 1
 
     def pair_region(
         self,
@@ -527,29 +604,6 @@ class _Parser:
         if primary is None:  # pragma: no cover - callers pass at least one ref
             raise DocLensError("member with no sides")
         kind = primary.cell_type
-        key = self._key_of(de_cell, en_cell)
-        if de_cell and en_cell:
-            if de_cell.cell_type != en_cell.cell_type:
-                self.observe(
-                    "member_kind_mismatch",
-                    member=key,
-                    detail=f"paired cells have kinds {de_cell.cell_type}/{en_cell.cell_type}",
-                )
-            if (de_cell.lang_attr is None) != (en_cell.lang_attr is None):
-                self.observe(
-                    "lang_attr_mismatch",
-                    member=key,
-                    detail=(
-                        f"lang attribute present on one side only "
-                        f"(de: {de_cell.lang_attr!r}, en: {en_cell.lang_attr!r})"
-                    ),
-                )
-            if de_cell.part != en_cell.part:
-                self.observe(
-                    "layout_cross_language",
-                    member=key,
-                    detail="member is inline on one half and in the companion on the other",
-                )
         langness = (
             "localized"
             if (de_cell and de_cell.lang_attr) or (en_cell and en_cell.lang_attr)
@@ -559,7 +613,7 @@ class _Parser:
         if role == "header":
             langness = "localized"  # header members are per-language by design
         member = Member(
-            key=key,
+            key=self._key_of(de_cell, en_cell),
             kind=kind,
             role=role,
             langness=langness,
@@ -568,11 +622,33 @@ class _Parser:
             de=de_cell,
             en=en_cell,
         )
+        if de_cell and en_cell:
+            if de_cell.cell_type != en_cell.cell_type:
+                self.observe_member(
+                    "member_kind_mismatch",
+                    member,
+                    detail=f"paired cells have kinds {de_cell.cell_type}/{en_cell.cell_type}",
+                )
+            if (de_cell.lang_attr is None) != (en_cell.lang_attr is None):
+                self.observe_member(
+                    "lang_attr_mismatch",
+                    member,
+                    detail=(
+                        f"lang attribute present on one side only "
+                        f"(de: {de_cell.lang_attr!r}, en: {en_cell.lang_attr!r})"
+                    ),
+                )
+            if de_cell.part != en_cell.part:
+                self.observe_member(
+                    "layout_cross_language",
+                    member,
+                    detail="member is inline on one half and in the companion on the other",
+                )
         if member.is_one_sided:
             side: Lang = "de" if de_cell else "en"
-            self.observe(
+            self.observe_member(
                 "one_sided_member",
-                member=key,
+                member,
                 side=side,
                 detail=f"present on the {side} side only",
             )
@@ -580,11 +656,11 @@ class _Parser:
             member.langness == "shared"
             and de_cell is not None
             and en_cell is not None
-            and de_cell.lines != en_cell.lines
+            and _lines_sans_id(de_cell) != _lines_sans_id(en_cell)
         ):
-            self.observe(
+            self.observe_member(
                 "shared_divergence",
-                member=key,
+                member,
                 detail="shared member's projections differ byte-wise",
             )
         return member
@@ -669,6 +745,7 @@ class _Parser:
         groups = self._emit_groups(de_seg, en_seg, group_merge)
         orphans = self._place_companions(groups, de_comp_idxs, en_comp_idxs)
         self._assign_positional_ordinals(header, groups, orphans)
+        self._materialize_member_observations()
 
         # Document-level observations.
         self._check_layout_invariant()
@@ -790,34 +867,41 @@ class _Parser:
             if primary is None:  # pragma: no cover
                 continue
             if member.role not in ("voiceover", "notes"):
-                self.observe(
+                self.observe_member(
                     "unexpected_companion_cell",
-                    member=member.key,
+                    member,
                     detail=f"companion cell with role {member.role!r}",
                 )
             de_owner = _bare(member.de.for_slide) if member.de else None
             en_owner = _bare(member.en.for_slide) if member.en else None
             if member.de and member.en and de_owner != en_owner:
-                self.observe(
+                self.observe_member(
                     "owner_mismatch",
-                    member=member.key,
+                    member,
                     detail=f"for_slide differs between halves (de: {de_owner}, en: {en_owner})",
                 )
             owner = de_owner or en_owner
             if owner is None and _bare(primary.slide_id) == TITLE_SLIDE_ID:
-                # Pre-#242 legacy: slide_id="title" with no for_slide is
-                # title intent.
+                # Pre-#242 legacy: slide_id="title" with no for_slide is title
+                # *intent* — the "title" id is an owner reference, not the
+                # member's identity, and keying it id:title would collide with
+                # the title anchor. The stamp machinery refuses this unowned
+                # shape rather than guessing (#527), and so do we — with the
+                # actual fix spelled out instead of a misleading duplicate_id.
+                # Re-keying positionally keeps the remaining enumeration clean.
                 owner = TITLE_SLIDE_ID
-                self.observe(
-                    "legacy_title_intent",
-                    member=member.key,
-                    detail='companion cell with slide_id="title" and no for_slide',
+                member.key = MemberKey.positional("?", member.kind, -1)
+                self.refuse(
+                    "legacy_title_companion",
+                    f'companion cell with slide_id="title" and no for_slide '
+                    f"(line {primary.line_number}) — pre-#242 legacy title intent; "
+                    f'give the cell for_slide="title" and its own slide_id',
                 )
             group = by_anchor.get(owner) if owner is not None else None
             if group is None:
-                self.observe(
+                self.observe_member(
                     "owner_missing",
-                    member=member.key,
+                    member,
                     detail=f"for_slide {owner!r} matches no slide anchor",
                 )
                 orphans.append(member)

--- a/src/clm/slides/doc_lenses.py
+++ b/src/clm/slides/doc_lenses.py
@@ -1,0 +1,1024 @@
+"""Lens projections between the ≤4-file bundle and :class:`BilingualDeck`.
+
+Sync v3 Phase 1 (#520): ``parse_bundle`` reads the two deck halves plus the
+optional voiceover companions into one
+:class:`~clm.slides.bilingual_doc.BilingualDeck`; ``project`` renders one
+file's text back out of the model. The round-trip laws (design §4,
+property-tested in ``tests/slides/test_doc_lenses.py``)::
+
+    project(parse_bundle(...).deck, lang, part) == input text   # byte-identity
+    parse_bundle(*(project(deck, ...) for each file)) == deck   # identity
+
+Byte-identity is achieved structurally: every input cell is assigned to
+exactly one member side, which stores the cell's verbatim lines, and
+projection re-emits the sides of one ``(lang, part)`` sorted by their source
+ordinal. Parsing never rewrites a header, never re-anchors a narrative, and
+never mints an id — the §3.4 one-time normalization owns id stamping, which
+is precisely what makes the round trip lossless (the #501 lesson: extract's
+id minting is why ``inline ∘ extract`` was never byte-identity).
+
+Mismatches between the projections (a one-sided member, a diverged shared
+cell, the #443 id'd-on-one-half shape) are recorded as first-class
+:class:`~clm.slides.bilingual_doc.Observation`\\ s on the document (design
+§3.2). Input that fails the §3.4 normalize precondition — duplicate ids,
+id-less anchors, id-less localized or narrative cells on both halves —
+yields a framed :class:`~clm.slides.bilingual_doc.NormalizeRefusal` for the
+whole deck: never an exception, never a degraded heuristic parse. Every
+offending condition is enumerated, never just the first.
+
+Parsing runs in strict phases so a cell can never land in two members:
+
+1. read + segment each file (header zone / title group / anchored groups),
+2. pair — globally by bare id, then positionally (rule 2) within each
+   paired region, per kind-class,
+3. emit — walk each region in merged order; an EN cell that is some DE
+   cell's partner is always emitted by that pair, never solo.
+
+This module must not import from the v2 sync core (``sync_plan`` /
+``sync_apply`` / ``sync_code``) — enforced by the import-cleanliness test
+(design §12.5).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from collections.abc import Callable
+from pathlib import Path
+
+from attrs import define, field
+
+from clm.notebooks.slide_parser import comment_token_for_path
+from clm.slides.bilingual_doc import (
+    HEADER_GROUP,
+    ORPHAN_GROUP,
+    PREFACE_GROUP,
+    BilingualDeck,
+    Lang,
+    Member,
+    MemberKey,
+    NormalizeRefusal,
+    Observation,
+    ParseOutcome,
+    Part,
+    RefusalReason,
+    SideCell,
+    SlideGroup,
+)
+from clm.slides.pairing import (
+    TITLE_SLIDE_ID,
+    derive_split_pair,
+    derive_split_pair_from_stem,
+    is_title_macro_cell,
+    order_split_pair,
+)
+from clm.slides.raw_cells import RawCell, split_cells
+from clm.slides.slug import strip_preserve_marker
+
+# The single vo_anchor read path (the attribute is not part of CellMetadata);
+# importing the private helper rather than copying its regex keeps the two
+# from drifting — the same pattern voiceover_tools itself uses on normalizer.
+from clm.slides.voiceover_tools import _parse_vo_anchor, resolve_companion
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "DocLensError",
+    "LoadedBundle",
+    "load_bundle",
+    "parse_bundle",
+    "project",
+]
+
+LANGS: tuple[Lang, ...] = ("de", "en")
+PARTS: tuple[Part, ...] = ("deck", "companion")
+
+# A cell reference within one language side: (part, cell index in that file).
+_Ref = tuple[Part, int]
+
+
+class DocLensError(Exception):
+    """An internal lens invariant was violated (a bug, not bad input)."""
+
+
+# ---------------------------------------------------------------------------
+# Reading one source file
+# ---------------------------------------------------------------------------
+
+
+@define
+class _Source:
+    """One source file, losslessly split: verbatim preamble lines + cells."""
+
+    lang: Lang
+    part: Part
+    preamble_lines: tuple[str, ...]
+    raw: list[RawCell]
+    cells: list[SideCell]
+
+
+def _read_source(text: str, lang: Lang, part: Part, comment_token: str) -> _Source:
+    """Split one file into verbatim preamble lines and :class:`SideCell`\\ s.
+
+    The preamble is kept as a *line list* rather than the joined string that
+    :func:`clm.slides.raw_cells.split_cells` returns, so a file whose first
+    line is blank (preamble ``""``) survives the round trip —
+    ``reconstruct`` drops a falsy preamble, this lens must not.
+    """
+    lines = text.split("\n")
+    _, raw = split_cells(text, comment_token)
+    if raw:
+        preamble_lines = tuple(lines[: raw[0].line_number - 1])
+    else:
+        preamble_lines = tuple(lines)
+    cells = [
+        SideCell(
+            lines=tuple(cell.lines),
+            index=i,
+            line_number=cell.line_number,
+            part=part,
+            lang_attr=cell.metadata.lang,
+            tags=tuple(cell.metadata.tags),
+            slide_id=cell.metadata.slide_id,
+            for_slide=cell.metadata.for_slide,
+            vo_anchor=_parse_vo_anchor(cell.header),
+            cell_type=cell.metadata.cell_type,
+        )
+        for i, cell in enumerate(raw)
+    ]
+    return _Source(lang=lang, part=part, preamble_lines=preamble_lines, raw=raw, cells=cells)
+
+
+# ---------------------------------------------------------------------------
+# Per-side deck segmentation (header zone, title group, anchored groups)
+# ---------------------------------------------------------------------------
+
+
+@define
+class _GroupSeg:
+    """One side's slice of a slide group: anchor cell index + member indices."""
+
+    group_id: str  # bare anchor id; TITLE_SLIDE_ID / PREFACE_GROUP for specials
+    anchor_idx: int | None  # None only for the preface group
+    member_idxs: list[int] = field(factory=list)
+
+
+@define
+class _DeckSeg:
+    """One deck half segmented into header zone and groups, by cell index."""
+
+    header_idxs: list[int] = field(factory=list)
+    groups: list[_GroupSeg] = field(factory=list)
+
+
+def _bare(slide_id: str | None) -> str | None:
+    return strip_preserve_marker(slide_id) if slide_id else None
+
+
+def _segment_deck(source: _Source) -> _DeckSeg:
+    """Segment one deck half into header zone / title group / anchored groups.
+
+    The header zone is everything before the title macro (the j2 import line
+    and friends). The title macro anchors the ``title`` group; every
+    ``is_slide_start`` cell anchors its own group. Without a title macro,
+    cells before the first slide form the synthetic preface group. Id-less
+    anchors are refused before segmentation runs (phase 1), so every real
+    group here has a usable id.
+    """
+    raw = source.raw
+    first_slide = next((i for i, c in enumerate(raw) if c.metadata.is_slide_start), len(raw))
+    title_idx = next(
+        (i for i, c in enumerate(raw[:first_slide]) if is_title_macro_cell(c)),
+        None,
+    )
+    seg = _DeckSeg()
+    current: _GroupSeg | None = None
+    for i, cell in enumerate(raw):
+        if i == title_idx:
+            current = _GroupSeg(group_id=TITLE_SLIDE_ID, anchor_idx=i)
+            seg.groups.append(current)
+            continue
+        if cell.metadata.is_slide_start:
+            group_id = _bare(cell.metadata.slide_id) or f"~idless@{cell.line_number}"
+            current = _GroupSeg(group_id=group_id, anchor_idx=i)
+            seg.groups.append(current)
+            continue
+        if current is not None:
+            current.member_idxs.append(i)
+        elif title_idx is not None:
+            # Before the title macro: the header zone.
+            seg.header_idxs.append(i)
+        else:
+            # No title macro: cells before the first slide form the preface.
+            current = _GroupSeg(group_id=PREFACE_GROUP, anchor_idx=None)
+            seg.groups.append(current)
+            current.member_idxs.append(i)
+    return seg
+
+
+# ---------------------------------------------------------------------------
+# Pairing helpers
+# ---------------------------------------------------------------------------
+
+
+def _pair_class(cell: SideCell) -> tuple[str, bool, str]:
+    """The kind-class used for positional (rule 2) pairing of id-less cells.
+
+    ``(cell_type, has-lang-attr, narrative-role)`` — finer than the key's
+    kind so a shared cell never pairs with a localized one, while the
+    rendered pos-key still uses the plain cell kind (design §3.3).
+    """
+    role = "voiceover" if "voiceover" in cell.tags else "notes" if "notes" in cell.tags else ""
+    return (cell.cell_type, cell.lang_attr is not None, role)
+
+
+def _companion_pool_key(cell: SideCell) -> tuple[str | None, str, bool, str]:
+    """Positional pool key for companion cells: adds the bare ``for_slide``.
+
+    Mirrors the shape rule of ``assign_ids.stamp_ids_in_companion_pair`` but
+    deliberately without ``vo_anchor``: pairing wants recall (a drifted
+    anchor is member state to report, not a reason to split the member),
+    stamping wanted precision.
+    """
+    kind, localized, role = _pair_class(cell)
+    return (_bare(cell.for_slide), kind, localized, role)
+
+
+def _merged_order(
+    de_items: list[int],
+    en_items: list[int],
+    pair_de_to_en: dict[int, int],
+) -> list[tuple[int | None, int | None]]:
+    """Merge two per-side index sequences into one document order.
+
+    ``pair_de_to_en`` maps paired DE items to their EN partner *within these
+    sequences*. Paired items are sync points; between two sync points
+    DE-only items come first (in DE order), then EN-only items (in EN order)
+    — the deterministic analogue of ``unify_texts``'s cursor walk. Returns
+    ``(de_item, en_item)`` tuples with ``None`` for the absent side.
+    """
+    paired_en = set(pair_de_to_en.values())
+    en_pos = {item: i for i, item in enumerate(en_items)}
+    out: list[tuple[int | None, int | None]] = []
+    en_cursor = 0
+
+    def emit_en_solos_before(limit: int) -> None:
+        nonlocal en_cursor
+        while en_cursor < limit:
+            item = en_items[en_cursor]
+            if item not in paired_en:
+                out.append((None, item))
+            en_cursor += 1
+
+    for de_item in de_items:
+        partner = pair_de_to_en.get(de_item)
+        if partner is None:
+            out.append((de_item, None))
+            continue
+        emit_en_solos_before(en_pos[partner])
+        en_cursor = max(en_cursor, en_pos[partner] + 1)
+        out.append((de_item, partner))
+    emit_en_solos_before(len(en_items))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The parser
+# ---------------------------------------------------------------------------
+
+
+class _Parser:
+    """One parse run over a bundle — collects members, observations, refusals."""
+
+    def __init__(
+        self,
+        de_deck: _Source,
+        en_deck: _Source,
+        de_comp: _Source | None,
+        en_comp: _Source | None,
+        comment_token: str,
+    ) -> None:
+        self.de_deck = de_deck
+        self.en_deck = en_deck
+        self.de_comp = de_comp
+        self.en_comp = en_comp
+        self.comment_token = comment_token
+        self.observations: list[Observation] = []
+        self.refusals: list[RefusalReason] = []
+        # DE cell -> EN cell pairing, across parts (one map per bundle).
+        self.pairs: dict[_Ref, _Ref] = {}
+        self.paired_en: set[_Ref] = set()
+
+    # -- plumbing -------------------------------------------------------------
+
+    def _source(self, lang: Lang, part: Part) -> _Source | None:
+        if part == "deck":
+            return self.de_deck if lang == "de" else self.en_deck
+        return self.de_comp if lang == "de" else self.en_comp
+
+    def _cell(self, lang: Lang, ref: _Ref) -> SideCell:
+        source = self._source(lang, ref[0])
+        if source is None:  # pragma: no cover - guarded by construction
+            raise DocLensError(f"no {ref[0]} source on the {lang} side")
+        return source.cells[ref[1]]
+
+    def observe(
+        self,
+        kind: str,
+        member: MemberKey | None = None,
+        side: Lang | None = None,
+        detail: str = "",
+    ) -> None:
+        self.observations.append(Observation(kind=kind, member=member, side=side, detail=detail))
+
+    def refuse(self, code: str, detail: str, member: MemberKey | None = None) -> None:
+        self.refusals.append(RefusalReason(code=code, detail=detail, member=member))
+
+    # -- phase 1: keying preconditions ------------------------------------------
+
+    def check_keying(self) -> None:
+        """Enumerate duplicate ids and id-less anchors (design §3.3).
+
+        Ids must be unique per *side* across the deck half and its companion
+        (the ≤4-file namespace of #527/#528): one id names one member, whose
+        DE and EN sides are the only sanctioned repetition. The legacy
+        inherited-id narrative (``slide_id`` equal to the owning slide's) is
+        exactly such a duplicate — a normalize-first refusal, per §12.1.
+        """
+        for lang in LANGS:
+            counts: Counter[str] = Counter()
+            where: dict[str, list[str]] = {}
+            for part in PARTS:
+                source = self._source(lang, part)
+                if source is None:
+                    continue
+                for cell in source.cells:
+                    bare = _bare(cell.slide_id)
+                    if bare is None:
+                        continue
+                    counts[bare] += 1
+                    where.setdefault(bare, []).append(f"{part}.{lang} line {cell.line_number}")
+            for bare, n in sorted(counts.items()):
+                if n > 1:
+                    self.refuse(
+                        "duplicate_id",
+                        f'slide_id "{bare}" appears {n} times on the {lang} side '
+                        f"({', '.join(where[bare])})",
+                        member=MemberKey.for_id(bare),
+                    )
+        for lang, deck in (("de", self.de_deck), ("en", self.en_deck)):
+            for cell in deck.cells:
+                if ("slide" in cell.tags or "subslide" in cell.tags) and cell.slide_id is None:
+                    self.refuse(
+                        "idless_anchor",
+                        f"slide-start cell without slide_id (deck.{lang} line {cell.line_number})",
+                    )
+
+    # -- phase 2: pairing --------------------------------------------------------
+
+    def pair_by_id(self) -> None:
+        """Global by-id pairing over each side's deck + companion cells.
+
+        Anchors (slide starts and the title macro) are excluded — they pair
+        via group pairing. Pairing across parts and across groups is allowed
+        on purpose: a member mid-relayout (inline on one half, companion on
+        the other) or mid-move is still *one* member (design §7.3 / P2).
+        """
+        by_id: dict[Lang, dict[str, _Ref]] = {"de": {}, "en": {}}
+        for lang in LANGS:
+            for part in PARTS:
+                source = self._source(lang, part)
+                if source is None:
+                    continue
+                for i, raw in enumerate(source.raw):
+                    if part == "deck" and self._is_anchor(raw):
+                        continue
+                    bare = _bare(source.cells[i].slide_id)
+                    if bare is not None:
+                        by_id[lang][bare] = (part, i)
+        for bare, de_ref in by_id["de"].items():
+            en_ref = by_id["en"].get(bare)
+            if en_ref is not None:
+                self.pairs[de_ref] = en_ref
+
+    @staticmethod
+    def _is_anchor(raw: RawCell) -> bool:
+        return raw.metadata.is_slide_start or is_title_macro_cell(raw)
+
+    def _unpaired(self, lang: Lang, part: Part, idxs: list[int]) -> list[int]:
+        if lang == "de":
+            return [i for i in idxs if (part, i) not in self.pairs]
+        taken = set(self.pairs.values())
+        return [i for i in idxs if (part, i) not in taken]
+
+    def pair_positionally(self, de_idxs: list[int], en_idxs: list[int], part: Part) -> None:
+        """Rule-2 pairing of one kind-class pool of leftover cells.
+
+        First id-less × id-less by ordinal (the steady-state shared members),
+        then id'd × id-less (the #443 id-stamp-pending shape); whatever
+        remains stays one-sided.
+        """
+        de_pool = self._unpaired("de", part, de_idxs)
+        en_pool = self._unpaired("en", part, en_idxs)
+        de_idless = [i for i in de_pool if self._cell("de", (part, i)).slide_id is None]
+        en_idless = [i for i in en_pool if self._cell("en", (part, i)).slide_id is None]
+        for de_i, en_i in zip(de_idless, en_idless, strict=False):
+            self.pairs[(part, de_i)] = (part, en_i)
+        # The #443 pass: an id'd cell on one half adopts the positional
+        # id-less residue on the other; the id'd side's key wins.
+        de_idd = [i for i in de_pool if self._cell("de", (part, i)).slide_id is not None]
+        en_idd = [i for i in en_pool if self._cell("en", (part, i)).slide_id is not None]
+        de_idless_rest = de_idless[len(en_idless) :]
+        en_idless_rest = en_idless[len(de_idless) :]
+        for de_i, en_i in zip(de_idd, en_idless_rest, strict=False):
+            self.pairs[(part, de_i)] = (part, en_i)
+            key = _bare(self._cell("de", (part, de_i)).slide_id)
+            self.observe(
+                "id_stamp_pending_twin",
+                member=MemberKey.for_id(key or "?"),
+                side="en",
+                detail="id'd on the de half only; the en twin pairs positionally (#443)",
+            )
+        for de_i, en_i in zip(de_idless_rest, en_idd, strict=False):
+            self.pairs[(part, de_i)] = (part, en_i)
+            key = _bare(self._cell("en", (part, en_i)).slide_id)
+            self.observe(
+                "id_stamp_pending_twin",
+                member=MemberKey.for_id(key or "?"),
+                side="de",
+                detail="id'd on the en half only; the de twin pairs positionally (#443)",
+            )
+
+    def pair_region(
+        self,
+        de_idxs: list[int],
+        en_idxs: list[int],
+        part: Part,
+        pool_of: Callable[[SideCell], object] | None = None,
+    ) -> None:
+        """Bucket one region's cells by kind-class, then pair each bucket."""
+        classify = pool_of or _pair_class
+        pools: dict[object, tuple[list[int], list[int]]] = {}
+        for i in de_idxs:
+            pools.setdefault(classify(self._cell("de", (part, i))), ([], []))[0].append(i)
+        for i in en_idxs:
+            pools.setdefault(classify(self._cell("en", (part, i))), ([], []))[1].append(i)
+        for de_pool, en_pool in pools.values():
+            self.pair_positionally(de_pool, en_pool, part)
+
+    def _region_pair_map(
+        self, de_idxs: list[int], en_idxs: list[int], part: Part
+    ) -> dict[int, int]:
+        """Same-region subset of the global pairing, for merge ordering."""
+        en_set = set(en_idxs)
+        out: dict[int, int] = {}
+        for de_i in de_idxs:
+            partner = self.pairs.get((part, de_i))
+            if partner is not None and partner[0] == part and partner[1] in en_set:
+                out[de_i] = partner[1]
+        return out
+
+    # -- phase 3: emission ---------------------------------------------------------
+
+    def emit_region(
+        self,
+        de_idxs: list[int],
+        en_idxs: list[int],
+        part: Part,
+        role_hint: str | None = None,
+    ) -> list[Member]:
+        """Build the members of one region in merged document order.
+
+        A DE cell always emits (with its partner wherever that partner
+        lives); an EN cell that is *any* DE cell's partner is skipped here —
+        its member is emitted from the DE side, even when the partner sits
+        in another group or part (a moved / mid-relayout member).
+        """
+        members: list[Member] = []
+        merged = _merged_order(de_idxs, en_idxs, self._region_pair_map(de_idxs, en_idxs, part))
+        for de_i, en_i in merged:
+            if de_i is not None:
+                de_ref: _Ref = (part, de_i)
+                partner = self.pairs.get(de_ref)
+                if partner is not None and (en_i is None or partner != (part, en_i)):
+                    # Partner lives in another region (moved or mid-relayout).
+                    members.append(self.build_member(de_ref, partner, role_hint))
+                    continue
+                members.append(
+                    self.build_member(de_ref, (part, en_i) if en_i is not None else None, role_hint)
+                )
+                continue
+            if en_i is None:  # pragma: no cover - _merged_order never emits (None, None)
+                continue
+            if (part, en_i) in self.paired_en:
+                continue  # emitted by its DE partner's region
+            members.append(self.build_member(None, (part, en_i), role_hint))
+        return members
+
+    def build_member(
+        self,
+        de_ref: _Ref | None,
+        en_ref: _Ref | None,
+        role_hint: str | None = None,
+    ) -> Member:
+        de_cell = self._cell("de", de_ref) if de_ref else None
+        en_cell = self._cell("en", en_ref) if en_ref else None
+        primary = de_cell or en_cell
+        if primary is None:  # pragma: no cover - callers pass at least one ref
+            raise DocLensError("member with no sides")
+        kind = primary.cell_type
+        key = self._key_of(de_cell, en_cell)
+        if de_cell and en_cell:
+            if de_cell.cell_type != en_cell.cell_type:
+                self.observe(
+                    "member_kind_mismatch",
+                    member=key,
+                    detail=f"paired cells have kinds {de_cell.cell_type}/{en_cell.cell_type}",
+                )
+            if (de_cell.lang_attr is None) != (en_cell.lang_attr is None):
+                self.observe(
+                    "lang_attr_mismatch",
+                    member=key,
+                    detail=(
+                        f"lang attribute present on one side only "
+                        f"(de: {de_cell.lang_attr!r}, en: {en_cell.lang_attr!r})"
+                    ),
+                )
+            if de_cell.part != en_cell.part:
+                self.observe(
+                    "layout_cross_language",
+                    member=key,
+                    detail="member is inline on one half and in the companion on the other",
+                )
+        langness = (
+            "localized"
+            if (de_cell and de_cell.lang_attr) or (en_cell and en_cell.lang_attr)
+            else "shared"
+        )
+        role = role_hint or self._role_of(primary, kind)
+        if role == "header":
+            langness = "localized"  # header members are per-language by design
+        member = Member(
+            key=key,
+            kind=kind,
+            role=role,
+            langness=langness,
+            layout="companion" if primary.part == "companion" else "inline",
+            owner=None,
+            de=de_cell,
+            en=en_cell,
+        )
+        if member.is_one_sided:
+            side: Lang = "de" if de_cell else "en"
+            self.observe(
+                "one_sided_member",
+                member=key,
+                side=side,
+                detail=f"present on the {side} side only",
+            )
+        if (
+            member.langness == "shared"
+            and de_cell is not None
+            and en_cell is not None
+            and de_cell.lines != en_cell.lines
+        ):
+            self.observe(
+                "shared_divergence",
+                member=key,
+                detail="shared member's projections differ byte-wise",
+            )
+        return member
+
+    @staticmethod
+    def _role_of(cell: SideCell, kind: str) -> str:
+        if "slide" in cell.tags:
+            return "slide"
+        if "subslide" in cell.tags:
+            return "subslide"
+        if "voiceover" in cell.tags:
+            return "voiceover"
+        if "notes" in cell.tags:
+            return "notes"
+        if kind == "code":
+            return "code"
+        return "aux"
+
+    def _key_of(self, de_cell: SideCell | None, en_cell: SideCell | None) -> MemberKey:
+        for cell in (de_cell, en_cell):
+            if cell is None:
+                continue
+            bare = _bare(cell.slide_id)
+            if bare is not None:
+                return MemberKey.for_id(bare)
+        # Positional key — the ordinal is assigned once the merged member
+        # order of the owning group is known (``_assign_positional_ordinals``).
+        kind = de_cell.cell_type if de_cell else en_cell.cell_type  # type: ignore[union-attr]
+        return MemberKey.positional("?", kind, -1)
+
+    # -- §3.4 precondition -----------------------------------------------------------
+
+    def check_normalized(self, member: Member) -> None:
+        """Every localized and every lang-tagged narrative member must carry
+        an id on at least one side (the #443 one-sided-id shape is a
+        transition, not a violation)."""
+        if member.key.scheme == "id":
+            return
+        if member.langness != "localized" or member.role == "header":
+            return
+        code = "idless_narrative" if member.role in ("voiceover", "notes") else "idless_localized"
+        lines = [
+            f"{side}.{cell.part} line {cell.line_number}"
+            for side, cell in (("de", member.de), ("en", member.en))
+            if cell is not None
+        ]
+        self.refuse(
+            code,
+            f"id-less {member.role} cell ({', '.join(lines)}) — localized and narrative "
+            f"cells must carry their own slide_id",
+        )
+
+    # -- main ------------------------------------------------------------------------
+
+    def run(self) -> ParseOutcome:
+        self.check_keying()
+        if self.refusals:
+            return ParseOutcome(refusal=NormalizeRefusal(reasons=self.refusals))
+
+        de_seg = _segment_deck(self.de_deck)
+        en_seg = _segment_deck(self.en_deck)
+
+        # Phase 2: all pairing, before any member is built.
+        self.pair_by_id()
+        group_merge = self._pair_groups(de_seg, en_seg)
+        self.pair_region(de_seg.header_idxs, en_seg.header_idxs, "deck")
+        for de_gi, en_gi in group_merge:
+            de_members = de_seg.groups[de_gi].member_idxs if de_gi is not None else []
+            en_members = en_seg.groups[en_gi].member_idxs if en_gi is not None else []
+            if de_gi is not None and en_gi is not None:
+                self.pair_region(de_members, en_members, "deck")
+        de_comp_idxs = list(range(len(self.de_comp.cells))) if self.de_comp else []
+        en_comp_idxs = list(range(len(self.en_comp.cells))) if self.en_comp else []
+        if de_comp_idxs or en_comp_idxs:
+            self.pair_region(de_comp_idxs, en_comp_idxs, "companion", pool_of=_companion_pool_key)
+        self.paired_en = set(self.pairs.values())
+
+        # Phase 3: emission.
+        header = self.emit_region(
+            de_seg.header_idxs, en_seg.header_idxs, "deck", role_hint="header"
+        )
+        groups = self._emit_groups(de_seg, en_seg, group_merge)
+        orphans = self._place_companions(groups, de_comp_idxs, en_comp_idxs)
+        self._assign_positional_ordinals(header, groups, orphans)
+
+        # Document-level observations.
+        self._check_layout_invariant()
+        if self.de_deck.preamble_lines != self.en_deck.preamble_lines:
+            self.observe("preamble_divergence", detail="deck preambles differ between halves")
+        self._check_wrong_language()
+
+        deck = BilingualDeck(
+            comment_token=self.comment_token,
+            de_deck_preamble=self.de_deck.preamble_lines,
+            en_deck_preamble=self.en_deck.preamble_lines,
+            de_companion_preamble=self.de_comp.preamble_lines if self.de_comp else None,
+            en_companion_preamble=self.en_comp.preamble_lines if self.en_comp else None,
+            header=header,
+            groups=groups,
+            orphans=orphans,
+            observations=self.observations,
+        )
+        for member in deck.members():
+            self.check_normalized(member)
+        self._check_key_uniqueness(deck)
+        if self.refusals:
+            return ParseOutcome(refusal=NormalizeRefusal(reasons=self.refusals))
+        return ParseOutcome(deck=deck)
+
+    # -- groups ------------------------------------------------------------------------
+
+    def _pair_groups(
+        self, de_seg: _DeckSeg, en_seg: _DeckSeg
+    ) -> list[tuple[int | None, int | None]]:
+        de_ids = [g.group_id for g in de_seg.groups]
+        en_ids = [g.group_id for g in en_seg.groups]
+        common_de = [gid for gid in de_ids if gid in set(en_ids)]
+        common_en = [gid for gid in en_ids if gid in set(de_ids)]
+        if common_de != common_en:
+            self.observe(
+                "group_order_divergence",
+                detail=f"group order differs between halves (de: {common_de}, en: {common_en})",
+            )
+        en_by_id = {g.group_id: gi for gi, g in enumerate(en_seg.groups)}
+        pair_map = {
+            de_gi: en_by_id[g.group_id]
+            for de_gi, g in enumerate(de_seg.groups)
+            if g.group_id in en_by_id
+        }
+        return _merged_order(
+            list(range(len(de_seg.groups))), list(range(len(en_seg.groups))), pair_map
+        )
+
+    def _emit_groups(
+        self,
+        de_seg: _DeckSeg,
+        en_seg: _DeckSeg,
+        group_merge: list[tuple[int | None, int | None]],
+    ) -> list[SlideGroup]:
+        groups: list[SlideGroup] = []
+        for de_gi, en_gi in group_merge:
+            de_group = de_seg.groups[de_gi] if de_gi is not None else None
+            en_group = en_seg.groups[en_gi] if en_gi is not None else None
+            some_group = de_group or en_group
+            if some_group is None:  # pragma: no cover - merge never yields (None, None)
+                continue
+            group_id = some_group.group_id
+            if de_group is None or en_group is None:
+                self.observe(
+                    "one_sided_group",
+                    side="de" if de_group else "en",
+                    detail=f'group "{group_id}" exists on one half only',
+                )
+            anchor = self._build_anchor(group_id, de_group, en_group)
+            group = SlideGroup(anchor_id=group_id, anchor=anchor)
+            anchor_key = anchor.key if anchor else None
+            group.members = self.emit_region(
+                de_group.member_idxs if de_group else [],
+                en_group.member_idxs if en_group else [],
+                "deck",
+            )
+            for member in group.members:
+                member.owner = anchor_key
+            groups.append(group)
+        return groups
+
+    def _build_anchor(
+        self,
+        group_id: str,
+        de_group: _GroupSeg | None,
+        en_group: _GroupSeg | None,
+    ) -> Member | None:
+        de_idx = de_group.anchor_idx if de_group else None
+        en_idx = en_group.anchor_idx if en_group else None
+        if de_idx is None and en_idx is None:
+            return None  # the preface group
+        is_title = group_id == TITLE_SLIDE_ID
+        member = self.build_member(
+            ("deck", de_idx) if de_idx is not None else None,
+            ("deck", en_idx) if en_idx is not None else None,
+            role_hint="header" if is_title else None,
+        )
+        # The anchor's identity is the group identity; the title macro
+        # carries no slide_id and anchors the reserved id "title" (§3.3).
+        member.key = MemberKey.for_id(group_id)
+        return member
+
+    # -- companions ----------------------------------------------------------------------
+
+    def _place_companions(
+        self,
+        groups: list[SlideGroup],
+        de_idxs: list[int],
+        en_idxs: list[int],
+    ) -> list[Member]:
+        if not de_idxs and not en_idxs:
+            return []
+        members = self.emit_region(de_idxs, en_idxs, "companion")
+        by_anchor = {group.anchor_id: group for group in groups}
+        orphans: list[Member] = []
+        for member in members:
+            primary = member.de or member.en
+            if primary is None:  # pragma: no cover
+                continue
+            if member.role not in ("voiceover", "notes"):
+                self.observe(
+                    "unexpected_companion_cell",
+                    member=member.key,
+                    detail=f"companion cell with role {member.role!r}",
+                )
+            de_owner = _bare(member.de.for_slide) if member.de else None
+            en_owner = _bare(member.en.for_slide) if member.en else None
+            if member.de and member.en and de_owner != en_owner:
+                self.observe(
+                    "owner_mismatch",
+                    member=member.key,
+                    detail=f"for_slide differs between halves (de: {de_owner}, en: {en_owner})",
+                )
+            owner = de_owner or en_owner
+            if owner is None and _bare(primary.slide_id) == TITLE_SLIDE_ID:
+                # Pre-#242 legacy: slide_id="title" with no for_slide is
+                # title intent.
+                owner = TITLE_SLIDE_ID
+                self.observe(
+                    "legacy_title_intent",
+                    member=member.key,
+                    detail='companion cell with slide_id="title" and no for_slide',
+                )
+            group = by_anchor.get(owner) if owner is not None else None
+            if group is None:
+                self.observe(
+                    "owner_missing",
+                    member=member.key,
+                    detail=f"for_slide {owner!r} matches no slide anchor",
+                )
+                orphans.append(member)
+            else:
+                member.owner = group.anchor.key if group.anchor else None
+                group.members.append(member)
+        return orphans
+
+    # -- finishing -------------------------------------------------------------------------
+
+    def _assign_positional_ordinals(
+        self,
+        header: list[Member],
+        groups: list[SlideGroup],
+        orphans: list[Member],
+    ) -> None:
+        """Fill in rule-2 pos keys now that merged member order is known."""
+
+        def assign(members: list[Member], group_token: str) -> None:
+            counters: Counter[str] = Counter()
+            for member in members:
+                if member.key.scheme == "id":
+                    continue
+                ordinal = counters[member.kind]
+                counters[member.kind] += 1
+                member.key = MemberKey.positional(group_token, member.kind, ordinal)
+
+        assign(header, HEADER_GROUP)
+        for group in groups:
+            assign(group.members, group.anchor_id)
+        assign(orphans, ORPHAN_GROUP)
+
+    def _check_layout_invariant(self) -> None:
+        for lang in LANGS:
+            deck = self._source(lang, "deck")
+            comp = self._source(lang, "companion")
+            if deck is None:  # pragma: no cover
+                continue
+            has_inline_vo = any("voiceover" in c.tags for c in deck.cells)
+            separated = comp is not None and bool(comp.cells)
+            if has_inline_vo and separated:
+                self.observe(
+                    "layout_mixed",
+                    side=lang,
+                    detail="half has both inline voiceover cells and a companion file",
+                )
+        de_separated = self.de_comp is not None and bool(self.de_comp.cells)
+        en_separated = self.en_comp is not None and bool(self.en_comp.cells)
+        if de_separated != en_separated:
+            self.observe(
+                "layout_cross_language",
+                detail="one half uses a voiceover companion, the other does not",
+            )
+
+    def _check_wrong_language(self) -> None:
+        for lang in LANGS:
+            for part in PARTS:
+                source = self._source(lang, part)
+                if source is None:
+                    continue
+                for cell in source.cells:
+                    if cell.lang_attr is not None and cell.lang_attr != lang:
+                        self.observe(
+                            "wrong_language_cell",
+                            side=lang,
+                            detail=(
+                                f"{part}.{lang} line {cell.line_number} carries "
+                                f'lang="{cell.lang_attr}"'
+                            ),
+                        )
+
+    def _check_key_uniqueness(self, deck: BilingualDeck) -> None:
+        counts: Counter[str] = Counter()
+        for member in deck.members():
+            counts[member.key.render()] += 1
+        for handle, n in sorted(counts.items()):
+            if n > 1:
+                self.refuse(
+                    "duplicate_id",
+                    f"member key {handle} resolves to {n} distinct members",
+                    member=MemberKey.parse(handle),
+                )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def parse_bundle(
+    de_text: str,
+    en_text: str,
+    de_companion: str | None = None,
+    en_companion: str | None = None,
+    *,
+    comment_token: str = "#",
+) -> ParseOutcome:
+    """Parse the ≤4-file bundle into one :class:`BilingualDeck` (design §3.2).
+
+    ``de_text`` / ``en_text`` are the two deck halves; the companions are
+    optional (``None`` = the file does not exist; an empty string is an
+    existing empty file). Mismatches between the projections are recorded as
+    observations on the returned deck; input failing the §3.4 normalize
+    precondition yields a framed
+    :class:`~clm.slides.bilingual_doc.NormalizeRefusal` instead — never an
+    exception, never a heuristic parse.
+    """
+    parser = _Parser(
+        de_deck=_read_source(de_text, "de", "deck", comment_token),
+        en_deck=_read_source(en_text, "en", "deck", comment_token),
+        de_comp=(
+            _read_source(de_companion, "de", "companion", comment_token)
+            if de_companion is not None
+            else None
+        ),
+        en_comp=(
+            _read_source(en_companion, "en", "companion", comment_token)
+            if en_companion is not None
+            else None
+        ),
+        comment_token=comment_token,
+    )
+    return parser.run()
+
+
+def project(deck: BilingualDeck, lang: Lang, part: Part = "deck") -> str | None:
+    """Render one file's text from the model (design §4).
+
+    Returns ``None`` for a companion part the bundle never had. Emission is
+    verbatim: the preamble lines plus every member side of ``(lang, part)``
+    sorted by source ordinal — projection never rewrites a header or a body,
+    so ``project ∘ parse`` is byte-identity by construction.
+    """
+    if part == "deck":
+        preamble = deck.de_deck_preamble if lang == "de" else deck.en_deck_preamble
+    else:
+        maybe = deck.de_companion_preamble if lang == "de" else deck.en_companion_preamble
+        if maybe is None:
+            return None
+        preamble = maybe
+    sides = [
+        side
+        for member in deck.members()
+        if (side := member.side(lang)) is not None and side.part == part
+    ]
+    sides.sort(key=lambda side: side.index)
+    indexes = [side.index for side in sides]
+    if indexes != list(range(len(sides))):
+        raise DocLensError(
+            f"projection of ({lang}, {part}) lost or duplicated cells: indexes {indexes}"
+        )
+    lines = list(preamble)
+    for side in sides:
+        lines.extend(side.lines)
+    return "\n".join(lines)
+
+
+@define
+class LoadedBundle:
+    """A bundle read from disk plus its parse outcome."""
+
+    de_path: Path
+    en_path: Path
+    de_companion_path: Path | None
+    en_companion_path: Path | None
+    comment_token: str
+    outcome: ParseOutcome
+
+
+def load_bundle(path: Path, twin: Path | None = None) -> LoadedBundle:
+    """Read a deck bundle from disk and parse it.
+
+    ``path`` may be a deck half (``slides_x.de.py``), a deck stem
+    (``slides_x.py``), or one half with ``twin`` naming the other.
+    Companions are resolved through the standard subdir-then-sibling rule
+    (:func:`clm.slides.voiceover_tools.resolve_companion`).
+    """
+    if twin is not None:
+        pair = order_split_pair(path, twin)
+        if pair is None:
+            raise DocLensError(f"{path} and {twin} do not form a de/en deck pair")
+    else:
+        pair = derive_split_pair(path) or derive_split_pair_from_stem(path)
+        if pair is None:
+            raise DocLensError(f"{path} is not a split deck half/stem with an existing twin")
+    de_path, en_path = pair
+    comment_token = comment_token_for_path(de_path)
+    de_companion = resolve_companion(de_path)
+    en_companion = resolve_companion(en_path)
+    outcome = parse_bundle(
+        de_path.read_text(encoding="utf-8"),
+        en_path.read_text(encoding="utf-8"),
+        de_companion.read_text(encoding="utf-8") if de_companion else None,
+        en_companion.read_text(encoding="utf-8") if en_companion else None,
+        comment_token=comment_token,
+    )
+    return LoadedBundle(
+        de_path=de_path,
+        en_path=en_path,
+        de_companion_path=de_companion,
+        en_companion_path=en_companion,
+        comment_token=comment_token,
+        outcome=outcome,
+    )

--- a/tests/cli/test_sync_import_cleanliness.py
+++ b/tests/cli/test_sync_import_cleanliness.py
@@ -83,6 +83,30 @@ def test_importing_the_engine_modules_loads_no_model_client():
     assert probe.stdout.strip().endswith("OK")
 
 
+def test_v3_doc_modules_import_no_v2_sync_core():
+    # Sync v3 (#520, design §12.5): the v3 model + lens modules must never import
+    # from the v2 plan/apply core — Phase 4's removal is "delete the modules,
+    # delete the flag check, done", and any v3 -> v2 import would block it. Same
+    # fresh-subprocess mechanism as above (sys.modules is session-polluted under
+    # xdist, so an in-process check would be order-dependent).
+    probe = _run_probe(
+        """
+        import sys
+        import clm.slides.bilingual_doc, clm.slides.doc_lenses
+
+        for mod in (
+            "clm.slides.sync_plan",
+            "clm.slides.sync_apply",
+            "clm.slides.sync_code",
+        ):
+            assert mod not in sys.modules, f"{mod} must not load from the v3 doc modules"
+        print("OK")
+        """
+    )
+    assert probe.returncode == 0, probe.stderr or probe.stdout
+    assert probe.stdout.strip().endswith("OK")
+
+
 def test_resolving_autopilot_loads_it_but_still_not_openai():
     # Accessing slides_sync_cmd (PEP 562 back-compat / the lazy verb spec) imports the
     # autopilot module — but even THAT does not construct a client, so the OpenAI SDK

--- a/tests/data/doc_corpus/topic_alpha/slides_alpha.de.py
+++ b/tests/data/doc_corpus/topic_alpha/slides_alpha.de.py
@@ -1,0 +1,21 @@
+# j2 from 'macros.j2' import header_de
+# {{ header_de("Alpha DE") }}
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="alpha-intro"
+#
+# # Einführung
+#
+# - Erster Punkt
+
+# %% [markdown] lang="de" slide_id="alpha-intro-note"
+# Ein lokalisierter Hinweis.
+
+# %% tags=["keep"]
+shared_value = 1
+
+# %% [markdown] lang="de" tags=["subslide"] slide_id="alpha-details"
+#
+# ## Details
+
+# %% lang="de" slide_id="alpha-example-code"
+print("Hallo")

--- a/tests/data/doc_corpus/topic_alpha/slides_alpha.en.py
+++ b/tests/data/doc_corpus/topic_alpha/slides_alpha.en.py
@@ -1,0 +1,21 @@
+# j2 from 'macros.j2' import header_en
+# {{ header_en("Alpha EN") }}
+
+# %% [markdown] lang="en" tags=["slide"] slide_id="alpha-intro"
+#
+# # Introduction
+#
+# - First point
+
+# %% [markdown] lang="en" slide_id="alpha-intro-note"
+# A localized note.
+
+# %% tags=["keep"]
+shared_value = 1
+
+# %% [markdown] lang="en" tags=["subslide"] slide_id="alpha-details"
+#
+# ## Details
+
+# %% lang="en" slide_id="alpha-example-code"
+print("Hello")

--- a/tests/data/doc_corpus/topic_alpha/voiceover/voiceover_alpha.de.py
+++ b/tests/data/doc_corpus/topic_alpha/voiceover/voiceover_alpha.de.py
@@ -1,0 +1,7 @@
+# %% [markdown] lang="de" tags=["notes"] for_slide="title" vo_anchor="tm:title#0" slide_id="alpha-greeting"
+#
+# - Willkommen zum Alpha-Deck!
+
+# %% [markdown] lang="de" tags=["notes"] for_slide="alpha-intro" vo_anchor="id:alpha-intro#0" slide_id="alpha-intro-vo"
+#
+# - Hinweise zur Einführung.

--- a/tests/data/doc_corpus/topic_alpha/voiceover/voiceover_alpha.en.py
+++ b/tests/data/doc_corpus/topic_alpha/voiceover/voiceover_alpha.en.py
@@ -1,0 +1,7 @@
+# %% [markdown] lang="en" tags=["notes"] for_slide="title" vo_anchor="tm:title#0" slide_id="alpha-greeting"
+#
+# - Welcome to the alpha deck!
+
+# %% [markdown] lang="en" tags=["notes"] for_slide="alpha-intro" vo_anchor="id:alpha-intro#0" slide_id="alpha-intro-vo"
+#
+# - Notes on the introduction.

--- a/tests/data/doc_corpus/topic_beta/slides_beta.de.py
+++ b/tests/data/doc_corpus/topic_beta/slides_beta.de.py
@@ -1,0 +1,9 @@
+# j2 from 'macros.j2' import header_de
+# {{ header_de("Beta DE") }}
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="beta-start"
+#
+# # Beta Anfang
+
+# %% tags=["keep"]
+import math

--- a/tests/data/doc_corpus/topic_beta/slides_beta.en.py
+++ b/tests/data/doc_corpus/topic_beta/slides_beta.en.py
@@ -1,0 +1,9 @@
+# j2 from 'macros.j2' import header_en
+# {{ header_en("Beta EN") }}
+
+# %% [markdown] lang="en" tags=["slide"] slide_id="beta-start"
+#
+# # Beta Start
+
+# %% tags=["keep"]
+import math

--- a/tests/data/doc_corpus/topic_beta/voiceover_beta.de.py
+++ b/tests/data/doc_corpus/topic_beta/voiceover_beta.de.py
@@ -1,0 +1,3 @@
+# %% [markdown] lang="de" tags=["voiceover"] for_slide="beta-start" vo_anchor="id:beta-start#0" slide_id="beta-start-vo"
+#
+# - Gesprochener Text.

--- a/tests/data/doc_corpus/topic_beta/voiceover_beta.en.py
+++ b/tests/data/doc_corpus/topic_beta/voiceover_beta.en.py
@@ -1,0 +1,3 @@
+# %% [markdown] lang="en" tags=["voiceover"] for_slide="beta-start" vo_anchor="id:beta-start#0" slide_id="beta-start-vo"
+#
+# - Spoken text.

--- a/tests/data/doc_corpus/topic_delta/slides_delta.de.py
+++ b/tests/data/doc_corpus/topic_delta/slides_delta.de.py
@@ -1,0 +1,12 @@
+# j2 from 'macros.j2' import header_de
+# {{ header_de("Delta DE") }}
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="delta-main"
+#
+# # Delta
+
+# %% [markdown] lang="de" slide_id="delta-noted"
+# Deutscher Hinweis.
+
+# %% tags=["keep"]
+shared = 1

--- a/tests/data/doc_corpus/topic_delta/slides_delta.en.py
+++ b/tests/data/doc_corpus/topic_delta/slides_delta.en.py
@@ -1,0 +1,15 @@
+# j2 from 'macros.j2' import header_en
+# {{ header_en("Delta EN") }}
+
+# %% [markdown] lang="en" tags=["slide"] slide_id="delta-main"
+#
+# # Delta
+
+# %% [markdown] lang="en"
+# English note.
+
+# %% tags=["keep"]
+shared = 2
+
+# %% [markdown] lang="en" slide_id="delta-extra"
+# An extra English-only cell.

--- a/tests/data/doc_corpus/topic_epsilon/slides_epsilon.de.cpp
+++ b/tests/data/doc_corpus/topic_epsilon/slides_epsilon.de.cpp
@@ -1,0 +1,8 @@
+// j2 from 'macros.j2' import header_de
+// {{ header_de("Epsilon DE") }}
+
+// %% [markdown] lang="de" tags=["slide"] slide_id="epsilon-intro"
+// # Einführung C++
+
+// %% tags=["keep"]
+int shared_int = 1;

--- a/tests/data/doc_corpus/topic_epsilon/slides_epsilon.en.cpp
+++ b/tests/data/doc_corpus/topic_epsilon/slides_epsilon.en.cpp
@@ -1,0 +1,8 @@
+// j2 from 'macros.j2' import header_en
+// {{ header_en("Epsilon EN") }}
+
+// %% [markdown] lang="en" tags=["slide"] slide_id="epsilon-intro"
+// # Introduction C++
+
+// %% tags=["keep"]
+int shared_int = 1;

--- a/tests/data/doc_corpus/topic_gamma/slides_gamma.de.py
+++ b/tests/data/doc_corpus/topic_gamma/slides_gamma.de.py
@@ -1,0 +1,12 @@
+# j2 from 'macros.j2' import header_de
+# {{ header_de("Gamma DE") }}
+
+# %% [markdown] lang="de" tags=["slide"] slide_id="gamma-one"
+#
+# # Gamma Eins
+
+# %% [markdown] lang="de" tags=["voiceover"] slide_id="gamma-one-vo"
+# Gesprochener Hinweis.
+
+# %% [markdown] lang="de" tags=["notes"] slide_id="gamma-one-note"
+# Eine Notiz.

--- a/tests/data/doc_corpus/topic_gamma/slides_gamma.en.py
+++ b/tests/data/doc_corpus/topic_gamma/slides_gamma.en.py
@@ -1,0 +1,12 @@
+# j2 from 'macros.j2' import header_en
+# {{ header_en("Gamma EN") }}
+
+# %% [markdown] lang="en" tags=["slide"] slide_id="gamma-one"
+#
+# # Gamma One
+
+# %% [markdown] lang="en" tags=["voiceover"] slide_id="gamma-one-vo"
+# Spoken note.
+
+# %% [markdown] lang="en" tags=["notes"] slide_id="gamma-one-note"
+# A note.

--- a/tests/slides/test_bilingual_doc.py
+++ b/tests/slides/test_bilingual_doc.py
@@ -1,0 +1,113 @@
+"""Tests for :mod:`clm.slides.bilingual_doc` — the sync v3 document model.
+
+The model itself is thin (parsing/projection live in ``doc_lenses`` and are
+tested in ``test_doc_lenses.py``); what is pinned here is the identity
+surface: :class:`MemberKey` render/parse totality and the model accessors
+agents will navigate by (#520 Phase 1, design §3).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clm.slides.bilingual_doc import (
+    HEADER_GROUP,
+    BilingualDeck,
+    Member,
+    MemberKey,
+    NormalizeRefusal,
+    RefusalReason,
+    SideCell,
+    SlideGroup,
+)
+
+
+class TestMemberKey:
+    def test_id_key_renders_and_parses(self):
+        key = MemberKey.for_id("intro-functions")
+        assert key.render() == "id:intro-functions"
+        assert MemberKey.parse("id:intro-functions") == key
+
+    def test_positional_key_renders_and_parses(self):
+        key = MemberKey.positional(HEADER_GROUP, "j2", 0)
+        assert key.render() == "pos:~header/j2/0"
+        assert MemberKey.parse("pos:~header/j2/0") == key
+
+    def test_keys_are_hashable_values(self):
+        assert MemberKey.for_id("a") == MemberKey.for_id("a")
+        assert len({MemberKey.for_id("a"), MemberKey.for_id("a")}) == 1
+        assert MemberKey.for_id("a") != MemberKey.positional("g", "markdown", 0)
+
+    @pytest.mark.parametrize("bad", ["", "intro", "idx:intro", "id:", ":x"])
+    def test_parse_rejects_non_keys(self, bad: str):
+        with pytest.raises(ValueError):
+            MemberKey.parse(bad)
+
+
+def _member(key: MemberKey) -> Member:
+    side = SideCell(
+        lines=('# %% tags=["keep"]', "x = 1", ""),
+        index=0,
+        line_number=1,
+        part="deck",
+        lang_attr=None,
+        tags=("keep",),
+        slide_id=None,
+        for_slide=None,
+        vo_anchor=None,
+        cell_type="code",
+    )
+    return Member(
+        key=key,
+        kind="code",
+        role="code",
+        langness="shared",
+        layout="inline",
+        owner=None,
+        de=side,
+        en=side,
+    )
+
+
+class TestBilingualDeck:
+    def _deck(self) -> BilingualDeck:
+        anchor = _member(MemberKey.for_id("intro"))
+        group = SlideGroup(anchor_id="intro", anchor=anchor)
+        group.members.append(_member(MemberKey.positional("intro", "code", 0)))
+        return BilingualDeck(
+            comment_token="#",
+            de_deck_preamble=(),
+            en_deck_preamble=(),
+            de_companion_preamble=None,
+            en_companion_preamble=("",),
+            groups=[group],
+        )
+
+    def test_members_iterates_anchor_and_members(self):
+        deck = self._deck()
+        keys = [m.key.render() for m in deck.members()]
+        assert keys == ["id:intro", "pos:intro/code/0"]
+
+    def test_member_by_key(self):
+        deck = self._deck()
+        assert deck.member_by_key(MemberKey.for_id("intro")) is not None
+        assert deck.member_by_key(MemberKey.for_id("absent")) is None
+
+    def test_has_companion_distinguishes_absent_from_empty(self):
+        deck = self._deck()
+        assert not deck.has_companion("de")  # None = file absent
+        assert deck.has_companion("en")  # empty tuple-ish = present file
+
+
+class TestNormalizeRefusal:
+    def test_render_enumerates_every_reason(self):
+        refusal = NormalizeRefusal(
+            reasons=[
+                RefusalReason(code="duplicate_id", detail="id x twice"),
+                RefusalReason(code="idless_localized", detail="line 7"),
+            ]
+        )
+        text = refusal.render()
+        assert "normalize" in text
+        assert "duplicate_id" in text
+        assert "idless_localized" in text

--- a/tests/slides/test_doc_lens_corpus.py
+++ b/tests/slides/test_doc_lens_corpus.py
@@ -1,0 +1,146 @@
+"""The #520 Phase 1 exit gate: ``project ∘ parse`` byte-identity over a corpus.
+
+Two scopes:
+
+* **Bundled** (``tests/data/doc_corpus`` — always present, runs in the fast
+  suite and CI): five normalized deck pairs covering the shapes the design
+  names for Phase 1 — a ``voiceover/`` subdir companion (notes role), a
+  sibling companion (voiceover role), the legacy inline-voiceover layout,
+  an observation-carrying pair (shared divergence, one-sided member, the
+  #443 id-stamp-pending shape), and a ``//``-token C++ deck. Zero refusals
+  allowed here.
+* **Real corpus** (``CLM_SYNC_CORPUS_DIR`` or the maintainer's PythonCourses
+  checkout; ``integration + slow``, local/release-time only — the CLM repo
+  CI carries no course content): byte-identity must hold for **every**
+  parsed pair, refusals must be framed and bounded. Refusals are expected:
+  the §3.4 normalize precondition is stricter than v2 (the legacy
+  inherited-id companions and residual id-less localized cells are the
+  standing normalize worklist from PythonCourses#78) — the ceiling pins
+  that population so it can only shrink.
+
+Following the ``test_sync_corpus_*`` conventions: corpus resolution via env
+var, then the maintainer path; scale-dependent assertions only on the real
+corpus; discovery through the prefix-agnostic pairing helpers (which prune
+ignored/private dirs and never treat ``voiceover_*`` companions as decks).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from clm.slides.doc_lenses import LoadedBundle, load_bundle, project
+from clm.slides.pairing import find_split_slide_files_recursive, iter_split_pairs
+
+_BUNDLED_CORPUS = Path(__file__).parent.parent / "data" / "doc_corpus"
+
+# The known v3-precondition failures on the real corpus, measured 2026-07-02
+# post-PythonCourses#78: 59 decks with legacy inherited-id companions
+# (slide_id == for_slide duplicates the deck id in the ≤4-file namespace)
+# + 3 decks with residual id-less localized cells = 62. The ceiling gives a
+# little headroom for ordinary authoring churn; a real rise means id-less /
+# duplicate-id content is being reintroduced.
+_REAL_REFUSAL_CEILING = 80
+_REAL_PARSED_FLOOR = 600
+
+
+def _real_corpus_dir() -> Path | None:
+    env = os.environ.get("CLM_SYNC_CORPUS_DIR")
+    if env:
+        path = Path(env)
+        if path.is_dir():
+            return path
+    maintainer = Path(r"C:\Users\tc\Programming\Python\Courses\Own\PythonCourses\slides")
+    if maintainer.is_dir():
+        return maintainer
+    return None
+
+
+def _discover(root: Path) -> list[tuple[Path, Path]]:
+    pairs, solos = iter_split_pairs(find_split_slide_files_recursive(root))
+    assert not solos, f"corpus contains unpaired deck halves: {solos}"
+    return pairs
+
+
+def _assert_byte_identity(bundle: LoadedBundle) -> None:
+    deck = bundle.outcome.deck
+    assert deck is not None
+    for lang, part, path in (
+        ("de", "deck", bundle.de_path),
+        ("en", "deck", bundle.en_path),
+        ("de", "companion", bundle.de_companion_path),
+        ("en", "companion", bundle.en_companion_path),
+    ):
+        want = path.read_text(encoding="utf-8") if path else None
+        got = project(deck, lang, part)  # type: ignore[arg-type]
+        assert got == want, f"projection of {lang}/{part} diverges for {bundle.de_path.name}"
+
+
+class TestBundledDocCorpus:
+    """Fast-suite gate over the vendored normalized fixtures."""
+
+    def test_every_bundled_pair_parses_and_round_trips(self):
+        pairs = _discover(_BUNDLED_CORPUS)
+        assert len(pairs) == 5
+        for de_path, _en_path in pairs:
+            bundle = load_bundle(de_path)
+            assert bundle.outcome.ok, (
+                f"{de_path.name}: {bundle.outcome.refusal.render()}"
+                if bundle.outcome.refusal
+                else de_path.name
+            )
+            _assert_byte_identity(bundle)
+
+    def test_companion_layouts_are_both_exercised(self):
+        pairs = {de.parent.name: de for de, _ in _discover(_BUNDLED_CORPUS)}
+        alpha = load_bundle(pairs["topic_alpha"])
+        assert alpha.de_companion_path is not None
+        assert alpha.de_companion_path.parent.name == "voiceover"  # subdir layout
+        beta = load_bundle(pairs["topic_beta"])
+        assert beta.de_companion_path is not None
+        assert beta.de_companion_path.parent.name == "topic_beta"  # sibling layout
+
+    def test_observation_fixture_reports_expected_kinds(self):
+        pairs = {de.parent.name: de for de, _ in _discover(_BUNDLED_CORPUS)}
+        bundle = load_bundle(pairs["topic_delta"])
+        deck = bundle.outcome.deck
+        assert deck is not None
+        assert {o.kind for o in deck.observations} == {
+            "id_stamp_pending_twin",
+            "shared_divergence",
+            "one_sided_member",
+        }
+
+
+_real = _real_corpus_dir()
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.skipif(_real is None, reason="real course corpus not available")
+class TestRealCorpus:
+    """The full-corpus exit gate — local/release-time (integration + slow)."""
+
+    def test_byte_identity_over_the_full_corpus(self):
+        assert _real is not None
+        pairs = _discover(_real)
+        assert len(pairs) >= _REAL_PARSED_FLOOR
+        parsed = 0
+        refused: list[str] = []
+        for de_path, _en_path in pairs:
+            bundle = load_bundle(de_path)
+            if not bundle.outcome.ok:
+                refusal = bundle.outcome.refusal
+                assert refusal is not None and refusal.reasons, (
+                    f"{de_path.name}: refusal must be framed with enumerated reasons"
+                )
+                refused.append(de_path.name)
+                continue
+            parsed += 1
+            _assert_byte_identity(bundle)
+        assert parsed >= _REAL_PARSED_FLOOR, f"only {parsed} pairs parsed"
+        assert len(refused) <= _REAL_REFUSAL_CEILING, (
+            f"{len(refused)} refusals exceed the ceiling {_REAL_REFUSAL_CEILING}: {refused[:10]}…"
+        )

--- a/tests/slides/test_doc_lens_corpus.py
+++ b/tests/slides/test_doc_lens_corpus.py
@@ -41,9 +41,18 @@ _BUNDLED_CORPUS = Path(__file__).parent.parent / "data" / "doc_corpus"
 # (slide_id == for_slide duplicates the deck id in the ≤4-file namespace)
 # + 3 decks with residual id-less localized cells = 62. The ceiling gives a
 # little headroom for ordinary authoring churn; a real rise means id-less /
-# duplicate-id content is being reintroduced.
-_REAL_REFUSAL_CEILING = 80
-_REAL_PARSED_FLOOR = 600
+# duplicate-id content is being reintroduced. Refusal CODES are pinned too:
+# a new code appearing on the real corpus means the parser started refusing
+# a shape it used to accept — investigate before widening the set.
+_REAL_REFUSAL_CEILING = 70
+_REAL_PARSED_FLOOR = 620
+_EXPECTED_REFUSAL_CODES = {
+    "duplicate_id",
+    "idless_localized",
+    "idless_narrative",
+    "idless_anchor",
+    "legacy_title_companion",
+}
 
 
 def _real_corpus_dir() -> Path | None:
@@ -129,6 +138,7 @@ class TestRealCorpus:
         assert len(pairs) >= _REAL_PARSED_FLOOR
         parsed = 0
         refused: list[str] = []
+        unexpected_codes: dict[str, set[str]] = {}
         for de_path, _en_path in pairs:
             bundle = load_bundle(de_path)
             if not bundle.outcome.ok:
@@ -137,6 +147,9 @@ class TestRealCorpus:
                     f"{de_path.name}: refusal must be framed with enumerated reasons"
                 )
                 refused.append(de_path.name)
+                codes = {r.code for r in refusal.reasons}
+                if not codes <= _EXPECTED_REFUSAL_CODES:
+                    unexpected_codes[de_path.name] = codes - _EXPECTED_REFUSAL_CODES
                 continue
             parsed += 1
             _assert_byte_identity(bundle)
@@ -144,3 +157,4 @@ class TestRealCorpus:
         assert len(refused) <= _REAL_REFUSAL_CEILING, (
             f"{len(refused)} refusals exceed the ceiling {_REAL_REFUSAL_CEILING}: {refused[:10]}…"
         )
+        assert not unexpected_codes, f"refusals with unexpected codes: {unexpected_codes}"

--- a/tests/slides/test_doc_lenses.py
+++ b/tests/slides/test_doc_lenses.py
@@ -14,6 +14,7 @@ enumerated, never exceptions, never heuristic parses).
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -422,6 +423,261 @@ class TestRefusals:
         assert project(deck, "de", "deck") == "just some text\n"
         assert project(deck, "en", "deck") == "other text\n"
 
+    def test_empty_slide_id_anchor_refuses_as_idless(self):
+        # slide_id="" (and "!") carries no identity — it must hit the
+        # idless_anchor refusal, not mint an empty or line-number key.
+        de = _strip_final_blank(
+            HEADER_DE + '# %% [markdown] lang="de" tags=["slide"] slide_id=""\n# # A\n\n'
+        )
+        en = _strip_final_blank(
+            HEADER_EN + '# %% [markdown] lang="en" tags=["slide"] slide_id="!"\n# # A\n\n'
+        )
+        outcome = parse_bundle(de, en)
+        assert not outcome.ok
+        assert outcome.refusal is not None
+        assert {r.code for r in outcome.refusal.reasons} == {"idless_anchor"}
+
+
+class TestPairingAlignment:
+    """The #443 adoption must be slot-aware (review finding: interleaved
+    id'd cells previously stole the wrong twin via tail-residue pairing)."""
+
+    def test_443_interleaved_shared_cells_adopt_the_matching_twin(self):
+        # Three shared cells A/X/B; the author stamped an id on DE's X only.
+        # X must adopt EN's byte-equal x — not shift B onto the wrong twin.
+        cells = [_shared_code("cell_a", 1), _shared_code("cell_x", 2), _shared_code("cell_b", 3)]
+        de = _strip_final_blank(
+            HEADER_DE
+            + _slide("g", "de", "G")
+            + cells[0]
+            + cells[1].replace('tags=["keep"]', 'tags=["keep"] slide_id="x-cell"')
+            + cells[2]
+        )
+        en = _strip_final_blank(HEADER_EN + _slide("g", "en", "G") + "".join(cells))
+        outcome = _assert_round_trip(de, en)
+        deck = outcome.deck
+        assert deck is not None
+        member = deck.member_by_key(MemberKey.for_id("x-cell"))
+        assert member is not None
+        assert member.de is not None and member.en is not None
+        assert member.de.lines[1:] == member.en.lines[1:]  # the true twin
+        kinds = [o.kind for o in deck.observations]
+        assert kinds == ["id_stamp_pending_twin"]  # no false shared_divergence
+
+    def test_new_one_sided_idd_shared_cell_does_not_steal_a_twin(self):
+        # A genuinely new id'd shared cell on DE only (different body): it
+        # must stay one-sided and leave the id-less alignment untouched.
+        de = _strip_final_blank(
+            HEADER_DE
+            + _slide("g", "de", "G")
+            + '# %% tags=["keep"] slide_id="new-cell"\nbrand_new = 0\n\n'
+            + _shared_code("cell_a", 1)
+            + _shared_code("cell_b", 2)
+        )
+        en = _strip_final_blank(
+            HEADER_EN
+            + _slide("g", "en", "G")
+            + _shared_code("cell_a", 1)
+            + _shared_code("cell_b", 2)
+        )
+        outcome = _assert_round_trip(de, en)
+        deck = outcome.deck
+        assert deck is not None
+        member = deck.member_by_key(MemberKey.for_id("new-cell"))
+        assert member is not None
+        assert member.en is None  # one-sided, nothing adopted
+        kinds = [o.kind for o in deck.observations]
+        assert kinds == ["one_sided_member"]  # and no divergence noise
+
+    def test_reverse_443_direction_en_idd_de_idless(self):
+        # The mirror of test_443_shape...: id'd on the EN half, id-less DE
+        # twin — one member under the EN id, observation side="de".
+        de = _strip_final_blank(
+            HEADER_DE + _slide("a", "de", "A") + '# %% [markdown] lang="de"\n# T\n\n'
+        )
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A") + _localized("noted", "en", "T"))
+        outcome = _assert_round_trip(de, en)
+        deck = outcome.deck
+        assert deck is not None
+        member = deck.member_by_key(MemberKey.for_id("noted"))
+        assert member is not None
+        assert member.de is not None and member.en is not None
+        obs = [o for o in deck.observations if o.kind == "id_stamp_pending_twin"]
+        assert len(obs) == 1
+        assert obs[0].side == "de"
+        assert obs[0].member == MemberKey.for_id("noted")
+
+    def test_reverse_443_in_companion_files(self):
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A"))
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A"))
+        de_c = _strip_final_blank(
+            '# %% [markdown] lang="de" tags=["notes"] for_slide="a"\n#\n# - Text\n\n'
+        )
+        en_c = _strip_final_blank(_companion_cell("a-vo", "en", "a", "Text"))
+        outcome = _assert_round_trip(de, en, de_c, en_c)
+        deck = outcome.deck
+        assert deck is not None
+        member = deck.member_by_key(MemberKey.for_id("a-vo"))
+        assert member is not None
+        assert member.de is not None and member.en is not None
+        obs = [o for o in deck.observations if o.kind == "id_stamp_pending_twin"]
+        assert len(obs) == 1 and obs[0].side == "de"
+
+
+class TestObservationKeys:
+    """Observations must carry the member's FINAL key (P1: identity computed
+    once and carried unchanged) — never the pre-ordinal sentinel."""
+
+    def test_one_sided_idless_member_observation_resolves(self):
+        de = _strip_final_blank(
+            HEADER_DE + _slide("a", "de", "A") + "# %%\n# de-only shared extra\n\n"
+        )
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A"))
+        outcome = _assert_round_trip(de, en)
+        deck = outcome.deck
+        assert deck is not None
+        obs = [o for o in deck.observations if o.kind == "one_sided_member"]
+        assert len(obs) == 1
+        assert obs[0].member is not None
+        assert obs[0].member.render() == "pos:a/code/0"
+        assert deck.member_by_key(obs[0].member) is not None
+
+    def test_two_diverged_shared_cells_get_distinct_observation_keys(self):
+        de = _strip_final_blank(
+            HEADER_DE + _slide("a", "de", "A") + _shared_code("x", 1) + _shared_code("y", 1)
+        )
+        en = _strip_final_blank(
+            HEADER_EN + _slide("a", "en", "A") + _shared_code("x", 2) + _shared_code("y", 2)
+        )
+        outcome = _assert_round_trip(de, en)
+        deck = outcome.deck
+        assert deck is not None
+        obs = [o for o in deck.observations if o.kind == "shared_divergence"]
+        assert len(obs) == 2
+        keys = {o.member.render() for o in obs if o.member is not None}
+        assert keys == {"pos:a/code/0", "pos:a/code/1"}
+        for o in obs:
+            assert o.member is not None
+            assert deck.member_by_key(o.member) is not None
+
+
+class TestObservationKinds:
+    """Each documented observation kind fires from a realistic input."""
+
+    def test_member_kind_mismatch(self):
+        de = _strip_final_blank(
+            HEADER_DE + _slide("a", "de", "A") + '# %% [markdown] lang="de" slide_id="odd"\n# T\n\n'
+        )
+        en = _strip_final_blank(
+            HEADER_EN + _slide("a", "en", "A") + '# %% lang="en" slide_id="odd"\nprint("t")\n\n'
+        )
+        outcome = _assert_round_trip(de, en)
+        assert outcome.deck is not None
+        obs = {o.kind for o in outcome.deck.observations}
+        assert "member_kind_mismatch" in obs
+
+    def test_lang_attr_mismatch(self):
+        de = _strip_final_blank(
+            HEADER_DE + _slide("a", "de", "A") + '# %% [markdown] lang="de" slide_id="odd"\n# T\n\n'
+        )
+        en = _strip_final_blank(
+            HEADER_EN + _slide("a", "en", "A") + '# %% [markdown] slide_id="odd"\n# T\n\n'
+        )
+        outcome = _assert_round_trip(de, en)
+        assert outcome.deck is not None
+        obs = [o for o in outcome.deck.observations if o.kind == "lang_attr_mismatch"]
+        assert len(obs) == 1
+        assert obs[0].member == MemberKey.for_id("odd")
+
+    def test_owner_mismatch(self):
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A") + _slide("b", "de", "B"))
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A") + _slide("b", "en", "B"))
+        de_c = _strip_final_blank(_companion_cell("vo", "de", "a", "Text"))
+        en_c = _strip_final_blank(_companion_cell("vo", "en", "b", "Text"))
+        outcome = _assert_round_trip(de, en, de_c, en_c)
+        assert outcome.deck is not None
+        obs = [o for o in outcome.deck.observations if o.kind == "owner_mismatch"]
+        assert len(obs) == 1
+        assert obs[0].member == MemberKey.for_id("vo")
+
+    def test_unexpected_companion_cell(self):
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A"))
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A"))
+        de_c = _strip_final_blank('# %% lang="de" slide_id="odd-code"\nprint("?")\n\n')
+        en_c = _strip_final_blank('# %% lang="en" slide_id="odd-code"\nprint("?")\n\n')
+        outcome = _assert_round_trip(de, en, de_c, en_c)
+        assert outcome.deck is not None
+        assert "unexpected_companion_cell" in {o.kind for o in outcome.deck.observations}
+
+    def test_legacy_title_companion_refuses_with_the_actual_fix(self):
+        # Pre-#242 shape: slide_id="title", no for_slide. The "title" id is an
+        # owner reference, not the member's identity — keying it would collide
+        # with the title anchor. Like `--stamp-ids`, the parse refuses the
+        # unowned shape rather than guessing, and the detail names the real
+        # fix instead of a misleading duplicate_id.
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A"))
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A"))
+        de_c = _strip_final_blank(
+            '# %% [markdown] lang="de" tags=["notes"] slide_id="title"\n#\n# - Gruß\n\n'
+        )
+        en_c = _strip_final_blank(
+            '# %% [markdown] lang="en" tags=["notes"] slide_id="title"\n#\n# - Greeting\n\n'
+        )
+        outcome = parse_bundle(de, en, de_c, en_c)
+        assert not outcome.ok
+        assert outcome.refusal is not None
+        codes = {r.code for r in outcome.refusal.reasons}
+        assert "legacy_title_companion" in codes
+        assert "duplicate_id" not in codes  # never the misleading collision
+        legacy = next(r for r in outcome.refusal.reasons if r.code == "legacy_title_companion")
+        assert 'for_slide="title"' in legacy.detail
+
+    def test_legacy_title_companion_refuses_without_title_macro_too(self):
+        de = _strip_final_blank(_slide("a", "de", "A"))
+        en = _strip_final_blank(_slide("a", "en", "A"))
+        de_c = _strip_final_blank(
+            '# %% [markdown] lang="de" tags=["notes"] slide_id="title"\n#\n# - Gruß\n\n'
+        )
+        en_c = _strip_final_blank(
+            '# %% [markdown] lang="en" tags=["notes"] slide_id="title"\n#\n# - Greeting\n\n'
+        )
+        outcome = parse_bundle(de, en, de_c, en_c)
+        assert not outcome.ok
+        assert outcome.refusal is not None
+        assert "legacy_title_companion" in {r.code for r in outcome.refusal.reasons}
+
+
+class TestGroupStructure:
+    def test_subslide_anchors_its_own_group(self):
+        sub = '# %% [markdown] lang="{lang}" tags=["subslide"] slide_id="a-sub"\n#\n# ## Sub\n\n'
+        de = _strip_final_blank(
+            HEADER_DE + _slide("a", "de", "A") + sub.format(lang="de") + _shared_code("x")
+        )
+        en = _strip_final_blank(
+            HEADER_EN + _slide("a", "en", "A") + sub.format(lang="en") + _shared_code("x")
+        )
+        outcome = _assert_round_trip(de, en)
+        deck = outcome.deck
+        assert deck is not None
+        assert [g.anchor_id for g in deck.groups] == ["title", "a", "a-sub"]
+        sub_group = deck.groups[2]
+        assert sub_group.anchor is not None
+        assert sub_group.anchor.role == "subslide"
+        # The shared cell after the subslide belongs to the SUBSLIDE's group.
+        assert [m.key.render() for m in sub_group.members] == ["pos:a-sub/code/0"]
+
+    def test_preface_group_without_title_macro(self):
+        de = _strip_final_blank("# %%\nimport math\n\n" + _slide("a", "de", "A"))
+        en = _strip_final_blank("# %%\nimport math\n\n" + _slide("a", "en", "A"))
+        outcome = _assert_round_trip(de, en)
+        deck = outcome.deck
+        assert deck is not None
+        assert deck.header == []
+        assert [g.anchor_id for g in deck.groups] == ["~preface", "a"]
+        preface = deck.groups[0]
+        assert preface.anchor is None
+        assert [m.key.render() for m in preface.members] == ["pos:~preface/code/0"]
+
 
 class TestByteEdgeCases:
     def test_leading_blank_line_survives(self):
@@ -536,25 +792,57 @@ def test_round_trip_property(bundle: tuple[str, str, str | None, str | None]) ->
 
 
 @given(bundle=_normalized_bundle(), data=st.data())
-@settings(deadline=None, suppress_health_check=[HealthCheck.too_slow], max_examples=80)
+@settings(deadline=None, suppress_health_check=[HealthCheck.too_slow], max_examples=100)
 def test_round_trip_survives_one_sided_mutations(
     bundle: tuple[str, str, str | None, str | None], data: st.DataObject
 ) -> None:
     """Byte-identity and reparse-identity are unconditional on parseable
-    input: whatever one-sided edit an author makes, either the parse refuses
-    (framed) or the round trip holds."""
+    input: whatever one-sided edit an author makes — on either half, in the
+    deck or in a companion — either the parse refuses (framed) or the round
+    trip holds."""
     de, en, de_c, en_c = bundle
-    mutation = data.draw(st.sampled_from(["edit_shared", "drop_en_cell", "add_en_cell", "none"]))
-    if mutation == "edit_shared":
-        en = en.replace(" = 1", " = 2")
-    elif mutation == "drop_en_cell":
-        cells = en.split("\n# %%")
-        if len(cells) > 1:
-            idx = data.draw(st.integers(min_value=1, max_value=len(cells) - 1))
-            cells.pop(idx)
-            en = "\n# %%".join(cells)
-    elif mutation == "add_en_cell":
-        en = en + "\n" + _strip_final_blank(_localized("extra-en", "en", "added"))
+    side = data.draw(st.sampled_from(["de", "en"]))
+    menu = ["edit_shared", "drop_cell", "add_cell", "strip_id", "none"]
+    if (de_c if side == "de" else en_c) is not None:
+        menu += ["drop_companion_cell", "strip_companion_id"]
+    mutation = data.draw(st.sampled_from(menu))
+
+    def mutate(text: str) -> str:
+        if mutation == "edit_shared" and " = 1" in text:
+            return text.replace(" = 1", " = 2", 1)
+        if mutation == "drop_cell":
+            cells = text.split("\n# %%")
+            if len(cells) > 1:
+                idx = data.draw(st.integers(min_value=1, max_value=len(cells) - 1))
+                cells.pop(idx)
+                return "\n# %%".join(cells)
+        if mutation == "add_cell":
+            return text + "\n" + _strip_final_blank(_localized(f"extra-{side}", side, "added"))
+        if mutation == "strip_id":
+            # Remove the first localized member's slide_id (the #443 shape).
+            return re.sub(r'(\[markdown\] lang="[a-z]+") slide_id="[^"]*"', r"\1", text, count=1)
+        return text
+
+    def mutate_companion(text: str) -> str:
+        if mutation == "drop_companion_cell":
+            cells = text.split("\n# %%")
+            if len(cells) > 1:
+                cells.pop(len(cells) - 1)
+                return "\n# %%".join(cells)
+        if mutation == "strip_companion_id":
+            return re.sub(r' slide_id="[^"]*"', "", text, count=1)
+        return text
+
+    if mutation in ("drop_companion_cell", "strip_companion_id"):
+        if side == "de" and de_c is not None:
+            de_c = mutate_companion(de_c)
+        elif en_c is not None:
+            en_c = mutate_companion(en_c)
+    elif side == "de":
+        de = mutate(de)
+    else:
+        en = mutate(en)
+
     outcome = parse_bundle(de, en, de_c, en_c)
     if not outcome.ok:
         assert outcome.refusal is not None

--- a/tests/slides/test_doc_lenses.py
+++ b/tests/slides/test_doc_lenses.py
@@ -1,0 +1,570 @@
+"""Round-trip law suite for :mod:`clm.slides.doc_lenses` (#520 Phase 1).
+
+The non-negotiable laws (design §4)::
+
+    project(parse_bundle(...).deck, lang, part) == input text   # byte-identity
+    parse_bundle(*(project(deck, ...) for each file)) == deck   # identity
+
+Structure mirrors ``test_split.py`` — the proven template for lens law
+suites: tiny string builders + one-shape-per-test unit cases for diagnosable
+failures, Hypothesis properties over generated bundles, and negative tests
+pinning the framed-refusal contract (§3.4: refusals are typed and
+enumerated, never exceptions, never heuristic parses).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from clm.slides.bilingual_doc import MemberKey, ParseOutcome
+from clm.slides.doc_lenses import parse_bundle, project
+
+# ---------------------------------------------------------------------------
+# Builders — DE and EN halves constructed in lockstep
+# ---------------------------------------------------------------------------
+
+HEADER_DE = "# j2 from 'macros.j2' import header_de\n# {{ header_de(\"Titel DE\") }}\n\n"
+HEADER_EN = "# j2 from 'macros.j2' import header_en\n# {{ header_en(\"Title EN\") }}\n\n"
+
+
+def _slide(slug: str, lang: str, title: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{slug}"\n#\n# # {title}\n\n'
+
+
+def _localized(slug: str, lang: str, text: str) -> str:
+    return f'# %% [markdown] lang="{lang}" slide_id="{slug}"\n# {text}\n\n'
+
+
+def _shared_code(name: str, value: int = 1) -> str:
+    return f'# %% tags=["keep"]\n{name} = {value}\n\n'
+
+
+def _inline_vo(slug: str, lang: str, text: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["voiceover"] slide_id="{slug}"\n# {text}\n\n'
+
+
+def _companion_cell(slug: str, lang: str, owner: str, text: str, tag: str = "notes") -> str:
+    return (
+        f'# %% [markdown] lang="{lang}" tags=["{tag}"] for_slide="{owner}" '
+        f'vo_anchor="id:{owner}#0" slide_id="{slug}"\n#\n# - {text}\n\n'
+    )
+
+
+def _strip_final_blank(text: str) -> str:
+    """Builders end blocks with a blank separator; files end with one newline."""
+    return text[:-1] if text.endswith("\n\n") else text
+
+
+def _assert_round_trip(
+    de: str,
+    en: str,
+    de_comp: str | None = None,
+    en_comp: str | None = None,
+    comment_token: str = "#",
+) -> ParseOutcome:
+    outcome = parse_bundle(de, en, de_comp, en_comp, comment_token=comment_token)
+    assert outcome.ok, outcome.refusal.render() if outcome.refusal else "?"
+    deck = outcome.deck
+    assert deck is not None
+    assert project(deck, "de", "deck") == de
+    assert project(deck, "en", "deck") == en
+    assert project(deck, "de", "companion") == de_comp
+    assert project(deck, "en", "companion") == en_comp
+    # The other direction: parsing the projections yields the same document.
+    again = parse_bundle(
+        project(deck, "de", "deck") or "",
+        project(deck, "en", "deck") or "",
+        project(deck, "de", "companion"),
+        project(deck, "en", "companion"),
+        comment_token=comment_token,
+    )
+    assert again.ok
+    assert again.deck == deck
+    return outcome
+
+
+# ---------------------------------------------------------------------------
+# Direct unit cases — one shape per test
+# ---------------------------------------------------------------------------
+
+
+class TestParseNormalizedDeck:
+    def _pair(self) -> tuple[str, str]:
+        de = _strip_final_blank(
+            HEADER_DE
+            + _slide("intro", "de", "Einführung")
+            + _localized("intro-note", "de", "Hinweis")
+            + _shared_code("x")
+            + _slide("details", "de", "Details")
+        )
+        en = _strip_final_blank(
+            HEADER_EN
+            + _slide("intro", "en", "Introduction")
+            + _localized("intro-note", "en", "Note")
+            + _shared_code("x")
+            + _slide("details", "en", "Details")
+        )
+        return de, en
+
+    def test_round_trips_byte_identically(self):
+        de, en = self._pair()
+        _assert_round_trip(de, en)
+
+    def test_structure_and_keys(self):
+        de, en = self._pair()
+        deck = parse_bundle(de, en).deck
+        assert deck is not None
+        assert deck.observations == []
+        # Header zone: the j2 import line; the macro anchors the title group.
+        assert [m.key.render() for m in deck.header] == ["pos:~header/j2/0"]
+        assert [g.anchor_id for g in deck.groups] == ["title", "intro", "details"]
+        title = deck.groups[0]
+        assert title.anchor is not None
+        assert title.anchor.key == MemberKey.for_id("title")
+        assert title.anchor.role == "header"
+        intro = deck.groups[1]
+        member_keys = [m.key.render() for m in intro.members]
+        assert member_keys == ["id:intro-note", "pos:intro/code/0"]
+        note = intro.members[0]
+        assert note.langness == "localized"
+        assert note.role == "aux"
+        assert note.owner == MemberKey.for_id("intro")
+        shared = intro.members[1]
+        assert shared.langness == "shared"
+        assert shared.role == "code"
+
+    def test_localized_code_cell_gets_code_role(self):
+        de = _strip_final_blank(
+            HEADER_DE
+            + _slide("a", "de", "A")
+            + '# %% lang="de" slide_id="a-code"\nprint("Hallo")\n\n'
+        )
+        en = _strip_final_blank(
+            HEADER_EN
+            + _slide("a", "en", "A")
+            + '# %% lang="en" slide_id="a-code"\nprint("Hello")\n\n'
+        )
+        outcome = _assert_round_trip(de, en)
+        assert outcome.deck is not None
+        member = outcome.deck.member_by_key(MemberKey.for_id("a-code"))
+        assert member is not None
+        assert member.role == "code"
+        assert member.langness == "localized"
+
+    def test_preserve_marker_id_keys_bare(self):
+        de = _strip_final_blank(
+            HEADER_DE + _slide("a", "de", "A") + _localized("!kept-id", "de", "T")
+        )
+        en = _strip_final_blank(
+            HEADER_EN + _slide("a", "en", "A") + _localized("!kept-id", "en", "T")
+        )
+        outcome = _assert_round_trip(de, en)
+        assert outcome.deck is not None
+        member = outcome.deck.member_by_key(MemberKey.for_id("kept-id"))
+        assert member is not None
+        assert member.de is not None
+        assert member.de.slide_id == "!kept-id"  # bytes stay verbatim
+
+
+class TestCompanions:
+    def test_companion_members_join_their_owner_group(self):
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A"))
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A"))
+        de_c = _strip_final_blank(
+            _companion_cell("a-greet", "de", "title", "Willkommen!")
+            + _companion_cell("a-vo", "de", "a", "Hinweis.")
+        )
+        en_c = _strip_final_blank(
+            _companion_cell("a-greet", "en", "title", "Welcome!")
+            + _companion_cell("a-vo", "en", "a", "Note.")
+        )
+        outcome = _assert_round_trip(de, en, de_c, en_c)
+        deck = outcome.deck
+        assert deck is not None
+        assert deck.observations == []
+        assert deck.orphans == []
+        title, group_a = deck.groups
+        assert [m.key.render() for m in title.members] == ["id:a-greet"]
+        assert title.members[0].layout == "companion"
+        assert title.members[0].owner == MemberKey.for_id("title")
+        assert [m.key.render() for m in group_a.members] == ["id:a-vo"]
+        assert group_a.members[0].role == "notes"
+
+    def test_orphan_companion_cell_is_kept_and_observed(self):
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A"))
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A"))
+        de_c = _strip_final_blank(_companion_cell("lost", "de", "no-such-slide", "Text"))
+        en_c = _strip_final_blank(_companion_cell("lost", "en", "no-such-slide", "Text"))
+        outcome = _assert_round_trip(de, en, de_c, en_c)
+        deck = outcome.deck
+        assert deck is not None
+        assert [m.key.render() for m in deck.orphans] == ["id:lost"]
+        assert [o.kind for o in deck.observations] == ["owner_missing"]
+
+    def test_missing_companion_projects_to_none(self):
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A"))
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A"))
+        deck = parse_bundle(de, en).deck
+        assert deck is not None
+        assert project(deck, "de", "companion") is None
+        assert project(deck, "en", "companion") is None
+
+    def test_empty_companion_string_round_trips_as_empty(self):
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A"))
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A"))
+        _assert_round_trip(de, en, "", "")
+
+    def test_solo_companion_is_cross_language_layout(self):
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A"))
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A"))
+        de_c = _strip_final_blank(_companion_cell("a-vo", "de", "a", "Nur DE."))
+        outcome = _assert_round_trip(de, en, de_c, None)
+        deck = outcome.deck
+        assert deck is not None
+        kinds = [o.kind for o in deck.observations]
+        assert "layout_cross_language" in kinds
+        assert "one_sided_member" in kinds
+
+    def test_inline_voiceover_plus_companion_is_layout_mixed(self):
+        de = _strip_final_blank(
+            HEADER_DE + _slide("a", "de", "A") + _inline_vo("a-inline", "de", "Inline.")
+        )
+        en = _strip_final_blank(
+            HEADER_EN + _slide("a", "en", "A") + _inline_vo("a-inline", "en", "Inline.")
+        )
+        de_c = _strip_final_blank(_companion_cell("a-vo", "de", "a", "Companion."))
+        en_c = _strip_final_blank(_companion_cell("a-vo", "en", "a", "Companion."))
+        outcome = _assert_round_trip(de, en, de_c, en_c)
+        deck = outcome.deck
+        assert deck is not None
+        assert {o.kind for o in deck.observations} == {"layout_mixed"}
+
+    def test_mid_relayout_member_pairs_across_parts(self):
+        # The same id inline on the DE half but in the EN companion: one
+        # member, mid-relayout (design §7.3 / P2) — never two members.
+        de = _strip_final_blank(
+            HEADER_DE + _slide("a", "de", "A") + _inline_vo("a-vo", "de", "Inline DE.")
+        )
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A"))
+        en_c = _strip_final_blank(
+            _companion_cell("a-vo", "en", "a", "Companion EN.", tag="voiceover")
+        )
+        outcome = _assert_round_trip(de, en, None, en_c)
+        deck = outcome.deck
+        assert deck is not None
+        member = deck.member_by_key(MemberKey.for_id("a-vo"))
+        assert member is not None
+        assert member.de is not None and member.de.part == "deck"
+        assert member.en is not None and member.en.part == "companion"
+        assert "layout_cross_language" in {o.kind for o in deck.observations}
+
+
+class TestObservations:
+    def test_shared_divergence_is_observed_and_bytes_kept(self):
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A") + _shared_code("x", 1))
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A") + _shared_code("x", 2))
+        outcome = _assert_round_trip(de, en)
+        deck = outcome.deck
+        assert deck is not None
+        assert [o.kind for o in deck.observations] == ["shared_divergence"]
+
+    def test_one_sided_member_is_observed(self):
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A"))
+        en = _strip_final_blank(
+            HEADER_EN + _slide("a", "en", "A") + _localized("en-only", "en", "Extra")
+        )
+        outcome = _assert_round_trip(de, en)
+        deck = outcome.deck
+        assert deck is not None
+        obs = [o for o in deck.observations if o.kind == "one_sided_member"]
+        assert len(obs) == 1
+        assert obs[0].member == MemberKey.for_id("en-only")
+        assert obs[0].side == "en"
+
+    def test_443_shape_is_a_transition_not_a_refusal(self):
+        # Id'd on the DE half, id-less twin on the EN half: one member under
+        # the id'd side's key with an id-stamp-pending observation (§3.3).
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A") + _localized("noted", "de", "T"))
+        en = _strip_final_blank(
+            HEADER_EN + _slide("a", "en", "A") + '# %% [markdown] lang="en"\n# T\n\n'
+        )
+        outcome = _assert_round_trip(de, en)
+        deck = outcome.deck
+        assert deck is not None
+        member = deck.member_by_key(MemberKey.for_id("noted"))
+        assert member is not None
+        assert member.de is not None and member.en is not None
+        assert [o.kind for o in deck.observations] == ["id_stamp_pending_twin"]
+
+    def test_one_sided_group_is_observed(self):
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A") + _slide("b", "de", "B"))
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A"))
+        outcome = _assert_round_trip(de, en)
+        deck = outcome.deck
+        assert deck is not None
+        kinds = [o.kind for o in deck.observations]
+        assert "one_sided_group" in kinds
+
+    def test_group_order_divergence_is_observed(self):
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A") + _slide("b", "de", "B"))
+        en = _strip_final_blank(HEADER_EN + _slide("b", "en", "B") + _slide("a", "en", "A"))
+        outcome = _assert_round_trip(de, en)
+        deck = outcome.deck
+        assert deck is not None
+        assert "group_order_divergence" in {o.kind for o in deck.observations}
+
+    def test_wrong_language_cell_is_observed(self):
+        de = _strip_final_blank(
+            HEADER_DE + _slide("a", "de", "A") + _localized("odd", "en", "englisch im DE-File")
+        )
+        en = _strip_final_blank(
+            HEADER_EN + _slide("a", "en", "A") + _localized("odd2", "en", "fine")
+        )
+        outcome = parse_bundle(de, en)
+        assert outcome.ok
+        assert outcome.deck is not None
+        assert "wrong_language_cell" in {o.kind for o in outcome.deck.observations}
+
+    def test_preamble_divergence_is_observed(self):
+        de = "# leading DE comment\n" + _strip_final_blank(HEADER_DE + _slide("a", "de", "A"))
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A"))
+        outcome = _assert_round_trip(de, en)
+        assert outcome.deck is not None
+        assert "preamble_divergence" in {o.kind for o in outcome.deck.observations}
+
+
+class TestRefusals:
+    def test_legacy_bundled_corpus_pair_refuses(self):
+        # The v2-era bundled corpus deck carries the inherited-id voiceover
+        # and id-less localized shapes — under the §3.4 precondition it must
+        # refuse with the duplicate enumerated on both sides.
+        data = Path(__file__).parent.parent / "data" / "sync_corpus"
+        de = (data / "deck_features.de.py").read_text(encoding="utf-8")
+        en = (data / "deck_features.en.py").read_text(encoding="utf-8")
+        outcome = parse_bundle(de, en)
+        assert not outcome.ok
+        assert outcome.refusal is not None
+        codes = [r.code for r in outcome.refusal.reasons]
+        assert codes.count("duplicate_id") == 2  # "intro" on each side
+        assert "normalize" in outcome.refusal.render()
+
+    def test_duplicate_id_within_one_side_refuses(self):
+        de = _strip_final_blank(
+            HEADER_DE + _slide("a", "de", "A") + _localized("a", "de", "shadows the anchor")
+        )
+        en = _strip_final_blank(
+            HEADER_EN + _slide("a", "en", "A") + _localized("a", "en", "shadows the anchor")
+        )
+        outcome = parse_bundle(de, en)
+        assert not outcome.ok
+        assert outcome.refusal is not None
+        assert {r.code for r in outcome.refusal.reasons} == {"duplicate_id"}
+
+    def test_companion_inherit_shape_refuses(self):
+        # Legacy companions whose narrative slide_id equals for_slide (the
+        # owner's id) duplicate the deck id inside the ≤4-file namespace.
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A"))
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A"))
+        de_c = _strip_final_blank(_companion_cell("a", "de", "a", "geerbt"))
+        en_c = _strip_final_blank(_companion_cell("a", "en", "a", "inherited"))
+        outcome = parse_bundle(de, en, de_c, en_c)
+        assert not outcome.ok
+        assert outcome.refusal is not None
+        assert {r.code for r in outcome.refusal.reasons} == {"duplicate_id"}
+
+    def test_idless_anchor_refuses(self):
+        de = _strip_final_blank(HEADER_DE + '# %% [markdown] lang="de" tags=["slide"]\n# # A\n\n')
+        en = _strip_final_blank(HEADER_EN + '# %% [markdown] lang="en" tags=["slide"]\n# # A\n\n')
+        outcome = parse_bundle(de, en)
+        assert not outcome.ok
+        assert outcome.refusal is not None
+        codes = [r.code for r in outcome.refusal.reasons]
+        assert codes == ["idless_anchor", "idless_anchor"]  # enumerated per side
+
+    def test_idless_localized_on_both_halves_refuses(self):
+        de = _strip_final_blank(
+            HEADER_DE + _slide("a", "de", "A") + '# %% [markdown] lang="de"\n# ohne Id\n\n'
+        )
+        en = _strip_final_blank(
+            HEADER_EN + _slide("a", "en", "A") + '# %% [markdown] lang="en"\n# no id\n\n'
+        )
+        outcome = parse_bundle(de, en)
+        assert not outcome.ok
+        assert outcome.refusal is not None
+        assert {r.code for r in outcome.refusal.reasons} == {"idless_localized"}
+
+    def test_idless_inline_narrative_refuses(self):
+        de = _strip_final_blank(
+            HEADER_DE
+            + _slide("a", "de", "A")
+            + '# %% [markdown] lang="de" tags=["voiceover"]\n# ohne Id\n\n'
+        )
+        en = _strip_final_blank(
+            HEADER_EN
+            + _slide("a", "en", "A")
+            + '# %% [markdown] lang="en" tags=["voiceover"]\n# no id\n\n'
+        )
+        outcome = parse_bundle(de, en)
+        assert not outcome.ok
+        assert outcome.refusal is not None
+        assert {r.code for r in outcome.refusal.reasons} == {"idless_narrative"}
+
+    def test_refusal_never_raises(self):
+        # Degenerate input: not a deck at all — still a typed outcome.
+        outcome = parse_bundle("just some text\n", "other text\n")
+        assert outcome.ok  # no cells, no ids: an empty but valid document
+        deck = outcome.deck
+        assert deck is not None
+        assert project(deck, "de", "deck") == "just some text\n"
+        assert project(deck, "en", "deck") == "other text\n"
+
+
+class TestByteEdgeCases:
+    def test_leading_blank_line_survives(self):
+        # raw_cells.reconstruct drops an empty preamble; the lens must not.
+        de = "\n" + _strip_final_blank(HEADER_DE + _slide("a", "de", "A"))
+        en = "\n" + _strip_final_blank(HEADER_EN + _slide("a", "en", "A"))
+        _assert_round_trip(de, en)
+
+    def test_no_trailing_newline_survives(self):
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A")).rstrip("\n")
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A")).rstrip("\n")
+        _assert_round_trip(de, en)
+
+    def test_extra_blank_runs_survive(self):
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A")) + "\n\n\n"
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A")) + "\n\n\n"
+        _assert_round_trip(de, en)
+
+    def test_cpp_comment_token_round_trips(self):
+        de = (
+            "// j2 from 'macros.j2' import header_de\n"
+            '// {{ header_de("Titel") }}\n\n'
+            '// %% [markdown] lang="de" tags=["slide"] slide_id="cpp-a"\n// # A\n\n'
+            '// %% tags=["keep"]\nint x = 1;\n'
+        )
+        en = (
+            "// j2 from 'macros.j2' import header_en\n"
+            '// {{ header_en("Title") }}\n\n'
+            '// %% [markdown] lang="en" tags=["slide"] slide_id="cpp-a"\n// # A\n\n'
+            '// %% tags=["keep"]\nint x = 1;\n'
+        )
+        _assert_round_trip(de, en, comment_token="//")
+
+    def test_j2_widget_cell_mid_group_is_a_shared_member(self):
+        widget = '# {{ img("diagram.png") }}\n\n'
+        de = _strip_final_blank(HEADER_DE + _slide("a", "de", "A") + widget)
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A") + widget)
+        outcome = _assert_round_trip(de, en)
+        deck = outcome.deck
+        assert deck is not None
+        assert deck.observations == []
+        member = deck.member_by_key(MemberKey.parse("pos:a/j2/0"))
+        assert member is not None
+        assert member.langness == "shared"
+        assert member.role == "aux"
+
+
+# ---------------------------------------------------------------------------
+# Hypothesis properties
+# ---------------------------------------------------------------------------
+
+
+@st.composite
+def _normalized_bundle(draw) -> tuple[str, str, str | None, str | None]:
+    """Generate a canonical normalized bundle (§3.4 steady state).
+
+    Every localized/narrative cell is id'd, DE/EN twins share ids, shared
+    cells are byte-identical, companions mirror. Non-canonical shapes are
+    covered by the mutation property below and by the unit tests.
+    """
+    n_groups = draw(st.integers(min_value=1, max_value=4))
+    de_parts, en_parts = [HEADER_DE], [HEADER_EN]
+    comp_de: list[str] = []
+    comp_en: list[str] = []
+    # Wholly-inline-or-wholly-companion (the #501 invariant): a canonical
+    # deck never mixes inline voiceover with a companion file.
+    with_companion = draw(st.booleans())
+    member_kinds = ["localized", "shared", "code"] + ([] if with_companion else ["inline_vo"])
+    for g in range(n_groups):
+        slug = f"s{g}"
+        de_parts.append(_slide(slug, "de", f"Titel {g}"))
+        en_parts.append(_slide(slug, "en", f"Title {g}"))
+        n_members = draw(st.integers(min_value=0, max_value=3))
+        for m in range(n_members):
+            kind = draw(st.sampled_from(member_kinds))
+            mslug = f"{slug}-m{m}"
+            if kind == "localized":
+                de_parts.append(_localized(mslug, "de", f"DE {mslug}"))
+                en_parts.append(_localized(mslug, "en", f"EN {mslug}"))
+            elif kind == "shared":
+                de_parts.append(_shared_code(f"var_{g}_{m}"))
+                en_parts.append(_shared_code(f"var_{g}_{m}"))
+            elif kind == "inline_vo":
+                de_parts.append(_inline_vo(mslug, "de", f"VO DE {mslug}"))
+                en_parts.append(_inline_vo(mslug, "en", f"VO EN {mslug}"))
+            else:
+                de_parts.append(f'# %% lang="de" slide_id="{mslug}"\nprint("de")\n\n')
+                en_parts.append(f'# %% lang="en" slide_id="{mslug}"\nprint("en")\n\n')
+        if with_companion and draw(st.booleans()):
+            comp_de.append(_companion_cell(f"{slug}-vo", "de", slug, f"Text {slug}"))
+            comp_en.append(_companion_cell(f"{slug}-vo", "en", slug, f"Text {slug}"))
+    de = _strip_final_blank("".join(de_parts))
+    en = _strip_final_blank("".join(en_parts))
+    de_c = _strip_final_blank("".join(comp_de)) if comp_de else None
+    en_c = _strip_final_blank("".join(comp_en)) if comp_en else None
+    return de, en, de_c, en_c
+
+
+@given(bundle=_normalized_bundle())
+@settings(deadline=None, suppress_health_check=[HealthCheck.too_slow], max_examples=80)
+def test_round_trip_property(bundle: tuple[str, str, str | None, str | None]) -> None:
+    de, en, de_c, en_c = bundle
+    outcome = _assert_round_trip(de, en, de_c, en_c)
+    deck = outcome.deck
+    assert deck is not None
+    # Canonical bundles parse without noise: no observations, and every
+    # localized member is id-keyed (the §3.4 steady state).
+    assert deck.observations == []
+    for member in deck.members():
+        if member.langness == "localized" and member.role != "header":
+            assert member.key.scheme == "id"
+
+
+@given(bundle=_normalized_bundle(), data=st.data())
+@settings(deadline=None, suppress_health_check=[HealthCheck.too_slow], max_examples=80)
+def test_round_trip_survives_one_sided_mutations(
+    bundle: tuple[str, str, str | None, str | None], data: st.DataObject
+) -> None:
+    """Byte-identity and reparse-identity are unconditional on parseable
+    input: whatever one-sided edit an author makes, either the parse refuses
+    (framed) or the round trip holds."""
+    de, en, de_c, en_c = bundle
+    mutation = data.draw(st.sampled_from(["edit_shared", "drop_en_cell", "add_en_cell", "none"]))
+    if mutation == "edit_shared":
+        en = en.replace(" = 1", " = 2")
+    elif mutation == "drop_en_cell":
+        cells = en.split("\n# %%")
+        if len(cells) > 1:
+            idx = data.draw(st.integers(min_value=1, max_value=len(cells) - 1))
+            cells.pop(idx)
+            en = "\n# %%".join(cells)
+    elif mutation == "add_en_cell":
+        en = en + "\n" + _strip_final_blank(_localized("extra-en", "en", "added"))
+    outcome = parse_bundle(de, en, de_c, en_c)
+    if not outcome.ok:
+        assert outcome.refusal is not None
+        assert outcome.refusal.reasons  # framed, enumerated
+        return
+    deck = outcome.deck
+    assert deck is not None
+    assert project(deck, "de", "deck") == de
+    assert project(deck, "en", "deck") == en
+    assert project(deck, "de", "companion") == de_c
+    assert project(deck, "en", "companion") == en_c
+    again = parse_bundle(de, en, de_c, en_c)
+    assert again.deck == deck


### PR DESCRIPTION
## Sync v3 Phase 1 — model + lenses (umbrella #520)

Implements Phase 1 of `docs/claude/design/sync-total-identity-document-model.md`: the canonical bilingual document model and its lens projections.

### What's new

- **`clm.slides.bilingual_doc`** — the `BilingualDeck` model: header members, ordered `SlideGroup`s (id'd anchor + members), total `MemberKey` identity per §3.3 (`id:<bare slide_id>`, else `pos:<group>/<kind>/<ordinal>` among the group's id-less members of that kind). Members store *verbatim per-side cells*, so in-flight divergence stays representable and projection never regenerates bytes.
- **`clm.slides.doc_lenses`** — `parse_bundle(de, en, de_comp?, en_comp?) -> ParseOutcome` and `project(deck, lang, part) -> str | None`, plus a `load_bundle` file driver (pair discovery via the prefix-agnostic `pairing` helpers, companions via `resolve_companion`). Parsing runs in strict pair-then-emit phases so a cell can never land in two members; pairing is global-by-id first (a moved or mid-relayout member stays **one** member, per P2/§7.3), then slot-aware positional per kind-class (rule 2), with the #443 id'd-on-one-half shape resolved as one member carrying an `id_stamp_pending_twin` observation.
- **Observations vs refusals (§3.2/§3.4)** — mismatches (one-sided members/groups, shared divergence judged modulo the id attribute, lang/layout/owner mismatches, orphaned companions) are recorded, member-keyed observations; normalize-precondition failures (duplicate ids incl. the legacy inherited-id companion shape, id-less anchors incl. empty/marker-only ids, id-less localized/narrative cells, the pre-#242 `slide_id="title"` companion) yield a framed `NormalizeRefusal` with every reason enumerated — never an exception, never a heuristic parse.

### The Phase 1 exit gate

`project ∘ parse == byte-identity` over the full corpus — **verified against the real PythonCourses corpus: 644/706 pairs parse with zero byte divergences across all four projections** (deck + companion, both languages). The 62 refusals are the standing normalize worklist (59 legacy inherited-id companion decks + 3 residual id-less localized cells) — pinned in the gate by a ceiling (70), a parsed floor (620), and a closed refusal-code set, so the population can only shrink.

Law suite: golden unit shapes + Hypothesis properties (canonical bundles round-trip with zero observations; arbitrary one-sided mutations on either half — companions included — either refuse framed or round-trip byte-identically), a bundled corpus (`tests/data/doc_corpus`: subdir + sibling companion layouts, legacy inline voiceover, observation shapes, `//`-token C++ deck) running in the fast suite, and the `integration+slow` full-corpus gate for local/release runs.

### Guard rails

- Import-cleanliness probe (same fresh-subprocess mechanism as the 1.16 agent-path test) pins that the v3 modules never import `sync_plan`/`sync_apply`/`sync_code` — keeping Phase 4's v2 deletion clean per §12.5.
- Pre-merge adversarial multi-agent review: 24 raw findings, 12 confirmed after refutation passes, all fixed in the second commit (slot-aware #443 adoption, final-key observations, empty-id refusal, dedicated `legacy_title_companion` refusal, plus the test gaps: subslide anchoring, both #443 directions, preface groups, per-kind observation coverage).

No CLI surface change; the v2 engine is untouched. Next: Phase 2 (generic 3-way differ + transition table, shadow mode).

Refs #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xju9N384PqCWxiaBtMx9Uj
