### PR TITLE
feat(sync): Phase 3 — per-item apply v3, record verb, member-keyed ledger (#520)

### DIFF
--- a/changelog.d/520-sync-v3-phase3.added.md
+++ b/changelog.d/520-sync-v3-phase3.added.md
@@ -1,0 +1,17 @@
+- **Sync v3 Phase 3 (#520): per-item apply, the `record` verb, and the
+  member-keyed committed ledger — behind `CLM_SYNC_ENGINE=v3`.** The committed
+  per-topic `.clm/sync-ledger.json` is promoted to the v3 trust store (schema-2
+  envelope; the v1 sections coexist untouched, and the v2 engine round-trips
+  the v3 `decks` section verbatim): per-member entries record langness, layout,
+  per-side fingerprints, tags, provenance, and a hash version that lazily
+  invalidates on hashing changes. `clm slides sync apply` (under
+  `CLM_SYNC_ENGINE=v3`) executes every mechanical diff row deterministically
+  and resolves framed items from a per-item validated `--decisions` JSON
+  document (multi-cell smuggling and stale handles rejected individually, valid
+  answers land regardless), re-parses the mutated bundle before writing, writes
+  the ≤4 files atomically, and records each landed item into the ledger; the
+  new `clm slides sync record` verb (bless/accept collapsed) banks a verified
+  deck's state wholesale or per member, gated on the structural verify and
+  performing the pos→id key migration at record time. Engine dispatch is a
+  single verb-layer switch (`CLM_SYNC_ENGINE`, v2 default), with the schema-3
+  JSON envelope keeping `is_clean`/`needs_model`/`needs_agent` stable.

--- a/src/clm/cli/commands/slides/sync.py
+++ b/src/clm/cli/commands/slides/sync.py
@@ -43,6 +43,7 @@ Exit codes:
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -111,6 +112,24 @@ if TYPE_CHECKING:
     from clm.slides.sync_translate import SlideTranslator
 
 CACHE_DB_NAME = "clm-llm.sqlite"
+
+
+def _v3_engine() -> bool:
+    """The §12.5 engine switch: ``CLM_SYNC_ENGINE=v3`` opts a verb into the
+    v3 core (#520 Phase 3). This is the ONE dispatch point per verb — no
+    v2/v3 branching lives below the verb layer, so Phase 4's cutover is
+    "flip the default, delete the v2 modules, delete this check"."""
+    return os.environ.get("CLM_SYNC_ENGINE", "").strip().lower() == "v3"
+
+
+def _reject_v2_flags_under_v3(**flags: object) -> None:
+    """Fail fast when a v2-only option reaches the v3 engine."""
+    given = [f"--{name.replace('_', '-')}" for name, value in flags.items() if value]
+    if given:
+        raise click.UsageError(
+            f"{', '.join(given)} belongs to the v2 engine and is not supported with "
+            f"CLM_SYNC_ENGINE=v3 (the v3 engine always trusts the committed ledger)"
+        )
 
 
 def _resolve_prog_lang(path: Path) -> str:
@@ -1759,8 +1778,15 @@ def slides_sync_group() -> None:
       task       emit a framed model task for a tier-2/3 item (read-only, no model)
       accept     validate a model answer + write it to both halves (writes, no model)
       apply      apply the reconciliation (writes; see `apply --help` re: models)
+      record     v3 engine: record the verified state into the committed ledger
       autopilot  legacy all-in-one WITH embedded models (agent-less human)
       baseline   inspect/maintain the watermark accelerator
+
+    \b
+    CLM_SYNC_ENGINE=v3 switches report/apply (and enables record) onto the v3
+    document-model engine (#520): one canonical bilingual deck, a generic
+    3-way member diff, and the committed per-topic ledger as the only trust
+    store. v2 stays the default through Phase 3.
     """
 
 
@@ -2008,6 +2034,19 @@ def sync_report_cmd(
     ``--baseline-from PATH[@REF]`` pins it explicitly when the rename can't be detected.
     ``--since DATE|REF`` resolves a timeframe to the baseline ref (sugar over --baseline).
     """
+    if _v3_engine():
+        _reject_v2_flags_under_v3(
+            explain=explain,
+            baseline=baseline_ref,
+            baseline_from=baseline_from_spec,
+            since=since_spec,
+            use_watermark=use_watermark,
+            cache_dir=cache_dir,
+            ledger=ledger,
+        )
+        from clm.cli.commands.slides.sync_v3 import run_report_v3
+
+        sys.exit(run_report_v3(de_path, en_path, as_json=as_json))
     baseline_ref = _apply_since(since_spec, baseline_ref, baseline_from_spec, de_path)
     _run_report(
         de_path,
@@ -2067,6 +2106,59 @@ def sync_shadow_cmd(scope: Path, baseline_ref: str, as_json: bool) -> None:
         click.echo(json.dumps(report.to_payload(), indent=2, ensure_ascii=False))
     else:
         click.echo(report.render_text())
+
+
+@slides_sync_group.command("record")
+@_DECK_ARG
+@_EN_ARG
+@click.option(
+    "--member",
+    "members",
+    multiple=True,
+    metavar="KEY",
+    help="Record only these member handles (default: the whole deck, swept).",
+)
+@click.option(
+    "--provenance",
+    default="record",
+    show_default=True,
+    metavar="WHO",
+    help="Trust provenance to stamp: 'record', 'agent', or 'semantic:<model>'.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit the record result as JSON.")
+def sync_record_cmd(
+    de_path: Path,
+    en_path: Path | None,
+    members: tuple[str, ...],
+    provenance: str,
+    as_json: bool,
+) -> None:
+    """Record the deck's current verified state into the committed ledger (v3).
+
+    The bless/accept confirmation paths collapsed into one verb (#520 Phase 3,
+    design §8): after you have verified — or reconciled — a deck, ``record``
+    banks its members' current fingerprints in ``<topic>/.clm/sync-ledger.json``
+    so ``report`` trusts them until they drift. Gated on the structural verify
+    (a corrupt pair is refused, nothing written). A full record sweeps stale
+    entries and performs the §7.3 pos→id key migration (logged); ``--member``
+    upserts just the named handles. Requires ``CLM_SYNC_ENGINE=v3``.
+    """
+    if not _v3_engine():
+        raise click.UsageError(
+            "`sync record` is a v3-engine verb — set CLM_SYNC_ENGINE=v3 (the v2 "
+            "equivalents are `sync baseline bless --ledger` / `sync accept --record`)"
+        )
+    from clm.cli.commands.slides.sync_v3 import run_record_v3
+
+    sys.exit(
+        run_record_v3(
+            de_path,
+            en_path,
+            members=members,
+            provenance=provenance,
+            as_json=as_json,
+        )
+    )
 
 
 @slides_sync_group.command("diagnose")
@@ -2160,6 +2252,29 @@ def sync_diagnose_cmd(
         "Ignored with --baseline / --baseline-from / --no-watermark."
     ),
 )
+@click.option(
+    "--decisions",
+    "decisions_spec",
+    default=None,
+    metavar="FILE|-",
+    help=(
+        "v3 engine only (CLM_SYNC_ENGINE=v3): a JSON decision document answering "
+        "framed report items per member handle ('-' reads stdin). Invalid answers "
+        "are rejected per item; valid ones land."
+    ),
+)
+@click.option(
+    "--member",
+    "members",
+    multiple=True,
+    metavar="KEY",
+    help="v3 engine only: apply only the item(s) with these member handles.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="v3 engine only: execute and validate everything, write nothing.",
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit the apply result as JSON.")
 def sync_apply_cmd(
     de_path: Path,
@@ -2172,6 +2287,9 @@ def sync_apply_cmd(
     cache_dir: Path | None,
     ledger: bool,
     auto_heal: bool,
+    decisions_spec: str | None,
+    members: tuple[str, ...],
+    dry_run: bool,
     as_json: bool,
 ) -> None:
     """Apply the deterministic tier-1 reconciliation — writes, but never calls a model.
@@ -2200,6 +2318,31 @@ def sync_apply_cmd(
     ``--since DATE|REF`` resolves a timeframe to the baseline ref (sugar over
     --baseline); it works over a directory exactly as --baseline does.
     """
+    if _v3_engine():
+        _reject_v2_flags_under_v3(
+            baseline=baseline_ref,
+            baseline_from=baseline_from_spec,
+            since=since_spec,
+            cache_dir=cache_dir,
+            ledger=ledger,
+        )
+        from clm.cli.commands.slides.sync_v3 import run_apply_v3
+
+        sys.exit(
+            run_apply_v3(
+                de_path,
+                en_path,
+                decisions_spec=decisions_spec,
+                members=members,
+                dry_run=dry_run,
+                as_json=as_json,
+            )
+        )
+    if decisions_spec is not None or members or dry_run:
+        raise click.UsageError(
+            "--decisions/--member/--dry-run belong to the v3 engine — set "
+            "CLM_SYNC_ENGINE=v3 to use them"
+        )
     # Resolve --since BEFORE the directory dispatch so a dir + conflicting --baseline is
     # still rejected and --since works over a directory sweep (#446).
     baseline_ref = _apply_since(since_spec, baseline_ref, baseline_from_spec, de_path)

--- a/src/clm/cli/commands/slides/sync_v3.py
+++ b/src/clm/cli/commands/slides/sync_v3.py
@@ -44,12 +44,24 @@ def _echo_json(payload: dict) -> None:
     click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
 
 
-def _scope_pairs(de_path: Path, en_path: Path | None) -> list[tuple[Path, Path | None]]:
-    """DECK|DIR scope → the bundles to visit (each as load_bundle inputs)."""
+def _scope_pairs(
+    de_path: Path, en_path: Path | None
+) -> tuple[list[tuple[Path, Path | None]], list[Path]]:
+    """DECK|DIR scope → the bundles to visit plus any unpaired solo halves.
+
+    A solo half (its twin deleted or misnamed) is total divergence — it must
+    never vanish silently from a sweep (the v2 engines warn per solo, and so
+    do the v3 runners).
+    """
     if de_path.is_dir():
-        pairs, _solos = iter_split_pairs(find_split_slide_files_recursive(de_path))
-        return [(de, en) for de, en in pairs]
-    return [(de_path, en_path)]
+        pairs, solos = iter_split_pairs(find_split_slide_files_recursive(de_path))
+        return [(de, en) for de, en in pairs], list(solos)
+    return [(de_path, en_path)], []
+
+
+def _warn_solos(solos: list[Path]) -> None:
+    for solo in solos:
+        click.echo(f"warning: skipping {solo.name} — no twin half found", err=True)
 
 
 def _load(de_path: Path, en_path: Path | None) -> LoadedBundle:
@@ -112,7 +124,9 @@ def run_report_v3(de_path: Path, en_path: Path | None, *, as_json: bool) -> int:
     """The v3 read verb. Exit 0 clean / 1 work pending / 2 error."""
     results: list[tuple[LoadedBundle, DeckDiff]] = []
     errors: list[str] = []
-    for de, en in _scope_pairs(de_path, en_path):
+    pairs, solos = _scope_pairs(de_path, en_path)
+    _warn_solos(solos)
+    for de, en in pairs:
         try:
             bundle = _load(de, en)
         except DocLensError as exc:
@@ -133,6 +147,7 @@ def run_report_v3(de_path: Path, en_path: Path | None, *, as_json: bool) -> int:
                     "needs_model": any(d.needs_model for _, d in results),
                     "needs_agent": any(d.needs_agent for _, d in results) or bool(errors),
                     "errors": errors,
+                    "skipped_solos": [str(p) for p in solos],
                     "pairs": payloads,
                 }
             )
@@ -170,11 +185,14 @@ def run_apply_v3(
 
     decisions: dict[str, doc_apply.Decision] = {}
     if decisions_spec is not None:
-        text = (
-            sys.stdin.read()
-            if decisions_spec == "-"
-            else Path(decisions_spec).read_text(encoding="utf-8")
-        )
+        try:
+            text = (
+                sys.stdin.read()
+                if decisions_spec == "-"
+                else Path(decisions_spec).read_text(encoding="utf-8")
+            )
+        except OSError as exc:
+            raise click.UsageError(f"cannot read the decision document: {exc}") from exc
         decisions, decision_errors = doc_apply.load_decisions_text(text)
         if decision_errors:
             for error in decision_errors:
@@ -204,11 +222,30 @@ def run_apply_v3(
         dry_run=dry_run,
         commit=_head_commit(bundle.de_path),
     )
-    if outcome.error is None and not dry_run and (outcome.wrote or outcome.count("recorded")):
-        doc_ledger.save(ledger, ledger_path)
+    verify_violations: list[str] = []
+    if outcome.error is None and not dry_run and outcome.ledger_changed:
+        # The structural write-gate on the TRUST store (design §5): landed
+        # file mutations stay (review them with git), but a pair that fails
+        # the structural verify is never recorded as verified — same gate
+        # `record` applies. Lazy import: sync_verify still loads v2 modules.
+        from clm.slides.sync_verify import structural_gate
+
+        verify_violations = [
+            v.message
+            for v in structural_gate(
+                bundle.de_path.read_text(encoding="utf-8"),
+                bundle.en_path.read_text(encoding="utf-8"),
+                bundle.comment_token,
+            )
+        ]
+        if not verify_violations:
+            doc_ledger.save(ledger, ledger_path)
 
     if as_json:
-        _echo_json(outcome.to_payload())
+        payload = outcome.to_payload()
+        payload["ledger_recorded"] = outcome.ledger_changed and not verify_violations
+        payload["verify_violations"] = verify_violations
+        _echo_json(payload)
     else:
         for result in outcome.results:
             click.echo(f"  {result.status:8s} {result.action} {result.key}  {result.reason}")
@@ -219,9 +256,17 @@ def run_apply_v3(
             click.echo(f"wrote {names}" + (" (dry run)" if dry_run else ""))
         elif dry_run:
             click.echo("dry run — nothing written")
+        for violation in verify_violations:
+            click.echo(f"verify: {violation}", err=True)
+        if verify_violations:
+            click.echo(
+                "structural verify failed — applied changes were written but NOT "
+                "recorded into the ledger; fix the pair, then `sync record`",
+                err=True,
+            )
     if outcome.error is not None:
         return 2
-    return 0 if outcome.all_applied else 1
+    return 0 if outcome.all_applied and not verify_violations else 1
 
 
 def _head_commit(path: Path) -> str | None:
@@ -257,7 +302,9 @@ def run_record_v3(
     rows: list[dict] = []
     refused = 0
     errors = 0
-    for de, en in _scope_pairs(de_path, en_path):
+    pairs, solos = _scope_pairs(de_path, en_path)
+    _warn_solos(solos)
+    for de, en in pairs:
         row = _record_one(de, en, members=members, provenance=provenance)
         rows.append(row)
         if row.get("error"):
@@ -317,9 +364,10 @@ def _record_one(
 
     ledger_path = doc_ledger.ledger_path_for(bundle.de_path)
     ledger = doc_ledger.load(ledger_path)
+    deck_key = doc_ledger.deck_key_for(bundle.de_path)
     recorded, migrations = doc_ledger.record_deck_snapshot(
         ledger,
-        doc_ledger.deck_key_for(bundle.de_path),
+        deck_key,
         bundle.outcome.deck,
         provenance=provenance,
         commit=_head_commit(bundle.de_path),
@@ -328,6 +376,17 @@ def _record_one(
     doc_ledger.save(ledger, ledger_path)
     row["recorded"] = recorded
     row["ledger"] = str(ledger_path)
+    if members:
+        deck_ledger = ledger.decks.get(deck_key)
+        known = deck_ledger.members.keys() if deck_ledger is not None else set()
+        unknown = sorted(k for k in members if k not in known)
+        if unknown:
+            row["unknown_members"] = unknown
+            click.echo(
+                f"warning: {bundle.de_path.name}: no such member(s) in the current "
+                f"deck: {', '.join(unknown)}",
+                err=True,
+            )
     if migrations:
         # The §7.3 key migration is an explicit, logged rename.
         row["key_migrations"] = dict(sorted(migrations.items()))

--- a/src/clm/cli/commands/slides/sync_v3.py
+++ b/src/clm/cli/commands/slides/sync_v3.py
@@ -1,0 +1,349 @@
+"""The v3 engine facade for the sync verbs (#520 Phase 3, design §12.5).
+
+One dispatch point per verb: ``clm.cli.commands.slides.sync`` resolves
+``CLM_SYNC_ENGINE`` (``v2`` default through Phase 3) and hands the whole verb
+to a runner here — no v2/v3 branching below the verb layer. This module
+drives only the v3 core (``doc_lenses`` / ``sync_diff`` / ``doc_ledger`` /
+``doc_apply``); the single v2-adjacent import is the *structural verify gate*
+on the ``record`` write path (``sync_verify``, a keep component that still
+imports v2 modules), loaded lazily inside the function so importing this
+module never pulls in the v2 core — pinned by the import-cleanliness test.
+
+Verbs (design §8):
+
+* ``report`` — read-only, ledger-trusted; schema-3 envelope with the stable
+  ``is_clean`` / ``needs_model`` / ``needs_agent`` booleans; framed items
+  carry their decision vocabulary so an agent can answer in one document.
+* ``apply``  — per-item: every mechanical row plus validated decisions; the
+  ledger records each landed item; exit 0 all-applied / 1 residue / 2 error.
+* ``record`` — bless/accept collapsed: gated on the structural verify, then
+  the deck's current state is recorded wholesale (or per ``--member``),
+  performing the §7.3 pos→id key migration at record time (logged).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from clm.slides import doc_apply, doc_ledger
+from clm.slides.doc_lenses import DocLensError, LoadedBundle, load_bundle
+from clm.slides.pairing import (
+    find_split_slide_files_recursive,
+    iter_split_pairs,
+)
+from clm.slides.sync_diff import DeckDiff, diff_outcome
+
+__all__ = ["run_apply_v3", "run_record_v3", "run_report_v3"]
+
+
+def _echo_json(payload: dict) -> None:
+    click.echo(json.dumps(payload, indent=2, ensure_ascii=False))
+
+
+def _scope_pairs(de_path: Path, en_path: Path | None) -> list[tuple[Path, Path | None]]:
+    """DECK|DIR scope → the bundles to visit (each as load_bundle inputs)."""
+    if de_path.is_dir():
+        pairs, _solos = iter_split_pairs(find_split_slide_files_recursive(de_path))
+        return [(de, en) for de, en in pairs]
+    return [(de_path, en_path)]
+
+
+def _load(de_path: Path, en_path: Path | None) -> LoadedBundle:
+    return load_bundle(de_path, en_path)
+
+
+def _diff_bundle(bundle: LoadedBundle) -> DeckDiff:
+    ledger = doc_ledger.load(doc_ledger.ledger_path_for(bundle.de_path))
+    deck_ledger = ledger.decks.get(doc_ledger.deck_key_for(bundle.de_path))
+    base = doc_ledger.baseline_from_ledger(deck_ledger) if deck_ledger is not None else None
+    return diff_outcome(bundle.outcome, base)
+
+
+def _item_payloads(diff: DeckDiff) -> list[dict]:
+    """The §6.4 item rows, each framed item carrying its answer vocabulary."""
+    items = []
+    for item in diff.items:
+        payload = item.payload()
+        answers = doc_apply.decision_vocabulary(item.action)
+        if answers:
+            payload["answers"] = list(answers)
+        items.append(payload)
+    return items
+
+
+def _pair_payload(bundle: LoadedBundle, diff: DeckDiff) -> dict:
+    payload = diff.to_payload()
+    payload["items"] = _item_payloads(diff)
+    payload["de_path"] = str(bundle.de_path)
+    payload["en_path"] = str(bundle.en_path)
+    return payload
+
+
+def _render_pair(bundle: LoadedBundle, diff: DeckDiff) -> str:
+    lines = [
+        f"{bundle.de_path.name}: "
+        + (
+            f"clean ({diff.in_sync_count} member(s) in sync)"
+            if diff.is_clean
+            else f"{len(diff.items)} item(s), {diff.in_sync_count} in sync"
+        )
+    ]
+    if diff.refusal is not None:
+        lines.append("  " + diff.refusal.render().replace("\n", "\n  "))
+    for item in diff.items:
+        answers = doc_apply.decision_vocabulary(item.action)
+        suffix = f"  [answers: {', '.join(answers)}]" if answers else ""
+        lines.append(
+            f"  {item.outcome}/{item.action} {item.key} ({item.direction}) {item.detail}{suffix}"
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# report
+# ---------------------------------------------------------------------------
+
+
+def run_report_v3(de_path: Path, en_path: Path | None, *, as_json: bool) -> int:
+    """The v3 read verb. Exit 0 clean / 1 work pending / 2 error."""
+    results: list[tuple[LoadedBundle, DeckDiff]] = []
+    errors: list[str] = []
+    for de, en in _scope_pairs(de_path, en_path):
+        try:
+            bundle = _load(de, en)
+        except DocLensError as exc:
+            errors.append(str(exc))
+            continue
+        results.append((bundle, _diff_bundle(bundle)))
+    clean = all(diff.is_clean for _, diff in results) and not errors
+    if as_json:
+        payloads = [_pair_payload(bundle, diff) for bundle, diff in results]
+        if not de_path.is_dir() and len(payloads) == 1 and not errors:
+            _echo_json(payloads[0])
+        else:
+            _echo_json(
+                {
+                    "schema": 3,
+                    "engine": "v3",
+                    "is_clean": clean,
+                    "needs_model": any(d.needs_model for _, d in results),
+                    "needs_agent": any(d.needs_agent for _, d in results) or bool(errors),
+                    "errors": errors,
+                    "pairs": payloads,
+                }
+            )
+    else:
+        for bundle, diff in results:
+            click.echo(_render_pair(bundle, diff))
+        for error in errors:
+            click.echo(f"ERROR: {error}", err=True)
+    if errors and not results:
+        return 2
+    return 0 if clean else 1
+
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+
+def run_apply_v3(
+    de_path: Path,
+    en_path: Path | None,
+    *,
+    decisions_spec: str | None,
+    members: tuple[str, ...],
+    dry_run: bool,
+    as_json: bool,
+) -> int:
+    """The v3 write verb. Exit 0 all-applied / 1 residue / 2 error."""
+    if de_path.is_dir():
+        raise click.UsageError("apply works on a single deck — run report over the directory")
+    try:
+        bundle = _load(de_path, en_path)
+    except DocLensError as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    decisions: dict[str, doc_apply.Decision] = {}
+    if decisions_spec is not None:
+        text = (
+            sys.stdin.read()
+            if decisions_spec == "-"
+            else Path(decisions_spec).read_text(encoding="utf-8")
+        )
+        decisions, decision_errors = doc_apply.load_decisions_text(text)
+        if decision_errors:
+            for error in decision_errors:
+                click.echo(f"decision error: {error}", err=True)
+            return 2
+
+    diff = _diff_bundle(bundle)
+    if diff.refusal is not None:
+        message = diff.refusal.render()
+        if as_json:
+            _echo_json({"schema": 3, "engine": "v3", "error": message, "items": []})
+        else:
+            click.echo(message, err=True)
+        return 2
+    assert bundle.outcome.deck is not None
+
+    ledger_path = doc_ledger.ledger_path_for(bundle.de_path)
+    ledger = doc_ledger.load(ledger_path)
+    outcome = doc_apply.apply_deck(
+        bundle,
+        bundle.outcome.deck,
+        diff,
+        ledger,
+        doc_ledger.deck_key_for(bundle.de_path),
+        decisions=decisions,
+        only_members=set(members) if members else None,
+        dry_run=dry_run,
+        commit=_head_commit(bundle.de_path),
+    )
+    if outcome.error is None and not dry_run and (outcome.wrote or outcome.count("recorded")):
+        doc_ledger.save(ledger, ledger_path)
+
+    if as_json:
+        _echo_json(outcome.to_payload())
+    else:
+        for result in outcome.results:
+            click.echo(f"  {result.status:8s} {result.action} {result.key}  {result.reason}")
+        if outcome.error:
+            click.echo(f"ERROR: {outcome.error}", err=True)
+        elif outcome.wrote:
+            names = ", ".join(p.name for p in outcome.written_paths)
+            click.echo(f"wrote {names}" + (" (dry run)" if dry_run else ""))
+        elif dry_run:
+            click.echo("dry run — nothing written")
+    if outcome.error is not None:
+        return 2
+    return 0 if outcome.all_applied else 1
+
+
+def _head_commit(path: Path) -> str | None:
+    """Best-effort git provenance for ledger records (never fails a write)."""
+    try:
+        from clm.core.git_info import get_git_info
+
+        commit = get_git_info(path.parent).get("commit")
+        return commit if isinstance(commit, str) else None
+    except Exception:  # noqa: BLE001 - provenance must never fail the verb
+        return None
+
+
+# ---------------------------------------------------------------------------
+# record
+# ---------------------------------------------------------------------------
+
+
+def run_record_v3(
+    de_path: Path,
+    en_path: Path | None,
+    *,
+    members: tuple[str, ...],
+    provenance: str,
+    as_json: bool,
+) -> int:
+    """The v3 trust verb: bless/accept collapsed, gated on structural verify.
+
+    Exit 0 all recorded / 1 some pairs refused / 2 error.
+    """
+    if provenance not in ("record", "agent") and not provenance.startswith("semantic:"):
+        raise click.UsageError("--provenance must be 'record', 'agent', or 'semantic:<model>'")
+    rows: list[dict] = []
+    refused = 0
+    errors = 0
+    for de, en in _scope_pairs(de_path, en_path):
+        row = _record_one(de, en, members=members, provenance=provenance)
+        rows.append(row)
+        if row.get("error"):
+            errors += 1
+        elif row.get("refused"):
+            refused += 1
+        if not as_json:
+            _render_record_row(row)
+    if as_json:
+        _echo_json(
+            {
+                "schema": 3,
+                "engine": "v3",
+                "recorded": sum(r.get("recorded", 0) for r in rows),
+                "refused": refused,
+                "errors": errors,
+                "pairs": rows,
+            }
+        )
+    if errors:
+        return 2
+    return 1 if refused else 0
+
+
+def _record_one(
+    de_path: Path,
+    en_path: Path | None,
+    *,
+    members: tuple[str, ...],
+    provenance: str,
+) -> dict:
+    try:
+        bundle = _load(de_path, en_path)
+    except DocLensError as exc:
+        return {"de_path": str(de_path), "error": str(exc)}
+    row: dict = {"de_path": str(bundle.de_path), "en_path": str(bundle.en_path)}
+    if bundle.outcome.refusal is not None:
+        row["refused"] = True
+        row["reasons"] = [f"[{r.code}] {r.detail}" for r in bundle.outcome.refusal.reasons]
+        return row
+    assert bundle.outcome.deck is not None
+
+    # The structural verify gate (design §5/§8): a structurally corrupt pair
+    # is never recorded as verified. Lazy import — sync_verify still imports
+    # v2 modules, and this module must stay clean of them at import time.
+    from clm.slides.sync_verify import structural_gate
+
+    violations = structural_gate(
+        bundle.de_path.read_text(encoding="utf-8"),
+        bundle.en_path.read_text(encoding="utf-8"),
+        bundle.comment_token,
+    )
+    if violations:
+        row["refused"] = True
+        row["reasons"] = [v.message for v in violations]
+        return row
+
+    ledger_path = doc_ledger.ledger_path_for(bundle.de_path)
+    ledger = doc_ledger.load(ledger_path)
+    recorded, migrations = doc_ledger.record_deck_snapshot(
+        ledger,
+        doc_ledger.deck_key_for(bundle.de_path),
+        bundle.outcome.deck,
+        provenance=provenance,
+        commit=_head_commit(bundle.de_path),
+        member_keys=set(members) if members else None,
+    )
+    doc_ledger.save(ledger, ledger_path)
+    row["recorded"] = recorded
+    row["ledger"] = str(ledger_path)
+    if migrations:
+        # The §7.3 key migration is an explicit, logged rename.
+        row["key_migrations"] = dict(sorted(migrations.items()))
+    return row
+
+
+def _render_record_row(row: dict) -> None:
+    name = Path(row["de_path"]).name
+    if row.get("error"):
+        click.echo(f"{name}: ERROR {row['error']}", err=True)
+        return
+    if row.get("refused"):
+        click.echo(f"{name}: REFUSED")
+        for reason in row.get("reasons", []):
+            click.echo(f"  - {reason}")
+        return
+    click.echo(f"{name}: recorded {row['recorded']} member(s) -> {row['ledger']}")
+    for old, new in row.get("key_migrations", {}).items():
+        click.echo(f"  key migrated {old} -> {new}")

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1775,6 +1775,7 @@ clm slides sync accept   DECK --item ID --answer - # validate + write an answer
 clm slides sync baseline {show,bless,clear,prune}  # the watermark accelerator
 clm slides sync autopilot DECK [opts]              # legacy all-in-one WITH models
 clm slides sync shadow   DECK|DIR --baseline REF   # [experimental] v2-vs-v3 comparison
+clm slides sync record   DECK|DIR [opts]           # [v3 engine only] record verified state
 ```
 
 | Verb | Writes? | Model? | Key? | What it does |
@@ -1787,6 +1788,7 @@ clm slides sync shadow   DECK|DIR --baseline REF   # [experimental] v2-vs-v3 com
 | `baseline` | (varies) | no | no | inspect/maintain the demoted watermark accelerator |
 | `autopilot` | yes | **yes** | **yes** | the legacy all-in-one — the **only** place the embedded models live |
 | `shadow` | no | no | no | [experimental, #520 transition window] both engines' verdicts side by side at an explicit git baseline |
+| `record` | ledger only | no | no | [v3 engine only, `CLM_SYNC_ENGINE=v3`] bank the deck's verified state in the committed per-topic ledger |
 
 `DECK` is, everywhere, either half (`<deck>.de.<ext>`), the bilingual stem, or a
 **directory** (a batch sweep). Bare `clm slides sync DECK` is an alias for
@@ -2087,6 +2089,46 @@ items, v3 as member-keyed `outcome/action` items with full excerpts. Used to
 triage engine disagreements while v3 burns in; it writes nothing, needs no model,
 and is removed (or folded into `report`) at cutover. `--json` emits a
 `{"schema": 3, "mode": "shadow", "summary", "pairs"}` payload.
+
+#### `CLM_SYNC_ENGINE=v3` — the document-model engine (experimental, #520 Phase 3)
+
+Setting the environment variable `CLM_SYNC_ENGINE=v3` switches `report` and
+`apply` onto the sync **v3** engine and enables the v3-only `record` verb
+(v2 stays the default; the flag exists only for the transition window and the
+verbs keep their names and exit codes across the cutover). The v3 engine
+parses the whole ≤4-file bundle (both deck halves plus any separated
+voiceover companions) into **one** canonical bilingual document, diffs it
+member-by-member against the **committed per-topic ledger**
+(`<topic>/.clm/sync-ledger.json` — the only trust store; no watermark, no git
+baseline), and reports one `outcome/action` item per member, keyed by a stable
+member handle (`id:<slide-id>` / `pos:<group>/<kind>/<n>`).
+
+- `report DECK|DIR [--json]` — exit `0` clean / `1` work pending / `2` error.
+  The JSON envelope is self-describing (`"schema": 3, "engine": "v3"`) and
+  keeps the stable `is_clean` / `needs_model` / `needs_agent` booleans. A
+  member never recorded in the ledger is **`unverified`** (cold) — framed for
+  verification, never silently trusted. Framed items carry an `answers` list
+  naming the decision shapes `apply --decisions` accepts for them.
+- `apply DECK [--decisions FILE|-] [--member KEY]... [--dry-run] [--json]` —
+  **per item**: every mechanical row executes deterministically; framed items
+  execute only with a valid decision (`{"decisions": [{"key": …, "choice": …}
+  | {"key": …, "body": …}]}`), each answer validated individually (a body
+  smuggling a cell delimiter, a wrong choice, or a stale handle is rejected
+  with a reason while the valid answers still land). The mutated bundle is
+  re-parsed before anything touches disk and written atomically (≤4 files);
+  every landed item is recorded into the ledger. Exit `0` all-applied / `1`
+  residue / `2` error.
+- `record DECK|DIR [--member KEY]... [--provenance WHO] [--json]` — the
+  bless/accept confirmation paths collapsed into one verb: bank the deck's
+  current state as verified (gated on the structural verify; a corrupt pair
+  is refused untouched). A full record sweeps stale entries and performs the
+  pos→id key migration when a cell gained an id (logged). Exit `0` recorded /
+  `1` some pairs refused / `2` error.
+
+The v2-only options (`--use-watermark`, `--baseline`, `--baseline-from`,
+`--since`, `--cache-dir`, `--ledger`) are rejected under the v3 engine, and
+the v3-only apply options are rejected under v2. `verify`, `task`, `accept`,
+`baseline`, and `autopilot` are unaffected by the flag in this phase.
 
 #### `clm slides sync diagnose`
 

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -220,6 +220,10 @@ class ApplyOutcome:
     #: an I/O error) — no file and no ledger entry was touched.
     error: str | None = None
     dry_run: bool = False
+    #: The in-memory ledger was updated (landed items recorded) — the caller
+    #: must persist it. Independent of ``wrote``: a confirm-only pass changes
+    #: the ledger without touching any file.
+    ledger_changed: bool = False
 
     def count(self, status: str) -> int:
         return sum(1 for r in self.results if r.status == status)
@@ -379,7 +383,10 @@ class _Executor:
         if preamble is None:
             if not cells:
                 return None
-            preamble = ()
+            # A newly created file mirrors its twin's preamble (the jupytext
+            # header block is language-neutral) rather than starting bare.
+            twin_preamble = self.preambles.get((_other(lang), part))
+            preamble = twin_preamble if twin_preamble is not None else ()
         lines = list(preamble)
         for cell in cells:
             lines.extend(cell.lines)
@@ -432,28 +439,30 @@ class _Executor:
         target_stream.insert(insert_at, member)
         self._set_side(member, target, new_cell)
 
-    def _locate_twin(self, item: DiffItem, twin: Lang) -> tuple[Member, SideCell]:
-        """The twin-side cell a mechanical row acts on.
+    @staticmethod
+    def _holder(item: DiffItem, lang: Lang) -> Member | None:
+        """The member carrying the item's ``lang`` cell.
 
-        Id-keyed members carry both sides on one member. Positional pool
-        slots may not (a one-sided insert shifts the cross-side pairing), so
-        the twin is located by its *base* fingerprint — the mechanical
-        guarantee is exactly that the twin has not moved off base. Anything
-        not uniquely locatable fails the item (P8: never guess).
+        The :class:`DiffItem` side convention: ``member`` carries the DE
+        cell (and, when ``twin`` is ``None``, every present side); a set
+        ``twin`` carries the EN cell of a pool slot whose cross-side pairing
+        shifted. Resolving each side through this rule is what keeps the
+        executor from ever acting on a neighboring slot's cell.
         """
-        if item.twin is not None:
-            # The differ located the slot's twin-side member for us (a
-            # shifted cross-side pairing) — always the right cell.
-            cell = item.twin.side(twin)
+        if item.twin is not None and lang == "en":
+            return item.twin
+        return item.member
+
+    def _locate_twin(self, item: DiffItem, twin: Lang) -> tuple[Member, SideCell]:
+        """The twin-side cell a row acts on (holder rule, then fp search).
+
+        Anything not uniquely locatable fails the item (P8: never guess).
+        """
+        holder = self._holder(item, twin)
+        if holder is not None:
+            cell = holder.side(twin)
             if cell is not None:
-                return item.twin, cell
-        member = item.member
-        if member is not None:
-            # No shifted pairing was signalled, so the member's own twin-side
-            # cell (paired at parse time) is the slot's cell.
-            cell = member.side(twin)
-            if cell is not None:
-                return member, cell
+                return holder, cell
         base_fp = item.base.side_fp(twin) if item.base is not None else None
         if base_fp is None:
             raise _ItemError(f"cannot locate the {twin} twin of {item.key} (no base fingerprint)")
@@ -474,10 +483,11 @@ class _Executor:
 
     @staticmethod
     def _item_part(item: DiffItem) -> str:
-        member = item.member
-        if member is not None:
+        for holder in (item.member, item.twin):
+            if holder is None:
+                continue
             for lang in _SIDES:
-                cell = member.side(lang)
+                cell = holder.side(lang)
                 if cell is not None:
                     return cell.part
         if item.base is not None:
@@ -485,13 +495,13 @@ class _Executor:
         return "deck"
 
     def _moved_cell(self, item: DiffItem, side: Lang) -> tuple[Member, SideCell]:
-        member = item.member
-        if member is None:
+        holder = self._holder(item, side)
+        if holder is None:
             raise _ItemError(f"item {item.key} carries no member (executor bug)")
-        cell = member.side(side)
+        cell = holder.side(side)
         if cell is None:
             raise _ItemError(f"the {side} side of {item.key} is missing")
-        return member, cell
+        return holder, cell
 
     # -- mechanical rows -------------------------------------------------------
 
@@ -581,7 +591,8 @@ class _Executor:
         target_part = moved.part
         if twin.part == target_part:
             raise _ItemError(f"the {twin_lang} side of {item.key} already relayouted")
-        self._stream_remove(twin_lang, twin.part, member)
+        # Every raising validation runs BEFORE the first mutation: a failed
+        # item must be a strict no-op (never leave the twin half-removed).
         if target_part == "companion":
             owner = moved.for_slide or (member.owner.value if member.owner is not None else None)
             if owner is None:
@@ -590,12 +601,15 @@ class _Executor:
             new_cell = evolve(
                 twin, lines=(header, *twin.lines[1:]), part="companion", for_slide=owner
             )
-            if self.preambles.get((twin_lang, "companion")) is None:
-                mirror = self.preambles.get((moved_side, "companion"))
-                self.preambles[(twin_lang, "companion")] = mirror if mirror is not None else ()
         else:
             header = _set_for_slide(twin.header, None)
             new_cell = evolve(twin, lines=(header, *twin.lines[1:]), part="deck", for_slide=None)
+        if not any(m is member for m in self.streams.get((moved_side, target_part), [])):
+            raise _ItemError(f"the relayouted {moved_side} cell of {item.key} is unlocatable")
+        if target_part == "companion" and self.preambles.get((twin_lang, "companion")) is None:
+            mirror = self.preambles.get((moved_side, "companion"))
+            self.preambles[(twin_lang, "companion")] = mirror if mirror is not None else ()
+        self._stream_remove(twin_lang, twin.part, member)
         self._insert_mirrored(member, moved_side, twin_lang, target_part, new_cell)
 
     def propagate_preamble(self, item: DiffItem, source: Lang) -> None:
@@ -679,11 +693,15 @@ class _Executor:
                 f"pool {group}/{kind}: {len(leftovers)} target cell(s) have no source "
                 f"twin — re-run report"
             )
-        part = self._item_part(item)
-        self._permute_occupants(target, part, desired)
-
-    def _members_by_handle(self) -> dict[str, Member]:
-        return {m.key.render(): m for m in self.deck.members()}
+        # A pool's cells may span parts (the pool key carries none): permute
+        # each part's occupants within their own stream.
+        by_part: dict[str, list[Member]] = {}
+        for m in desired:
+            cell = m.side(target)
+            assert cell is not None
+            by_part.setdefault(cell.part, []).append(m)
+        for part, members in by_part.items():
+            self._permute_occupants(target, part, members)
 
     def _mirror_scope_order(self, group: str, part: str, source: Lang) -> None:
         target = _other(source)
@@ -758,6 +776,9 @@ class _Executor:
         cell = member.side(target)
         if cell is None:
             raise _ItemError(f"the {target} side of {item.key} is missing")
+        # Validate before mutating: a failed item must be a strict no-op.
+        if not any(m is member for m in self.streams.get((source, cell.part), [])):
+            raise _ItemError(f"the moved {source} cell of {item.key} is unlocatable")
         self._stream_remove(target, cell.part, member)
         self._insert_mirrored(member, source, target, cell.part, cell)
 
@@ -786,8 +807,13 @@ def _record_item(
     item: DiffItem,
     *,
     provenance: str,
-) -> None:
-    """Update the ledger for one landed item (surgical, never wholesale)."""
+) -> set[tuple[str, str]]:
+    """Update the ledger for one landed item (surgical, never wholesale).
+
+    Returns the ``(group, kind)`` pools that were re-recorded wholesale, so
+    the caller can un-bless the pool siblings that still carry unresolved
+    items (:func:`_drop_unresolved_from_pools`).
+    """
     key = item.key
     action = item.action
 
@@ -795,7 +821,7 @@ def _record_item(
         if item.base is not None:
             target.members.pop(item.base.key, None)
         _upsert(target, fresh, key, provenance)
-        return
+        return set()
     if action == "record_group_rename":
         if item.base is not None and item.base.key.startswith("id:"):
             old_group = item.base.key.split(":", 1)[1]
@@ -804,17 +830,17 @@ def _record_item(
             if new_group is not None:
                 rename_group_scopes(target, old_group, new_group)
         _upsert(target, fresh, key, provenance)
-        return
+        return set()
     if action in ("record_order", "mirror_order", "order_decision"):
         if key.startswith("id:"):
             _upsert(target, fresh, key, provenance)
-            return
+            return set()
         if "/pool." in key:
             body = key.split(":", 1)[1]
             group, tail, _ = body.rsplit("/", 2)
             kind = tail[len("pool.") :]
             rerecord_pool(target, fresh, group, kind)
-            return
+            return {(group, kind)}
         if "/order." in key:
             body = key.split(":", 1)[1]
             group, tail, _ = body.rsplit("/", 2)
@@ -823,28 +849,29 @@ def _record_item(
                 record_group_order(target, fresh)
             else:
                 record_order_scope(target, fresh, group, part)
-            return
-        return
+            return set()
+        return set()
     if action in ("record_preamble", "propagate_preamble", "conflict_preamble"):
         part = key.split(":", 1)[1].rsplit("/", 2)[1]
         record_preamble_scope(target, fresh, part)
-        return
+        return set()
     if action in ("record_remove", "mirror_remove", "remove_vs_edit", "remove_localized_side"):
         pool = _pool_scope(item)
         if pool is not None:
             rerecord_pool(target, fresh, *pool)
-        else:
-            if key not in fresh.members:
-                target.members.pop(key, None)
-            else:  # a "keep"/re-add resolution: the member persists — record it
-                _upsert(target, fresh, key, provenance)
-        return
+            return {pool}
+        if key not in fresh.members:
+            target.members.pop(key, None)
+        else:  # a "keep"/re-add resolution: the member persists — record it
+            _upsert(target, fresh, key, provenance)
+        return set()
 
     pool = _pool_scope(item)
     if pool is not None:
         rerecord_pool(target, fresh, *pool)
-        return
+        return {pool}
     _upsert(target, fresh, key, provenance)
+    return set()
 
 
 def _upsert(target: DeckLedger, fresh: DeckLedger, key: str, provenance: str) -> None:
@@ -861,19 +888,60 @@ def _upsert(target: DeckLedger, fresh: DeckLedger, key: str, provenance: str) ->
     )
 
 
-def _sweep_migrated_pos(target: DeckLedger) -> None:
-    """Drop stale ``pos:`` entries whose fingerprints match an ``id:`` entry.
+def _member_fp_pair(member: Member) -> tuple[str | None, str | None]:
+    return (
+        content_fingerprint(member.de) if member.de else None,
+        content_fingerprint(member.en) if member.en else None,
+    )
 
-    After a stamp/migration the same cell must not be trusted under two keys;
-    dropping the positional one only removes trust (fail-safe re-check).
+
+def _sweep_migrated_pos(target: DeckLedger, landed: list[tuple[DiffItem, str]]) -> None:
+    """Drop the stale ``pos:`` entry a landed stamp/migration superseded.
+
+    Targeted, never a blanket fp sweep (duplicated boilerplate content
+    legitimately shares fingerprints with id'd cells — a blanket sweep would
+    delete fresh confirmations): only the fingerprints of the *migrated base
+    entries themselves* (or the stamped member, whose fp the id attribute
+    does not change) are matched.
     """
-    id_fps = {
-        (lm.entry.de_fp, lm.entry.en_fp) for k, lm in target.members.items() if k.startswith("id:")
-    }
+    migrated_fps: set[tuple[str | None, str | None]] = set()
+    for item, _provenance in landed:
+        if item.action not in ("stamp_twin_id", "record_key_migration", "record_group_rename"):
+            continue
+        if item.base is not None:
+            migrated_fps.add((item.base.de_fp, item.base.en_fp))
+        if item.member is not None:
+            migrated_fps.add(_member_fp_pair(item.member))
+    if not migrated_fps:
+        return
     for key in [k for k in target.members if k.startswith("pos:")]:
         lm = target.members[key]
-        if (lm.entry.de_fp, lm.entry.en_fp) in id_fps:
+        if (lm.entry.de_fp, lm.entry.en_fp) in migrated_fps:
             del target.members[key]
+
+
+def _drop_unresolved_from_pools(
+    target: DeckLedger,
+    rerecorded_pools: set[tuple[str, str]],
+    unresolved: list[Member],
+) -> None:
+    """Un-bless pool entries whose members still carry unresolved items.
+
+    ``rerecord_pool`` is wholesale by necessity (ordinals renumber
+    together), but a pool sibling whose framed item was left pending /
+    rejected / failed must NOT come out of the pass trusted at its diverged
+    state — its fresh entries are dropped back to cold (fail-safe: it
+    re-checks as ``unverified`` next round, never silently in sync).
+    """
+    if not rerecorded_pools or not unresolved:
+        return
+    unresolved_fps = {_member_fp_pair(m) for m in unresolved}
+    for group, kind in rerecorded_pools:
+        prefix = f"pos:{group}/{kind}/"
+        for key in [k for k in target.members if k.startswith(prefix)]:
+            lm = target.members[key]
+            if (lm.entry.de_fp, lm.entry.en_fp) in unresolved_fps:
+                del target.members[key]
 
 
 # ---------------------------------------------------------------------------
@@ -962,10 +1030,11 @@ def _apply_body_decision(ex: _Executor, item: DiffItem, body: str) -> None:
             ex._insert_mirrored(member, surviving, gone, source_cell.part, new_cell)
             return
         for lang in _SIDES:
-            cell = member.side(lang)
-            if cell is None:
+            holder = ex._holder(item, lang)
+            cell = holder.side(lang) if holder is not None else None
+            if holder is None or cell is None:
                 raise _ItemError(f"the {lang} side of {item.key} is missing")
-            ex._set_side(member, lang, evolve(cell, lines=_replace_body(cell, body)))
+            ex._set_side(holder, lang, evolve(cell, lines=_replace_body(cell, body)))
         return
     raise _ItemError(f"'{item.action}' does not accept a body answer")
 
@@ -973,16 +1042,17 @@ def _apply_body_decision(ex: _Executor, item: DiffItem, body: str) -> None:
 def _apply_choice_decision(ex: _Executor, item: DiffItem, choice: str) -> None:
     action = item.action
     if choice == "confirm":
-        member = item.member
-        if member is None:
+        de_holder = ex._holder(item, "de")
+        en_holder = ex._holder(item, "en")
+        de_cell = de_holder.side("de") if de_holder is not None else None
+        en_cell = en_holder.side("en") if en_holder is not None else None
+        if de_cell is None and en_cell is None:
             raise _ItemError("item carries no member to confirm")
-        if member.is_one_sided:
+        if de_cell is None or en_cell is None:
             raise _ItemError(
                 "cannot confirm a one-sided member — supply the twin first (translate/edit)"
             )
-        de_attr = member.de.lang_attr is not None if member.de else False
-        en_attr = member.en.lang_attr is not None if member.en else False
-        if de_attr != en_attr:
+        if (de_cell.lang_attr is not None) != (en_cell.lang_attr is not None):
             raise _ItemError(
                 "cannot confirm a member mid-transition (the sides disagree about "
                 "lang attributes) — complete or revert the transition first"
@@ -994,26 +1064,18 @@ def _apply_choice_decision(ex: _Executor, item: DiffItem, choice: str) -> None:
             ex.propagate(item_with_side(item, side), side)
             return
         if action == "unify_choose_body":
-            member = item.member
-            if member is None:
-                raise _ItemError("item carries no member")
-            chosen = member.side(side)
-            twin = member.side(_other(side))
-            if chosen is None or twin is None:
-                raise _ItemError(f"both sides of {item.key} are needed to unify")
-            ex._set_side(member, _other(side), evolve(twin, lines=_replace_body(twin, chosen.body)))
+            _, chosen = ex._moved_cell(item, side)
+            twin_holder, twin = ex._locate_twin(item, _other(side))
+            ex._set_side(
+                twin_holder, _other(side), evolve(twin, lines=_replace_body(twin, chosen.body))
+            )
             return
         if action == "conflict_owner":
-            member = item.member
-            if member is None:
-                raise _ItemError("item carries no member")
-            chosen = member.side(side)
-            twin = member.side(_other(side))
-            if chosen is None or twin is None:
-                raise _ItemError(f"both sides of {item.key} are needed")
+            _, chosen = ex._moved_cell(item, side)
+            twin_holder, twin = ex._locate_twin(item, _other(side))
             header = _set_for_slide(twin.header, chosen.for_slide)
             ex._set_side(
-                member,
+                twin_holder,
                 _other(side),
                 evolve(twin, lines=(header, *twin.lines[1:]), for_slide=chosen.for_slide),
             )
@@ -1026,29 +1088,29 @@ def _apply_choice_decision(ex: _Executor, item: DiffItem, choice: str) -> None:
             return
         raise _ItemError(f"'{action}' does not accept a side choice")
     if choice == "remove":
-        # A deliberate removal: delete every remaining side of the member.
-        # No base-fingerprint check here — the agent explicitly chose to
-        # discard the (possibly edited) survivor.
-        member = item.member
-        if member is None:
-            raise _ItemError("item carries no member")
-        removed = False
-        for lang in _SIDES:
-            cell = member.side(lang)
-            if cell is not None:
-                ex._stream_remove(lang, cell.part, member)
-                ex._set_side(member, lang, None)
-                removed = True
-        if not removed:
-            raise _ItemError(f"{item.key} has no remaining cells to remove")
+        # A deliberate removal: delete the SURVIVING side of the slot. Only
+        # ``item.side`` (the already-gone side) tells which cell is the
+        # slot's — under a shifted pool pairing the member's other-side cell
+        # belongs to a neighboring slot and must never be touched.
+        if item.side is None:
+            raise _ItemError(
+                f"{item.key} names no removed side — reconcile manually (edit + record)"
+            )
+        survivor = _other(item.side)
+        holder = ex._holder(item, survivor)
+        cell = holder.side(survivor) if holder is not None else None
+        if holder is None or cell is None:
+            raise _ItemError(f"{item.key} has no remaining cell to remove")
+        ex._stream_remove(survivor, cell.part, holder)
+        ex._set_side(holder, survivor, None)
         return
     if choice == "keep":
         # remove_vs_edit: keep the edited survivor and re-add it on the twin.
-        member = item.member
-        if member is None:
-            raise _ItemError("item carries no member")
-        present = "de" if member.de is not None else "en"
-        ex.copy_new(item, present)  # type: ignore[arg-type]
+        if item.side is None:
+            raise _ItemError(
+                f"{item.key} names no removed side — reconcile manually (edit + record)"
+            )
+        ex.copy_new(item, _other(item.side))
         return
     raise _ItemError(f"unsupported choice {choice!r}")
 
@@ -1135,9 +1197,11 @@ def apply_deck(
 
     ordered = sorted(enumerate(diff.items), key=lambda e: (_PHASES.get(e[1].action, 9), e[0]))
     landed: list[tuple[DiffItem, str]] = []  # (item, provenance)
+    unresolved_items: list[DiffItem] = []  # pending / rejected / failed
     seen_decisions: set[str] = set()
     for _, item in ordered:
         if only_members is not None and item.key not in only_members:
+            unresolved_items.append(item)  # a skipped pool sibling must not be blessed
             outcome.results.append(
                 ItemResult(item.key, item.action, "skipped", "excluded by --member")
             )
@@ -1174,6 +1238,7 @@ def apply_deck(
                 )
             else:
                 assert item.action in FRAMED_ACTIONS
+                unresolved_items.append(item)
                 outcome.results.append(
                     ItemResult(
                         item.key,
@@ -1184,6 +1249,7 @@ def apply_deck(
                 )
         except _ItemError as exc:
             status = "rejected" if decision is not None else "failed"
+            unresolved_items.append(item)
             outcome.results.append(ItemResult(item.key, item.action, status, str(exc)))
     for key in decisions:
         if key not in seen_decisions:
@@ -1246,6 +1312,8 @@ def apply_deck(
         from clm.infrastructure.utils.path_utils import atomic_write_all
 
         try:
+            for path, _text in writes:
+                path.parent.mkdir(parents=True, exist_ok=True)
             atomic_write_all(writes)
         except OSError as exc:
             outcome.error = f"write failed: {exc}"
@@ -1257,9 +1325,20 @@ def apply_deck(
     fresh = snapshot_deck(final_deck, provenance="apply", commit=commit)
     target = ledger.decks.setdefault(deck_key, DeckLedger())
     priority = {"record_group_rename": 0, "record_key_migration": 1}
+    rerecorded_pools: set[tuple[str, str]] = set()
     for item, provenance in sorted(landed, key=lambda e: priority.get(e[0].action, 2)):
-        _record_item(target, fresh, item, provenance=provenance)
-    _sweep_migrated_pos(target)
+        rerecorded_pools |= _record_item(target, fresh, item, provenance=provenance)
+    # Never bless the unresolved: a wholesale pool re-record must not trust
+    # siblings whose framed items were left pending/rejected/failed.
+    unresolved_members = [
+        holder
+        for item in unresolved_items
+        for holder in (item.member, item.twin)
+        if holder is not None
+    ]
+    _drop_unresolved_from_pools(target, rerecorded_pools, unresolved_members)
+    _sweep_migrated_pos(target, landed)
+    outcome.ledger_changed = True
     return outcome
 
 

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -1,0 +1,1286 @@
+"""The v3 per-item apply executor (#520 Phase 3, design §6.2/§8).
+
+Executes the deterministic rows of a :class:`~clm.slides.sync_diff.DeckDiff`
+(the :data:`~clm.slides.sync_diff.MECHANICAL_ACTIONS` registry) plus any
+*validated decisions* an agent supplied for framed items — **per item**,
+value-keyed by :class:`~clm.slides.bilingual_doc.MemberKey` handle: invalid
+answers are rejected individually with reasons, valid ones land, and nothing
+already applied is lost. The ledger records each landed item.
+
+Write discipline:
+
+* Mutations happen on an in-memory per-``(lang, part)`` cell-stream view of
+  the parsed deck; unmutated cells re-emit their verbatim bytes (the lens
+  guarantee lifted into the executor — emission is preamble + concatenated
+  cell lines, exactly what :func:`~clm.slides.doc_lenses.project` produces).
+* Before anything touches disk the mutated bundle is **re-parsed**
+  (:func:`~clm.slides.doc_lenses.parse_bundle`): a refusal aborts the whole
+  write, leaving every file untouched — the executor can never write a bundle
+  the lens cannot read back.
+* Writes go through :func:`~clm.infrastructure.utils.path_utils.atomic_write_all`
+  (≤4 files per deck), the same boundary ``split``/``unify`` use.
+* P8 stays load-bearing: this module executes only what the differ *emitted*
+  as mechanical (the differ already refuses to emit a mechanical row when the
+  base carried a divergence, a pool has a deficit, or a twin is estranged) —
+  and any executor-side ambiguity (a twin cell it cannot locate uniquely, a
+  base fingerprint that no longer matches) fails that one item, never guesses.
+
+Decision documents (design §8) re-home the ``sync_accept`` guards: a body
+answer is validated as ONE cell's body (the multi-cell smuggling rejection —
+a body carrying a ``<token> %%`` boundary would re-split on read-back and
+mint phantom cells / duplicate ids), choices are validated against the
+per-action vocabulary, and a stale handle is rejected, not guessed at.
+
+This module is part of the v3 core: it must not import from the v2 sync core
+(``sync_plan`` / ``sync_apply`` / ``sync_code``) — enforced by the
+import-cleanliness test (design §12.5).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from attrs import define, evolve, field, frozen
+
+from clm.slides.bilingual_doc import BilingualDeck, Lang, Member, SideCell
+from clm.slides.doc_ledger import (
+    DeckLedger,
+    LedgerMember,
+    TopicLedger,
+    record_group_order,
+    record_order_scope,
+    record_preamble_scope,
+    rename_group_scopes,
+    rerecord_pool,
+    snapshot_deck,
+)
+from clm.slides.doc_lenses import LoadedBundle, parse_bundle
+from clm.slides.raw_cells import is_cell_boundary
+from clm.slides.sync_diff import (
+    FRAMED_ACTIONS,
+    MECHANICAL_ACTIONS,
+    DeckDiff,
+    DiffItem,
+    _iter_with_groups,
+    _member_group_token,
+    content_fingerprint,
+)
+from clm.slides.sync_writeback import set_header_tags, swap_lang
+
+__all__ = [
+    "ApplyOutcome",
+    "Decision",
+    "ItemResult",
+    "apply_deck",
+    "decision_vocabulary",
+    "parse_decisions",
+]
+
+_SIDES: tuple[Lang, Lang] = ("de", "en")
+_SLIDE_ID_ATTR_RE = re.compile(r'\s*slide_id="[^"]*"')
+_FOR_SLIDE_ATTR_RE = re.compile(r'\s*for_slide="[^"]*"')
+
+
+def _other(lang: Lang) -> Lang:
+    return "en" if lang == "de" else "de"
+
+
+# ---------------------------------------------------------------------------
+# Decisions
+# ---------------------------------------------------------------------------
+
+
+@frozen
+class Decision:
+    """One agent answer to a framed item, keyed by the member handle."""
+
+    key: str
+    choice: str | None = None
+    body: str | None = None
+
+
+#: Framed actions this executor can resolve from a decision, with the answer
+#: shapes each accepts. Everything else is agent-manual in Phase 3: edit the
+#: files, re-run ``report``, then ``record``.
+_DECISION_VOCABULARY: dict[str, tuple[str, ...]] = {
+    "translate_edit": ("body",),
+    "translate_new": ("body",),
+    "verify_translation": ("confirm",),
+    "verify_cold": ("confirm",),
+    "conflict_shared": ("de", "en", "body"),
+    "pending_divergence": ("de", "en"),
+    "remove_vs_edit": ("remove", "keep"),
+    "remove_localized_side": ("remove", "body"),
+    "unify_choose_body": ("de", "en", "body"),
+    "conflict_owner": ("de", "en"),
+    "conflict_preamble": ("de", "en"),
+    "order_decision": ("de", "en"),
+}
+
+
+def decision_vocabulary(action: str) -> tuple[str, ...]:
+    """The answer shapes ``apply --decisions`` accepts for a framed action."""
+    return _DECISION_VOCABULARY.get(action, ())
+
+
+def parse_decisions(payload: object) -> tuple[dict[str, Decision], list[str]]:
+    """Decode a decision document; malformed rows are collected as errors.
+
+    Accepts ``{"decisions": [...]}`` or a bare list; each row is
+    ``{"key": "<member handle>", "choice": "..."} | {"key": ..., "body": "..."}``.
+    """
+    errors: list[str] = []
+    rows = payload.get("decisions") if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        return {}, ["decision document must be a list or {'decisions': [...]}"]
+    decisions: dict[str, Decision] = {}
+    for i, row in enumerate(rows):
+        if not isinstance(row, dict) or not isinstance(row.get("key"), str):
+            errors.append(f"decision #{i}: needs a 'key' string (the member handle)")
+            continue
+        choice = row.get("choice")
+        body = row.get("body")
+        if choice is not None and not isinstance(choice, str):
+            errors.append(f"decision #{i} ({row['key']}): 'choice' must be a string")
+            continue
+        if body is not None and not isinstance(body, str):
+            errors.append(f"decision #{i} ({row['key']}): 'body' must be a string")
+            continue
+        if (choice is None) == (body is None):
+            errors.append(f"decision #{i} ({row['key']}): give exactly one of 'choice' or 'body'")
+            continue
+        if row["key"] in decisions:
+            errors.append(f"decision #{i} ({row['key']}): duplicate key")
+            continue
+        decisions[row["key"]] = Decision(key=row["key"], choice=choice, body=body)
+    return decisions, errors
+
+
+def load_decisions_text(text: str) -> tuple[dict[str, Decision], list[str]]:
+    """:func:`parse_decisions` over raw JSON text."""
+    try:
+        payload = json.loads(text)
+    except ValueError as exc:
+        return {}, [f"decision document is not valid JSON: {exc}"]
+    return parse_decisions(payload)
+
+
+def _validate_body(body: str, comment_token: str) -> str | None:
+    """The re-homed ``sync_accept`` body guards (single-cell shape)."""
+    if not body.strip():
+        return "the answer body is empty"
+    if any(is_cell_boundary(line, comment_token) for line in body.split("\n")):
+        return (
+            f"the answer body contains a '{comment_token} %%' cell delimiter that "
+            "would split it into multiple cells on read-back (minting a phantom "
+            "cell / duplicate slide_id) — return just the one cell's body"
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Results
+# ---------------------------------------------------------------------------
+
+
+@frozen
+class ItemResult:
+    """One item's per-item outcome."""
+
+    key: str
+    action: str
+    #: applied  — a file mutation landed (and was recorded)
+    #: recorded — a ledger-only record landed
+    #: pending  — framed item without a decision (untouched residue)
+    #: rejected — a supplied decision failed validation (nothing changed)
+    #: failed   — a mechanical row the executor could not resolve safely
+    #: skipped  — excluded by the ``--member`` filter
+    status: str
+    reason: str = ""
+
+    def payload(self) -> dict:
+        return {
+            "key": self.key,
+            "action": self.action,
+            "status": self.status,
+            "reason": self.reason,
+        }
+
+
+@define
+class ApplyOutcome:
+    """The whole apply pass over one deck."""
+
+    results: list[ItemResult] = field(factory=list)
+    wrote: bool = False
+    written_paths: list[Path] = field(factory=list)
+    #: A whole-write abort (the re-parse gate refused the mutated bundle, or
+    #: an I/O error) — no file and no ledger entry was touched.
+    error: str | None = None
+    dry_run: bool = False
+
+    def count(self, status: str) -> int:
+        return sum(1 for r in self.results if r.status == status)
+
+    @property
+    def all_applied(self) -> bool:
+        return self.error is None and all(r.status in ("applied", "recorded") for r in self.results)
+
+    def to_payload(self) -> dict:
+        return {
+            "schema": 3,
+            "engine": "v3",
+            "dry_run": self.dry_run,
+            "error": self.error,
+            "wrote": self.wrote,
+            "written": [str(p) for p in self.written_paths],
+            "counts": {
+                status: self.count(status)
+                for status in ("applied", "recorded", "pending", "rejected", "failed", "skipped")
+            },
+            "items": [r.payload() for r in self.results],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Header surgery helpers
+# ---------------------------------------------------------------------------
+
+
+def _with_slide_id_of(source_lines: tuple[str, ...], target_header: str) -> tuple[str, ...]:
+    """``source_lines`` with the *target's* verbatim ``slide_id`` attribute.
+
+    A verbatim propagate must not overwrite the twin's id bytes: the two
+    halves can legitimately differ in the ``!`` preserve marker, and the
+    fingerprint ignores the attribute anyway (parity is judged modulo id).
+    """
+    target_match = _SLIDE_ID_ATTR_RE.search(target_header)
+    header = _SLIDE_ID_ATTR_RE.sub("", source_lines[0])
+    if target_match:
+        header = header + target_match.group(0)
+    return (header, *source_lines[1:])
+
+
+def _set_for_slide(header: str, for_slide: str | None) -> str:
+    """Set (or drop) the header's ``for_slide`` attribute."""
+    stripped = _FOR_SLIDE_ATTR_RE.sub("", header)
+    if for_slide is None:
+        return stripped
+    return stripped.rstrip() + f' for_slide="{for_slide}"'
+
+
+def _replace_body(cell: SideCell, body: str) -> tuple[str, ...]:
+    """The cell's lines with a new body, preserving its trailing separator."""
+    old_body = cell.lines[1:]
+    trailing = 0
+    for line in reversed(old_body):
+        if line == "":
+            trailing += 1
+        else:
+            break
+    new_body = body.split("\n")
+    while new_body and new_body[-1] == "":
+        new_body.pop()
+    return (cell.lines[0], *new_body, *([""] * trailing))
+
+
+# ---------------------------------------------------------------------------
+# The executor
+# ---------------------------------------------------------------------------
+
+#: Execution phases: content rewrites, then inserts, then removes, then
+#: layout moves, then reorders, then preambles — so a reorder always sees the
+#: post-insert/post-remove streams. Records are ledger-only and phase-free.
+_PHASES: dict[str, int] = {
+    "propagate_shared_edit": 0,
+    "mirror_tags": 0,
+    "mirror_owner": 0,
+    "stamp_twin_id": 0,
+    "translate_edit": 0,
+    "conflict_shared": 0,
+    "pending_divergence": 0,
+    "unify_choose_body": 0,
+    "conflict_owner": 0,
+    "verify_translation": 0,
+    "verify_cold": 0,
+    "copy_new_shared": 1,
+    "translate_new": 1,
+    "remove_vs_edit": 1,
+    "mirror_remove": 2,
+    "remove_localized_side": 2,
+    "mirror_layout": 3,
+    "mirror_order": 4,
+    "order_decision": 4,
+    "propagate_preamble": 5,
+    "conflict_preamble": 5,
+}
+
+#: Mechanical rows that are pure ledger records (no file mutation).
+_RECORD_ONLY = frozenset(
+    {
+        "record_symmetric_edit",
+        "record_symmetric_add",
+        "record_remove",
+        "record_tags",
+        "record_fork",
+        "record_unify",
+        "record_key_migration",
+        "record_relayout",
+        "record_owner",
+        "record_order",
+        "record_group_rename",
+        "record_preamble",
+    }
+)
+
+
+class _ItemError(Exception):
+    """A per-item execution failure: this item fails, others proceed."""
+
+
+@define
+class _Executor:
+    bundle: LoadedBundle
+    deck: BilingualDeck
+    comment_token: str
+
+    streams: dict[tuple[Lang, str], list[Member]] = field(factory=dict)
+    preambles: dict[tuple[Lang, str], tuple[str, ...] | None] = field(factory=dict)
+    mutated: bool = False
+
+    def __attrs_post_init__(self) -> None:
+        order: dict[tuple[Lang, str], list[tuple[int, Member]]] = {}
+        for member in self.deck.members():
+            for lang in _SIDES:
+                cell = member.side(lang)
+                if cell is not None:
+                    order.setdefault((lang, cell.part), []).append((cell.index, member))
+        self.streams = {
+            key: [m for _, m in sorted(entries, key=lambda e: e[0])]
+            for key, entries in order.items()
+        }
+        for lang in _SIDES:
+            self.streams.setdefault((lang, "deck"), [])
+        self.preambles = {
+            ("de", "deck"): self.deck.de_deck_preamble,
+            ("en", "deck"): self.deck.en_deck_preamble,
+            ("de", "companion"): self.deck.de_companion_preamble,
+            ("en", "companion"): self.deck.en_companion_preamble,
+        }
+
+    # -- emission -----------------------------------------------------------
+
+    def emit(self, lang: Lang, part: str) -> str | None:
+        preamble = self.preambles.get((lang, part))
+        members = self.streams.get((lang, part), [])
+        cells = [c for m in members if (c := m.side(lang)) is not None and c.part == part]
+        if preamble is None:
+            if not cells:
+                return None
+            preamble = ()
+        lines = list(preamble)
+        for cell in cells:
+            lines.extend(cell.lines)
+        return "\n".join(lines)
+
+    def emit_all(self) -> dict[tuple[Lang, str], str | None]:
+        return {
+            (lang, part): self.emit(lang, part) for lang in _SIDES for part in ("deck", "companion")
+        }
+
+    # -- stream plumbing ------------------------------------------------------
+
+    def _set_side(self, member: Member, lang: Lang, cell: SideCell | None) -> None:
+        if lang == "de":
+            member.de = cell
+        else:
+            member.en = cell
+        self.mutated = True
+
+    def _stream_remove(self, lang: Lang, part: str, member: Member) -> None:
+        stream = self.streams.get((lang, part), [])
+        for i, m in enumerate(stream):
+            if m is member:
+                del stream[i]
+                return
+
+    def _insert_mirrored(
+        self, member: Member, source: Lang, target: Lang, part: str, new_cell: SideCell
+    ) -> None:
+        """Insert ``member``'s new ``target`` cell after the mirrored predecessor.
+
+        Walk backwards from the member's position in the *source* stream to
+        the nearest member that also has a cell in the target stream; insert
+        right after it (or at the top of the file when none precedes it).
+        """
+        source_stream = self.streams.get((source, part), [])
+        target_stream = self.streams.setdefault((target, part), [])
+        try:
+            pos = next(i for i, m in enumerate(source_stream) if m is member)
+        except StopIteration:
+            raise _ItemError("the source cell is not in its own stream (executor bug)") from None
+        insert_at = 0
+        for prev in reversed(source_stream[:pos]):
+            for j, m in enumerate(target_stream):
+                if m is prev:
+                    insert_at = j + 1
+                    break
+            if insert_at:
+                break
+        target_stream.insert(insert_at, member)
+        self._set_side(member, target, new_cell)
+
+    def _locate_twin(self, item: DiffItem, twin: Lang) -> tuple[Member, SideCell]:
+        """The twin-side cell a mechanical row acts on.
+
+        Id-keyed members carry both sides on one member. Positional pool
+        slots may not (a one-sided insert shifts the cross-side pairing), so
+        the twin is located by its *base* fingerprint — the mechanical
+        guarantee is exactly that the twin has not moved off base. Anything
+        not uniquely locatable fails the item (P8: never guess).
+        """
+        if item.twin is not None:
+            # The differ located the slot's twin-side member for us (a
+            # shifted cross-side pairing) — always the right cell.
+            cell = item.twin.side(twin)
+            if cell is not None:
+                return item.twin, cell
+        member = item.member
+        if member is not None:
+            # No shifted pairing was signalled, so the member's own twin-side
+            # cell (paired at parse time) is the slot's cell.
+            cell = member.side(twin)
+            if cell is not None:
+                return member, cell
+        base_fp = item.base.side_fp(twin) if item.base is not None else None
+        if base_fp is None:
+            raise _ItemError(f"cannot locate the {twin} twin of {item.key} (no base fingerprint)")
+        part = self._item_part(item)
+        matches = [
+            (m, c)
+            for m in self.streams.get((twin, part), [])
+            if (c := m.side(twin)) is not None
+            and c.part == part
+            and content_fingerprint(c) == base_fp
+        ]
+        if len(matches) != 1:
+            raise _ItemError(
+                f"the {twin} twin of {item.key} is not uniquely locatable "
+                f"({len(matches)} base-identical candidates) — reconcile manually"
+            )
+        return matches[0]
+
+    @staticmethod
+    def _item_part(item: DiffItem) -> str:
+        member = item.member
+        if member is not None:
+            for lang in _SIDES:
+                cell = member.side(lang)
+                if cell is not None:
+                    return cell.part
+        if item.base is not None:
+            return "companion" if item.base.layout == "companion" else "deck"
+        return "deck"
+
+    def _moved_cell(self, item: DiffItem, side: Lang) -> tuple[Member, SideCell]:
+        member = item.member
+        if member is None:
+            raise _ItemError(f"item {item.key} carries no member (executor bug)")
+        cell = member.side(side)
+        if cell is None:
+            raise _ItemError(f"the {side} side of {item.key} is missing")
+        return member, cell
+
+    # -- mechanical rows -------------------------------------------------------
+
+    def propagate(self, item: DiffItem, source: Lang) -> None:
+        """Verbatim copy of the ``source`` cell onto its twin (id kept)."""
+        _, moved = self._moved_cell(item, source)
+        twin_member, twin_cell = self._locate_twin(item, _other(source))
+        new_lines = _with_slide_id_of(moved.lines, twin_cell.header)
+        self._set_side(twin_member, _other(source), evolve(twin_cell, lines=new_lines))
+
+    def copy_new(self, item: DiffItem, source: Lang) -> None:
+        member, moved = self._moved_cell(item, source)
+        target = _other(source)
+        if member.side(target) is not None:
+            raise _ItemError(f"the {target} side of {item.key} already exists")
+        new_cell = evolve(moved, lines=moved.lines)
+        self._insert_mirrored(member, source, target, moved.part, new_cell)
+
+    def mirror_remove(self, item: DiffItem, gone: Lang) -> None:
+        present = _other(gone)
+        member, cell = self._locate_twin(item, present)
+        if item.base is not None:
+            base_fp = item.base.side_fp(present)
+            if base_fp is not None and content_fingerprint(cell) != base_fp:
+                raise _ItemError(
+                    f"the surviving {present} side of {item.key} moved off base "
+                    f"since the diff — re-run report"
+                )
+        self._stream_remove(present, cell.part, member)
+        self._set_side(member, present, None)
+
+    def mirror_tags(self, item: DiffItem, source: Lang) -> None:
+        _, moved = self._moved_cell(item, source)
+        twin_member, twin_cell = self._locate_twin(item, _other(source))
+        new_header = set_header_tags(twin_cell.header, moved.tags)
+        self._set_side(
+            twin_member,
+            _other(source),
+            evolve(twin_cell, lines=(new_header, *twin_cell.lines[1:]), tags=moved.tags),
+        )
+
+    def stamp_twin_id(self, item: DiffItem, unstamped: Lang) -> None:
+        member = item.member
+        if member is None:
+            raise _ItemError(f"item {item.key} carries no member")
+        idd_cell = member.side(_other(unstamped))
+        twin_cell = member.side(unstamped)
+        if idd_cell is None or twin_cell is None or idd_cell.slide_id is None:
+            raise _ItemError(f"the id-stamp shape of {item.key} no longer holds — re-run report")
+        if twin_cell.slide_id is not None:
+            raise _ItemError(f"the {unstamped} side of {item.key} already carries an id")
+        new_header = twin_cell.header.rstrip() + f' slide_id="{idd_cell.slide_id}"'
+        self._set_side(
+            member,
+            unstamped,
+            evolve(
+                twin_cell,
+                lines=(new_header, *twin_cell.lines[1:]),
+                slide_id=idd_cell.slide_id,
+            ),
+        )
+
+    def mirror_owner(self, item: DiffItem, source: Lang) -> None:
+        _, moved = self._moved_cell(item, source)
+        twin_member, twin_cell = self._locate_twin(item, _other(source))
+        new_header = _set_for_slide(twin_cell.header, moved.for_slide)
+        self._set_side(
+            twin_member,
+            _other(source),
+            evolve(
+                twin_cell,
+                lines=(new_header, *twin_cell.lines[1:]),
+                for_slide=moved.for_slide,
+            ),
+        )
+
+    def mirror_layout(self, item: DiffItem, moved_side: Lang) -> None:
+        """Complete a half-done inline↔companion relayout on the twin."""
+        member = item.member
+        if member is None:
+            raise _ItemError(f"item {item.key} carries no member")
+        moved = member.side(moved_side)
+        twin_lang = _other(moved_side)
+        twin = member.side(twin_lang)
+        if moved is None or twin is None:
+            raise _ItemError(f"the relayout shape of {item.key} no longer holds")
+        target_part = moved.part
+        if twin.part == target_part:
+            raise _ItemError(f"the {twin_lang} side of {item.key} already relayouted")
+        self._stream_remove(twin_lang, twin.part, member)
+        if target_part == "companion":
+            owner = moved.for_slide or (member.owner.value if member.owner is not None else None)
+            if owner is None:
+                raise _ItemError(f"cannot derive the owning slide for {item.key}")
+            header = _set_for_slide(twin.header, owner)
+            new_cell = evolve(
+                twin, lines=(header, *twin.lines[1:]), part="companion", for_slide=owner
+            )
+            if self.preambles.get((twin_lang, "companion")) is None:
+                mirror = self.preambles.get((moved_side, "companion"))
+                self.preambles[(twin_lang, "companion")] = mirror if mirror is not None else ()
+        else:
+            header = _set_for_slide(twin.header, None)
+            new_cell = evolve(twin, lines=(header, *twin.lines[1:]), part="deck", for_slide=None)
+        self._insert_mirrored(member, moved_side, twin_lang, target_part, new_cell)
+
+    def propagate_preamble(self, item: DiffItem, source: Lang) -> None:
+        part = item.key.rsplit("/", 2)[1]  # pos:~preamble/<part>/0
+        lines = self.preambles.get((source, part))
+        if lines is None:
+            raise _ItemError(f"the {source} {part} preamble is absent")
+        self.preambles[(_other(source), part)] = tuple(lines)
+        self.mutated = True
+
+    # -- reorders ---------------------------------------------------------------
+
+    def mirror_order(self, item: DiffItem, source: Lang) -> None:
+        key = item.key
+        if key.startswith("id:"):
+            self._mirror_member_move(item, source)
+        elif "/pool." in key:
+            group, kind = self._scope_of(key, "pool.")
+            self._mirror_pool_order(group, kind, source, item)
+        elif "/order." in key:
+            group, part = self._scope_of(key, "order.")
+            if group == "~groups":
+                self._mirror_group_order(source, part)
+            else:
+                self._mirror_scope_order(group, part, source)
+        else:
+            raise _ItemError(f"unrecognized order scope {key}")
+
+    @staticmethod
+    def _scope_of(key: str, marker: str) -> tuple[str, str]:
+        body = key.split(":", 1)[1]
+        group, tail, _ordinal = body.rsplit("/", 2)
+        if not tail.startswith(marker):
+            raise _ItemError(f"unrecognized order scope {key}")
+        return group, tail[len(marker) :]
+
+    def _pool_members(self, group: str, kind: str, lang: Lang) -> list[Member]:
+        members: list[tuple[int, Member]] = []
+        for member, owner_group in _iter_with_groups(self.deck):
+            if member.key.scheme != "pos" or member.kind != kind:
+                continue
+            if _member_group_token(member, owner_group) != group:
+                continue
+            cell = member.side(lang)
+            if cell is not None:
+                members.append((cell.index, member))
+        return [m for _, m in sorted(members, key=lambda e: e[0])]
+
+    def _permute_occupants(self, lang: Lang, part: str, desired: list[Member]) -> None:
+        """Reorder ``desired`` members among their own stream slots."""
+        stream = self.streams.get((lang, part), [])
+        desired_ids = {id(m) for m in desired}
+        slots = [i for i, m in enumerate(stream) if id(m) in desired_ids]
+        if len(slots) != len(desired):
+            raise _ItemError("order scope changed since the diff — re-run report")
+        for slot, member in zip(slots, desired, strict=True):
+            stream[slot] = member
+        self.mutated = True
+
+    def _mirror_pool_order(self, group: str, kind: str, source: Lang, item: DiffItem) -> None:
+        target = _other(source)
+        src_members = self._pool_members(group, kind, source)
+        tgt_members = self._pool_members(group, kind, target)
+        src_fps = [content_fingerprint(c) for m in src_members if (c := m.side(source)) is not None]
+        by_fp: dict[str, list[Member]] = {}
+        for m in tgt_members:
+            cell = m.side(target)
+            assert cell is not None
+            by_fp.setdefault(content_fingerprint(cell), []).append(m)
+        desired: list[Member] = []
+        for fp in src_fps:
+            bucket = by_fp.get(fp)
+            if not bucket:
+                raise _ItemError(
+                    f"pool {group}/{kind}: the sides' contents no longer mirror — re-run report"
+                )
+            desired.append(bucket.pop(0))
+        leftovers = [m for bucket in by_fp.values() for m in bucket]
+        if leftovers:
+            raise _ItemError(
+                f"pool {group}/{kind}: {len(leftovers)} target cell(s) have no source "
+                f"twin — re-run report"
+            )
+        part = self._item_part(item)
+        self._permute_occupants(target, part, desired)
+
+    def _members_by_handle(self) -> dict[str, Member]:
+        return {m.key.render(): m for m in self.deck.members()}
+
+    def _mirror_scope_order(self, group: str, part: str, source: Lang) -> None:
+        target = _other(source)
+        scope: dict[Lang, list[Member]] = {"de": [], "en": []}
+        for member, owner_group in _iter_with_groups(self.deck):
+            if member.key.scheme != "id":
+                continue
+            if _member_group_token(member, owner_group) != group:
+                continue
+            for lang in _SIDES:
+                cell = member.side(lang)
+                if cell is not None and cell.part == part:
+                    scope[lang].append(member)
+        for lang in _SIDES:
+            stream = self.streams.get((lang, part), [])
+            pos = {id(m): i for i, m in enumerate(stream)}
+            scope[lang].sort(key=lambda m: pos.get(id(m), -1))
+        target_ids = {id(m) for m in scope[target]}
+        common = [m for m in scope[source] if id(m) in target_ids]
+        self._permute_occupants(target, part, common)
+
+    def _mirror_group_order(self, source: Lang, part: str) -> None:
+        """Reorder whole slide groups on the target side to the source order.
+
+        The target stream is clustered per owning group (on a deck part the
+        anchors bracket cells, so a group's cells are contiguous by
+        construction; on a companion part cells cluster by owner). The
+        clusters are re-emitted in the source side's group order; cells owned
+        by no group (headers before, orphans after) keep their edges.
+        """
+        target = _other(source)
+        stream = self.streams.get((target, part), [])
+        member_group: dict[int, str] = {}
+        for group in self.deck.groups:
+            for member in group.all_members():
+                member_group[id(member)] = group.anchor_id
+        prefix: list[Member] = []
+        clusters: dict[str, list[Member]] = {}
+        cluster_order: list[str] = []
+        suffix: list[Member] = []
+        for member in stream:
+            gid = member_group.get(id(member))
+            if gid is None:
+                (prefix if not clusters else suffix).append(member)
+                continue
+            if gid not in clusters:
+                clusters[gid] = []
+                cluster_order.append(gid)
+            clusters[gid].append(member)
+        anchored: list[tuple[int, str]] = []
+        for g in self.deck.groups:
+            if g.anchor is None:
+                continue
+            cell = g.anchor.side(source)
+            if cell is not None and cell.part == part:
+                anchored.append((cell.index, g.anchor_id))
+        source_order = [gid for _, gid in sorted(anchored)]
+        desired = [gid for gid in source_order if gid in clusters]
+        desired += [gid for gid in cluster_order if gid not in desired]
+        new_stream = prefix + [m for gid in desired for m in clusters[gid]] + suffix
+        if len(new_stream) != len(stream):  # pragma: no cover - pure regrouping
+            raise _ItemError("group reorder would lose cells — reorder manually")
+        self.streams[(target, part)] = new_stream
+        self.mutated = True
+
+    def _mirror_member_move(self, item: DiffItem, source: Lang) -> None:
+        """Cross-group move: re-home the twin cell under the moved group."""
+        member = item.member
+        if member is None:
+            raise _ItemError(f"item {item.key} carries no member")
+        target = _other(source)
+        cell = member.side(target)
+        if cell is None:
+            raise _ItemError(f"the {target} side of {item.key} is missing")
+        self._stream_remove(target, cell.part, member)
+        self._insert_mirrored(member, source, target, cell.part, cell)
+
+
+# ---------------------------------------------------------------------------
+# Ledger updates for landed items
+# ---------------------------------------------------------------------------
+
+
+def _pool_scope(item: DiffItem) -> tuple[str, str] | None:
+    """The ``(group, kind)`` pool an applied pos-keyed item belongs to."""
+    key = item.key
+    if key.startswith("pos:"):
+        body = key.split(":", 1)[1]
+        group, kind, _ordinal = body.rsplit("/", 2)
+        for marker in ("pool.", "order."):
+            if kind.startswith(marker):
+                return None
+        return group, kind
+    return None
+
+
+def _record_item(
+    target: DeckLedger,
+    fresh: DeckLedger,
+    item: DiffItem,
+    *,
+    provenance: str,
+) -> None:
+    """Update the ledger for one landed item (surgical, never wholesale)."""
+    key = item.key
+    action = item.action
+
+    if action in ("record_key_migration",):
+        if item.base is not None:
+            target.members.pop(item.base.key, None)
+        _upsert(target, fresh, key, provenance)
+        return
+    if action == "record_group_rename":
+        if item.base is not None and item.base.key.startswith("id:"):
+            old_group = item.base.key.split(":", 1)[1]
+            new_group = key.split(":", 1)[1] if key.startswith("id:") else None
+            target.members.pop(item.base.key, None)
+            if new_group is not None:
+                rename_group_scopes(target, old_group, new_group)
+        _upsert(target, fresh, key, provenance)
+        return
+    if action in ("record_order", "mirror_order", "order_decision"):
+        if key.startswith("id:"):
+            _upsert(target, fresh, key, provenance)
+            return
+        if "/pool." in key:
+            body = key.split(":", 1)[1]
+            group, tail, _ = body.rsplit("/", 2)
+            kind = tail[len("pool.") :]
+            rerecord_pool(target, fresh, group, kind)
+            return
+        if "/order." in key:
+            body = key.split(":", 1)[1]
+            group, tail, _ = body.rsplit("/", 2)
+            part = tail[len("order.") :]
+            if group == "~groups":
+                record_group_order(target, fresh)
+            else:
+                record_order_scope(target, fresh, group, part)
+            return
+        return
+    if action in ("record_preamble", "propagate_preamble", "conflict_preamble"):
+        part = key.split(":", 1)[1].rsplit("/", 2)[1]
+        record_preamble_scope(target, fresh, part)
+        return
+    if action in ("record_remove", "mirror_remove", "remove_vs_edit", "remove_localized_side"):
+        pool = _pool_scope(item)
+        if pool is not None:
+            rerecord_pool(target, fresh, *pool)
+        else:
+            if key not in fresh.members:
+                target.members.pop(key, None)
+            else:  # a "keep"/re-add resolution: the member persists — record it
+                _upsert(target, fresh, key, provenance)
+        return
+
+    pool = _pool_scope(item)
+    if pool is not None:
+        rerecord_pool(target, fresh, *pool)
+        return
+    _upsert(target, fresh, key, provenance)
+
+
+def _upsert(target: DeckLedger, fresh: DeckLedger, key: str, provenance: str) -> None:
+    lm = fresh.members.get(key)
+    if lm is None:
+        target.members.pop(key, None)
+        return
+    target.members[key] = LedgerMember(
+        entry=lm.entry,
+        provenance=provenance,
+        state=lm.state,
+        hash_version=lm.hash_version,
+        confirmed_commit=lm.confirmed_commit,
+    )
+
+
+def _sweep_migrated_pos(target: DeckLedger) -> None:
+    """Drop stale ``pos:`` entries whose fingerprints match an ``id:`` entry.
+
+    After a stamp/migration the same cell must not be trusted under two keys;
+    dropping the positional one only removes trust (fail-safe re-check).
+    """
+    id_fps = {
+        (lm.entry.de_fp, lm.entry.en_fp) for k, lm in target.members.items() if k.startswith("id:")
+    }
+    for key in [k for k in target.members if k.startswith("pos:")]:
+        lm = target.members[key]
+        if (lm.entry.de_fp, lm.entry.en_fp) in id_fps:
+            del target.members[key]
+
+
+# ---------------------------------------------------------------------------
+# The apply pass
+# ---------------------------------------------------------------------------
+
+
+def _decision_target_side(item: DiffItem) -> Lang:
+    """The side a body answer lands on: the twin of the moved/present side."""
+    if item.side is not None:
+        return _other(item.side)
+    if item.member is not None and item.member.is_one_sided:
+        return "de" if item.member.de is None else "en"
+    raise _ItemError("cannot derive the target side for this item — answer with a choice")
+
+
+def _execute_decision(
+    ex: _Executor, item: DiffItem, decision: Decision, comment_token: str
+) -> None:
+    allowed = decision_vocabulary(item.action)
+    if not allowed:
+        raise _ItemError(
+            f"'{item.action}' has no decision vocabulary in Phase 3 — edit the files, "
+            f"re-run report, then record"
+        )
+    if decision.body is not None:
+        if "body" not in allowed:
+            raise _ItemError(
+                f"'{item.action}' does not accept a body answer (allowed: {', '.join(allowed)})"
+            )
+        error = _validate_body(decision.body, comment_token)
+        if error:
+            raise _ItemError(error)
+        _apply_body_decision(ex, item, decision.body)
+        return
+    choice = decision.choice or ""
+    if choice not in allowed:
+        raise _ItemError(
+            f"choice {choice!r} is not valid for '{item.action}' (allowed: {', '.join(allowed)})"
+        )
+    _apply_choice_decision(ex, item, choice)
+
+
+def _apply_body_decision(ex: _Executor, item: DiffItem, body: str) -> None:
+    member = item.member
+    if item.action == "translate_edit":
+        target = _decision_target_side(item)
+        twin_member, twin_cell = ex._locate_twin(item, target)
+        ex._set_side(twin_member, target, evolve(twin_cell, lines=_replace_body(twin_cell, body)))
+        return
+    if item.action == "translate_new":
+        if member is None:
+            raise _ItemError("item carries no member")
+        target = _decision_target_side(item)
+        source = _other(target)
+        source_cell = member.side(source)
+        if source_cell is None:
+            raise _ItemError(f"the {source} source cell of {item.key} is missing")
+        if member.side(target) is not None:
+            raise _ItemError(f"the {target} side of {item.key} already exists")
+        header = (
+            swap_lang(source_cell.header, target) if source_cell.lang_attr else (source_cell.header)
+        )
+        new_cell = evolve(
+            source_cell,
+            lines=_replace_body(evolve(source_cell, lines=(header, *source_cell.lines[1:])), body),
+            lang_attr=target if source_cell.lang_attr else None,
+        )
+        ex._insert_mirrored(member, source, target, source_cell.part, new_cell)
+        return
+    if item.action in ("conflict_shared", "unify_choose_body", "remove_localized_side"):
+        if member is None:
+            raise _ItemError("item carries no member")
+        if item.action == "remove_localized_side":
+            # Recreate the deleted variant with the provided body.
+            gone = item.side
+            if gone is None:
+                raise _ItemError("item names no deleted side")
+            surviving = _other(gone)
+            source_cell = member.side(surviving)
+            if source_cell is None or member.side(gone) is not None:
+                raise _ItemError(f"the shape of {item.key} no longer holds — re-run report")
+            header = swap_lang(source_cell.header, gone)
+            base = evolve(source_cell, lines=(header, *source_cell.lines[1:]))
+            new_cell = evolve(base, lines=_replace_body(base, body), lang_attr=gone)
+            ex._insert_mirrored(member, surviving, gone, source_cell.part, new_cell)
+            return
+        for lang in _SIDES:
+            cell = member.side(lang)
+            if cell is None:
+                raise _ItemError(f"the {lang} side of {item.key} is missing")
+            ex._set_side(member, lang, evolve(cell, lines=_replace_body(cell, body)))
+        return
+    raise _ItemError(f"'{item.action}' does not accept a body answer")
+
+
+def _apply_choice_decision(ex: _Executor, item: DiffItem, choice: str) -> None:
+    action = item.action
+    if choice == "confirm":
+        member = item.member
+        if member is None:
+            raise _ItemError("item carries no member to confirm")
+        if member.is_one_sided:
+            raise _ItemError(
+                "cannot confirm a one-sided member — supply the twin first (translate/edit)"
+            )
+        de_attr = member.de.lang_attr is not None if member.de else False
+        en_attr = member.en.lang_attr is not None if member.en else False
+        if de_attr != en_attr:
+            raise _ItemError(
+                "cannot confirm a member mid-transition (the sides disagree about "
+                "lang attributes) — complete or revert the transition first"
+            )
+        return  # confirmation is a pure ledger record; nothing mutates
+    if choice in ("de", "en"):
+        side: Lang = choice  # type: ignore[assignment]
+        if action in ("conflict_shared", "pending_divergence"):
+            ex.propagate(item_with_side(item, side), side)
+            return
+        if action == "unify_choose_body":
+            member = item.member
+            if member is None:
+                raise _ItemError("item carries no member")
+            chosen = member.side(side)
+            twin = member.side(_other(side))
+            if chosen is None or twin is None:
+                raise _ItemError(f"both sides of {item.key} are needed to unify")
+            ex._set_side(member, _other(side), evolve(twin, lines=_replace_body(twin, chosen.body)))
+            return
+        if action == "conflict_owner":
+            member = item.member
+            if member is None:
+                raise _ItemError("item carries no member")
+            chosen = member.side(side)
+            twin = member.side(_other(side))
+            if chosen is None or twin is None:
+                raise _ItemError(f"both sides of {item.key} are needed")
+            header = _set_for_slide(twin.header, chosen.for_slide)
+            ex._set_side(
+                member,
+                _other(side),
+                evolve(twin, lines=(header, *twin.lines[1:]), for_slide=chosen.for_slide),
+            )
+            return
+        if action == "conflict_preamble":
+            ex.propagate_preamble(item, side)
+            return
+        if action == "order_decision":
+            ex.mirror_order(item, side)
+            return
+        raise _ItemError(f"'{action}' does not accept a side choice")
+    if choice == "remove":
+        # A deliberate removal: delete every remaining side of the member.
+        # No base-fingerprint check here — the agent explicitly chose to
+        # discard the (possibly edited) survivor.
+        member = item.member
+        if member is None:
+            raise _ItemError("item carries no member")
+        removed = False
+        for lang in _SIDES:
+            cell = member.side(lang)
+            if cell is not None:
+                ex._stream_remove(lang, cell.part, member)
+                ex._set_side(member, lang, None)
+                removed = True
+        if not removed:
+            raise _ItemError(f"{item.key} has no remaining cells to remove")
+        return
+    if choice == "keep":
+        # remove_vs_edit: keep the edited survivor and re-add it on the twin.
+        member = item.member
+        if member is None:
+            raise _ItemError("item carries no member")
+        present = "de" if member.de is not None else "en"
+        ex.copy_new(item, present)  # type: ignore[arg-type]
+        return
+    raise _ItemError(f"unsupported choice {choice!r}")
+
+
+def item_with_side(item: DiffItem, side: Lang) -> DiffItem:
+    """A view of ``item`` re-pointed at ``side`` as the moved side."""
+    return evolve(item, side=side)
+
+
+def _execute_mechanical(ex: _Executor, item: DiffItem) -> None:
+    action = item.action
+    side = item.side
+    if action == "propagate_shared_edit":
+        if side is None:
+            raise _ItemError("item names no moved side")
+        ex.propagate(item, side)
+    elif action == "copy_new_shared":
+        if side is None:
+            raise _ItemError("item names no source side")
+        ex.copy_new(item, side)
+    elif action == "mirror_remove":
+        if side is None:
+            raise _ItemError("item names no removed side")
+        ex.mirror_remove(item, side)
+    elif action == "mirror_tags":
+        if side is None:
+            raise _ItemError("item names no moved side")
+        ex.mirror_tags(item, side)
+    elif action == "stamp_twin_id":
+        if side is None:
+            raise _ItemError("item names no unstamped side")
+        ex.stamp_twin_id(item, side)
+    elif action == "mirror_owner":
+        if side is None:
+            raise _ItemError("item names no moved side")
+        ex.mirror_owner(item, side)
+    elif action == "mirror_layout":
+        if side is None:
+            raise _ItemError("item names no moved side")
+        ex.mirror_layout(item, side)
+    elif action == "mirror_order":
+        if side is None:
+            raise _ItemError("item names no moved side")
+        ex.mirror_order(item, side)
+    elif action == "propagate_preamble":
+        if side is None:
+            raise _ItemError("item names no moved side")
+        ex.propagate_preamble(item, side)
+    else:  # pragma: no cover - the registry and this executor move together
+        raise _ItemError(f"no executor for mechanical action '{action}'")
+
+
+def apply_deck(
+    bundle: LoadedBundle,
+    deck: BilingualDeck,
+    diff: DeckDiff,
+    ledger: TopicLedger,
+    deck_key: str,
+    *,
+    decisions: dict[str, Decision] | None = None,
+    only_members: set[str] | None = None,
+    dry_run: bool = False,
+    commit: str | None = None,
+) -> ApplyOutcome:
+    """Apply a deck's diff per item; update ``ledger`` in memory.
+
+    Mechanical rows execute unconditionally (subject to ``only_members``);
+    framed rows execute only with a valid decision, otherwise they stay
+    ``pending``. On success the mutated bundle is re-parsed (abort on
+    refusal), written atomically, and every landed item is recorded into
+    ``ledger`` — which the **caller** persists (so a CLI can batch or refuse
+    the save on a failed verify gate).
+    """
+    decisions = decisions or {}
+    outcome = ApplyOutcome(dry_run=dry_run)
+    ex = _Executor(bundle=bundle, deck=deck, comment_token=bundle.comment_token)
+    originals = ex.emit_all()
+
+    # Positional entries are recorded per pool (ordinals renumber together),
+    # so a lone `confirm` on one pos-keyed cold member would silently bless
+    # its still-unverified pool siblings. Require the whole pool's cold items
+    # to be confirmed in the same document.
+    incoherent_pools = _incoherent_pool_confirms(diff, decisions)
+
+    ordered = sorted(enumerate(diff.items), key=lambda e: (_PHASES.get(e[1].action, 9), e[0]))
+    landed: list[tuple[DiffItem, str]] = []  # (item, provenance)
+    seen_decisions: set[str] = set()
+    for _, item in ordered:
+        if only_members is not None and item.key not in only_members:
+            outcome.results.append(
+                ItemResult(item.key, item.action, "skipped", "excluded by --member")
+            )
+            continue
+        decision = decisions.get(item.key)
+        if decision is not None:
+            seen_decisions.add(item.key)
+        try:
+            if (
+                decision is not None
+                and decision.choice == "confirm"
+                and item.key.startswith("pos:")
+                and _pool_scope(item) in incoherent_pools
+            ):
+                raise _ItemError(
+                    "positional members are recorded per pool — confirm every cold "
+                    "member of this (group, kind) pool in one document, or use "
+                    "`sync record`"
+                )
+            if item.action in _RECORD_ONLY:
+                landed.append((item, "apply"))
+                outcome.results.append(ItemResult(item.key, item.action, "recorded", item.detail))
+            elif item.action in MECHANICAL_ACTIONS:
+                _execute_mechanical(ex, item)
+                landed.append((item, "apply"))
+                outcome.results.append(ItemResult(item.key, item.action, "applied", item.detail))
+            elif decision is not None:
+                _execute_decision(ex, item, decision, bundle.comment_token)
+                landed.append((item, "agent"))
+                outcome.results.append(
+                    ItemResult(
+                        item.key, item.action, "applied", f"decision: {decision.choice or 'body'}"
+                    )
+                )
+            else:
+                assert item.action in FRAMED_ACTIONS
+                outcome.results.append(
+                    ItemResult(
+                        item.key,
+                        item.action,
+                        "pending",
+                        item.detail,
+                    )
+                )
+        except _ItemError as exc:
+            status = "rejected" if decision is not None else "failed"
+            outcome.results.append(ItemResult(item.key, item.action, status, str(exc)))
+    for key in decisions:
+        if key not in seen_decisions:
+            outcome.results.append(
+                ItemResult(
+                    key, "?", "rejected", "no such item in the current report (stale handle)"
+                )
+            )
+
+    if not landed:
+        return outcome
+
+    finals = ex.emit_all()
+    changed = {key for key in finals if finals[key] != originals[key]}
+    final_deck = deck
+    if changed:
+        parse = parse_bundle(
+            finals[("de", "deck")] or "",
+            finals[("en", "deck")] or "",
+            finals[("de", "companion")],
+            finals[("en", "companion")],
+            comment_token=bundle.comment_token,
+        )
+        if parse.refusal is not None or parse.deck is None:
+            reasons = (
+                "; ".join(f"[{r.code}] {r.detail}" for r in parse.refusal.reasons)
+                if parse.refusal
+                else "no deck"
+            )
+            outcome.error = (
+                f"the mutated bundle failed the re-parse gate ({reasons}) — nothing was written"
+            )
+            for i, result in enumerate(outcome.results):
+                if result.status in ("applied", "recorded"):
+                    outcome.results[i] = ItemResult(
+                        result.key, result.action, "failed", "aborted by the re-parse gate"
+                    )
+            return outcome
+        final_deck = parse.deck
+
+    if dry_run:
+        return outcome
+
+    if changed:
+        writes: list[tuple[Path, str]] = []
+        paths = {
+            ("de", "deck"): bundle.de_path,
+            ("en", "deck"): bundle.en_path,
+            ("de", "companion"): bundle.de_companion_path,
+            ("en", "companion"): bundle.en_companion_path,
+        }
+        for file_key in sorted(changed, key=str):
+            text = finals[file_key]
+            path = paths.get(file_key)
+            if text is None:
+                continue  # never delete a file; layout removals empty it instead
+            if path is None:
+                path = _new_companion_path(bundle, file_key[0])
+            writes.append((path, text))
+        from clm.infrastructure.utils.path_utils import atomic_write_all
+
+        try:
+            atomic_write_all(writes)
+        except OSError as exc:
+            outcome.error = f"write failed: {exc}"
+            return outcome
+        outcome.wrote = True
+        outcome.written_paths = [p for p, _ in writes]
+
+    # Ledger updates for landed items — renames/migrations first, then the rest.
+    fresh = snapshot_deck(final_deck, provenance="apply", commit=commit)
+    target = ledger.decks.setdefault(deck_key, DeckLedger())
+    priority = {"record_group_rename": 0, "record_key_migration": 1}
+    for item, provenance in sorted(landed, key=lambda e: priority.get(e[0].action, 2)):
+        _record_item(target, fresh, item, provenance=provenance)
+    _sweep_migrated_pos(target)
+    return outcome
+
+
+def _incoherent_pool_confirms(
+    diff: DeckDiff, decisions: dict[str, Decision]
+) -> set[tuple[str, str]]:
+    """Pools where only *some* cold members received a confirm decision."""
+    cold_by_pool: dict[tuple[str, str], set[str]] = {}
+    for item in diff.items:
+        if item.action not in ("verify_cold", "verify_translation"):
+            continue
+        pool = _pool_scope(item)
+        if pool is not None:
+            cold_by_pool.setdefault(pool, set()).add(item.key)
+    confirmed = {key for key, decision in decisions.items() if decision.choice == "confirm"}
+    return {pool for pool, keys in cold_by_pool.items() if not keys <= confirmed}
+
+
+def _new_companion_path(bundle: LoadedBundle, lang: Lang) -> Path:
+    """Where a newly created companion file goes (standard subdir layout)."""
+    from clm.slides.voiceover_tools import COMPANION_SUBDIR, companion_name
+
+    deck_path = bundle.de_path if lang == "de" else bundle.en_path
+    return deck_path.parent / COMPANION_SUBDIR / companion_name(deck_path)

--- a/src/clm/slides/doc_ledger.py
+++ b/src/clm/slides/doc_ledger.py
@@ -1,0 +1,543 @@
+"""The v3 member-keyed sync ledger — the committed trust store (#520 Phase 3).
+
+Design: ``docs/claude/design/sync-total-identity-document-model.md`` §5. The
+per-topic committed file ``<topic>/.clm/sync-ledger.json`` becomes the **only**
+trust store of the v3 engine: per :class:`~clm.slides.bilingual_doc.MemberKey`,
+it records the member's verified state — langness, layout, per-side content
+fingerprints, tags, provenance, and the hash-function version — plus the
+per-deck order context (id-keyed member order, group order, preamble
+fingerprints) the differ needs to judge ``order`` outcomes.
+
+**Coexistence with the v1 ledger (Phase 3 only).** Through Phase 3 the v2
+engine remains the default and keeps its ``(slide_id, role)``-keyed sections in
+the same file. The file therefore carries a schema-2 envelope holding *both*:
+the v1 ``slides`` / ``idless`` sections (opaque to this module — preserved
+verbatim on save) and the v3 ``decks`` section (opaque to ``sync_ledger`` —
+preserved verbatim there). Neither engine can clobber the other's trust.
+Phase 4 deletes the v1 sections with the v2 core.
+
+**Trust semantics (§5).**
+
+* A member with **no entry is cold** — the differ reports it ``unverified``
+  with a framed verification task, never a silent assumption. This is what
+  :attr:`~clm.slides.sync_diff.DeckBaseline.complete` ``= False`` encodes.
+* **Stale = fingerprint mismatch** — fail-safe by construction: a drifted
+  member produces a re-check item.
+* ``hash_version`` gates every entry: an entry recorded under an older
+  fingerprint function is dropped to cold at load (re-verify, never trust a
+  hash a newer engine would compute differently — the #458 lesson).
+* Ledger merge conflicts are true positives; canonical sorted JSON keeps a
+  per-topic merge local and line-mergeable (drop-to-``unverified`` on a
+  genuine same-member conflict).
+
+This module is part of the v3 core: pure storage + snapshot plumbing, no
+imports from the v2 sync core (``sync_plan`` / ``sync_apply`` / ``sync_code``)
+— enforced by the import-cleanliness test (design §12.5). The structural
+verify gate on the write path lives at the verb layer (the CLI ``record`` /
+``apply`` runners), because ``sync_verify`` still imports v2 modules.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from attrs import define, field, frozen
+
+from clm.slides.bilingual_doc import BilingualDeck, Lang
+from clm.slides.sync_diff import DeckBaseline, MemberBaseline, baseline_from_deck
+
+__all__ = [
+    "LEDGER_FILENAME",
+    "LEDGER_HASH_VERSION",
+    "LEDGER_SUBDIR",
+    "SCHEMA_VERSION",
+    "DeckLedger",
+    "LedgerMember",
+    "TopicLedger",
+    "baseline_from_ledger",
+    "deck_key_for",
+    "ledger_path_for",
+    "load",
+    "record_deck_snapshot",
+    "save",
+]
+
+#: The v3 envelope schema. Schema 1 files (v1-only) load as an empty v3 store
+#: with the v1 payload preserved; schema 2 carries both engines' sections.
+SCHEMA_VERSION = 2
+
+#: Version of the v3 fingerprint functions (:func:`~clm.slides.sync_diff.content_fingerprint`
+#: and friends). Bump when the hashing form changes; entries recorded under an
+#: older version drop to cold at load (§5's lazy migration rule, #458).
+LEDGER_HASH_VERSION = 1
+
+#: Same committed location the v1 ledger established (issue #448 / #453);
+#: duplicated here (not imported) so Phase 4 can delete ``sync_ledger`` whole.
+LEDGER_SUBDIR = ".clm"
+LEDGER_FILENAME = "sync-ledger.json"
+
+#: The v1 sections this module must round-trip untouched.
+_V1_KEYS = ("slides", "idless")
+
+_SIDES: tuple[Lang, Lang] = ("de", "en")
+
+
+@frozen
+class LedgerMember:
+    """One member's recorded §5 entry: the engine view plus trust metadata.
+
+    ``entry`` is the exact :class:`~clm.slides.sync_diff.MemberBaseline` the
+    differ compares against — fingerprints per side, tags, owner-free
+    signatures. ``provenance`` records *who* asserted the verification
+    (``apply`` / ``accept`` / ``record`` / ``agent`` / ``semantic:<model>``),
+    kept so a later run can selectively distrust a source without nuking the
+    ledger. ``state`` is always ``verified`` today (an unverified member is
+    simply absent).
+    """
+
+    entry: MemberBaseline
+    provenance: str
+    state: str = "verified"
+    hash_version: int = LEDGER_HASH_VERSION
+    confirmed_commit: str | None = None
+
+
+@define
+class DeckLedger:
+    """The recorded state of one deck bundle inside its topic ledger.
+
+    Mirrors :class:`~clm.slides.sync_diff.DeckBaseline` (members + order
+    context) with per-member trust metadata. Order context is recorded when
+    the corresponding scope was verified (a full ``record``, or an applied
+    order item) — a scope with no recorded order simply contributes no order
+    trust, it is never assumed.
+    """
+
+    members: dict[str, LedgerMember] = field(factory=dict)
+    group_order: list[str] = field(factory=list)
+    group_order_by_side: dict[str, list[str]] = field(factory=dict)
+    #: keyed ``(lang, group, part)`` exactly as ``DeckBaseline.member_order``
+    member_order: dict[tuple[str, str, str], list[str]] = field(factory=dict)
+    #: keyed ``(lang, part)`` exactly as ``DeckBaseline.preamble_fps``
+    preamble_fps: dict[tuple[str, str], str | None] = field(factory=dict)
+
+
+@define
+class TopicLedger:
+    """The whole per-topic file: v3 deck sections + the opaque v1 payload."""
+
+    decks: dict[str, DeckLedger] = field(factory=dict)
+    #: v1 ``slides`` / ``idless`` sections, preserved verbatim (never read).
+    v1_payload: dict[str, object] = field(factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Paths and deck keys
+# ---------------------------------------------------------------------------
+
+
+def ledger_path_for(de_path: Path) -> Path:
+    """The committed ledger path for the topic owning ``de_path``."""
+    return de_path.parent / LEDGER_SUBDIR / LEDGER_FILENAME
+
+
+def deck_key_for(de_path: Path) -> str:
+    """The deck's key inside its topic ledger: the language-free stem.
+
+    ``slides_intro.de.py`` → ``slides_intro`` (any source suffix). Deck
+    identity stays path-derived through Phase 3 (design §12 decision 4); a
+    renamed deck cold-starts, which is fail-safe.
+    """
+    stem = de_path.name
+    stem = stem[: -len(de_path.suffix)] if de_path.suffix else stem
+    for lang_suffix in (".de", ".en"):
+        if stem.endswith(lang_suffix):
+            return stem[: -len(lang_suffix)]
+    return stem
+
+
+# ---------------------------------------------------------------------------
+# Serialization — canonical sorted JSON (merge-local, line-mergeable)
+# ---------------------------------------------------------------------------
+
+
+def _member_to_json(lm: LedgerMember) -> dict[str, object]:
+    e = lm.entry
+    return {
+        "langness": e.langness,
+        "layout": e.layout,
+        "kind": e.kind,
+        "role": e.role,
+        "owner": e.owner,
+        "de_fp": e.de_fp,
+        "en_fp": e.en_fp,
+        "de_body_fp": e.de_body_fp,
+        "en_body_fp": e.en_body_fp,
+        "de_tags": list(e.de_tags) if e.de_tags is not None else None,
+        "en_tags": list(e.en_tags) if e.en_tags is not None else None,
+        "de_sig": e.de_sig,
+        "en_sig": e.en_sig,
+        "provenance": lm.provenance,
+        "state": lm.state,
+        "hash_version": lm.hash_version,
+        "confirmed_commit": lm.confirmed_commit,
+    }
+
+
+def _member_from_json(key: str, rec: dict) -> LedgerMember | None:
+    try:
+        entry = MemberBaseline(
+            key=key,
+            langness=rec["langness"],
+            layout=rec["layout"],
+            kind=rec["kind"],
+            role=rec["role"],
+            owner=rec.get("owner"),
+            de_fp=rec.get("de_fp"),
+            en_fp=rec.get("en_fp"),
+            de_body_fp=rec.get("de_body_fp"),
+            en_body_fp=rec.get("en_body_fp"),
+            de_tags=tuple(rec["de_tags"]) if rec.get("de_tags") is not None else None,
+            en_tags=tuple(rec["en_tags"]) if rec.get("en_tags") is not None else None,
+            de_sig=rec.get("de_sig"),
+            en_sig=rec.get("en_sig"),
+        )
+    except (KeyError, TypeError):
+        return None  # malformed entry: cold, never a crash
+    return LedgerMember(
+        entry=entry,
+        provenance=str(rec.get("provenance", "record")),
+        state=str(rec.get("state", "verified")),
+        hash_version=int(rec.get("hash_version", 0)),
+        confirmed_commit=rec.get("confirmed_commit"),
+    )
+
+
+def _deck_to_json(deck: DeckLedger) -> dict[str, object]:
+    return {
+        "members": {key: _member_to_json(lm) for key, lm in deck.members.items()},
+        "group_order": list(deck.group_order),
+        "group_order_by_side": {
+            lang: list(order) for lang, order in deck.group_order_by_side.items()
+        },
+        "member_order": [
+            {"lang": lang, "group": group, "part": part, "handles": list(handles)}
+            for (lang, group, part), handles in sorted(deck.member_order.items())
+        ],
+        "preamble_fps": {
+            f"{lang}:{part}": fp for (lang, part), fp in sorted(deck.preamble_fps.items())
+        },
+    }
+
+
+def _deck_from_json(rec: dict) -> DeckLedger:
+    deck = DeckLedger()
+    members = rec.get("members", {})
+    if isinstance(members, dict):
+        for key, entry_rec in members.items():
+            if not isinstance(entry_rec, dict):
+                continue
+            lm = _member_from_json(key, entry_rec)
+            if lm is not None:
+                deck.members[key] = lm
+    group_order = rec.get("group_order", [])
+    if isinstance(group_order, list):
+        deck.group_order = [str(g) for g in group_order]
+    by_side = rec.get("group_order_by_side", {})
+    if isinstance(by_side, dict):
+        deck.group_order_by_side = {
+            str(lang): [str(g) for g in order]
+            for lang, order in by_side.items()
+            if isinstance(order, list)
+        }
+    member_order = rec.get("member_order", [])
+    if isinstance(member_order, list):
+        for row in member_order:
+            if not isinstance(row, dict) or not isinstance(row.get("handles"), list):
+                continue
+            try:
+                key = (str(row["lang"]), str(row["group"]), str(row["part"]))
+            except KeyError:
+                continue
+            deck.member_order[key] = [str(h) for h in row["handles"]]
+    preambles = rec.get("preamble_fps", {})
+    if isinstance(preambles, dict):
+        for joined, fp in preambles.items():
+            lang, sep, part = str(joined).partition(":")
+            if sep:
+                deck.preamble_fps[(lang, part)] = fp if isinstance(fp, str) else None
+    return deck
+
+
+def load(path: Path) -> TopicLedger:
+    """Read a topic ledger; absent/malformed degrades to empty (fail-safe cold).
+
+    Accepts schema 1 (a v1-only file: empty v3 store, v1 sections preserved)
+    and schema 2 (the coexistence envelope). Anything else is treated as
+    empty — the deck cold-starts, never crashes and never trusts.
+    """
+    if not path.is_file():
+        return TopicLedger()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return TopicLedger()
+    if not isinstance(data, dict) or data.get("schema") not in (1, SCHEMA_VERSION):
+        return TopicLedger()
+    ledger = TopicLedger(
+        v1_payload={k: data[k] for k in _V1_KEYS if k in data},
+    )
+    decks = data.get("decks", {})
+    if isinstance(decks, dict):
+        for deck_key, rec in decks.items():
+            if isinstance(rec, dict):
+                ledger.decks[deck_key] = _deck_from_json(rec)
+    return ledger
+
+
+def _to_json(ledger: TopicLedger) -> str:
+    payload: dict[str, object] = {
+        "schema": SCHEMA_VERSION,
+        "decks": {key: _deck_to_json(deck) for key, deck in sorted(ledger.decks.items())},
+    }
+    payload.update(ledger.v1_payload)
+    return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+def save(ledger: TopicLedger, path: Path) -> None:
+    """Write the ledger atomically (canonical JSON), creating ``.clm/``."""
+    from clm.infrastructure.utils.path_utils import atomic_write_bytes
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_bytes(path, _to_json(ledger).encode("utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Building the differ's baseline from the ledger (§5 → §6.1)
+# ---------------------------------------------------------------------------
+
+
+def baseline_from_ledger(deck_ledger: DeckLedger) -> DeckBaseline:
+    """The :class:`DeckBaseline` view of a recorded deck — ``complete=False``.
+
+    A member missing here is **cold** (an ``unverified`` framed item), never
+    "new". Entries whose ``hash_version`` predates the current fingerprint
+    function are dropped to cold (§5 lazy migration): their hashes are
+    incomparable, so re-verify instead of mis-trusting.
+    """
+    base = DeckBaseline(complete=False)
+    for key, lm in deck_ledger.members.items():
+        if lm.hash_version != LEDGER_HASH_VERSION:
+            continue  # stale hashing form: cold, re-verify (#458)
+        base.members[key] = lm.entry
+    base.group_order = list(deck_ledger.group_order)
+    base.group_order_by_side = {
+        lang: list(deck_ledger.group_order_by_side.get(lang, [])) for lang in _SIDES
+    }
+    for (lang, group, part), handles in deck_ledger.member_order.items():
+        for side in _SIDES:
+            if lang == side:
+                base.member_order[(side, group, part)] = list(handles)
+    base.preamble_fps = dict(deck_ledger.preamble_fps)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Recording (the write path — the verb-layer callers gate on verify)
+# ---------------------------------------------------------------------------
+
+
+def snapshot_deck(
+    deck: BilingualDeck,
+    *,
+    provenance: str,
+    commit: str | None = None,
+) -> DeckLedger:
+    """A full :class:`DeckLedger` snapshot of a parsed deck's current state."""
+    base = baseline_from_deck(deck)
+    return DeckLedger(
+        members={
+            key: LedgerMember(entry=entry, provenance=provenance, confirmed_commit=commit)
+            for key, entry in base.members.items()
+        },
+        group_order=list(base.group_order),
+        group_order_by_side={lang: list(base.group_order_by_side[lang]) for lang in _SIDES},
+        member_order={key: list(handles) for key, handles in base.member_order.items()},
+        preamble_fps=dict(base.preamble_fps),
+    )
+
+
+def record_deck_snapshot(
+    ledger: TopicLedger,
+    deck_key: str,
+    deck: BilingualDeck,
+    *,
+    provenance: str,
+    commit: str | None = None,
+    member_keys: set[str] | None = None,
+) -> tuple[int, dict[str, str]]:
+    """Record ``deck``'s current state into ``ledger`` (in memory).
+
+    Full record (``member_keys=None``): the deck section is replaced
+    wholesale — stale keys (removed members, superseded ``pos:`` ordinals)
+    are swept, and any §7.3 ``pos → id`` key migration happens implicitly:
+    the member is re-recorded under its current (id) key. Returns the number
+    of member entries written and the detected key migrations
+    ``{old_key: new_key}`` (same fingerprints under a renamed key — the
+    explicit, logged rename the design demands).
+
+    Partial record: only the listed member keys are upserted (order/preamble
+    pseudo-scopes go through the ``record_*_scope`` helpers); everything
+    else — including possibly-stale twin entries — is left in place, which is
+    fail-safe (a stale entry mismatches and re-checks, never silently
+    trusts).
+    """
+    fresh = snapshot_deck(deck, provenance=provenance, commit=commit)
+    old = ledger.decks.get(deck_key)
+    migrations = _detect_key_migrations(old, fresh) if old is not None else {}
+    if member_keys is None:
+        ledger.decks[deck_key] = fresh
+        return len(fresh.members), migrations
+    target = old if old is not None else DeckLedger()
+    recorded = 0
+    for key in sorted(member_keys):
+        lm = fresh.members.get(key)
+        if lm is None:
+            continue
+        for old_key, new_key in migrations.items():
+            if new_key == key:
+                target.members.pop(old_key, None)
+        target.members[key] = lm
+        recorded += 1
+    ledger.decks[deck_key] = target
+    return recorded, {k: v for k, v in migrations.items() if v in member_keys}
+
+
+def _detect_key_migrations(old: DeckLedger, fresh: DeckLedger) -> dict[str, str]:
+    """Detect §7.3 ``pos → id`` renames between two snapshots.
+
+    A vanished ``pos:`` entry whose per-side fingerprints reappear under a
+    *new* ``id:`` key is the same member under its minted id. Detection is
+    conservative (unique fingerprint match only) — it exists for the log and
+    for partial records; a full record re-keys wholesale anyway.
+    """
+    gone = {
+        key: lm
+        for key, lm in old.members.items()
+        if key.startswith("pos:") and key not in fresh.members
+    }
+    new_idd = {
+        key: lm
+        for key, lm in fresh.members.items()
+        if key.startswith("id:") and key not in old.members
+    }
+    migrations: dict[str, str] = {}
+    claimed: set[str] = set()
+    for old_key, old_lm in sorted(gone.items()):
+        matches = [
+            new_key
+            for new_key, new_lm in sorted(new_idd.items())
+            if new_key not in claimed
+            and (new_lm.entry.de_fp, new_lm.entry.en_fp) == (old_lm.entry.de_fp, old_lm.entry.en_fp)
+        ]
+        if len(matches) == 1:
+            migrations[old_key] = matches[0]
+            claimed.add(matches[0])
+    return migrations
+
+
+# ---------------------------------------------------------------------------
+# Surgical scope updates (the per-item apply write path)
+#
+# Positional entries are pool-scoped: any change inside a (group, kind) pool
+# renumbers its ordinals, so the pool is always re-recorded WHOLESALE from the
+# post-apply snapshot — a per-entry patch could leave aliased ordinals. Order
+# and preamble trust likewise updates per scope, and only for scopes an
+# applied item actually verified — never wholesale (which would silently
+# bless pending divergences elsewhere in the deck).
+# ---------------------------------------------------------------------------
+
+
+def rerecord_pool(target: DeckLedger, fresh: DeckLedger, group: str, kind: str) -> int:
+    """Replace every ``pos:<group>/<kind>/*`` entry with the fresh pool state."""
+    prefix = f"pos:{group}/{kind}/"
+    for key in [k for k in target.members if k.startswith(prefix)]:
+        del target.members[key]
+    copied = 0
+    for key, lm in fresh.members.items():
+        if key.startswith(prefix):
+            target.members[key] = lm
+            copied += 1
+    return copied
+
+
+def record_order_scope(target: DeckLedger, fresh: DeckLedger, group: str, part: str) -> None:
+    """Adopt the fresh id-keyed member order for ``(group, part)``, both sides."""
+    for lang in _SIDES:
+        key = (lang, group, part)
+        if key in fresh.member_order:
+            target.member_order[key] = list(fresh.member_order[key])
+        else:
+            target.member_order.pop(key, None)
+
+
+def record_group_order(target: DeckLedger, fresh: DeckLedger) -> None:
+    """Adopt the fresh group order (both the merged and the per-side views)."""
+    target.group_order = list(fresh.group_order)
+    target.group_order_by_side = {
+        lang: list(order) for lang, order in fresh.group_order_by_side.items()
+    }
+
+
+def record_preamble_scope(target: DeckLedger, fresh: DeckLedger, part: str) -> None:
+    """Adopt the fresh preamble fingerprints for ``part`` (both sides)."""
+    for lang in _SIDES:
+        key = (lang, part)
+        if key in fresh.preamble_fps:
+            target.preamble_fps[key] = fresh.preamble_fps[key]
+        else:
+            target.preamble_fps.pop(key, None)
+
+
+def rename_group_scopes(target: DeckLedger, old_group: str, new_group: str) -> None:
+    """Re-key every scope referencing a renamed group (§7.3 group rename).
+
+    Covers the ``pos:`` member keys (their group token), the member-order
+    scopes, and the group-order lists. The anchor's own ``id:`` entry is
+    re-keyed by the caller through the member migration path.
+    """
+    for key in [k for k in target.members if k.startswith(f"pos:{old_group}/")]:
+        lm = target.members.pop(key)
+        suffix = key[len(f"pos:{old_group}/") :]
+        new_key = f"pos:{new_group}/{suffix}"
+        entry = MemberBaseline(
+            key=new_key,
+            langness=lm.entry.langness,
+            layout=lm.entry.layout,
+            kind=lm.entry.kind,
+            role=lm.entry.role,
+            owner=lm.entry.owner,
+            de_fp=lm.entry.de_fp,
+            en_fp=lm.entry.en_fp,
+            de_body_fp=lm.entry.de_body_fp,
+            en_body_fp=lm.entry.en_body_fp,
+            de_tags=lm.entry.de_tags,
+            en_tags=lm.entry.en_tags,
+            de_sig=lm.entry.de_sig,
+            en_sig=lm.entry.en_sig,
+        )
+        target.members[new_key] = LedgerMember(
+            entry=entry,
+            provenance=lm.provenance,
+            state=lm.state,
+            hash_version=lm.hash_version,
+            confirmed_commit=lm.confirmed_commit,
+        )
+    for lang, group, part in [k for k in target.member_order if k[1] == old_group]:
+        target.member_order[(lang, new_group, part)] = target.member_order.pop((lang, group, part))
+    target.group_order = [new_group if g == old_group else g for g in target.group_order]
+    target.group_order_by_side = {
+        lang: [new_group if g == old_group else g for g in order]
+        for lang, order in target.group_order_by_side.items()
+    }

--- a/src/clm/slides/doc_ledger.py
+++ b/src/clm/slides/doc_ledger.py
@@ -391,7 +391,9 @@ def record_deck_snapshot(
     pseudo-scopes go through the ``record_*_scope`` helpers); everything
     else — including possibly-stale twin entries — is left in place, which is
     fail-safe (a stale entry mismatches and re-checks, never silently
-    trusts).
+    trusts). A ``pos:`` key re-records its whole ``(group, kind)`` pool —
+    positional ordinals renumber together, so a per-entry patch would leave
+    aliased ordinals (see the scope-update rules below).
     """
     fresh = snapshot_deck(deck, provenance=provenance, commit=commit)
     old = ledger.decks.get(deck_key)
@@ -402,6 +404,10 @@ def record_deck_snapshot(
     target = old if old is not None else DeckLedger()
     recorded = 0
     for key in sorted(member_keys):
+        if key.startswith("pos:"):
+            group, kind, _ordinal = key.split(":", 1)[1].rsplit("/", 2)
+            recorded += rerecord_pool(target, fresh, group, kind)
+            continue
         lm = fresh.members.get(key)
         if lm is None:
             continue

--- a/src/clm/slides/sync_diff.py
+++ b/src/clm/slides/sync_diff.py
@@ -260,6 +260,17 @@ class DeckBaseline:
     complete: bool = True
 
 
+def _pair_twin(de_member: Member | None, en_member: Member | None) -> Member | None:
+    """The EN-carrier of a pool slot when it differs from the DE-carrier.
+
+    ``DiffItem.twin`` side convention: ``member`` = the DE-carrying member
+    (`de_member or en_member`), ``twin`` = the distinct EN-carrying member.
+    """
+    if de_member is not None and en_member is not None and en_member is not de_member:
+        return en_member
+    return None
+
+
 def _member_group_token(member: Member, owner_group: str) -> str:
     if member.key.scheme == "pos":
         # rsplit: a group token may itself contain "/" (ids are free-form)
@@ -361,9 +372,11 @@ class DiffItem:
     member: Member | None = None
     base: MemberBaseline | None = None
     #: For positional pool slots whose two sides live on DIFFERENT parsed
-    #: members (a one-sided insert shifts the cross-side pairing): the member
-    #: carrying the slot's twin-side cell. ``None`` when ``member`` carries
-    #: both sides. The Phase-3 executor needs it to act on the right cell.
+    #: members (a one-sided insert shifts the cross-side pairing). Fixed
+    #: side convention: when ``twin`` is set, ``member`` carries the slot's
+    #: **DE** cell and ``twin`` its **EN** cell; when ``None``, ``member``
+    #: carries every present side. The Phase-3 executor resolves each side
+    #: through this convention so it always acts on the right cell.
     twin: Member | None = None
 
     def payload(self) -> dict:
@@ -378,11 +391,11 @@ class DiffItem:
             entry["group"] = self.group
         if self.side is not None:
             entry["side"] = self.side
-        if self.member is not None:
-            for lang in _SIDES:
-                cell = self.member.side(lang)
-                if cell is not None:
-                    entry[lang] = "\n".join(cell.lines)
+        for lang in _SIDES:
+            holder = self.twin if (self.twin is not None and lang == "en") else self.member
+            cell = holder.side(lang) if holder is not None else None
+            if cell is not None:
+                entry[lang] = "\n".join(cell.lines)
         return entry
 
 
@@ -1257,6 +1270,7 @@ class _Differ:
                 "both",
                 f"the recorded {recorded} side vanished while the {pending} twin appeared — decide",
                 group=group,
+                side=recorded,
                 member=member,
                 base=entry,
             )
@@ -1361,6 +1375,7 @@ class _Differ:
                 "both",
                 f"removed on the {gone} side but edited on the {present} side",
                 group=group,
+                side=gone,
                 member=member,
                 base=entry,
             )
@@ -1962,12 +1977,9 @@ class _Differ:
         """
         handle = entry.key
         member = de_member or en_member
-
-        def twin_of(main: Member | None) -> Member | None:
-            for cand in (de_member, en_member):
-                if cand is not None and cand is not main:
-                    return cand
-            return None
+        # The DiffItem side convention: `member` carries the slot's DE cell,
+        # `twin` its EN cell when the two live on different parsed members.
+        pair_twin = _pair_twin(de_member, en_member)
 
         if entry.one_sided:
             self._classify_pool_slot_base_one_sided(
@@ -1991,7 +2003,7 @@ class _Differ:
                     group=group,
                     member=member,
                     base=entry,
-                    twin=twin_of(member),
+                    twin=pair_twin,
                 )
             else:
                 self.in_sync += 1
@@ -2052,6 +2064,7 @@ class _Differ:
                     "both",
                     f"removed on the {gone} side but edited on the twin",
                     group=group,
+                    side=gone,
                     member=member,
                     base=entry,
                 )
@@ -2071,7 +2084,7 @@ class _Differ:
                     group=group,
                     member=member,
                     base=entry,
-                    twin=twin_of(member),
+                    twin=pair_twin,
                 )
             else:
                 self.emit(
@@ -2083,11 +2096,10 @@ class _Differ:
                     group=group,
                     member=member,
                     base=entry,
-                    twin=twin_of(member),
+                    twin=pair_twin,
                 )
             return
         moved: Lang = "de" if de_state == "changed" else "en"
-        moved_member = de_member if moved == "de" else en_member
         moved_cell = de_cell if moved == "de" else en_cell
         twin_cell = en_cell if moved == "de" else de_cell
         if moved_cell is None:  # pragma: no cover - changed implies present
@@ -2121,9 +2133,9 @@ class _Differ:
                 f"({list(twin_cell.tags)} → {list(moved_cell.tags)})",
                 group=group,
                 side=moved,
-                member=moved_member,
+                member=member,
                 base=entry,
-                twin=twin_of(moved_member),
+                twin=pair_twin,
             )
             return
         self.emit(
@@ -2134,9 +2146,9 @@ class _Differ:
             f"shared positional member edited on the {moved} side — verbatim copy",
             group=group,
             side=moved,
-            member=moved_member,
+            member=member,
             base=entry,
-            twin=twin_of(moved_member),
+            twin=pair_twin,
         )
 
     def _classify_pool_slot_base_one_sided(
@@ -2160,7 +2172,8 @@ class _Differ:
         pending: Lang = "en" if recorded == "de" else "de"
         rec_state, rec_member = (de_state, de_member) if recorded == "de" else (en_state, en_member)
         pen_state, pen_member = (en_state, en_member) if recorded == "de" else (de_state, de_member)
-        member = rec_member or pen_member
+        member = de_member or en_member  # the DiffItem convention: DE carrier first
+        pair_twin = _pair_twin(de_member, en_member)
         if rec_state == "missing":
             if pen_state == "absent":
                 self.emit(
@@ -2181,8 +2194,10 @@ class _Differ:
                     f"the recorded {recorded} side vanished while the {pending} "
                     f"twin landed — decide",
                     group=group,
+                    side=recorded,
                     member=member,
                     base=entry,
+                    twin=pair_twin,
                 )
             return
         if pen_state == "ambiguous":
@@ -2227,6 +2242,7 @@ class _Differ:
                 group=group,
                 member=member,
                 base=entry,
+                twin=pair_twin,
             )
             return
         self.emit(
@@ -2239,6 +2255,7 @@ class _Differ:
             group=group,
             member=member,
             base=entry,
+            twin=pair_twin,
         )
 
     def _classify_pool_slot_localized(
@@ -2253,13 +2270,7 @@ class _Differ:
         """Localized positional pools exist only for per-language headers."""
         handle = entry.key
         member = de_member or en_member
-
-        def twin_of(main: Member | None) -> Member | None:
-            for cand in (de_member, en_member):
-                if cand is not None and cand is not main:
-                    return cand
-            return None
-
+        pair_twin = _pair_twin(de_member, en_member)
         if "missing" in (de_state, en_state):
             gone: Lang = "de" if de_state == "missing" else "en"
             self.emit(
@@ -2285,10 +2296,9 @@ class _Differ:
                 group=group,
                 member=member,
                 base=entry,
-                twin=twin_of(member),
+                twin=pair_twin,
             )
             return
-        moved_member = de_member if moved == ["de"] else en_member
         self.emit(
             handle,
             "edit",
@@ -2297,9 +2307,9 @@ class _Differ:
             f"the {moved[0]} header variant was edited — adapt the twin",
             group=group,
             side=moved[0],  # type: ignore[arg-type]
-            member=moved_member,
+            member=member,
             base=entry,
-            twin=twin_of(moved_member),
+            twin=pair_twin,
         )
 
     def _classify_pool_news(

--- a/src/clm/slides/sync_diff.py
+++ b/src/clm/slides/sync_diff.py
@@ -360,6 +360,11 @@ class DiffItem:
     side: Lang | None = None
     member: Member | None = None
     base: MemberBaseline | None = None
+    #: For positional pool slots whose two sides live on DIFFERENT parsed
+    #: members (a one-sided insert shifts the cross-side pairing): the member
+    #: carrying the slot's twin-side cell. ``None`` when ``member`` carries
+    #: both sides. The Phase-3 executor needs it to act on the right cell.
+    twin: Member | None = None
 
     def payload(self) -> dict:
         entry: dict = {
@@ -509,6 +514,7 @@ class _Differ:
         side: Lang | None = None,
         member: Member | None = None,
         base: MemberBaseline | None = None,
+        twin: Member | None = None,
     ) -> None:
         if action not in MECHANICAL_ACTIONS and action not in FRAMED_ACTIONS:
             raise ValueError(f"unregistered diff action: {action}")  # pragma: no cover
@@ -523,6 +529,7 @@ class _Differ:
                 side=side,
                 member=member,
                 base=base,
+                twin=twin if twin is not member else None,
             )
         )
 
@@ -1955,6 +1962,13 @@ class _Differ:
         """
         handle = entry.key
         member = de_member or en_member
+
+        def twin_of(main: Member | None) -> Member | None:
+            for cand in (de_member, en_member):
+                if cand is not None and cand is not main:
+                    return cand
+            return None
+
         if entry.one_sided:
             self._classify_pool_slot_base_one_sided(
                 group, entry, de_state, en_state, de_member, en_member
@@ -1977,6 +1991,7 @@ class _Differ:
                     group=group,
                     member=member,
                     base=entry,
+                    twin=twin_of(member),
                 )
             else:
                 self.in_sync += 1
@@ -2056,6 +2071,7 @@ class _Differ:
                     group=group,
                     member=member,
                     base=entry,
+                    twin=twin_of(member),
                 )
             else:
                 self.emit(
@@ -2067,6 +2083,7 @@ class _Differ:
                     group=group,
                     member=member,
                     base=entry,
+                    twin=twin_of(member),
                 )
             return
         moved: Lang = "de" if de_state == "changed" else "en"
@@ -2106,6 +2123,7 @@ class _Differ:
                 side=moved,
                 member=moved_member,
                 base=entry,
+                twin=twin_of(moved_member),
             )
             return
         self.emit(
@@ -2118,6 +2136,7 @@ class _Differ:
             side=moved,
             member=moved_member,
             base=entry,
+            twin=twin_of(moved_member),
         )
 
     def _classify_pool_slot_base_one_sided(
@@ -2234,6 +2253,13 @@ class _Differ:
         """Localized positional pools exist only for per-language headers."""
         handle = entry.key
         member = de_member or en_member
+
+        def twin_of(main: Member | None) -> Member | None:
+            for cand in (de_member, en_member):
+                if cand is not None and cand is not main:
+                    return cand
+            return None
+
         if "missing" in (de_state, en_state):
             gone: Lang = "de" if de_state == "missing" else "en"
             self.emit(
@@ -2259,6 +2285,7 @@ class _Differ:
                 group=group,
                 member=member,
                 base=entry,
+                twin=twin_of(member),
             )
             return
         moved_member = de_member if moved == ["de"] else en_member
@@ -2272,6 +2299,7 @@ class _Differ:
             side=moved[0],  # type: ignore[arg-type]
             member=moved_member,
             base=entry,
+            twin=twin_of(moved_member),
         )
 
     def _classify_pool_news(

--- a/src/clm/slides/sync_ledger.py
+++ b/src/clm/slides/sync_ledger.py
@@ -66,6 +66,11 @@ if TYPE_CHECKING:
     from clm.slides.sync_semantic import SemanticJudge
 
 SCHEMA_VERSION = 1
+#: Schemas this module can read. Schema 2 is the Phase-3 coexistence envelope
+#: (#520): the same file additionally carries the v3 ``decks`` section, which
+#: this module preserves verbatim via ``SyncLedger.extra`` — the v1 sections
+#: keep their schema-1 shape inside it. Written by ``clm.slides.doc_ledger``.
+_READABLE_SCHEMAS = (1, 2)
 #: The committed ledger lives under the build-internal ``.clm/`` tree (issue #453),
 #: alongside ``cassettes/`` — both are committed build inputs, neither is student output.
 LEDGER_SUBDIR = ".clm"
@@ -128,6 +133,10 @@ class SyncLedger:
     schema: int = SCHEMA_VERSION
     entries: dict[tuple[str, str], LedgerEntry] = field(default_factory=dict)
     idless: dict[IdlessKey, LedgerEntry] = field(default_factory=dict)
+    #: Unknown top-level sections (the v3 ``decks`` store, #520 Phase 3),
+    #: preserved verbatim across a load→save round trip so a v2 record can
+    #: never clobber the v3 engine's trust. Never read by this module.
+    extra: dict[str, object] = field(default_factory=dict)
 
     def trusts(self, slide_id: str, role: str, de_hash: str, en_hash: str) -> bool:
         """True iff ``(slide_id, role)`` is recorded in-sync at *exactly* these hashes.
@@ -181,7 +190,7 @@ def load(path: Path) -> SyncLedger:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return SyncLedger()
-    if not isinstance(data, dict) or data.get("schema") != SCHEMA_VERSION:
+    if not isinstance(data, dict) or data.get("schema") not in _READABLE_SCHEMAS:
         return SyncLedger()
     entries: dict[tuple[str, str], LedgerEntry] = {}
     slides = data.get("slides", {})
@@ -222,7 +231,8 @@ def load(path: Path) -> SyncLedger:
                 confirmed_oracle=rec.get("confirmed_oracle", "structural"),
                 hash_version=rec.get("hash_version", WATERMARK_HASH_VERSION),
             )
-    return SyncLedger(schema=SCHEMA_VERSION, entries=entries, idless=idless)
+    extra = {k: v for k, v in data.items() if k not in ("schema", "slides", "idless")}
+    return SyncLedger(schema=SCHEMA_VERSION, entries=entries, idless=idless, extra=extra)
 
 
 def _to_json(ledger: SyncLedger) -> str:
@@ -262,9 +272,13 @@ def _to_json(ledger: SyncLedger) -> str:
             ledger.idless.items(), key=lambda kv: (str(kv[0][0]), kv[0][1], kv[0][2])
         )
     ]
-    payload: dict[str, object] = {"schema": ledger.schema, "slides": slides}
+    # A file carrying preserved v3 sections stays on the coexistence
+    # envelope (schema 2); a plain v1 payload keeps its schema-1 shape.
+    schema = 2 if ledger.extra else ledger.schema
+    payload: dict[str, object] = {"schema": schema, "slides": slides}
     if idless:
         payload["idless"] = idless
+    payload.update(ledger.extra)
     return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
 
 

--- a/tests/cli/test_sync_import_cleanliness.py
+++ b/tests/cli/test_sync_import_cleanliness.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import subprocess
 import sys
 import textwrap
+from pathlib import Path
 
 
 def _run_probe(script: str) -> subprocess.CompletedProcess[str]:
@@ -93,6 +94,7 @@ def test_v3_doc_modules_import_no_v2_sync_core():
         """
         import sys
         import clm.slides.bilingual_doc, clm.slides.doc_lenses, clm.slides.sync_diff
+        import clm.slides.doc_ledger, clm.slides.doc_apply
 
         for mod in (
             "clm.slides.sync_plan",
@@ -105,6 +107,37 @@ def test_v3_doc_modules_import_no_v2_sync_core():
     )
     assert probe.returncode == 0, probe.stderr or probe.stdout
     assert probe.stdout.strip().endswith("OK")
+
+
+def test_v3_cli_facade_imports_no_v2_sync_core():
+    # The §12.5 dispatch design: the v3 verb runners (report/apply/record)
+    # bind only the v3 core in their module-level import list. (A sys.modules
+    # probe cannot see this — importing the facade triggers the parent
+    # package's eager import of the v2 ``sync`` module, which is exactly the
+    # one file Phase 4 edits at cutover.) The one v2-adjacent component the
+    # facade uses — the structural verify gate — must stay a function-local
+    # import, so "delete the v2 modules" cannot be blocked by this facade.
+    import ast
+
+    from clm.cli.commands.slides import sync_v3
+
+    source = Path(sync_v3.__file__).read_text(encoding="utf-8")
+    forbidden = {
+        "clm.slides.sync_plan",
+        "clm.slides.sync_apply",
+        "clm.slides.sync_code",
+        "clm.slides.sync_verify",
+    }
+    for node in ast.parse(source).body:  # module level only, by design
+        if isinstance(node, ast.Import):
+            names = {alias.name for alias in node.names}
+        elif isinstance(node, ast.ImportFrom):
+            names = {node.module or ""}
+            names |= {f"{node.module}.{alias.name}" for alias in node.names if node.module}
+        else:
+            continue
+        hits = names & forbidden
+        assert not hits, f"v3 CLI facade imports {sorted(hits)} at module level"
 
 
 def test_resolving_autopilot_loads_it_but_still_not_openai():

--- a/tests/cli/test_sync_v3_cli.py
+++ b/tests/cli/test_sync_v3_cli.py
@@ -1,0 +1,182 @@
+"""CLI tests for the ``CLM_SYNC_ENGINE=v3`` verb dispatch (#520 Phase 3, §12.5).
+
+One dispatch point at the verb layer: ``report`` / ``apply`` switch to the v3
+engine under the env flag (v2 stays the default), ``record`` exists only
+there. The tests drive the full dogfood loop through the CLI — record →
+report clean → mutate → report flags → apply → report clean — and pin the
+envelope's stable booleans plus the flag hygiene in both directions.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands.slides.sync import slides_sync_group
+
+
+@pytest.fixture
+def cli_runner():
+    # Click 8.1 needs ``mix_stderr=False``; Click 8.2+ removed the parameter.
+    try:
+        return CliRunner(mix_stderr=False)
+    except TypeError:
+        return CliRunner()
+
+
+HEADER_DE = "# j2 from 'macros.j2' import header_de\n# {{ header_de(\"Titel DE\") }}\n\n"
+HEADER_EN = "# j2 from 'macros.j2' import header_en\n# {{ header_en(\"Title EN\") }}\n\n"
+
+DE = (
+    HEADER_DE
+    + '# %% [markdown] lang="de" tags=["slide"] slide_id="s0"\n#\n# # Titel\n\n'
+    + '# %% tags=["keep"]\nx = 1\n\n'
+    + '# %% [markdown] lang="de" slide_id="s0-m"\n# DE Text\n'
+)
+EN = (
+    HEADER_EN
+    + '# %% [markdown] lang="en" tags=["slide"] slide_id="s0"\n#\n# # Title\n\n'
+    + '# %% tags=["keep"]\nx = 1\n\n'
+    + '# %% [markdown] lang="en" slide_id="s0-m"\n# EN text\n'
+)
+
+
+def _write_pair(tmp_path: Path) -> tuple[Path, Path]:
+    de = tmp_path / "slides_t.de.py"
+    en = tmp_path / "slides_t.en.py"
+    de.write_text(DE, encoding="utf-8")
+    en.write_text(EN, encoding="utf-8")
+    return de, en
+
+
+def _json_payload(output: str) -> dict:
+    start = output.index("{")
+    return json.loads(output[start:])
+
+
+V3 = {"CLM_SYNC_ENGINE": "v3"}
+
+
+class TestDispatch:
+    def test_record_requires_the_v3_engine(self, cli_runner: CliRunner, tmp_path: Path):
+        de, _ = _write_pair(tmp_path)
+        result = cli_runner.invoke(slides_sync_group, ["record", str(de)])
+        assert result.exit_code != 0
+        assert "CLM_SYNC_ENGINE=v3" in result.output
+
+    def test_v3_only_apply_flags_are_rejected_under_v2(self, cli_runner: CliRunner, tmp_path: Path):
+        de, _ = _write_pair(tmp_path)
+        result = cli_runner.invoke(slides_sync_group, ["apply", str(de), "--dry-run"])
+        assert result.exit_code != 0
+        assert "CLM_SYNC_ENGINE=v3" in result.output
+
+    def test_v2_only_report_flags_are_rejected_under_v3(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        de, _ = _write_pair(tmp_path)
+        result = cli_runner.invoke(
+            slides_sync_group, ["report", str(de), "--use-watermark"], env=V3
+        )
+        assert result.exit_code != 0
+        assert "v2 engine" in result.output
+
+    def test_report_under_v2_still_runs_the_v2_engine(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch
+    ):
+        # No env flag: the v2 path runs (its envelope has no "engine": "v3").
+        de, _ = _write_pair(tmp_path)
+        monkeypatch.setenv("CLM_JOBS_DB_PATH", str(tmp_path / "jobs.sqlite"))
+        result = cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"])
+        if result.exit_code == 2:  # no git repo around tmp: v2 needs a baseline
+            assert "engine" not in (result.output or "")
+        else:
+            payload = _json_payload(result.output)
+            assert payload.get("engine") != "v3"
+
+
+class TestV3Loop:
+    def test_record_report_mutate_apply_report(self, cli_runner: CliRunner, tmp_path: Path):
+        de, en = _write_pair(tmp_path)
+
+        # A never-recorded deck is cold: work pending (exit 1), agent needed.
+        cold = cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"], env=V3)
+        assert cold.exit_code == 1, cold.output
+        payload = _json_payload(cold.output)
+        assert payload["schema"] == 3 and payload["engine"] == "v3"
+        assert payload["is_clean"] is False
+        assert payload["needs_agent"] is True
+        assert {i["action"] for i in payload["items"]} == {"verify_cold"}
+        assert all(i["answers"] == ["confirm"] for i in payload["items"])
+
+        # record blesses the current state (verify-gated).
+        record = cli_runner.invoke(slides_sync_group, ["record", str(de), "--json"], env=V3)
+        assert record.exit_code == 0, record.output
+        assert (tmp_path / ".clm" / "sync-ledger.json").is_file()
+
+        clean = cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"], env=V3)
+        assert clean.exit_code == 0, clean.output
+        assert _json_payload(clean.output)["is_clean"] is True
+
+        # One shared edit -> one mechanical item -> apply propagates it.
+        de.write_text(de.read_text(encoding="utf-8").replace("x = 1", "x = 42"), "utf-8")
+        flagged = cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"], env=V3)
+        assert flagged.exit_code == 1
+        items = _json_payload(flagged.output)["items"]
+        assert [i["action"] for i in items] == ["propagate_shared_edit"]
+
+        applied = cli_runner.invoke(slides_sync_group, ["apply", str(de), "--json"], env=V3)
+        assert applied.exit_code == 0, applied.output
+        assert "x = 42" in en.read_text(encoding="utf-8")
+
+        again = cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"], env=V3)
+        assert again.exit_code == 0, again.output
+
+    def test_apply_decisions_from_stdin(self, cli_runner: CliRunner, tmp_path: Path):
+        de, en = _write_pair(tmp_path)
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)], env=V3).exit_code == 0
+        de.write_text(de.read_text(encoding="utf-8").replace("DE Text", "DE neu"), "utf-8")
+        decisions = json.dumps({"decisions": [{"key": "id:s0-m", "body": "# EN new"}]})
+        result = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--decisions", "-", "--json"],
+            input=decisions,
+            env=V3,
+        )
+        assert result.exit_code == 0, result.output
+        assert "# EN new" in en.read_text(encoding="utf-8")
+
+    def test_apply_residue_exits_one(self, cli_runner: CliRunner, tmp_path: Path):
+        de, en = _write_pair(tmp_path)
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)], env=V3).exit_code == 0
+        de.write_text(de.read_text(encoding="utf-8").replace("DE Text", "DE neu"), "utf-8")
+        result = cli_runner.invoke(slides_sync_group, ["apply", str(de), "--json"], env=V3)
+        assert result.exit_code == 1, result.output
+        payload = _json_payload(result.output)
+        assert payload["counts"]["pending"] == 1
+        assert "DE neu" not in en.read_text(encoding="utf-8")
+
+    def test_record_refuses_a_structurally_corrupt_pair(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        de, en = _write_pair(tmp_path)
+        # Corrupt the EN half: drop the localized twin so the ids are asymmetric.
+        en.write_text(
+            en.read_text(encoding="utf-8").replace('slide_id="s0-m"', 'slide_id="s0-x"'),
+            "utf-8",
+        )
+        result = cli_runner.invoke(slides_sync_group, ["record", str(de), "--json"], env=V3)
+        assert result.exit_code == 1, result.output
+        payload = _json_payload(result.output)
+        assert payload["refused"] == 1
+        assert not (tmp_path / ".clm" / "sync-ledger.json").is_file()
+
+    def test_report_over_a_directory_aggregates(self, cli_runner: CliRunner, tmp_path: Path):
+        _write_pair(tmp_path)
+        result = cli_runner.invoke(slides_sync_group, ["report", str(tmp_path), "--json"], env=V3)
+        assert result.exit_code == 1, result.output
+        payload = _json_payload(result.output)
+        assert payload["engine"] == "v3"
+        assert len(payload["pairs"]) == 1

--- a/tests/cli/test_sync_v3_cli.py
+++ b/tests/cli/test_sync_v3_cli.py
@@ -180,3 +180,60 @@ class TestV3Loop:
         payload = _json_payload(result.output)
         assert payload["engine"] == "v3"
         assert len(payload["pairs"]) == 1
+
+    def test_confirm_only_apply_persists_the_ledger(self, cli_runner: CliRunner, tmp_path: Path):
+        # Review regression: a confirm-only apply mutates no file, but its
+        # ledger updates must still be saved — silently discarding them made
+        # every confirmation a no-op.
+        de, _en = _write_pair(tmp_path)
+        cold = cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"], env=V3)
+        decisions = json.dumps(
+            {
+                "decisions": [
+                    {"key": item["key"], "choice": "confirm"}
+                    for item in _json_payload(cold.output)["items"]
+                ]
+            }
+        )
+        result = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--decisions", "-", "--json"],
+            input=decisions,
+            env=V3,
+        )
+        assert result.exit_code == 0, result.output
+        payload = _json_payload(result.output)
+        assert payload["ledger_recorded"] is True
+        assert (tmp_path / ".clm" / "sync-ledger.json").is_file()
+        again = cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"], env=V3)
+        assert again.exit_code == 0, again.output
+
+    def test_apply_never_records_a_structurally_corrupt_pair(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        # Review regression: the lens tolerates (observes) an id-asymmetry
+        # the structural gate refuses — apply may write its mechanical items,
+        # but the ledger must not bless members of a corrupt pair.
+        de, en = _write_pair(tmp_path)
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)], env=V3).exit_code == 0
+        en.write_text(
+            en.read_text(encoding="utf-8").replace('slide_id="s0-m"', 'slide_id="s0-x"'),
+            "utf-8",
+        )
+        de.write_text(de.read_text(encoding="utf-8").replace("x = 1", "x = 42"), "utf-8")
+        ledger_before = (tmp_path / ".clm" / "sync-ledger.json").read_text(encoding="utf-8")
+        result = cli_runner.invoke(slides_sync_group, ["apply", str(de), "--json"], env=V3)
+        assert result.exit_code != 0, result.output
+        payload = _json_payload(result.output)
+        assert payload["ledger_recorded"] is False
+        assert payload["verify_violations"]
+        assert (tmp_path / ".clm" / "sync-ledger.json").read_text(encoding="utf-8") == ledger_before
+
+    def test_directory_sweep_warns_on_solo_halves(self, cli_runner: CliRunner, tmp_path: Path):
+        _write_pair(tmp_path)
+        (tmp_path / "slides_solo.de.py").write_text(DE, encoding="utf-8")
+        result = cli_runner.invoke(slides_sync_group, ["report", str(tmp_path), "--json"], env=V3)
+        payload = _json_payload(result.output)
+        assert any("slides_solo" in s for s in payload["skipped_solos"])
+        stderr = getattr(result, "stderr", "") or result.output
+        assert "no twin half found" in stderr

