### PR TITLE
feat(workers): accept a venv dir / project-relative path for the notebook kernel (Wave 2b)

### DIFF
--- a/changelog.d/516-notebook-kernel-python-direct.added.md
+++ b/changelog.d/516-notebook-kernel-python-direct.added.md
@@ -6,7 +6,12 @@
   interpreter with the new `clm provision kernel-env --python <path>`, then
   select it via the `CLM_NOTEBOOK_KERNEL_PYTHON` env var, a course-spec
   `<kernel-python>` element, or `clm.toml` `[jupyter] kernel_python` (that is the
-  precedence, most specific first). Unset ⇒ the kernel runs in clm's own
+  precedence, most specific first). The value can be the **venv directory** (clm
+  picks the platform interpreter inside it — `Scripts/python.exe` on Windows,
+  `bin/python` on POSIX) and a **relative** value is resolved against the project
+  root, so a single committed setting like `kernel_python = ".venv"` works
+  cross-platform and lets a globally-installed clm build a course whose runtime
+  stack lives in the course's own venv. Unset ⇒ the kernel runs in clm's own
   environment, exactly as before — this is fully opt-in. Only the `python3`
   kernel is affected; C++/C#/Java/TS kernels and Docker mode are unchanged. See
   `clm info commands` / `clm info spec-files` and

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -380,6 +380,27 @@ clm provision kernel-env --python /opt/course-venvs/ml/bin/python
 `clm.toml` `[jupyter] kernel_python`), and `clm info spec-files` for
 `<kernel-python>`.
 
