### PR TITLE
fix(ci): make the docs-only CI skip actually fire

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,15 @@ jobs:
         id: filter
         with:
           # ``code`` is true when at least one changed file is NOT docs-only.
+          #
+          # ``predicate-quantifier: every`` is essential: by default a file
+          # matches a filter when it matches ANY listed pattern, and every file
+          # matches at least one of these negations (nothing is simultaneously
+          # under docs/, under changelog.d/ AND a top-level *.md), which made
+          # ``code`` always true and ran the full pipeline for docs-only
+          # changes. With ``every``, a file counts as code only when it matches
+          # ALL negations, i.e. is none of the docs-only locations.
+          predicate-quantifier: every
           filters: |
             code:
               - '!docs/**'

--- a/changelog.d/543-ci-docs-only-skip.fixed.md
+++ b/changelog.d/543-ci-docs-only-skip.fixed.md
@@ -1,0 +1,1 @@
+- Fixed the CI docs-only skip never firing: the `changes` job's `dorny/paths-filter` exclusion list used the default "match any pattern" semantics, so every changed file matched at least one negation and the full test/lint/docker pipeline ran even for pure documentation changes. Setting `predicate-quantifier: every` makes the docs-only detection work as originally intended.


### PR DESCRIPTION
## Summary

Doc-only changes still ran the full CI pipeline (tests on 3.12/3.13, lint, Docker) even though `ci.yml` has a `changes` job intended to skip them. Verified on PR #541: it changed only `docs/proposals/video-narration-harvest.md`, yet `code` came out `true` and every job ran (~7.5 min test jobs, ~6 min Docker).

## Root cause

`dorny/paths-filter` defaults to `predicate-quantifier: some` — a changed file matches a filter if it matches **any** listed pattern. The `code` filter is an exclusion list of three negations (`!docs/**`, `!changelog.d/**`, `!*.md`), and no file can be under `docs/`, under `changelog.d/` **and** be a top-level `*.md` at once, so every file matched at least one negation. `code` was therefore always `true`.

## Fix

Set `predicate-quantifier: every` (added to paths-filter for exactly this exclusion-list case), so a file counts as code only when it matches **all** negations, i.e. lives in none of the docs-only locations. Also documents the gotcha in a comment so it doesn't regress.

The required-check structure is unchanged: required jobs still run and report success (their steps are gated on `needs.changes.outputs.code`), only the non-required Docker job skips wholesale — that part of the design was already correct.

## Test plan

- This PR itself touches `.github/workflows/ci.yml` + a `changelog.d/` fragment → the workflow file counts as code, so CI runs fully here.
- After merge, the next docs-only PR should show `Detect changes` → `code: false`, near-instant required checks, and a skipped Docker job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018f5UpWGpw4AMbaj7gE8bYM