--- a/tests/slides/test_doc_apply.py
+++ b/tests/slides/test_doc_apply.py
@@ -107,7 +107,7 @@ class _Deck:
             only_members=only_members,
             dry_run=dry_run,
         )
-        if outcome.error is None and not dry_run:
+        if outcome.error is None and not dry_run and outcome.ledger_changed:
             doc_ledger.save(ledger, ledger_path)
         return outcome
 
@@ -519,3 +519,127 @@ class TestWritePathOracle:
         again = deck.apply()
         assert again.results == []
         assert not again.wrote
+
+
+class TestReviewRegressions:
+    """Pins for the Phase-3 adversarial review findings (never regress)."""
+
+    def test_pool_rerecord_never_blesses_a_pending_sibling(self, tmp_path: Path):
+        # One pool: cell x edited on DE only (mechanical), cell y edited
+        # differently on BOTH sides (framed conflict). Applying the
+        # mechanical item re-records the pool wholesale — but the pending
+        # conflict's slot must come out COLD, never trusted at its diverged
+        # state (which would silently drop the required reconciliation).
+        deck = _deck(tmp_path)
+        deck.edit_de("x = 1", "x = 42")
+        deck.edit_de("y = 2", "y = 111")
+        deck.edit_en("y = 2", "y = 222")
+        outcome = deck.apply()
+        statuses = _statuses(outcome)
+        assert statuses["pos:s0/code/0"] == "applied"
+        assert statuses["pos:s0/code/1"] == "pending"
+        _, diff = deck.diff()
+        assert not diff.is_clean, "the pending conflict was silently blessed"
+        assert any(i.outcome in ("conflict", "unverified") for i in diff.items)
+
+    def test_member_filter_does_not_bless_the_skipped_sibling(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de("x = 1", "x = 42")
+        deck.edit_de("y = 2", "y = 99")
+        deck.apply(only_members={"pos:s0/code/0"})
+        _, diff = deck.diff()
+        assert not diff.is_clean, "the skipped edit was silently blessed"
+
+    def test_confirm_only_apply_marks_the_ledger_changed(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.write_de(*DE_PARTS, _localized("s0-new", "de", "Neu"))
+        deck.write_en(*EN_PARTS, _localized("s0-new", "en", "New"))
+        outcome = deck.apply(_decision("id:s0-new", choice="confirm"))
+        assert outcome.all_applied
+        assert not outcome.wrote
+        assert outcome.ledger_changed  # the CLI save gate keys on this
+        deck.assert_converged()
+
+    def test_duplicate_content_confirm_survives_the_migration_sweep(self, tmp_path: Path):
+        # A pos-keyed cell byte-identical (modulo slide_id) to an id'd cell:
+        # its recorded trust must survive an unrelated apply — the migration
+        # sweep is targeted, never a blanket fingerprint sweep.
+        idd_dup = '# %% [markdown] tags=["keep"] slide_id="s0-dup"\n# same text\n\n'
+        pos_dup = '# %% [markdown] tags=["keep"]\n# same text\n\n'
+        deck = _Deck(
+            tmp_path,
+            _build(HEADER_DE, _slide("s0", "de", "Titel"), idd_dup, pos_dup, _shared_code("x")),
+            _build(HEADER_EN, _slide("s0", "en", "Title"), idd_dup, pos_dup, _shared_code("x")),
+        )
+        deck.record()
+        deck.edit_de("x = 1", "x = 42")  # unrelated mechanical edit
+        assert deck.apply().all_applied
+        ledger = doc_ledger.load(doc_ledger.ledger_path_for(deck.de_path))
+        pos_keys = [k for k in ledger.decks["slides_t"].members if k.startswith("pos:s0/markdown")]
+        assert pos_keys, "the duplicate-content pos entry was swept by an unrelated apply"
+        deck.assert_converged()
+
+    # The verifier's repro shape: two per-language header cells BEFORE the
+    # title macro form the ~header localized pool; deleting the DE half of
+    # slot A while editing the EN half of slot B makes the parse pair slot
+    # B's DE cell with slot A's EN cell (shifted cross-side pairing).
+    HA_DE = "# j2 from 'macros.j2' import a_mac\n# {{ a_mac(\"A de\") }}\n\n"
+    HA_EN = "# j2 from 'macros.j2' import a_mac\n# {{ a_mac(\"A en\") }}\n\n"
+    HB_DE = "# j2 from 'macros.j2' import b_mac\n# {{ b_mac(\"B de\") }}\n\n"
+    HB_EN = "# j2 from 'macros.j2' import b_mac\n# {{ b_mac(\"B en\") }}\n\n"
+
+    def _shifted_deck(self, tmp_path: Path) -> _Deck:
+        deck = _Deck(
+            tmp_path,
+            _build(
+                self.HA_DE, self.HB_DE, HEADER_DE, _slide("s0", "de", "Titel"), _shared_code("x")
+            ),
+            _build(
+                self.HA_EN, self.HB_EN, HEADER_EN, _slide("s0", "en", "Title"), _shared_code("x")
+            ),
+        )
+        deck.record()
+        de_text = deck.de_path.read_text(encoding="utf-8")
+        deck.de_path.write_text(de_text.replace(self.HA_DE, ""), encoding="utf-8")
+        deck.edit_en('b_mac("B en")', 'b_mac("B en!")')
+        return deck
+
+    def test_shifted_pairing_carries_the_member_twin_convention(self, tmp_path: Path):
+        deck = self._shifted_deck(tmp_path)
+        _, diff = deck.diff()
+        edits = [i for i in diff.items if i.action == "translate_edit"]
+        assert len(edits) == 1, [(i.action, i.key) for i in diff.items]
+        item = edits[0]
+        # The pairing shifted: member carries the slot's DE cell, twin its
+        # EN cell — the executor's holder rule depends on exactly this.
+        assert item.twin is not None
+        assert item.member is not None and item.member.de is not None
+        assert "b_mac" in item.member.de.header
+        assert item.twin.en is not None and 'b_mac("B en!")' in item.twin.en.header
+        # ...and the report excerpts render each side from its carrier.
+        payload = item.payload()
+        assert 'b_mac("B de")' in payload["de"]
+        assert 'b_mac("B en!")' in payload["en"]
+        # A j2 header line is itself a cell boundary, so a body answer is
+        # structurally rejected — never a wrong-cell write, byte-unchanged.
+        before = deck.de_path.read_text(encoding="utf-8")
+        outcome = deck.apply(_decision(item.key, body='# {{ b_mac("B de!") }}'))
+        result = next(r for r in outcome.results if r.key == item.key)
+        assert result.status == "rejected"
+        assert deck.de_path.read_text(encoding="utf-8") == before
+
+    def test_shifted_pairing_remove_decision_touches_only_the_survivor(self, tmp_path: Path):
+        deck = self._shifted_deck(tmp_path)
+        _, diff = deck.diff()
+        removals = [i for i in diff.items if i.action == "remove_localized_side"]
+        assert removals, [(i.action, i.key) for i in diff.items]
+        decisions = {i.key: doc_apply.Decision(key=i.key, choice="remove") for i in removals}
+        outcome = deck.apply(decisions)
+        assert all(r.status == "applied" for r in outcome.results if r.key in decisions), (
+            outcome.to_payload()
+        )
+        en = deck.en_path.read_text(encoding="utf-8")
+        de = deck.de_path.read_text(encoding="utf-8")
+        assert "a_mac" not in en  # the surviving EN half of slot A was removed
+        assert 'b_mac("B de")' in de  # slot B's DE cell was NEVER touched
+        assert 'b_mac("B en!")' in en  # slot B's edited EN cell survived

--- a/tests/slides/test_doc_apply.py
+++ b/tests/slides/test_doc_apply.py
@@ -1,0 +1,521 @@
+"""Tests for :mod:`clm.slides.doc_apply` (#520 Phase 3, design §6.2/§8).
+
+Each test follows the dogfood loop the executor exists for: write a bundle,
+``record`` it into the ledger, apply ONE authoring action, diff against the
+ledger, apply — then assert the twin landed byte-correctly AND a fresh diff
+against the updated ledger is clean (the convergence contract). Decision
+handling asserts the re-homed accept guards: per-item rejection with reasons,
+multi-cell smuggling refused, stale handles refused, valid answers land.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from attrs import evolve
+
+from clm.slides import doc_apply, doc_ledger
+from clm.slides.doc_lenses import LoadedBundle, load_bundle
+from clm.slides.sync_diff import DeckDiff, diff_outcome
+
+HEADER_DE = "# j2 from 'macros.j2' import header_de\n# {{ header_de(\"Titel DE\") }}\n\n"
+HEADER_EN = "# j2 from 'macros.j2' import header_en\n# {{ header_en(\"Title EN\") }}\n\n"
+
+
+def _slide(slug: str, lang: str, title: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{slug}"\n#\n# # {title}\n\n'
+
+
+def _localized(slug: str, lang: str, text: str) -> str:
+    return f'# %% [markdown] lang="{lang}" slide_id="{slug}"\n# {text}\n\n'
+
+
+def _shared_code(name: str, value: int = 1, tags: str = "keep") -> str:
+    return f'# %% tags=["{tags}"]\n{name} = {value}\n\n'
+
+
+def _build(*parts: str) -> str:
+    return "".join(parts).rstrip("\n") + "\n"
+
+
+DE_PARTS = (
+    HEADER_DE,
+    _slide("s0", "de", "Titel"),
+    _shared_code("x"),
+    _shared_code("y", 2),
+    _localized("s0-m", "de", "DE Text"),
+)
+EN_PARTS = (
+    HEADER_EN,
+    _slide("s0", "en", "Title"),
+    _shared_code("x"),
+    _shared_code("y", 2),
+    _localized("s0-m", "en", "EN text"),
+)
+
+
+class _Deck:
+    """One on-disk bundle plus its recorded ledger — the loop harness."""
+
+    def __init__(self, tmp_path: Path, de: str, en: str) -> None:
+        self.de_path = tmp_path / "slides_t.de.py"
+        self.en_path = tmp_path / "slides_t.en.py"
+        self.de_path.write_text(de, encoding="utf-8")
+        self.en_path.write_text(en, encoding="utf-8")
+
+    def record(self) -> None:
+        bundle = self.load()
+        assert bundle.outcome.deck is not None
+        ledger_path = doc_ledger.ledger_path_for(self.de_path)
+        ledger = doc_ledger.load(ledger_path)
+        doc_ledger.record_deck_snapshot(
+            ledger,
+            doc_ledger.deck_key_for(self.de_path),
+            bundle.outcome.deck,
+            provenance="record",
+        )
+        doc_ledger.save(ledger, ledger_path)
+
+    def load(self) -> LoadedBundle:
+        return load_bundle(self.de_path, self.en_path)
+
+    def diff(self) -> tuple[LoadedBundle, DeckDiff]:
+        bundle = self.load()
+        ledger = doc_ledger.load(doc_ledger.ledger_path_for(self.de_path))
+        deck_ledger = ledger.decks.get(doc_ledger.deck_key_for(self.de_path))
+        base = doc_ledger.baseline_from_ledger(deck_ledger) if deck_ledger else None
+        return bundle, diff_outcome(bundle.outcome, base)
+
+    def apply(
+        self,
+        decisions: dict[str, doc_apply.Decision] | None = None,
+        *,
+        dry_run: bool = False,
+        only_members: set[str] | None = None,
+    ) -> doc_apply.ApplyOutcome:
+        bundle, diff = self.diff()
+        assert bundle.outcome.deck is not None
+        ledger_path = doc_ledger.ledger_path_for(self.de_path)
+        ledger = doc_ledger.load(ledger_path)
+        outcome = doc_apply.apply_deck(
+            bundle,
+            bundle.outcome.deck,
+            diff,
+            ledger,
+            doc_ledger.deck_key_for(self.de_path),
+            decisions=decisions,
+            only_members=only_members,
+            dry_run=dry_run,
+        )
+        if outcome.error is None and not dry_run:
+            doc_ledger.save(ledger, ledger_path)
+        return outcome
+
+    def edit_de(self, old: str, new: str) -> None:
+        text = self.de_path.read_text(encoding="utf-8")
+        assert old in text
+        self.de_path.write_text(text.replace(old, new), encoding="utf-8")
+
+    def edit_en(self, old: str, new: str) -> None:
+        text = self.en_path.read_text(encoding="utf-8")
+        assert old in text
+        self.en_path.write_text(text.replace(old, new), encoding="utf-8")
+
+    def write_de(self, *parts: str) -> None:
+        self.de_path.write_text(_build(*parts), encoding="utf-8")
+
+    def write_en(self, *parts: str) -> None:
+        self.en_path.write_text(_build(*parts), encoding="utf-8")
+
+    def assert_converged(self) -> None:
+        """The post-apply contract: a fresh diff vs the updated ledger is clean."""
+        _, diff = self.diff()
+        assert diff.is_clean, [(i.outcome, i.action, i.key, i.detail) for i in diff.items]
+
+
+def _deck(tmp_path: Path) -> _Deck:
+    deck = _Deck(tmp_path, _build(*DE_PARTS), _build(*EN_PARTS))
+    deck.record()
+    return deck
+
+
+def _statuses(outcome: doc_apply.ApplyOutcome) -> dict[str, str]:
+    return {r.key: r.status for r in outcome.results}
+
+
+# ---------------------------------------------------------------------------
+# Mechanical rows
+# ---------------------------------------------------------------------------
+
+
+class TestMechanicalRows:
+    def test_propagate_shared_edit_copies_verbatim(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de("x = 1", "x = 42")
+        outcome = deck.apply()
+        assert outcome.all_applied, outcome.to_payload()
+        assert "x = 42" in deck.en_path.read_text(encoding="utf-8")
+        deck.assert_converged()
+
+    def test_record_symmetric_edit_writes_no_files(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de("x = 1", "x = 42")
+        deck.edit_en("x = 1", "x = 42")
+        before = deck.de_path.read_text(encoding="utf-8")
+        outcome = deck.apply()
+        assert outcome.all_applied
+        assert not outcome.wrote
+        assert deck.de_path.read_text(encoding="utf-8") == before
+        deck.assert_converged()
+
+    def test_a_brand_new_member_is_cold_in_ledger_mode(self, tmp_path: Path):
+        # Design §5: a member with no ledger entry is UNVERIFIED, never a
+        # mechanical copy — the agent confirms (or records) it explicitly.
+        deck = _deck(tmp_path)
+        deck.write_de(
+            HEADER_DE,
+            _slide("s0", "de", "Titel"),
+            _shared_code("x"),
+            _shared_code("z", 9),  # new, between x and y
+            _shared_code("y", 2),
+            _localized("s0-m", "de", "DE Text"),
+        )
+        _, diff = deck.diff()
+        assert [(i.action) for i in diff.items] == ["verify_cold"]
+        outcome = deck.apply()
+        assert not outcome.wrote
+        assert outcome.count("pending") == 1
+
+    def test_copy_new_shared_completes_a_recorded_pending_twin(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        # A recorded pending twin: the entry knows only the DE side of "y".
+        ledger_path = doc_ledger.ledger_path_for(deck.de_path)
+        ledger = doc_ledger.load(ledger_path)
+        deck_ledger = ledger.decks["slides_t"]
+        key = "pos:s0/code/1"
+        lm = deck_ledger.members[key]
+        deck_ledger.members[key] = evolve(
+            lm,
+            entry=evolve(lm.entry, en_fp=None, en_body_fp=None, en_tags=None, en_sig=None),
+        )
+        doc_ledger.save(ledger, ledger_path)
+        deck.write_en(
+            HEADER_EN,
+            _slide("s0", "en", "Title"),
+            _shared_code("x"),
+            _localized("s0-m", "en", "EN text"),
+        )
+        _, diff = deck.diff()
+        assert [i.action for i in diff.items] == ["copy_new_shared"]
+        outcome = deck.apply()
+        assert outcome.all_applied, outcome.to_payload()
+        en = deck.en_path.read_text(encoding="utf-8")
+        assert en.index("x = 1") < en.index("y = 2") < en.index("# EN text")
+        deck.assert_converged()
+
+    def test_mirror_remove_deletes_the_twin(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.write_de(
+            HEADER_DE,
+            _slide("s0", "de", "Titel"),
+            _shared_code("x"),
+            _localized("s0-m", "de", "DE Text"),
+        )
+        outcome = deck.apply()
+        assert outcome.all_applied, outcome.to_payload()
+        assert "y = 2" not in deck.en_path.read_text(encoding="utf-8")
+        deck.assert_converged()
+
+    def test_mirror_tags_rewrites_only_the_header(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de(
+            '# %% [markdown] lang="de" slide_id="s0-m"',
+            '# %% [markdown] lang="de" tags=["notes"] slide_id="s0-m"',
+        )
+        outcome = deck.apply()
+        assert outcome.all_applied, outcome.to_payload()
+        en = deck.en_path.read_text(encoding="utf-8")
+        assert 'tags=["notes"]' in en
+        assert "# EN text" in en  # the body was untouched
+        deck.assert_converged()
+
+    def test_stamp_twin_id_completes_the_443_shape(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de('# %% tags=["keep"]\nx = 1', '# %% tags=["keep"] slide_id="x-cell"\nx = 1')
+        outcome = deck.apply()
+        assert outcome.all_applied, outcome.to_payload()
+        assert 'slide_id="x-cell"' in deck.en_path.read_text(encoding="utf-8")
+        deck.assert_converged()
+
+    def test_mirror_order_reorders_the_twin_pool(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.write_de(
+            HEADER_DE,
+            _slide("s0", "de", "Titel"),
+            _shared_code("y", 2),  # swapped with x
+            _shared_code("x"),
+            _localized("s0-m", "de", "DE Text"),
+        )
+        outcome = deck.apply()
+        assert outcome.all_applied, outcome.to_payload()
+        en = deck.en_path.read_text(encoding="utf-8")
+        assert en.index("y = 2") < en.index("x = 1")
+        deck.assert_converged()
+
+    def test_propagate_preamble(self, tmp_path: Path):
+        deck = _Deck(
+            tmp_path,
+            "# preamble v1\n" + _build(*DE_PARTS),
+            "# preamble v1\n" + _build(*EN_PARTS),
+        )
+        deck.record()
+        deck.edit_de("# preamble v1", "# preamble v2")
+        outcome = deck.apply()
+        assert outcome.all_applied, outcome.to_payload()
+        assert deck.en_path.read_text(encoding="utf-8").startswith("# preamble v2")
+        deck.assert_converged()
+
+    def test_group_rename_is_recorded_without_touching_files(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de('slide_id="s0"', 'slide_id="s0-neu"')
+        deck.edit_en('slide_id="s0"', 'slide_id="s0-neu"')
+        before = deck.de_path.read_text(encoding="utf-8")
+        outcome = deck.apply()
+        assert outcome.all_applied, outcome.to_payload()
+        assert not outcome.wrote
+        assert deck.de_path.read_text(encoding="utf-8") == before
+        deck.assert_converged()
+
+
+# ---------------------------------------------------------------------------
+# Per-item independence and safety
+# ---------------------------------------------------------------------------
+
+
+class TestPerItem:
+    def test_framed_items_stay_pending_while_mechanical_ones_land(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de("x = 1", "x = 42")  # mechanical
+        deck.edit_de("DE Text", "DE Text NEU")  # framed translate_edit
+        outcome = deck.apply()
+        statuses = _statuses(outcome)
+        assert statuses["pos:s0/code/0"] == "applied"
+        assert statuses["id:s0-m"] == "pending"
+        assert not outcome.all_applied
+        assert "x = 42" in deck.en_path.read_text(encoding="utf-8")
+        # The framed item survives the partial apply.
+        _, diff = deck.diff()
+        assert [(i.key, i.action) for i in diff.items] == [("id:s0-m", "translate_edit")]
+
+    def test_member_filter_skips_everything_else(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de("x = 1", "x = 42")
+        deck.edit_de("y = 2", "y = 99")
+        outcome = deck.apply(only_members={"pos:s0/code/0"})
+        assert {r.status for r in outcome.results} == {"applied", "skipped"}
+        en = deck.en_path.read_text(encoding="utf-8")
+        assert "x = 42" in en
+        assert "y = 99" not in en
+
+    def test_dry_run_writes_nothing(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de("x = 1", "x = 42")
+        before_en = deck.en_path.read_text(encoding="utf-8")
+        ledger_before = doc_ledger.ledger_path_for(deck.de_path).read_text(encoding="utf-8")
+        outcome = deck.apply(dry_run=True)
+        assert outcome.dry_run and not outcome.wrote
+        assert deck.en_path.read_text(encoding="utf-8") == before_en
+        assert doc_ledger.ledger_path_for(deck.de_path).read_text(encoding="utf-8") == ledger_before
+
+    def test_conflict_is_never_resolved_without_a_decision(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de("x = 1", "x = 111")
+        deck.edit_en("x = 1", "x = 222")
+        outcome = deck.apply()
+        assert _statuses(outcome) == {"pos:s0/code/0": "pending"}
+        assert "x = 111" in deck.de_path.read_text(encoding="utf-8")
+        assert "x = 222" in deck.en_path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Decisions
+# ---------------------------------------------------------------------------
+
+
+def _decision(key: str, *, choice: str | None = None, body: str | None = None):
+    return {key: doc_apply.Decision(key=key, choice=choice, body=body)}
+
+
+class TestDecisions:
+    def test_translate_edit_body_lands_on_the_twin(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de("DE Text", "DE Text NEU")
+        outcome = deck.apply(_decision("id:s0-m", body="# EN text NEW"))
+        assert outcome.all_applied, outcome.to_payload()
+        assert "# EN text NEW" in deck.en_path.read_text(encoding="utf-8")
+        deck.assert_converged()
+
+    def test_conflict_choice_propagates_the_chosen_side(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de("x = 1", "x = 111")
+        deck.edit_en("x = 1", "x = 222")
+        outcome = deck.apply(_decision("pos:s0/code/0", choice="de"))
+        assert outcome.all_applied, outcome.to_payload()
+        assert "x = 111" in deck.en_path.read_text(encoding="utf-8")
+        assert "x = 222" not in deck.en_path.read_text(encoding="utf-8")
+        deck.assert_converged()
+
+    def test_smuggled_cell_boundary_is_rejected_byte_unchanged(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de("DE Text", "DE Text NEU")
+        before = deck.en_path.read_text(encoding="utf-8")
+        outcome = deck.apply(
+            _decision("id:s0-m", body='# fine\n\n# %% [markdown] slide_id="evil"\n# smuggled')
+        )
+        statuses = _statuses(outcome)
+        assert statuses["id:s0-m"] == "rejected"
+        result = next(r for r in outcome.results if r.key == "id:s0-m")
+        assert "delimiter" in result.reason
+        assert deck.en_path.read_text(encoding="utf-8") == before
+
+    def test_stale_handle_is_rejected(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de("x = 1", "x = 42")
+        outcome = deck.apply(_decision("id:no-such-member", choice="de"))
+        statuses = _statuses(outcome)
+        assert statuses["id:no-such-member"] == "rejected"
+        assert statuses["pos:s0/code/0"] == "applied"  # the valid work still lands
+
+    def test_wrong_choice_for_the_action_is_rejected(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de("DE Text", "DE Text NEU")
+        outcome = deck.apply(_decision("id:s0-m", choice="remove"))
+        result = next(r for r in outcome.results if r.key == "id:s0-m")
+        assert result.status == "rejected"
+        assert "not valid" in result.reason or "does not accept" in result.reason
+
+    def test_verify_cold_confirm_records_the_member(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.write_de(*DE_PARTS, _localized("s0-new", "de", "Neu"))
+        deck.write_en(*EN_PARTS, _localized("s0-new", "en", "New"))
+        _, diff = deck.diff()
+        assert [(i.key, i.action) for i in diff.items] == [("id:s0-new", "verify_cold")]
+        outcome = deck.apply(_decision("id:s0-new", choice="confirm"))
+        assert outcome.all_applied, outcome.to_payload()
+        assert not outcome.wrote  # confirmation is a pure ledger record
+        deck.assert_converged()
+
+    def test_confirm_on_a_one_sided_member_is_rejected(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.write_de(*DE_PARTS, _localized("s0-new", "de", "Neu"))
+        outcome = deck.apply(_decision("id:s0-new", choice="confirm"))
+        result = next(r for r in outcome.results if r.key == "id:s0-new")
+        assert result.status == "rejected"
+        assert "one-sided" in result.reason
+
+    def test_remove_vs_edit_keep_readds_the_survivor(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.write_de(
+            HEADER_DE,
+            _slide("s0", "de", "Titel"),
+            _shared_code("x"),
+            _shared_code("y", 99),  # edited...
+            _localized("s0-m", "de", "DE Text"),
+        )
+        deck.write_en(
+            HEADER_EN,
+            _slide("s0", "en", "Title"),
+            _shared_code("x"),
+            # ...while removed on EN
+            _localized("s0-m", "en", "EN text"),
+        )
+        _, diff = deck.diff()
+        (item,) = diff.items
+        assert item.action == "remove_vs_edit"
+        outcome = deck.apply(_decision(item.key, choice="keep"))
+        assert outcome.all_applied, outcome.to_payload()
+        assert "y = 99" in deck.en_path.read_text(encoding="utf-8")
+        deck.assert_converged()
+
+    def test_remove_vs_edit_remove_deletes_the_survivor(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.write_de(
+            HEADER_DE,
+            _slide("s0", "de", "Titel"),
+            _shared_code("x"),
+            _shared_code("y", 99),
+            _localized("s0-m", "de", "DE Text"),
+        )
+        deck.write_en(
+            HEADER_EN,
+            _slide("s0", "en", "Title"),
+            _shared_code("x"),
+            _localized("s0-m", "en", "EN text"),
+        )
+        _, diff = deck.diff()
+        (item,) = diff.items
+        outcome = deck.apply(_decision(item.key, choice="remove"))
+        assert outcome.all_applied, outcome.to_payload()
+        assert "y = 99" not in deck.de_path.read_text(encoding="utf-8")
+        deck.assert_converged()
+
+
+# ---------------------------------------------------------------------------
+# The v3 write-path mutation oracle (design §11 Phase 3 exit gate)
+# ---------------------------------------------------------------------------
+
+
+class TestWritePathOracle:
+    """Propagate-or-frame, never silent — through the v3 write path.
+
+    The #269 cardinal invariant restated for v3: after ANY scripted one-sided
+    mutation, either apply propagates it (and the loop converges) or the
+    report frames it as agent work; a run must never read clean while a
+    change was dropped.
+    """
+
+    MUTATIONS = (
+        ("shared body edit", "x = 1", "x = 42"),
+        ("shared tag edit", '# %% tags=["keep"]\nx = 1', '# %% tags=["keep", "alt"]\nx = 1'),
+        ("localized body edit", "DE Text", "DE Text NEU"),
+        ("slide title edit", "# # Titel", "# # Titel NEU"),
+        ("header edit", 'header_de("Titel DE")', 'header_de("Titel DE Neu")'),
+    )
+
+    def test_every_one_sided_mutation_propagates_or_frames(self, tmp_path: Path):
+        for i, (label, old, new) in enumerate(self.MUTATIONS):
+            subdir = tmp_path / f"m{i}"
+            subdir.mkdir()
+            deck = _deck(subdir)
+            deck.edit_de(old, new)
+            _, diff = deck.diff()
+            assert not diff.is_clean, f"{label}: silently clean"
+            outcome = deck.apply()
+            if outcome.all_applied:
+                # Propagated: the loop converges and the twin carries the change.
+                deck.assert_converged()
+                assert outcome.wrote or outcome.count("recorded")
+            else:
+                # Framed: the residue is visible, nothing was dropped.
+                assert outcome.count("pending") > 0, f"{label}: {outcome.to_payload()}"
+
+    def test_both_sided_divergent_edit_is_a_framed_conflict(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de("x = 1", "x = 111")
+        deck.edit_en("x = 1", "x = 222")
+        _, diff = deck.diff()
+        assert not diff.is_clean
+        outcome = deck.apply()
+        assert outcome.count("pending") == 1
+        assert not outcome.wrote
+
+    def test_apply_then_report_is_stable(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de("x = 1", "x = 42")
+        deck.edit_de("y = 2", "y = 3")
+        assert deck.apply().all_applied
+        deck.assert_converged()
+        # A second apply is a no-op: nothing to do, nothing rewritten.
+        again = deck.apply()
+        assert again.results == []
+        assert not again.wrote

--- a/tests/slides/test_doc_ledger.py
+++ b/tests/slides/test_doc_ledger.py
@@ -1,0 +1,258 @@
+"""Tests for :mod:`clm.slides.doc_ledger` (#520 Phase 3, design §5).
+
+The member-keyed committed trust store: round-trip fidelity, the
+``complete=False`` ledger baseline, hash-version lazy migration, the §7.3
+pos→id key migration at record time, and — critically for the Phase-3
+transition — schema-2 coexistence with the v1 ``sync_ledger`` sections in the
+same file (neither engine may clobber the other's trust).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from attrs import evolve
+
+from clm.slides import doc_ledger, sync_ledger
+from clm.slides.bilingual_doc import BilingualDeck
+from clm.slides.doc_lenses import parse_bundle
+from clm.slides.sync_diff import baseline_from_deck, diff_deck
+
+HEADER_DE = "# j2 from 'macros.j2' import header_de\n# {{ header_de(\"Titel DE\") }}\n\n"
+HEADER_EN = "# j2 from 'macros.j2' import header_en\n# {{ header_en(\"Title EN\") }}\n\n"
+
+
+def _slide(slug: str, lang: str, title: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{slug}"\n#\n# # {title}\n\n'
+
+
+def _localized(slug: str, lang: str, text: str) -> str:
+    return f'# %% [markdown] lang="{lang}" slide_id="{slug}"\n# {text}\n\n'
+
+
+def _shared_code(name: str, value: int = 1) -> str:
+    return f'# %% tags=["keep"]\n{name} = {value}\n\n'
+
+
+def _build(*parts: str) -> str:
+    return "".join(parts).rstrip("\n") + "\n"
+
+
+DE0 = _build(
+    HEADER_DE,
+    _slide("s0", "de", "Titel"),
+    _shared_code("x"),
+    _localized("s0-m", "de", "DE Text"),
+)
+EN0 = _build(
+    HEADER_EN,
+    _slide("s0", "en", "Title"),
+    _shared_code("x"),
+    _localized("s0-m", "en", "EN text"),
+)
+
+
+def _parse(de: str, en: str) -> BilingualDeck:
+    outcome = parse_bundle(de, en)
+    assert outcome.deck is not None
+    return outcome.deck
+
+
+def _recorded_ledger(de: str = DE0, en: str = EN0) -> doc_ledger.TopicLedger:
+    ledger = doc_ledger.TopicLedger()
+    doc_ledger.record_deck_snapshot(ledger, "slides_x", _parse(de, en), provenance="record")
+    return ledger
+
+
+class TestRoundTrip:
+    def test_full_record_round_trips_through_json(self, tmp_path: Path):
+        ledger = _recorded_ledger()
+        path = tmp_path / ".clm" / "sync-ledger.json"
+        doc_ledger.save(ledger, path)
+        loaded = doc_ledger.load(path)
+        assert loaded.decks.keys() == {"slides_x"}
+        original = ledger.decks["slides_x"]
+        restored = loaded.decks["slides_x"]
+        assert restored.members == original.members
+        assert restored.group_order == original.group_order
+        assert restored.group_order_by_side == original.group_order_by_side
+        assert restored.member_order == original.member_order
+        assert restored.preamble_fps == original.preamble_fps
+
+    def test_ledger_baseline_equals_deck_snapshot_but_incomplete(self):
+        ledger = _recorded_ledger()
+        base = doc_ledger.baseline_from_ledger(ledger.decks["slides_x"])
+        snapshot = baseline_from_deck(_parse(DE0, EN0))
+        assert base.complete is False
+        assert base.members == snapshot.members
+        assert base.member_order == snapshot.member_order
+        assert base.group_order_by_side == snapshot.group_order_by_side
+        assert base.preamble_fps == snapshot.preamble_fps
+
+    def test_noop_diff_against_the_recorded_ledger_is_clean(self):
+        ledger = _recorded_ledger()
+        base = doc_ledger.baseline_from_ledger(ledger.decks["slides_x"])
+        diff = diff_deck(_parse(DE0, EN0), base)
+        assert diff.is_clean, [(i.action, i.key) for i in diff.items]
+
+    def test_absent_or_malformed_file_loads_empty(self, tmp_path: Path):
+        assert doc_ledger.load(tmp_path / "missing.json").decks == {}
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json", encoding="utf-8")
+        assert doc_ledger.load(bad).decks == {}
+        wrong = tmp_path / "wrong.json"
+        wrong.write_text('{"schema": 99, "decks": {}}', encoding="utf-8")
+        assert doc_ledger.load(wrong).decks == {}
+
+
+class TestTrustSemantics:
+    def test_new_member_is_cold_never_an_add(self):
+        ledger = _recorded_ledger()
+        base = doc_ledger.baseline_from_ledger(ledger.decks["slides_x"])
+        de = _build(
+            HEADER_DE,
+            _slide("s0", "de", "Titel"),
+            _shared_code("x"),
+            _localized("s0-m", "de", "DE Text"),
+            _localized("s0-new", "de", "Neu"),
+        )
+        en = _build(
+            HEADER_EN,
+            _slide("s0", "en", "Title"),
+            _shared_code("x"),
+            _localized("s0-m", "en", "EN text"),
+            _localized("s0-new", "en", "New"),
+        )
+        diff = diff_deck(_parse(de, en), base)
+        assert [(i.outcome, i.action) for i in diff.items] == [("unverified", "verify_cold")]
+
+    def test_stale_hash_version_drops_to_cold(self):
+        ledger = _recorded_ledger()
+        deck_ledger = ledger.decks["slides_x"]
+        key = "id:s0-m"
+        deck_ledger.members[key] = evolve(deck_ledger.members[key], hash_version=0)
+        base = doc_ledger.baseline_from_ledger(deck_ledger)
+        assert key not in base.members
+        diff = diff_deck(_parse(DE0, EN0), base)
+        assert [(i.key, i.action) for i in diff.items] == [(key, "verify_cold")]
+
+    def test_partial_record_upserts_only_the_named_members(self):
+        ledger = _recorded_ledger()
+        de = DE0.replace("DE Text", "DE Text NEU")
+        recorded, _ = doc_ledger.record_deck_snapshot(
+            ledger,
+            "slides_x",
+            _parse(de, EN0),
+            provenance="agent",
+            member_keys={"id:s0-m"},
+        )
+        assert recorded == 1
+        deck_ledger = ledger.decks["slides_x"]
+        assert deck_ledger.members["id:s0-m"].provenance == "agent"
+        # The untouched siblings keep their original provenance.
+        assert deck_ledger.members["id:s0"].provenance == "record"
+        base = doc_ledger.baseline_from_ledger(deck_ledger)
+        assert diff_deck(_parse(de, EN0), base).is_clean
+
+    def test_full_record_sweeps_stale_members(self):
+        ledger = _recorded_ledger()
+        de = _build(HEADER_DE, _slide("s0", "de", "Titel"), _shared_code("x"))
+        en = _build(HEADER_EN, _slide("s0", "en", "Title"), _shared_code("x"))
+        doc_ledger.record_deck_snapshot(ledger, "slides_x", _parse(de, en), provenance="record")
+        assert "id:s0-m" not in ledger.decks["slides_x"].members
+
+
+class TestKeyMigration:
+    def test_pos_to_id_migration_is_detected_and_logged(self):
+        ledger = _recorded_ledger()
+        stamped_de = DE0.replace(
+            '# %% tags=["keep"]\nx = 1', '# %% tags=["keep"] slide_id="x-cell"\nx = 1'
+        )
+        stamped_en = EN0.replace(
+            '# %% tags=["keep"]\nx = 1', '# %% tags=["keep"] slide_id="x-cell"\nx = 1'
+        )
+        recorded, migrations = doc_ledger.record_deck_snapshot(
+            ledger, "slides_x", _parse(stamped_de, stamped_en), provenance="record"
+        )
+        assert recorded > 0
+        assert migrations == {"pos:s0/code/0": "id:x-cell"}
+        members = ledger.decks["slides_x"].members
+        assert "id:x-cell" in members
+        assert "pos:s0/code/0" not in members
+
+
+class TestDeckKeys:
+    def test_deck_key_strips_language_and_suffix(self):
+        assert doc_ledger.deck_key_for(Path("slides_intro.de.py")) == "slides_intro"
+        assert doc_ledger.deck_key_for(Path("slides_intro.en.py")) == "slides_intro"
+        assert doc_ledger.deck_key_for(Path("slides_intro.de.cpp")) == "slides_intro"
+
+    def test_two_decks_share_one_topic_ledger(self, tmp_path: Path):
+        ledger = doc_ledger.TopicLedger()
+        doc_ledger.record_deck_snapshot(ledger, "slides_a", _parse(DE0, EN0), provenance="record")
+        doc_ledger.record_deck_snapshot(ledger, "slides_b", _parse(DE0, EN0), provenance="record")
+        path = tmp_path / "ledger.json"
+        doc_ledger.save(ledger, path)
+        assert doc_ledger.load(path).decks.keys() == {"slides_a", "slides_b"}
+
+
+class TestCoexistenceWithV1:
+    """The Phase-3 envelope: one file, two engines, no clobbering."""
+
+    def _v1_file(self, tmp_path: Path) -> Path:
+        path = tmp_path / "sync-ledger.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "slides": {
+                        "s1": {
+                            "slide": {
+                                "de_hash": "d1",
+                                "en_hash": "e1",
+                                "construct": None,
+                                "confirmed_commit": None,
+                                "confirmed_by": "bless",
+                                "confirmed_oracle": "structural",
+                                "hash_version": 3,
+                            }
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return path
+
+    def test_v3_save_preserves_the_v1_sections(self, tmp_path: Path):
+        path = self._v1_file(tmp_path)
+        ledger = doc_ledger.load(path)
+        assert ledger.decks == {}
+        doc_ledger.record_deck_snapshot(ledger, "slides_x", _parse(DE0, EN0), provenance="record")
+        doc_ledger.save(ledger, path)
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["schema"] == 2
+        assert "s1" in data["slides"]  # the v1 payload survived verbatim
+        assert "slides_x" in data["decks"]
+
+    def test_v2_load_and_save_preserve_the_v3_decks_section(self, tmp_path: Path):
+        path = self._v1_file(tmp_path)
+        v3 = doc_ledger.load(path)
+        doc_ledger.record_deck_snapshot(v3, "slides_x", _parse(DE0, EN0), provenance="record")
+        doc_ledger.save(v3, path)
+        # The v2 module reads its own sections from the schema-2 envelope...
+        v2 = sync_ledger.load(path)
+        assert ("s1", "slide") in v2.entries
+        assert "decks" in v2.extra
+        # ...and a v2 round trip keeps the v3 store byte-meaningful.
+        sync_ledger.save(v2, path)
+        again = doc_ledger.load(path)
+        assert "slides_x" in again.decks
+        assert again.decks["slides_x"].members == v3.decks["slides_x"].members
+
+    def test_plain_v1_round_trip_keeps_schema_1(self, tmp_path: Path):
+        path = self._v1_file(tmp_path)
+        v2 = sync_ledger.load(path)
+        sync_ledger.save(v2, path)
+        assert json.loads(path.read_text(encoding="utf-8"))["schema"] == 1

--- a/tests/slides/test_doc_ledger.py
+++ b/tests/slides/test_doc_ledger.py
@@ -137,6 +137,37 @@ class TestTrustSemantics:
         diff = diff_deck(_parse(DE0, EN0), base)
         assert [(i.key, i.action) for i in diff.items] == [(key, "verify_cold")]
 
+    def test_partial_record_of_a_pos_key_rerecords_its_whole_pool(self):
+        # Positional ordinals renumber together: a per-entry patch would mix
+        # ordinal generations (aliased keys), so a pos --member re-records
+        # the (group, kind) pool wholesale.
+        ledger = _recorded_ledger()
+        de = _build(
+            HEADER_DE,
+            _slide("s0", "de", "Titel"),
+            _shared_code("z", 9),  # new cell shifts the pool ordinals
+            _shared_code("x"),
+            _localized("s0-m", "de", "DE Text"),
+        )
+        en = _build(
+            HEADER_EN,
+            _slide("s0", "en", "Title"),
+            _shared_code("z", 9),
+            _shared_code("x"),
+            _localized("s0-m", "en", "EN text"),
+        )
+        recorded, _ = doc_ledger.record_deck_snapshot(
+            ledger,
+            "slides_x",
+            _parse(de, en),
+            provenance="record",
+            member_keys={"pos:s0/code/1"},
+        )
+        assert recorded == 2  # the whole pool, not one aliased ordinal
+        base = doc_ledger.baseline_from_ledger(ledger.decks["slides_x"])
+        diff = diff_deck(_parse(de, en), base)
+        assert not any(i.key.startswith("pos:s0/code") for i in diff.items)
+
     def test_partial_record_upserts_only_the_named_members(self):
         ledger = _recorded_ledger()
         de = DE0.replace("DE Text", "DE Text NEU")


### PR DESCRIPTION
## Sync v3 Phase 3 (#520)

Per `docs/claude/design/sync-total-identity-document-model.md` §5/§8/§11/§12.5 — the write path of the v3 engine, behind `CLM_SYNC_ENGINE=v3` (v2 stays the default).

### The ledger, promoted (`doc_ledger.py`)
- `<topic>/.clm/sync-ledger.json` becomes the v3 trust store: **member-keyed** §5 entries (the `MemberBaseline` engine view + provenance/state/hash_version) plus per-deck order/preamble context; `baseline_from_ledger` → `DeckBaseline(complete=False)`, so a never-recorded member is **cold** (framed `unverified`), never assumed.
- **Schema-2 coexistence envelope**: the v1 `slides`/`idless` sections live on in the same file untouched; the v2 `sync_ledger` now reads schema 2 and round-trips the v3 `decks` section verbatim (`SyncLedger.extra`) — neither engine can clobber the other's trust during the transition.
- `hash_version` drops entries to cold on a hashing-form change (the #458 rule); the §7.3 pos→id key migration happens **at record time**, logged.

### Per-item apply (`doc_apply.py`)
- Every `MECHANICAL_ACTIONS` row executes deterministically on a per-`(lang, part)` cell-stream view; `record_*` rows are ledger-only.
- **Decision documents** (§8) resolve framed items: `{"decisions": [{"key": …, "choice"|"body": …}]}`, validated **per item** through the re-homed `sync_accept` guards (multi-cell smuggling, per-action choice vocabulary, stale handles) — invalid answers are rejected with reasons while valid ones land.
- The mutated bundle is **re-parsed before any write** (refusal = abort, all files untouched), writes go through `atomic_write_all` (≤4 files), and every landed item is recorded surgically (pools wholesale, order/preamble per verified scope).

### CLI (`sync_v3.py` + one dispatch point per verb)
- `CLM_SYNC_ENGINE=v3` switches `report`/`apply` and enables the new **`sync record`** verb (bless/accept collapsed, structural-verify-gated). Schema-3 envelope keeps `is_clean`/`needs_model`/`needs_agent` stable; framed items carry their `answers` vocabulary. v2-only flags are rejected under v3 and vice versa. Exit codes per §8.

### Adversarial review (pre-merge, 29 agents)
10 confirmed defects, all fixed + pinned in `TestReviewRegressions` / CLI tests — highlights:
- **Wrong-cell writes on shifted pool pairings**: `DiffItem` gains a fixed member/twin side convention (member = DE carrier, twin = EN carrier); the executor resolves every side through one holder rule; remove/keep decisions touch only the surviving side.
- **Never bless the unresolved**: wholesale pool re-records drop entries of members whose framed items stayed pending/rejected/skipped; the migration sweep is targeted (a blanket fp sweep deleted fresh confirmations of duplicate-content cells).
- **Confirm-only applies persist** (`ledger_changed` save gate) and the apply-path ledger save is structural-verify-gated like `record`.
- Failed items are strict no-ops (validate-before-mutate); new companion files get parent dirs + the twin's jupytext preamble; directory sweeps warn on solo halves.

### Gates
- Fast suite: 9224 passed. Real-corpus self-diff ceiling holds (`TestRealCorpusSelfDiff -m ""`). Bundled noop + mutation oracles green.
- **v3 write-path mutation oracle** (`tests/slides/test_doc_apply.py::TestWritePathOracle`): propagate-or-frame, never silent; apply→report converges; both-sided conflicts never auto-resolve.
- Import cleanliness extended: `doc_ledger`/`doc_apply` in the v3 probe; the CLI facade's module-level imports AST-pinned clean of the v2 core.

Docs: `commands.md` info topic (record verb + `CLM_SYNC_ENGINE` section), changelog fragment.

**Next (per §11):** a real dogfood week on PythonCourses using only v3 verbs, then Phase 4 (flip the default, delete the watermark + v2 core). Track on #520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nm7hthC9AzcJyLWcDjzabG