+### Course repo with one bundled venv (global clm)
+
+A course repo often keeps **one** venv (its own `.venv`) that holds both clm and
+the course-runtime stack, and builds with a **globally installed** `clm`. Without
+configuration, a global `clm` would run the kernel in *its* venv (no ML stack)
+and the build would fail. Point clm at the course's own venv — the value can be
+the **venv directory**, and a **relative** path is resolved against the project
+root and to the right per-platform interpreter, so one committed setting works on
+Windows and POSIX:
+
+```toml
+# clm.toml (or .clm/config.toml) at the course repo root
+[jupyter]
+kernel_python = ".venv"    # → .venv/Scripts/python.exe (Windows) or .venv/bin/python (POSIX)
+```
+
+or per course, in the spec: `<kernel-python>.venv</kernel-python>`. `clm build`
+provisions the kernelspec from that automatically — no separate
+`clm provision kernel-env` step needed. (The course's `.venv` must include
+`ipykernel`; installing `course-runtime-requirements.txt` covers it.)
+
 > **Prefer Docker for heavy ML decks.** The Docker notebook image already bakes
 > in an equivalent course-runtime stack and is fully isolated, so Docker mode
 > needs none of the above. The course-venv route is for running ML decks in

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -1859,9 +1859,19 @@ async def main_build(
     # untouched. Docker mode ignores it (a host interpreter is meaningless in a
     # container). Resolved here where the spec is in scope; the executor just
     # provisions + injects JUPYTER_PATH.
-    from clm.infrastructure.workers.kernel_env import resolve_notebook_kernel_python
+    from clm.infrastructure.workers.kernel_env import (
+        resolve_kernel_interpreter,
+        resolve_notebook_kernel_python,
+    )
 
-    notebook_kernel_python = resolve_notebook_kernel_python(course.spec.kernel_python)
+    # First pick the winning tier (env > spec > clm.toml), then normalise it to
+    # an absolute interpreter: a value may be a venv *directory* (resolved to the
+    # platform interpreter inside it) and a relative value is anchored to the
+    # project root — so a single committed <kernel-python> works cross-platform
+    # and regardless of the invocation cwd.
+    notebook_kernel_python = resolve_kernel_interpreter(
+        resolve_notebook_kernel_python(course.spec.kernel_python)
+    )
 
     lifecycle_manager = WorkerLifecycleManager(
         config=worker_config,

--- a/src/clm/cli/commands/provision.py
+++ b/src/clm/cli/commands/provision.py
@@ -28,8 +28,10 @@ def provision_group() -> None:
     "python_exe",
     required=True,
     type=click.Path(path_type=Path),
-    help="Path to the Python interpreter (course venv) that should host the "
-    "Direct-mode notebook kernel. Must have 'ipykernel' installed.",
+    help="The course venv that should host the Direct-mode notebook kernel: "
+    "either the venv directory (clm picks the platform interpreter inside it) "
+    "or a specific Python interpreter. Relative paths resolve against the "
+    "project root. Must have 'ipykernel' installed.",
 )
 @click.option(
     "--no-validate",
@@ -42,22 +44,25 @@ def kernel_env(python_exe: Path, no_validate: bool) -> None:
 
     Writes a ``python3`` kernelspec pointing at the given interpreter and prints
     the ways to activate it. clm then runs the notebook kernel in that
-    environment (course-runtime packages like ``[ml]`` live there, not in clm's
-    own venv) while clm keeps driving nbconvert.
+    environment (the course-runtime ML/data-science stack lives there, not in
+    clm's own venv) while clm keeps driving nbconvert.
 
     This registers an interpreter you already have; it does not create the venv.
     """
     from clm.infrastructure.workers.kernel_env import (
         KERNEL_PYTHON_ENV_VAR,
         provision_course_kernel,
+        resolve_kernel_interpreter,
     )
 
+    # Accept a venv directory or a relative path, same as <kernel-python> /
+    # clm.toml: normalise to an absolute interpreter before provisioning.
+    resolved = Path(resolve_kernel_interpreter(str(python_exe)))
+
     try:
-        root = provision_course_kernel(python_exe, validate=not no_validate)
+        root = provision_course_kernel(resolved, validate=not no_validate)
     except RuntimeError as e:
         raise click.ClickException(str(e)) from e
-
-    resolved = python_exe.expanduser()
     click.echo(f"Registered course kernel for: {resolved}")
     click.echo(f"Kernelspec root: {root}")
     click.echo("")

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -3382,17 +3382,26 @@ Provision environments clm runs *against* (as opposed to clm's own venv).
 | `provision kernel-env --python PATH` | Register a course venv as the Direct-mode Python notebook kernel (Wave 2b) |
 
 `provision kernel-env` writes a `python3` kernelspec pointing at the given
-interpreter and prints how to activate it. clm then runs the notebook kernel in
-that environment — so the course-runtime ML/data-science stack (torch/pandas/…)
-lives in a **separate** course venv from clm, while clm keeps driving nbconvert.
-It registers an interpreter you already have; it does not create the venv. The
-interpreter must have `ipykernel` installed (pass `--no-validate` to skip that
-check).
+venv and prints how to activate it. clm then runs the notebook kernel in that
+environment — so the course-runtime ML/data-science stack (torch/pandas/…) lives
+in a **separate** course venv from clm, while clm keeps driving nbconvert. It
+registers a venv you already have; it does not create it. The venv must have
+`ipykernel` installed (pass `--no-validate` to skip that check).
+
+`--python` accepts either the **venv directory** (clm picks the platform
+interpreter inside it — `Scripts/python.exe` on Windows, `bin/python` on POSIX)
+or a specific interpreter; a relative value resolves against the project root.
+The same is true of the `<kernel-python>` element and `clm.toml`
+`[jupyter] kernel_python`, so a single committed value like `.venv` works
+cross-platform. (`clm build` also provisions the kernelspec automatically from
+those settings — this command is for pre-registering / validating.)
 
 Populate that course venv from the self-contained `course-runtime-requirements.txt`
 shipped in the clm repo (it includes `ipykernel`): `python -m pip install -r
 course-runtime-requirements.txt`. As of CLM {version} this stack is no longer a
-clm extra — see `clm info migration`.
+clm extra — see `clm info migration`. Pointing `<kernel-python>` at the course's
+own `.venv` is also how a **globally installed clm** builds a course whose
+runtime stack lives in that course's venv.
 
 Selection precedence for the kernel interpreter (most specific wins):
 

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -331,23 +331,35 @@ Defaults to `Coding-Akademie München` (de) / `Coding-Academy Munich` (en).
 
 ### `<kernel-python>` (Optional, CLM {version}+)
 
-Course-level interpreter that runs the **Python notebook kernel in Direct
-execution mode**. Point it at a course venv so the course-runtime ML/data-science
-stack (torch/pandas/…) runs in a separate environment from clm's own, while
-clm keeps driving the build. Empty/absent (the default) runs the kernel in
-clm's environment, exactly as before.
+Course-level venv that runs the **Python notebook kernel in Direct execution
+mode**. Point it at a course venv so the course-runtime ML/data-science stack
+(torch/pandas/…) runs in a separate environment from clm's own, while clm keeps
+driving the build. Empty/absent (the default) runs the kernel in clm's
+environment, exactly as before.
+
+The value may be the **venv directory** — clm picks the platform interpreter
+inside it (`Scripts/python.exe` on Windows, `bin/python` on POSIX) — or a
+specific interpreter. A **relative** value is resolved against the **project
+root** (the directory holding `pyproject.toml` / `clm.toml` / `.git`), not the
+current directory, so a single committed value works on every platform and no
+matter where `clm build` is invoked. This is what makes the element portable:
 
 ```xml
-<kernel-python>/opt/course-venvs/ml/bin/python</kernel-python>
+<!-- Portable: this repo's own .venv, resolved cross-platform (recommended). -->
+<kernel-python>.venv</kernel-python>
+
+<!-- Or an explicit interpreter / an out-of-tree venv directory: -->
+<kernel-python>/opt/course-venvs/ml</kernel-python>
 ```
 
-The interpreter must have `ipykernel` installed. Populate the course venv from
-the self-contained `course-runtime-requirements.txt` shipped in the clm repo
-(`python -m pip install -r course-runtime-requirements.txt`; it includes
-`ipykernel`), then register it once with `clm provision kernel-env --python
-<path>` (writes the kernelspec clm points the build at). This is the key lever
-for keeping a **plain-Python** course on a light venv while an ML-heavy course
-uses a fat one — no global reconfiguration.
+The venv must have `ipykernel` installed. Populate it from the self-contained
+`course-runtime-requirements.txt` shipped in the clm repo (`python -m pip install
+-r course-runtime-requirements.txt`; it includes `ipykernel`). You can optionally
+pre-register/validate it with `clm provision kernel-env --python <venv-or-path>`,
+but `clm build` provisions the kernelspec automatically from this element. This
+is the key lever for keeping a **plain-Python** course on a light venv while an
+ML-heavy course uses a fat one — and it lets a **globally installed clm** build a
+course whose runtime stack lives in the course's own venv.
 
 Precedence (highest first): the `CLM_NOTEBOOK_KERNEL_PYTHON` environment
 variable, then this `<kernel-python>`, then `clm.toml` `[jupyter] kernel_python`;

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -1498,13 +1498,14 @@ class CourseSpec:
     # *write* location of new files (e.g. a first-recorded cassette during a
     # build); reads always auto-detect both layouts. From ``<sidecar-layout>``.
     sidecar_layout: str | None = None
-    # Course-level interpreter for the Python notebook kernel in Direct mode
-    # (Wave 2b, issue #516 follow-up). Empty = clm's own environment. Set to a
-    # course venv path so course-runtime packages ([ml] etc.) run in a separate
-    # environment from clm. Overridden by the CLM_NOTEBOOK_KERNEL_PYTHON env
-    # var; overrides the project-level clm.toml [jupyter].kernel_python. Path is
-    # used verbatim (absolute or resolved by the shell/user); relative paths are
-    # taken as-is. From ``<kernel-python>``.
+    # Course-level venv for the Python notebook kernel in Direct mode (Wave 2b,
+    # issue #516 follow-up). Empty = clm's own environment. Set to a course venv
+    # so the course-runtime ML/data-science stack runs in a separate environment
+    # from clm. May be the venv *directory* (clm picks the platform interpreter
+    # inside it) or a specific interpreter; a relative value is anchored to the
+    # project root (see kernel_env.resolve_kernel_interpreter). Overridden by the
+    # CLM_NOTEBOOK_KERNEL_PYTHON env var; overrides the project-level clm.toml
+    # [jupyter].kernel_python. From ``<kernel-python>``.
     kernel_python: str = ""
     author: str = "Dr. Matthias Hölzl"
     organization: Text = field(

--- a/src/clm/infrastructure/config.py
+++ b/src/clm/infrastructure/config.py
@@ -252,13 +252,15 @@ class JupyterConfig(BaseModel):
     kernel_python: str = Field(
         default="",
         description=(
-            "Path to the interpreter that runs the Python notebook kernel in "
-            "Direct mode. Empty = use clm's own environment (default). Set to a "
-            "course venv to isolate course-runtime packages ([ml] etc.) from "
-            "clm's environment. This is the project-level (clm.toml) tier; the "
-            "env var CLM_NOTEBOOK_KERNEL_PYTHON and a course-spec <kernel-python> "
-            "element override it. See docs/claude/design/"
-            "dependency-environment-isolation.md."
+            "The course venv that runs the Python notebook kernel in Direct "
+            "mode. Empty = use clm's own environment (default). Set to a course "
+            "venv to isolate the course-runtime ML/data-science stack from clm's "
+            "environment. May be the venv directory (clm picks the platform "
+            "interpreter inside it) or a specific interpreter; a relative value "
+            "is anchored to the project root. This is the project-level "
+            "(clm.toml) tier; the env var CLM_NOTEBOOK_KERNEL_PYTHON and a "
+            "course-spec <kernel-python> element override it. See docs/claude/"
+            "design/dependency-environment-isolation.md."
         ),
     )
 

--- a/src/clm/infrastructure/workers/kernel_env.py
+++ b/src/clm/infrastructure/workers/kernel_env.py
@@ -76,6 +76,75 @@ def resolve_notebook_kernel_python(spec_value: str = "") -> str:
     return (get_config().jupyter.kernel_python or "").strip()
 
 
+def _venv_interpreter(venv_dir: Path) -> Path:
+    """Return the Python interpreter inside a virtualenv *directory*.
+
+    A venv stores its interpreter at ``Scripts/python.exe`` on Windows and
+    ``bin/python`` on POSIX — so a single committed ``<kernel-python>`` value
+    can point at the venv *directory* and resolve correctly on every platform,
+    instead of hard-coding one OS's interpreter layout.
+
+    Prefers whichever interpreter actually exists (so a POSIX venv checked out
+    on the same box as a Windows one still resolves), falling back to the
+    platform-native path when neither is present yet — so provisioning's
+    "not found" error names a concrete, expected location.
+    """
+    windows = venv_dir / "Scripts" / "python.exe"
+    posix = venv_dir / "bin" / "python"
+    ordered = (windows, posix) if os.name == "nt" else (posix, windows)
+    for candidate in ordered:
+        if candidate.is_file():
+            return candidate
+    return ordered[0]
+
+
+def resolve_kernel_interpreter(value: str, *, project_root: Path | None = None) -> str:
+    """Turn a raw kernel-python value into an absolute interpreter path.
+
+    Complements :func:`resolve_notebook_kernel_python` (which only picks the
+    winning *tier*): this normalises whatever that tier yielded into a concrete,
+    absolute interpreter, so the value threaded to the worker is platform- and
+    cwd-independent. The rules, in order:
+
+    - ``""`` (or whitespace) → ``""`` — use clm's own environment.
+    - ``~`` is expanded.
+    - A **relative** path is anchored to ``project_root`` (default:
+      :func:`find_project_root`, which locates the ``pyproject.toml`` /
+      ``clm.toml`` / ``.git`` dir) — NOT the process cwd — so a value committed
+      to a shared repo resolves the same no matter where ``clm build`` runs.
+    - A **directory** is treated as a virtualenv and resolved to the interpreter
+      inside it (``Scripts/python.exe`` on Windows, ``bin/python`` on POSIX),
+      so one committed value works cross-platform.
+    - Anything else is returned as an interpreter path verbatim (existence is
+      validated later, in :func:`provision_course_kernel`).
+
+    Args:
+        value: The raw kernel-python value (a venv directory or an interpreter,
+            absolute or project-relative). Typically the result of
+            :func:`resolve_notebook_kernel_python`.
+        project_root: Anchor for relative values. Defaults to
+            :func:`find_project_root`.
+
+    Returns:
+        An absolute interpreter path, or ``""`` for "use clm's env".
+    """
+    if not value or not value.strip():
+        return ""
+
+    path = Path(value.strip()).expanduser()
+    if not path.is_absolute():
+        if project_root is None:
+            from clm.infrastructure.utils.path_utils import find_project_root
+
+            project_root = find_project_root()
+        path = project_root / path
+
+    if path.is_dir():
+        path = _venv_interpreter(path)
+
+    return str(path)
+
+
 def _kernel_envs_root() -> Path:
     """Return the base dir under which per-interpreter kernelspecs are written.
 
@@ -182,6 +251,7 @@ def jupyter_path_with_kernel(root: Path, existing: str | None) -> str:
 __all__ = [
     "KERNEL_PYTHON_ENV_VAR",
     "resolve_notebook_kernel_python",
+    "resolve_kernel_interpreter",
     "provision_course_kernel",
     "jupyter_path_with_kernel",
 ]

--- a/tests/infrastructure/workers/test_kernel_env.py
+++ b/tests/infrastructure/workers/test_kernel_env.py
@@ -8,6 +8,7 @@ the ipykernel validation subprocess is patched or bypassed.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -18,6 +19,7 @@ from clm.infrastructure.workers.kernel_env import (
     KERNEL_PYTHON_ENV_VAR,
     jupyter_path_with_kernel,
     provision_course_kernel,
+    resolve_kernel_interpreter,
     resolve_notebook_kernel_python,
 )
 from clm.infrastructure.workers.worker_executor import DirectWorkerExecutor, WorkerConfig
@@ -66,6 +68,74 @@ def test_resolve_env_whitespace_is_ignored(monkeypatch):
     with patch("clm.infrastructure.config.get_config", return_value=fake_cfg):
         # Blank env falls through to the spec value.
         assert resolve_notebook_kernel_python("/spec/python") == "/spec/python"
+
+
+# --------------------------------------------------------------------------- #
+# resolve_kernel_interpreter — venv-dir + project-relative normalisation
+# --------------------------------------------------------------------------- #
+
+
+def _make_venv(root: Path) -> Path:
+    """Create a venv-shaped dir with BOTH interpreter layouts present."""
+    (root / "Scripts").mkdir(parents=True, exist_ok=True)
+    (root / "bin").mkdir(parents=True, exist_ok=True)
+    (root / "Scripts" / "python.exe").write_text("", encoding="utf-8")
+    (root / "bin" / "python").write_text("", encoding="utf-8")
+    return root
+
+
+def test_resolve_interpreter_empty_is_empty():
+    assert resolve_kernel_interpreter("") == ""
+    assert resolve_kernel_interpreter("   ") == ""
+
+
+def test_resolve_interpreter_venv_dir_picks_platform_interpreter(tmp_path):
+    venv = _make_venv(tmp_path / ".venv")
+    result = Path(resolve_kernel_interpreter(str(venv)))
+    if os.name == "nt":
+        assert result == venv / "Scripts" / "python.exe"
+    else:
+        assert result == venv / "bin" / "python"
+
+
+def test_resolve_interpreter_venv_dir_uses_existing_when_only_other_layout(tmp_path):
+    # Only the POSIX layout exists → resolve to it regardless of host OS.
+    venv = tmp_path / ".venv"
+    (venv / "bin").mkdir(parents=True)
+    (venv / "bin" / "python").write_text("", encoding="utf-8")
+    assert Path(resolve_kernel_interpreter(str(venv))) == venv / "bin" / "python"
+
+
+def test_resolve_interpreter_relative_anchored_to_project_root(tmp_path):
+    venv = _make_venv(tmp_path / ".venv")
+    result = Path(resolve_kernel_interpreter(".venv", project_root=tmp_path))
+    assert result.parent.parent == venv  # <root>/.venv/<bin|Scripts>/python*
+    assert result.is_file()
+
+
+def test_resolve_interpreter_relative_not_cwd(tmp_path, monkeypatch):
+    # A relative value must anchor to project_root, NOT the process cwd.
+    _make_venv(tmp_path / ".venv")
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    monkeypatch.chdir(other)
+    result = Path(resolve_kernel_interpreter(".venv", project_root=tmp_path))
+    assert str(tmp_path) in str(result)
+    assert str(other) not in str(result)
+
+
+def test_resolve_interpreter_direct_file_returned_absolute(tmp_path):
+    interp = tmp_path / "custom" / "python"
+    interp.parent.mkdir(parents=True)
+    interp.write_text("", encoding="utf-8")
+    assert Path(resolve_kernel_interpreter(str(interp))) == interp
+
+
+def test_resolve_interpreter_missing_venv_yields_platform_default(tmp_path):
+    # Non-existent path (venv not built yet) → returned so provisioning can emit
+    # an actionable "not found" naming a concrete interpreter.
+    result = resolve_kernel_interpreter(str(tmp_path / "absent"))
+    assert result == str(tmp_path / "absent")
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Why

Wave 2b's `<kernel-python>` / `[jupyter].kernel_python` knob required a
**platform-specific interpreter file** (`.venv/Scripts/python.exe` on Windows vs
`.venv/bin/python` on POSIX) and resolved relative paths against the **cwd**. So
no single value could be committed to a shared, cross-platform course repo.

That blocked the exact case a downstream course hit: a repo with **one bundled
`.venv`** (clm tooling + the course-runtime ML stack) built with a **globally
installed `clm`**. Now that clm 1.19 no longer bundles the ML stack, the global
clm runs the kernel in *its own* venv (no torch/pandas/…) and the build fails.
There was no committable, cross-platform way to point it at the course's `.venv`.

## What

New `resolve_kernel_interpreter()` normalises whatever tier won
(`resolve_notebook_kernel_python`) into an absolute interpreter:

- expands `~`;
- anchors a **relative** value to the **project root** (the `pyproject.toml` /
  `clm.toml` / `.git` dir), **not** the cwd — so a committed value resolves the
  same wherever `clm build` runs;
- resolves a venv **directory** to the interpreter inside it —
  `Scripts/python.exe` on Windows, `bin/python` on POSIX (preferring whichever
  actually exists), so one committed value is cross-platform.

So a single committed setting now works everywhere:

```xml
<kernel-python>.venv</kernel-python>
```
```toml
[jupyter]
kernel_python = ".venv"
```

Wired into `clm build` (normalise after tier selection) and `clm provision
kernel-env` (`--python` accepts a venv dir / relative path too). Unset ⇒
unchanged (clm's own env); `""` short-circuits before any filesystem access.

## Verified

- New unit tests: venv-dir → platform interpreter, existing-layout preference,
  project-root anchoring (explicitly **not** cwd), direct-file passthrough,
  missing-venv → actionable error. `test_kernel_env.py` + `test_provision_command.py`
  green (29 tests).
- End-to-end on Windows against a real course repo: `clm provision kernel-env
  --python .venv` (bare relative dir) resolved to
  `…\PythonCourses\.venv\Scripts\python.exe`, validated `ipykernel`, and wrote
  the kernelspec.
- ruff + mypy clean; pre-push fast suite green.

## Docs

`clm info spec-files` (`<kernel-python>`), `clm info commands` (`provision
kernel-env`), and the installation guide gain the venv-dir / project-relative
behaviour and a "course repo with one bundled venv (global clm)" section. Wave 2b
changelog fragment updated (still one coherent unreleased entry).

Follow-up to #531 / #533 (Wave 2b-1 / 2b-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
