### PR TITLE
docs(spec): document "live" as an example <activity> kind; isolate CLM_SYNC_ENGINE in tests

### DIFF
--- a/changelog.d/activity-kind-live-docs.changed.md
+++ b/changelog.d/activity-kind-live-docs.changed.md
@@ -1,0 +1,1 @@
+- Documented `"live"` (live session with no video) as an example `<activity>` `kind` in the `spec-files` info topic and the `ActivitySpec` docstring. The attribute was always free-form; no behavior change.

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -288,8 +288,8 @@ deck on disk, never resolved and never built — so a certification listing has
 ```
 
 The `<de>`/`<en>` text (required) is shown in the Video column; the Topic column
-is left blank (`—`). `kind` (optional: `"project"`, `"exam"`, …) and `id` are
-informational. An activity-only day satisfies the `--check-workdays` coverage
+is left blank (`—`). `kind` (optional, free-form: `"project"`, `"exam"`,
+`"live"` for a live session with no video, …) and `id` are informational. An activity-only day satisfies the `--check-workdays` coverage
 check and is **not** flagged as an empty day. A subsection may mix `<topic>` and
 `<activity>` children; activity rows render after the day's decks.
 

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -259,7 +259,8 @@ class ActivitySpec:
         text: The bilingual label shown in the Video column of the schedule
             (and as a bullet in the outline).
         kind: Optional free-form classifier (``"project"``, ``"exam"``,
-            ``"holiday"``, …) for styling/filtering. Never affects resolution.
+            ``"holiday"``, ``"live"`` for a live session with no video, …)
+            for styling/filtering. Never affects resolution.
         id: Optional, purely informational identifier.
     """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,6 +196,26 @@ def _isolate_db_path_env():
                 os.environ[key] = value
 
 
+@pytest.fixture(autouse=True)
+def _isolate_sync_engine_env():
+    """Clear ``CLM_SYNC_ENGINE`` for the duration of every test.
+
+    A developer dogfooding the v3 sync engine sets ``CLM_SYNC_ENGINE=v3``
+    session-wide; without isolation that bleeds into every test that exercises
+    the v2 default path (v2-only flags like ``--cache-dir`` are rejected under
+    v3, so a dozen sync CLI tests fail locally while passing in CI). Tests that
+    target a specific engine set the variable explicitly via ``monkeypatch``,
+    which runs after this fixture and is unaffected. Mirrors
+    ``_isolate_db_path_env`` (PR #511).
+    """
+    saved = os.environ.pop("CLM_SYNC_ENGINE", None)
+    try:
+        yield
+    finally:
+        if saved is not None:
+            os.environ["CLM_SYNC_ENGINE"] = saved
+
+
 # ====================================================================
 # Tool Availability Detection
 # ====================================================================


### PR DESCRIPTION
## Summary

- Document `"live"` (live session with no video) as an example `<activity>` `kind` in the `spec-files` info topic and the `ActivitySpec` docstring. The attribute has always been free-form, so this is docs-only — downstream agents authoring course specs asked whether `kind="live"` is accepted, and now the docs answer that directly.
- Drive-by hermeticity fix surfaced by the pre-push suite: a dev shell dogfooding the v3 sync engine exports `CLM_SYNC_ENGINE=v3` session-wide, which bled into 13 sync CLI tests that exercise the v2 default path (v2-only flags like `--cache-dir` are rejected under v3), failing locally while passing in CI. Added an autouse `_isolate_sync_engine_env` fixture in `tests/conftest.py`, mirroring `_isolate_db_path_env` (PR #511). Tests targeting a specific engine still opt in via `monkeypatch`.

## Test plan

- [x] `tests/slides/test_sync_apply_modelfree.py` + `tests/slides/test_sync_ledger.py` pass with `CLM_SYNC_ENGINE=v3` in the shell (70 passed)
- [x] Full fast suite green on the pre-push hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T59zAYneTxPQTYxnwwKBtZ
