### PR TITLE
refactor(slides): extract sync-free doc_identity + doc_write from v3 core (#546 Phase 1)

### DIFF
--- a/changelog.d/546-harvest-phase1-doc-identity.changed.md
+++ b/changelog.d/546-harvest-phase1-doc-identity.changed.md
@@ -1,0 +1,9 @@
+- Carved the sync-free identity/snapshot layer (`clm.slides.doc_identity`:
+  `content_fingerprint`, `pair_signature`, `baseline_from_deck`,
+  `iter_with_groups`, `member_group_token`) and the sync-free write surface
+  (`clm.slides.doc_write`: `DeckEmitter`, `write_changed_files`,
+  `new_companion_path`) out of the v3 sync differ/executor, so non-sync
+  consumers of the bilingual deck model (the upcoming `clm harvest` toolkit,
+  epic #546 Phase 1) can import identity and write files without pulling in
+  `sync_diff` or the ledger. No behavior change; `sync_diff` re-exports the
+  moved names.

--- a/docs/claude/handovers/video-narration-harvest-handover.md
+++ b/docs/claude/handovers/video-narration-harvest-handover.md
@@ -1,6 +1,6 @@
 # Handover: Video Narration Harvest (agent-first rebuild)
 
-**Status**: planning complete, implementation NOT started
+**Status**: Phase 1 implemented (v3 utility extraction); Phases 2–4 TODO
 **Last updated**: 2026-07-04
 **Canonical design source**: `docs/proposals/video-narration-harvest.md`
 (merged via PR #541, decisions folded in via PR #542). Read that proposal
@@ -70,17 +70,25 @@ pivot), #520 (sync-engine-v3), #501 (separated companions);
 
 ## 3. Phase Breakdown
 
-- **Phase 1 [TODO] — v3 utility extraction** (no behavior change).
-  Extract from `src/clm/slides/sync_diff.py` into a sync-free module
-  (working name `src/clm/slides/doc_identity.py`): `content_fingerprint`,
-  `baseline_from_deck` (general structural snapshot), `_iter_with_groups`/
-  `_member_group_token` (the privates `doc_apply.py:61-69` and
-  `doc_ledger.py` import today). Extract from `doc_apply.py` a sync-free
-  write surface: "given a `BilingualDeck` + member edits, emit and
-  atomically write the ≤4 files" without ledger/differ imports. Update
-  `tests/cli/test_sync_import_cleanliness.py` expectations. Acceptance:
-  differ/ledger/apply keep passing; new module importable without pulling
-  in `sync_diff`.
+- **Phase 1 [DONE] — v3 utility extraction** (no behavior change).
+  Landed as two new sync-free modules:
+  - `src/clm/slides/doc_identity.py`: `content_fingerprint`,
+    `pair_signature`, `body_fingerprint`, `lines_fingerprint`,
+    `MemberBaseline`/`DeckBaseline`, `iter_with_groups`,
+    `member_group_token`, `baseline_from_deck`. `sync_diff` imports from it
+    (aliasing the old private names) and keeps re-exporting the public four
+    in `__all__`; `doc_ledger` and `sync_shadow` now import from
+    `doc_identity` directly.
+  - `src/clm/slides/doc_write.py`: `DeckEmitter` (stream view + `emit`/
+    `emit_all` + `set_side`/`stream_remove`/`insert_mirrored`),
+    `DeckWriteError`, `new_companion_path`, `write_changed_files`.
+    `doc_apply._Executor` now subclasses `DeckEmitter` (its `_ItemError`
+    subclasses `DeckWriteError`); the apply write tail calls
+    `write_changed_files`.
+  - Tests: `tests/slides/test_doc_write.py` (byte-identity emission,
+    mutation round-trip, atomic multi-file + minted companion);
+    `tests/cli/test_sync_import_cleanliness.py` extended — the new modules
+    must import neither `sync_diff` nor `doc_ledger` nor the v2 core.
 - **Phase 2 [TODO] — `clm harvest report`** (read-only; can land during v3
   dogfooding). New group + verb wrapping the deterministic pipeline
   (`transcribe`→`detect`→`match`→`align`, cached via
@@ -113,8 +121,9 @@ pivot), #520 (sync-engine-v3), #501 (separated companions);
 - Proposal written, decisions resolved, merged to master
   (`docs/proposals/video-narration-harvest.md`; PRs #541 merged, #542
   merged/auto-merge armed 2026-07-04).
-- **No implementation code exists.** Epic issue: **#546** (phases, settled
-  decisions, and the Phase-3 gate mirrored there).
+- **Phase 1 implemented** (`doc_identity.py` + `doc_write.py`, see §3); no
+  harvest-facing code yet. Epic issue: **#546** (phases, settled decisions,
+  and the Phase-3 gate mirrored there).
 - Blocker for Phase 3 (and arguably 4): sync-engine-v3 must survive its
   **dogfood week on PythonCourses** first (see
   `docs/claude/sync-v3-handover.md`; v3 Phase 4 = flip default, delete v2).
@@ -126,23 +135,24 @@ pivot), #520 (sync-engine-v3), #501 (separated companions);
 
 ## 5. Next Steps
 
-Start **Phase 1**. Prerequisites: none (independent of v3 dogfooding; it
-only moves code). Steps: read `sync_diff.py` fingerprint/snapshot helpers
-(`content_fingerprint`/`_pair_sig`/`_body_fp` ~:153-192,
-`baseline_from_deck` ~:294-347) and the imports at `doc_apply.py:47-70`,
-`doc_ledger.py:47-48`; carve out `doc_identity.py`; then the sync-free
-write surface from `doc_apply` (`emit_all` ~:395, `atomic_write_all`
-~:1312, `_new_companion_path` ~:1360). Gotchas:
+Phase 1 is done (see §3). Next is **Phase 2 — `clm harvest report`**
+(read-only; can land during v3 dogfooding): new CLI group wrapping the
+deterministic pipeline, per-slide JSON keyed by `MemberKey`, reading decks
+through `load_bundle`. Phase 3 stays gated on the v3 dogfood week.
+Gotchas that remain live:
 - `tests/cli/test_sync_import_cleanliness.py` pins the v3 import graph
-  (model must not import v2; facade imports only v3 core) — extend, don't
-  fight it.
+  (model must not import v2; facade imports only v3 core; `doc_identity`/
+  `doc_write` must stay differ/ledger-free) — extend, don't fight it.
 - v2 and v3 coexist behind `CLM_SYNC_ENGINE`; touch only v3 modules.
-- Line numbers here are from the 2026-07-04 investigation; re-verify, the
-  v3 modules are actively changing during dogfooding.
+- The v3 modules are actively changing during dogfooding; re-verify line
+  numbers and shapes before building on them.
 
 ## 6. Key Files & Architecture
 
-Nothing created yet. The map (from the 2026-07-04 investigation):
+Created by Phase 1: `src/clm/slides/doc_identity.py` (identity/snapshot),
+`src/clm/slides/doc_write.py` (emitter + atomic write surface),
+`tests/slides/test_doc_write.py`. The rest of the map (from the 2026-07-04
+investigation):
 
 - **v3 model (reuse)**: `src/clm/slides/bilingual_doc.py` (model: `Member`,
   `MemberKey`, `SideCell`, `BilingualDeck`, `Observation`,

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -45,6 +45,11 @@ from pathlib import Path
 from attrs import define, evolve, field, frozen
 
 from clm.slides.bilingual_doc import BilingualDeck, Lang, Member, SideCell
+from clm.slides.doc_identity import (
+    content_fingerprint,
+    iter_with_groups,
+    member_group_token,
+)
 from clm.slides.doc_ledger import (
     DeckLedger,
     LedgerMember,
@@ -57,15 +62,13 @@ from clm.slides.doc_ledger import (
     snapshot_deck,
 )
 from clm.slides.doc_lenses import LoadedBundle, parse_bundle
+from clm.slides.doc_write import DeckEmitter, DeckWriteError, write_changed_files
 from clm.slides.raw_cells import is_cell_boundary
 from clm.slides.sync_diff import (
     FRAMED_ACTIONS,
     MECHANICAL_ACTIONS,
     DeckDiff,
     DiffItem,
-    _iter_with_groups,
-    _member_group_token,
-    content_fingerprint,
 )
 from clm.slides.sync_writeback import set_header_tags, swap_lang
 
@@ -340,104 +343,22 @@ _RECORD_ONLY = frozenset(
 )
 
 
-class _ItemError(Exception):
+class _ItemError(DeckWriteError):
     """A per-item execution failure: this item fails, others proceed."""
 
 
 @define
-class _Executor:
-    bundle: LoadedBundle
-    deck: BilingualDeck
-    comment_token: str
+class _Executor(DeckEmitter):
+    """The emitter's stream view plus the per-item action methods.
 
-    streams: dict[tuple[Lang, str], list[Member]] = field(factory=dict)
-    preambles: dict[tuple[Lang, str], tuple[str, ...] | None] = field(factory=dict)
-    mutated: bool = False
+    Emission and the generic stream plumbing (``set_side`` /
+    ``stream_remove`` / ``insert_mirrored``) live on
+    :class:`~clm.slides.doc_write.DeckEmitter`; this subclass adds the
+    diff-item executors on top.
+    """
 
-    def __attrs_post_init__(self) -> None:
-        order: dict[tuple[Lang, str], list[tuple[int, Member]]] = {}
-        for member in self.deck.members():
-            for lang in _SIDES:
-                cell = member.side(lang)
-                if cell is not None:
-                    order.setdefault((lang, cell.part), []).append((cell.index, member))
-        self.streams = {
-            key: [m for _, m in sorted(entries, key=lambda e: e[0])]
-            for key, entries in order.items()
-        }
-        for lang in _SIDES:
-            self.streams.setdefault((lang, "deck"), [])
-        self.preambles = {
-            ("de", "deck"): self.deck.de_deck_preamble,
-            ("en", "deck"): self.deck.en_deck_preamble,
-            ("de", "companion"): self.deck.de_companion_preamble,
-            ("en", "companion"): self.deck.en_companion_preamble,
-        }
-
-    # -- emission -----------------------------------------------------------
-
-    def emit(self, lang: Lang, part: str) -> str | None:
-        preamble = self.preambles.get((lang, part))
-        members = self.streams.get((lang, part), [])
-        cells = [c for m in members if (c := m.side(lang)) is not None and c.part == part]
-        if preamble is None:
-            if not cells:
-                return None
-            # A newly created file mirrors its twin's preamble (the jupytext
-            # header block is language-neutral) rather than starting bare.
-            twin_preamble = self.preambles.get((_other(lang), part))
-            preamble = twin_preamble if twin_preamble is not None else ()
-        lines = list(preamble)
-        for cell in cells:
-            lines.extend(cell.lines)
-        return "\n".join(lines)
-
-    def emit_all(self) -> dict[tuple[Lang, str], str | None]:
-        return {
-            (lang, part): self.emit(lang, part) for lang in _SIDES for part in ("deck", "companion")
-        }
-
-    # -- stream plumbing ------------------------------------------------------
-
-    def _set_side(self, member: Member, lang: Lang, cell: SideCell | None) -> None:
-        if lang == "de":
-            member.de = cell
-        else:
-            member.en = cell
-        self.mutated = True
-
-    def _stream_remove(self, lang: Lang, part: str, member: Member) -> None:
-        stream = self.streams.get((lang, part), [])
-        for i, m in enumerate(stream):
-            if m is member:
-                del stream[i]
-                return
-
-    def _insert_mirrored(
-        self, member: Member, source: Lang, target: Lang, part: str, new_cell: SideCell
-    ) -> None:
-        """Insert ``member``'s new ``target`` cell after the mirrored predecessor.
-
-        Walk backwards from the member's position in the *source* stream to
-        the nearest member that also has a cell in the target stream; insert
-        right after it (or at the top of the file when none precedes it).
-        """
-        source_stream = self.streams.get((source, part), [])
-        target_stream = self.streams.setdefault((target, part), [])
-        try:
-            pos = next(i for i, m in enumerate(source_stream) if m is member)
-        except StopIteration:
-            raise _ItemError("the source cell is not in its own stream (executor bug)") from None
-        insert_at = 0
-        for prev in reversed(source_stream[:pos]):
-            for j, m in enumerate(target_stream):
-                if m is prev:
-                    insert_at = j + 1
-                    break
-            if insert_at:
-                break
-        target_stream.insert(insert_at, member)
-        self._set_side(member, target, new_cell)
+    bundle: LoadedBundle = field(kw_only=True)
+    comment_token: str = field(kw_only=True)
 
     @staticmethod
     def _holder(item: DiffItem, lang: Lang) -> Member | None:
@@ -510,7 +431,7 @@ class _Executor:
         _, moved = self._moved_cell(item, source)
         twin_member, twin_cell = self._locate_twin(item, _other(source))
         new_lines = _with_slide_id_of(moved.lines, twin_cell.header)
-        self._set_side(twin_member, _other(source), evolve(twin_cell, lines=new_lines))
+        self.set_side(twin_member, _other(source), evolve(twin_cell, lines=new_lines))
 
     def copy_new(self, item: DiffItem, source: Lang) -> None:
         member, moved = self._moved_cell(item, source)
@@ -518,7 +439,7 @@ class _Executor:
         if member.side(target) is not None:
             raise _ItemError(f"the {target} side of {item.key} already exists")
         new_cell = evolve(moved, lines=moved.lines)
-        self._insert_mirrored(member, source, target, moved.part, new_cell)
+        self.insert_mirrored(member, source, target, moved.part, new_cell)
 
     def mirror_remove(self, item: DiffItem, gone: Lang) -> None:
         present = _other(gone)
@@ -530,14 +451,14 @@ class _Executor:
                     f"the surviving {present} side of {item.key} moved off base "
                     f"since the diff — re-run report"
                 )
-        self._stream_remove(present, cell.part, member)
-        self._set_side(member, present, None)
+        self.stream_remove(present, cell.part, member)
+        self.set_side(member, present, None)
 
     def mirror_tags(self, item: DiffItem, source: Lang) -> None:
         _, moved = self._moved_cell(item, source)
         twin_member, twin_cell = self._locate_twin(item, _other(source))
         new_header = set_header_tags(twin_cell.header, moved.tags)
-        self._set_side(
+        self.set_side(
             twin_member,
             _other(source),
             evolve(twin_cell, lines=(new_header, *twin_cell.lines[1:]), tags=moved.tags),
@@ -554,7 +475,7 @@ class _Executor:
         if twin_cell.slide_id is not None:
             raise _ItemError(f"the {unstamped} side of {item.key} already carries an id")
         new_header = twin_cell.header.rstrip() + f' slide_id="{idd_cell.slide_id}"'
-        self._set_side(
+        self.set_side(
             member,
             unstamped,
             evolve(
@@ -568,7 +489,7 @@ class _Executor:
         _, moved = self._moved_cell(item, source)
         twin_member, twin_cell = self._locate_twin(item, _other(source))
         new_header = _set_for_slide(twin_cell.header, moved.for_slide)
-        self._set_side(
+        self.set_side(
             twin_member,
             _other(source),
             evolve(
@@ -609,8 +530,8 @@ class _Executor:
         if target_part == "companion" and self.preambles.get((twin_lang, "companion")) is None:
             mirror = self.preambles.get((moved_side, "companion"))
             self.preambles[(twin_lang, "companion")] = mirror if mirror is not None else ()
-        self._stream_remove(twin_lang, twin.part, member)
-        self._insert_mirrored(member, moved_side, twin_lang, target_part, new_cell)
+        self.stream_remove(twin_lang, twin.part, member)
+        self.insert_mirrored(member, moved_side, twin_lang, target_part, new_cell)
 
     def propagate_preamble(self, item: DiffItem, source: Lang) -> None:
         part = item.key.rsplit("/", 2)[1]  # pos:~preamble/<part>/0
@@ -648,10 +569,10 @@ class _Executor:
 
     def _pool_members(self, group: str, kind: str, lang: Lang) -> list[Member]:
         members: list[tuple[int, Member]] = []
-        for member, owner_group in _iter_with_groups(self.deck):
+        for member, owner_group in iter_with_groups(self.deck):
             if member.key.scheme != "pos" or member.kind != kind:
                 continue
-            if _member_group_token(member, owner_group) != group:
+            if member_group_token(member, owner_group) != group:
                 continue
             cell = member.side(lang)
             if cell is not None:
@@ -706,10 +627,10 @@ class _Executor:
     def _mirror_scope_order(self, group: str, part: str, source: Lang) -> None:
         target = _other(source)
         scope: dict[Lang, list[Member]] = {"de": [], "en": []}
-        for member, owner_group in _iter_with_groups(self.deck):
+        for member, owner_group in iter_with_groups(self.deck):
             if member.key.scheme != "id":
                 continue
-            if _member_group_token(member, owner_group) != group:
+            if member_group_token(member, owner_group) != group:
                 continue
             for lang in _SIDES:
                 cell = member.side(lang)
@@ -779,8 +700,8 @@ class _Executor:
         # Validate before mutating: a failed item must be a strict no-op.
         if not any(m is member for m in self.streams.get((source, cell.part), [])):
             raise _ItemError(f"the moved {source} cell of {item.key} is unlocatable")
-        self._stream_remove(target, cell.part, member)
-        self._insert_mirrored(member, source, target, cell.part, cell)
+        self.stream_remove(target, cell.part, member)
+        self.insert_mirrored(member, source, target, cell.part, cell)
 
 
 # ---------------------------------------------------------------------------
@@ -990,7 +911,7 @@ def _apply_body_decision(ex: _Executor, item: DiffItem, body: str) -> None:
     if item.action == "translate_edit":
         target = _decision_target_side(item)
         twin_member, twin_cell = ex._locate_twin(item, target)
-        ex._set_side(twin_member, target, evolve(twin_cell, lines=_replace_body(twin_cell, body)))
+        ex.set_side(twin_member, target, evolve(twin_cell, lines=_replace_body(twin_cell, body)))
         return
     if item.action == "translate_new":
         if member is None:
@@ -1010,7 +931,7 @@ def _apply_body_decision(ex: _Executor, item: DiffItem, body: str) -> None:
             lines=_replace_body(evolve(source_cell, lines=(header, *source_cell.lines[1:])), body),
             lang_attr=target if source_cell.lang_attr else None,
         )
-        ex._insert_mirrored(member, source, target, source_cell.part, new_cell)
+        ex.insert_mirrored(member, source, target, source_cell.part, new_cell)
         return
     if item.action in ("conflict_shared", "unify_choose_body", "remove_localized_side"):
         if member is None:
@@ -1027,14 +948,14 @@ def _apply_body_decision(ex: _Executor, item: DiffItem, body: str) -> None:
             header = swap_lang(source_cell.header, gone)
             base = evolve(source_cell, lines=(header, *source_cell.lines[1:]))
             new_cell = evolve(base, lines=_replace_body(base, body), lang_attr=gone)
-            ex._insert_mirrored(member, surviving, gone, source_cell.part, new_cell)
+            ex.insert_mirrored(member, surviving, gone, source_cell.part, new_cell)
             return
         for lang in _SIDES:
             holder = ex._holder(item, lang)
             cell = holder.side(lang) if holder is not None else None
             if holder is None or cell is None:
                 raise _ItemError(f"the {lang} side of {item.key} is missing")
-            ex._set_side(holder, lang, evolve(cell, lines=_replace_body(cell, body)))
+            ex.set_side(holder, lang, evolve(cell, lines=_replace_body(cell, body)))
         return
     raise _ItemError(f"'{item.action}' does not accept a body answer")
 
@@ -1066,7 +987,7 @@ def _apply_choice_decision(ex: _Executor, item: DiffItem, choice: str) -> None:
         if action == "unify_choose_body":
             _, chosen = ex._moved_cell(item, side)
             twin_holder, twin = ex._locate_twin(item, _other(side))
-            ex._set_side(
+            ex.set_side(
                 twin_holder, _other(side), evolve(twin, lines=_replace_body(twin, chosen.body))
             )
             return
@@ -1074,7 +995,7 @@ def _apply_choice_decision(ex: _Executor, item: DiffItem, choice: str) -> None:
             _, chosen = ex._moved_cell(item, side)
             twin_holder, twin = ex._locate_twin(item, _other(side))
             header = _set_for_slide(twin.header, chosen.for_slide)
-            ex._set_side(
+            ex.set_side(
                 twin_holder,
                 _other(side),
                 evolve(twin, lines=(header, *twin.lines[1:]), for_slide=chosen.for_slide),
@@ -1101,8 +1022,8 @@ def _apply_choice_decision(ex: _Executor, item: DiffItem, choice: str) -> None:
         cell = holder.side(survivor) if holder is not None else None
         if holder is None or cell is None:
             raise _ItemError(f"{item.key} has no remaining cell to remove")
-        ex._stream_remove(survivor, cell.part, holder)
-        ex._set_side(holder, survivor, None)
+        ex.stream_remove(survivor, cell.part, holder)
+        ex.set_side(holder, survivor, None)
         return
     if choice == "keep":
         # remove_vs_edit: keep the edited survivor and re-add it on the twin.
@@ -1247,7 +1168,7 @@ def apply_deck(
                         item.detail,
                     )
                 )
-        except _ItemError as exc:
+        except DeckWriteError as exc:
             status = "rejected" if decision is not None else "failed"
             unresolved_items.append(item)
             outcome.results.append(ItemResult(item.key, item.action, status, str(exc)))
@@ -1294,32 +1215,12 @@ def apply_deck(
         return outcome
 
     if changed:
-        writes: list[tuple[Path, str]] = []
-        paths = {
-            ("de", "deck"): bundle.de_path,
-            ("en", "deck"): bundle.en_path,
-            ("de", "companion"): bundle.de_companion_path,
-            ("en", "companion"): bundle.en_companion_path,
-        }
-        for file_key in sorted(changed, key=str):
-            text = finals[file_key]
-            path = paths.get(file_key)
-            if text is None:
-                continue  # never delete a file; layout removals empty it instead
-            if path is None:
-                path = _new_companion_path(bundle, file_key[0])
-            writes.append((path, text))
-        from clm.infrastructure.utils.path_utils import atomic_write_all
-
         try:
-            for path, _text in writes:
-                path.parent.mkdir(parents=True, exist_ok=True)
-            atomic_write_all(writes)
+            outcome.written_paths = write_changed_files(bundle, finals, changed)
         except OSError as exc:
             outcome.error = f"write failed: {exc}"
             return outcome
         outcome.wrote = True
-        outcome.written_paths = [p for p, _ in writes]
 
     # Ledger updates for landed items — renames/migrations first, then the rest.
     fresh = snapshot_deck(final_deck, provenance="apply", commit=commit)
@@ -1355,11 +1256,3 @@ def _incoherent_pool_confirms(
             cold_by_pool.setdefault(pool, set()).add(item.key)
     confirmed = {key for key, decision in decisions.items() if decision.choice == "confirm"}
     return {pool for pool, keys in cold_by_pool.items() if not keys <= confirmed}
-
-
-def _new_companion_path(bundle: LoadedBundle, lang: Lang) -> Path:
-    """Where a newly created companion file goes (standard subdir layout)."""
-    from clm.slides.voiceover_tools import COMPANION_SUBDIR, companion_name
-
-    deck_path = bundle.de_path if lang == "de" else bundle.en_path
-    return deck_path.parent / COMPANION_SUBDIR / companion_name(deck_path)

--- a/src/clm/slides/doc_identity.py
+++ b/src/clm/slides/doc_identity.py
@@ -1,0 +1,246 @@
+"""Sync-free identity and snapshot utilities for the v3 deck model (#546 Phase 1).
+
+The fingerprint functions and the structural baseline snapshot were born
+inside the v3 differ (:mod:`clm.slides.sync_diff`) but are not diff logic:
+they define *what a member's identity and recorded state are*, which every
+consumer of the :class:`~clm.slides.bilingual_doc.BilingualDeck` model that
+mutates or records deck state needs — the sync ledger, the apply executor,
+and the ``clm harvest`` toolkit. This module carves them out so those
+consumers can import identity without pulling in the differ.
+
+Contents:
+
+* :func:`content_fingerprint` / :func:`pair_signature` /
+  :func:`body_fingerprint` / :func:`lines_fingerprint` — the hashing forms
+  the ledger records (versioned by
+  :data:`~clm.slides.doc_ledger.LEDGER_HASH_VERSION`).
+* :class:`MemberBaseline` / :class:`DeckBaseline` — one member's / one
+  deck's recorded state (design §5 / §6.1).
+* :func:`iter_with_groups` / :func:`member_group_token` — the canonical
+  walk over a deck's unified member stream with each member's group token.
+* :func:`baseline_from_deck` — snapshot a parsed deck as a complete
+  baseline.
+
+This module is pure (no I/O, no git) and must not import from the v2 sync
+core (``sync_plan`` / ``sync_apply`` / ``sync_code``) **nor from the v3
+differ** (``sync_diff``) — enforced by the import-cleanliness tests
+(design §12.5).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Iterator
+
+from attrs import define, field, frozen
+
+from clm.slides.bilingual_doc import (
+    HEADER_GROUP,
+    ORPHAN_GROUP,
+    BilingualDeck,
+    Lang,
+    Member,
+    SideCell,
+)
+from clm.slides.doc_lenses import _lines_sans_id
+
+__all__ = [
+    "DeckBaseline",
+    "MemberBaseline",
+    "baseline_from_deck",
+    "body_fingerprint",
+    "content_fingerprint",
+    "iter_with_groups",
+    "lines_fingerprint",
+    "member_group_token",
+    "pair_signature",
+]
+
+_SIDES: tuple[Lang, Lang] = ("de", "en")
+
+
+def content_fingerprint(cell: SideCell) -> str:
+    """The cell's byte fingerprint, modulo the ``slide_id`` attribute.
+
+    Covers every byte the projection emits (header attrs, body, trailing
+    separator lines) except the id attribute — the same parity rule the
+    lens applies to shared members, so an id stamp is a §7.3 transition,
+    never a content change. This is the fingerprint the ledger records.
+    """
+    return hashlib.sha256("\n".join(_lines_sans_id(cell)).encode("utf-8")).hexdigest()
+
+
+# The for_slide attribute, stripped alongside slide_id for the owner-free
+# signature: an owner re-home (or a group rename cascading into for_slide)
+# must not read as a content edit.
+_FOR_SLIDE_ATTR_RE = re.compile(r'\s*for_slide="[^"]*"')
+
+
+def pair_signature(cell: SideCell) -> str:
+    """The content fingerprint additionally modulo the ``for_slide`` attribute.
+
+    Everything except identity (slide_id) and ownership (for_slide) —
+    body, tags, lang attr, vo_anchor, unknown header attrs, separator
+    bytes. When this signature is base-identical on both sides, the only
+    thing that can have moved is the owner reference, which has its own
+    rows — so the content classification can be skipped without silencing
+    any other one-sided drift (the review's early-return finding).
+    """
+    lines = _lines_sans_id(cell)
+    header = _FOR_SLIDE_ATTR_RE.sub("", lines[0])
+    return hashlib.sha256("\n".join((header, *lines[1:])).encode("utf-8")).hexdigest()
+
+
+def body_fingerprint(cell: SideCell) -> str:
+    return hashlib.sha256(cell.body.encode("utf-8")).hexdigest()
+
+
+def lines_fingerprint(lines: tuple[str, ...] | None) -> str | None:
+    if lines is None:
+        return None
+    return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# The baseline
+# ---------------------------------------------------------------------------
+
+
+@frozen
+class MemberBaseline:
+    """One member's recorded state (design §5 entry, engine view).
+
+    ``de_fp`` / ``en_fp`` are per-side content fingerprints (``None`` = the
+    side was absent). A shared member normally records one value in both.
+    Tags and body fingerprints are carried separately so the classifier can
+    name the changed aspect without re-reading base bytes.
+    """
+
+    key: str  # rendered MemberKey
+    langness: str  # shared | localized
+    layout: str  # inline | companion
+    kind: str
+    role: str
+    owner: str | None  # rendered owner MemberKey
+    de_fp: str | None
+    en_fp: str | None
+    de_body_fp: str | None
+    en_body_fp: str | None
+    de_tags: tuple[str, ...] | None
+    en_tags: tuple[str, ...] | None
+    de_sig: str | None = None  # owner-free signature (see pair_signature)
+    en_sig: str | None = None
+
+    def side_fp(self, lang: Lang) -> str | None:
+        return self.de_fp if lang == "de" else self.en_fp
+
+    def side_sig(self, lang: Lang) -> str | None:
+        return self.de_sig if lang == "de" else self.en_sig
+
+    @property
+    def one_sided(self) -> bool:
+        return (self.de_fp is None) != (self.en_fp is None)
+
+
+@define
+class DeckBaseline:
+    """The recorded state of one deck: member entries plus order context.
+
+    ``complete`` distinguishes a *snapshot* (parsed from a git ref or the
+    Phase 2 shadow input — every member of the base state is present, so a
+    current member with no entry is genuinely **new**) from a *ledger*
+    (entries accumulate per verified member — a missing entry is **cold**,
+    an ``unverified`` framed item, design §5).
+    """
+
+    members: dict[str, MemberBaseline] = field(factory=dict)
+    #: anchor ids in base document order (rename detection)
+    group_order: list[str] = field(factory=list)
+    #: per side: anchor ids in that side's file order (order diff — per
+    #: side, never the DE-biased merged order)
+    group_order_by_side: dict[Lang, list[str]] = field(factory=dict)
+    #: per (lang, group, part): ID-KEYED member handles in that side's file
+    #: order. Positional handles are excluded — their ordinals renumber on
+    #: any insert/remove, so they alias different cells across states (the
+    #: pool alignment owns their order instead).
+    member_order: dict[tuple[Lang, str, str], list[str]] = field(factory=dict)
+    #: per (lang, part): preamble fingerprint (None = file absent at base)
+    preamble_fps: dict[tuple[str, str], str | None] = field(factory=dict)
+    complete: bool = True
+
+
+def member_group_token(member: Member, owner_group: str) -> str:
+    if member.key.scheme == "pos":
+        # rsplit: a group token may itself contain "/" (ids are free-form)
+        return member.key.value.rsplit("/", 2)[0]
+    return owner_group
+
+
+def iter_with_groups(deck: BilingualDeck) -> Iterator[tuple[Member, str]]:
+    """Yield ``(member, group_token)`` over the whole document."""
+    for member in deck.header:
+        yield member, HEADER_GROUP
+    for group in deck.groups:
+        if group.anchor is not None:
+            yield group.anchor, group.anchor_id
+        for member in group.members:
+            yield member, group.anchor_id
+    for member in deck.orphans:
+        yield member, ORPHAN_GROUP
+
+
+def baseline_from_deck(deck: BilingualDeck) -> DeckBaseline:
+    """Snapshot a parsed deck as a complete baseline (design §6.1).
+
+    This is how the Phase 2 shadow mode and the ``--since`` forensic view
+    obtain a base: parse the bundle at the base ref and record every
+    member's state. Phase 3 constructs the same shape from the ledger with
+    ``complete=False``.
+    """
+    base = DeckBaseline(complete=True)
+    order: dict[tuple[Lang, str, str], list[tuple[int, str]]] = {}
+    for member, group_token in iter_with_groups(deck):
+        entry = MemberBaseline(
+            key=member.key.render(),
+            langness=member.langness,
+            layout=member.layout,
+            kind=member.kind,
+            role=member.role,
+            owner=member.owner.render() if member.owner else None,
+            de_fp=content_fingerprint(member.de) if member.de else None,
+            en_fp=content_fingerprint(member.en) if member.en else None,
+            de_body_fp=body_fingerprint(member.de) if member.de else None,
+            en_body_fp=body_fingerprint(member.en) if member.en else None,
+            de_tags=member.de.tags if member.de else None,
+            en_tags=member.en.tags if member.en else None,
+            de_sig=pair_signature(member.de) if member.de else None,
+            en_sig=pair_signature(member.en) if member.en else None,
+        )
+        base.members[entry.key] = entry
+        if member.key.scheme != "id":
+            continue  # pos handles alias across states — never order-tracked
+        for lang in _SIDES:
+            cell = member.side(lang)
+            if cell is not None:
+                order.setdefault((lang, group_token, cell.part), []).append((cell.index, entry.key))
+    base.member_order = {
+        key: [handle for _, handle in sorted(entries)] for key, entries in order.items()
+    }
+    base.group_order = [g.anchor_id for g in deck.groups]
+    for lang in _SIDES:
+        seq: list[tuple[int, str]] = []
+        for group in deck.groups:
+            if group.anchor is None:
+                continue
+            cell = group.anchor.side(lang)
+            if cell is not None and cell.part == "deck":
+                seq.append((cell.index, group.anchor_id))
+        base.group_order_by_side[lang] = [gid for _, gid in sorted(seq)]
+    base.preamble_fps = {
+        ("de", "deck"): lines_fingerprint(deck.de_deck_preamble),
+        ("en", "deck"): lines_fingerprint(deck.en_deck_preamble),
+        ("de", "companion"): lines_fingerprint(deck.de_companion_preamble),
+        ("en", "companion"): lines_fingerprint(deck.en_companion_preamble),
+    }
+    return base

--- a/src/clm/slides/doc_ledger.py
+++ b/src/clm/slides/doc_ledger.py
@@ -20,7 +20,7 @@ Phase 4 deletes the v1 sections with the v2 core.
 
 * A member with **no entry is cold** — the differ reports it ``unverified``
   with a framed verification task, never a silent assumption. This is what
-  :attr:`~clm.slides.sync_diff.DeckBaseline.complete` ``= False`` encodes.
+  :attr:`~clm.slides.doc_identity.DeckBaseline.complete` ``= False`` encodes.
 * **Stale = fingerprint mismatch** — fail-safe by construction: a drifted
   member produces a re-check item.
 * ``hash_version`` gates every entry: an entry recorded under an older
@@ -45,7 +45,7 @@ from pathlib import Path
 from attrs import define, field, frozen
 
 from clm.slides.bilingual_doc import BilingualDeck, Lang
-from clm.slides.sync_diff import DeckBaseline, MemberBaseline, baseline_from_deck
+from clm.slides.doc_identity import DeckBaseline, MemberBaseline, baseline_from_deck
 
 __all__ = [
     "LEDGER_FILENAME",
@@ -67,7 +67,7 @@ __all__ = [
 #: with the v1 payload preserved; schema 2 carries both engines' sections.
 SCHEMA_VERSION = 2
 
-#: Version of the v3 fingerprint functions (:func:`~clm.slides.sync_diff.content_fingerprint`
+#: Version of the v3 fingerprint functions (:func:`~clm.slides.doc_identity.content_fingerprint`
 #: and friends). Bump when the hashing form changes; entries recorded under an
 #: older version drop to cold at load (§5's lazy migration rule, #458).
 LEDGER_HASH_VERSION = 1
@@ -87,7 +87,7 @@ _SIDES: tuple[Lang, Lang] = ("de", "en")
 class LedgerMember:
     """One member's recorded §5 entry: the engine view plus trust metadata.
 
-    ``entry`` is the exact :class:`~clm.slides.sync_diff.MemberBaseline` the
+    ``entry`` is the exact :class:`~clm.slides.doc_identity.MemberBaseline` the
     differ compares against — fingerprints per side, tags, owner-free
     signatures. ``provenance`` records *who* asserted the verification
     (``apply`` / ``accept`` / ``record`` / ``agent`` / ``semantic:<model>``),
@@ -107,7 +107,7 @@ class LedgerMember:
 class DeckLedger:
     """The recorded state of one deck bundle inside its topic ledger.
 
-    Mirrors :class:`~clm.slides.sync_diff.DeckBaseline` (members + order
+    Mirrors :class:`~clm.slides.doc_identity.DeckBaseline` (members + order
     context) with per-member trust metadata. Order context is recorded when
     the corresponding scope was verified (a full ``record``, or an applied
     order item) — a scope with no recorded order simply contributes no order

--- a/src/clm/slides/doc_write.py
+++ b/src/clm/slides/doc_write.py
@@ -1,0 +1,196 @@
+"""Sync-free write surface for the v3 deck model (#546 Phase 1).
+
+The emission and file-write half of the apply executor
+(:mod:`clm.slides.doc_apply`), carved out so any consumer of the
+:class:`~clm.slides.bilingual_doc.BilingualDeck` model — the sync executor
+today, the ``clm harvest`` accept verb next — can mutate members in memory
+and land the result on disk without importing the differ or the ledger.
+
+The contract ("given a ``BilingualDeck`` + member edits, emit and atomically
+write the ≤4 files"):
+
+* :class:`DeckEmitter` holds a per-``(lang, part)`` cell-stream view of the
+  parsed deck; unmutated cells re-emit their verbatim bytes (the lens
+  guarantee lifted into the writer — emission is preamble + concatenated
+  cell lines, exactly what :func:`~clm.slides.doc_lenses.project` produces).
+* Callers snapshot :meth:`DeckEmitter.emit_all` before mutating, mutate
+  through :meth:`~DeckEmitter.set_side` / :meth:`~DeckEmitter.stream_remove`
+  / :meth:`~DeckEmitter.insert_mirrored`, emit again, and re-parse the
+  mutated bundle (:func:`~clm.slides.doc_lenses.parse_bundle`) before
+  anything touches disk — a writer must never write a bundle the lens
+  cannot read back.
+* :func:`write_changed_files` lands the changed emissions through
+  :func:`~clm.infrastructure.utils.path_utils.atomic_write_all` (≤4 files
+  per deck), minting a companion path for a file the bundle did not have.
+
+This module must not import from the v2 sync core (``sync_plan`` /
+``sync_apply`` / ``sync_code``) nor from the v3 differ/ledger
+(``sync_diff`` / ``doc_ledger``) — enforced by the import-cleanliness
+tests (design §12.5).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from attrs import define, field
+
+from clm.slides.bilingual_doc import BilingualDeck, Lang, Member, SideCell
+from clm.slides.doc_lenses import LoadedBundle
+
+__all__ = [
+    "DeckEmitter",
+    "DeckWriteError",
+    "new_companion_path",
+    "write_changed_files",
+]
+
+_SIDES: tuple[Lang, Lang] = ("de", "en")
+
+
+class DeckWriteError(Exception):
+    """A deck mutation/emission failure the caller must handle per item."""
+
+
+def _other(lang: Lang) -> Lang:
+    return "en" if lang == "de" else "de"
+
+
+@define
+class DeckEmitter:
+    """A mutable per-``(lang, part)`` cell-stream view of a parsed deck."""
+
+    deck: BilingualDeck
+
+    streams: dict[tuple[Lang, str], list[Member]] = field(factory=dict)
+    preambles: dict[tuple[Lang, str], tuple[str, ...] | None] = field(factory=dict)
+    mutated: bool = False
+
+    def __attrs_post_init__(self) -> None:
+        order: dict[tuple[Lang, str], list[tuple[int, Member]]] = {}
+        for member in self.deck.members():
+            for lang in _SIDES:
+                cell = member.side(lang)
+                if cell is not None:
+                    order.setdefault((lang, cell.part), []).append((cell.index, member))
+        self.streams = {
+            key: [m for _, m in sorted(entries, key=lambda e: e[0])]
+            for key, entries in order.items()
+        }
+        for lang in _SIDES:
+            self.streams.setdefault((lang, "deck"), [])
+        self.preambles = {
+            ("de", "deck"): self.deck.de_deck_preamble,
+            ("en", "deck"): self.deck.en_deck_preamble,
+            ("de", "companion"): self.deck.de_companion_preamble,
+            ("en", "companion"): self.deck.en_companion_preamble,
+        }
+
+    # -- emission -----------------------------------------------------------
+
+    def emit(self, lang: Lang, part: str) -> str | None:
+        preamble = self.preambles.get((lang, part))
+        members = self.streams.get((lang, part), [])
+        cells = [c for m in members if (c := m.side(lang)) is not None and c.part == part]
+        if preamble is None:
+            if not cells:
+                return None
+            # A newly created file mirrors its twin's preamble (the jupytext
+            # header block is language-neutral) rather than starting bare.
+            twin_preamble = self.preambles.get((_other(lang), part))
+            preamble = twin_preamble if twin_preamble is not None else ()
+        lines = list(preamble)
+        for cell in cells:
+            lines.extend(cell.lines)
+        return "\n".join(lines)
+
+    def emit_all(self) -> dict[tuple[Lang, str], str | None]:
+        return {
+            (lang, part): self.emit(lang, part) for lang in _SIDES for part in ("deck", "companion")
+        }
+
+    # -- stream plumbing ------------------------------------------------------
+
+    def set_side(self, member: Member, lang: Lang, cell: SideCell | None) -> None:
+        if lang == "de":
+            member.de = cell
+        else:
+            member.en = cell
+        self.mutated = True
+
+    def stream_remove(self, lang: Lang, part: str, member: Member) -> None:
+        stream = self.streams.get((lang, part), [])
+        for i, m in enumerate(stream):
+            if m is member:
+                del stream[i]
+                return
+
+    def insert_mirrored(
+        self, member: Member, source: Lang, target: Lang, part: str, new_cell: SideCell
+    ) -> None:
+        """Insert ``member``'s new ``target`` cell after the mirrored predecessor.
+
+        Walk backwards from the member's position in the *source* stream to
+        the nearest member that also has a cell in the target stream; insert
+        right after it (or at the top of the file when none precedes it).
+        """
+        source_stream = self.streams.get((source, part), [])
+        target_stream = self.streams.setdefault((target, part), [])
+        try:
+            pos = next(i for i, m in enumerate(source_stream) if m is member)
+        except StopIteration:
+            raise DeckWriteError("the source cell is not in its own stream (writer bug)") from None
+        insert_at = 0
+        for prev in reversed(source_stream[:pos]):
+            for j, m in enumerate(target_stream):
+                if m is prev:
+                    insert_at = j + 1
+                    break
+            if insert_at:
+                break
+        target_stream.insert(insert_at, member)
+        self.set_side(member, target, new_cell)
+
+
+def new_companion_path(bundle: LoadedBundle, lang: Lang) -> Path:
+    """Where a newly created companion file goes (standard subdir layout)."""
+    from clm.slides.voiceover_tools import COMPANION_SUBDIR, companion_name
+
+    deck_path = bundle.de_path if lang == "de" else bundle.en_path
+    return deck_path.parent / COMPANION_SUBDIR / companion_name(deck_path)
+
+
+def write_changed_files(
+    bundle: LoadedBundle,
+    finals: dict[tuple[Lang, str], str | None],
+    changed: set[tuple[Lang, str]],
+) -> list[Path]:
+    """Atomically land the ``changed`` emissions of a bundle on disk.
+
+    A ``None`` emission is skipped — a writer never deletes a file; layout
+    removals empty it instead. A changed file the bundle has no path for
+    (a freshly minted companion) goes to :func:`new_companion_path`.
+    Raises :class:`OSError` on write failure; nothing is partially written
+    (the ``atomic_write_all`` boundary ``split``/``unify`` also use).
+    """
+    from clm.infrastructure.utils.path_utils import atomic_write_all
+
+    writes: list[tuple[Path, str]] = []
+    paths: dict[tuple[Lang, str], Path | None] = {
+        ("de", "deck"): bundle.de_path,
+        ("en", "deck"): bundle.en_path,
+        ("de", "companion"): bundle.de_companion_path,
+        ("en", "companion"): bundle.en_companion_path,
+    }
+    for file_key in sorted(changed, key=str):
+        text = finals[file_key]
+        path = paths.get(file_key)
+        if text is None:
+            continue  # never delete a file; layout removals empty it instead
+        if path is None:
+            path = new_companion_path(bundle, file_key[0])
+        writes.append((path, text))
+    for path, _text in writes:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_all(writes)
+    return [p for p, _ in writes]

--- a/src/clm/slides/sync_diff.py
+++ b/src/clm/slides/sync_diff.py
@@ -41,8 +41,6 @@ import-cleanliness test (design §12.5).
 
 from __future__ import annotations
 
-import hashlib
-import re
 from collections import Counter
 from difflib import SequenceMatcher
 from typing import Literal
@@ -50,7 +48,6 @@ from typing import Literal
 from attrs import define, field, frozen
 
 from clm.slides.bilingual_doc import (
-    HEADER_GROUP,
     ORPHAN_GROUP,
     BilingualDeck,
     Lang,
@@ -61,7 +58,30 @@ from clm.slides.bilingual_doc import (
     ParseOutcome,
     SideCell,
 )
-from clm.slides.doc_lenses import _lines_sans_id
+
+# The identity/snapshot layer lived here until #546 Phase 1 carved it out;
+# the names stay re-exported (see __all__) for the differ's callers.
+from clm.slides.doc_identity import (
+    DeckBaseline,
+    MemberBaseline,
+    baseline_from_deck,
+    content_fingerprint,
+)
+from clm.slides.doc_identity import (
+    body_fingerprint as _body_fp,
+)
+from clm.slides.doc_identity import (
+    iter_with_groups as _iter_with_groups,
+)
+from clm.slides.doc_identity import (
+    lines_fingerprint as _lines_fp,
+)
+from clm.slides.doc_identity import (
+    member_group_token as _member_group_token,
+)
+from clm.slides.doc_identity import (
+    pair_signature as _pair_sig,
+)
 
 _SIDES: tuple[Lang, Lang] = ("de", "en")
 
@@ -150,116 +170,6 @@ FRAMED_ACTIONS = frozenset(
 )
 
 
-def content_fingerprint(cell: SideCell) -> str:
-    """The cell's byte fingerprint, modulo the ``slide_id`` attribute.
-
-    Covers every byte the projection emits (header attrs, body, trailing
-    separator lines) except the id attribute — the same parity rule the
-    lens applies to shared members, so an id stamp is a §7.3 transition,
-    never a content change. This is the fingerprint the ledger records.
-    """
-    return hashlib.sha256("\n".join(_lines_sans_id(cell)).encode("utf-8")).hexdigest()
-
-
-# The for_slide attribute, stripped alongside slide_id for the owner-free
-# signature: an owner re-home (or a group rename cascading into for_slide)
-# must not read as a content edit.
-_FOR_SLIDE_ATTR_RE = re.compile(r'\s*for_slide="[^"]*"')
-
-
-def _pair_sig(cell: SideCell) -> str:
-    """The content fingerprint additionally modulo the ``for_slide`` attribute.
-
-    Everything except identity (slide_id) and ownership (for_slide) —
-    body, tags, lang attr, vo_anchor, unknown header attrs, separator
-    bytes. When this signature is base-identical on both sides, the only
-    thing that can have moved is the owner reference, which has its own
-    rows — so the content classification can be skipped without silencing
-    any other one-sided drift (the review's early-return finding).
-    """
-    lines = _lines_sans_id(cell)
-    header = _FOR_SLIDE_ATTR_RE.sub("", lines[0])
-    return hashlib.sha256("\n".join((header, *lines[1:])).encode("utf-8")).hexdigest()
-
-
-def _body_fp(cell: SideCell) -> str:
-    return hashlib.sha256(cell.body.encode("utf-8")).hexdigest()
-
-
-def _lines_fp(lines: tuple[str, ...] | None) -> str | None:
-    if lines is None:
-        return None
-    return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
-
-
-# ---------------------------------------------------------------------------
-# The baseline
-# ---------------------------------------------------------------------------
-
-
-@frozen
-class MemberBaseline:
-    """One member's recorded state (design §5 entry, engine view).
-
-    ``de_fp`` / ``en_fp`` are per-side content fingerprints (``None`` = the
-    side was absent). A shared member normally records one value in both.
-    Tags and body fingerprints are carried separately so the classifier can
-    name the changed aspect without re-reading base bytes.
-    """
-
-    key: str  # rendered MemberKey
-    langness: str  # shared | localized
-    layout: str  # inline | companion
-    kind: str
-    role: str
-    owner: str | None  # rendered owner MemberKey
-    de_fp: str | None
-    en_fp: str | None
-    de_body_fp: str | None
-    en_body_fp: str | None
-    de_tags: tuple[str, ...] | None
-    en_tags: tuple[str, ...] | None
-    de_sig: str | None = None  # owner-free signature (see _pair_sig)
-    en_sig: str | None = None
-
-    def side_fp(self, lang: Lang) -> str | None:
-        return self.de_fp if lang == "de" else self.en_fp
-
-    def side_sig(self, lang: Lang) -> str | None:
-        return self.de_sig if lang == "de" else self.en_sig
-
-    @property
-    def one_sided(self) -> bool:
-        return (self.de_fp is None) != (self.en_fp is None)
-
-
-@define
-class DeckBaseline:
-    """The recorded state of one deck: member entries plus order context.
-
-    ``complete`` distinguishes a *snapshot* (parsed from a git ref or the
-    Phase 2 shadow input — every member of the base state is present, so a
-    current member with no entry is genuinely **new**) from a *ledger*
-    (entries accumulate per verified member — a missing entry is **cold**,
-    an ``unverified`` framed item, design §5).
-    """
-
-    members: dict[str, MemberBaseline] = field(factory=dict)
-    #: anchor ids in base document order (rename detection)
-    group_order: list[str] = field(factory=list)
-    #: per side: anchor ids in that side's file order (order diff — per
-    #: side, never the DE-biased merged order)
-    group_order_by_side: dict[Lang, list[str]] = field(factory=dict)
-    #: per (lang, group, part): ID-KEYED member handles in that side's file
-    #: order. Positional handles are excluded — their ordinals renumber on
-    #: any insert/remove, so they alias different cells across states (the
-    #: pool alignment owns their order instead).
-    member_order: dict[tuple[Lang, str, str], list[str]] = field(factory=dict)
-    #: per (lang, part): preamble fingerprint (None = file absent at base)
-    preamble_fps: dict[tuple[str, str], str | None] = field(factory=dict)
-    complete: bool = True
-
-
 def _pair_twin(de_member: Member | None, en_member: Member | None) -> Member | None:
     """The EN-carrier of a pool slot when it differs from the DE-carrier.
 
@@ -269,82 +179,6 @@ def _pair_twin(de_member: Member | None, en_member: Member | None) -> Member | N
     if de_member is not None and en_member is not None and en_member is not de_member:
         return en_member
     return None
-
-
-def _member_group_token(member: Member, owner_group: str) -> str:
-    if member.key.scheme == "pos":
-        # rsplit: a group token may itself contain "/" (ids are free-form)
-        return member.key.value.rsplit("/", 2)[0]
-    return owner_group
-
-
-def _iter_with_groups(deck: BilingualDeck):
-    """Yield ``(member, group_token)`` over the whole document."""
-    for member in deck.header:
-        yield member, HEADER_GROUP
-    for group in deck.groups:
-        if group.anchor is not None:
-            yield group.anchor, group.anchor_id
-        for member in group.members:
-            yield member, group.anchor_id
-    for member in deck.orphans:
-        yield member, ORPHAN_GROUP
-
-
-def baseline_from_deck(deck: BilingualDeck) -> DeckBaseline:
-    """Snapshot a parsed deck as a complete baseline (design §6.1).
-
-    This is how the Phase 2 shadow mode and the ``--since`` forensic view
-    obtain a base: parse the bundle at the base ref and record every
-    member's state. Phase 3 constructs the same shape from the ledger with
-    ``complete=False``.
-    """
-    base = DeckBaseline(complete=True)
-    order: dict[tuple[Lang, str, str], list[tuple[int, str]]] = {}
-    for member, group_token in _iter_with_groups(deck):
-        entry = MemberBaseline(
-            key=member.key.render(),
-            langness=member.langness,
-            layout=member.layout,
-            kind=member.kind,
-            role=member.role,
-            owner=member.owner.render() if member.owner else None,
-            de_fp=content_fingerprint(member.de) if member.de else None,
-            en_fp=content_fingerprint(member.en) if member.en else None,
-            de_body_fp=_body_fp(member.de) if member.de else None,
-            en_body_fp=_body_fp(member.en) if member.en else None,
-            de_tags=member.de.tags if member.de else None,
-            en_tags=member.en.tags if member.en else None,
-            de_sig=_pair_sig(member.de) if member.de else None,
-            en_sig=_pair_sig(member.en) if member.en else None,
-        )
-        base.members[entry.key] = entry
-        if member.key.scheme != "id":
-            continue  # pos handles alias across states — never order-tracked
-        for lang in _SIDES:
-            cell = member.side(lang)
-            if cell is not None:
-                order.setdefault((lang, group_token, cell.part), []).append((cell.index, entry.key))
-    base.member_order = {
-        key: [handle for _, handle in sorted(entries)] for key, entries in order.items()
-    }
-    base.group_order = [g.anchor_id for g in deck.groups]
-    for lang in _SIDES:
-        seq: list[tuple[int, str]] = []
-        for group in deck.groups:
-            if group.anchor is None:
-                continue
-            cell = group.anchor.side(lang)
-            if cell is not None and cell.part == "deck":
-                seq.append((cell.index, group.anchor_id))
-        base.group_order_by_side[lang] = [gid for _, gid in sorted(seq)]
-    base.preamble_fps = {
-        ("de", "deck"): _lines_fp(deck.de_deck_preamble),
-        ("en", "deck"): _lines_fp(deck.en_deck_preamble),
-        ("de", "companion"): _lines_fp(deck.de_companion_preamble),
-        ("en", "companion"): _lines_fp(deck.en_companion_preamble),
-    }
-    return base
 
 
 # ---------------------------------------------------------------------------

--- a/src/clm/slides/sync_shadow.py
+++ b/src/clm/slides/sync_shadow.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from attrs import define, field
 
 from clm.notebooks.slide_parser import comment_token_for_path
+from clm.slides.doc_identity import baseline_from_deck
 from clm.slides.doc_lenses import load_bundle, parse_bundle
 from clm.slides.pairing import (
     derive_split_pair,
@@ -43,7 +44,7 @@ from clm.slides.pairing import (
     find_split_slide_files_recursive,
     iter_split_pairs,
 )
-from clm.slides.sync_diff import DeckDiff, baseline_from_deck, diff_deck
+from clm.slides.sync_diff import DeckDiff, diff_deck
 from clm.slides.voiceover_tools import COMPANION_SUBDIR, companion_name
 
 logger = logging.getLogger(__name__)

--- a/tests/cli/test_sync_import_cleanliness.py
+++ b/tests/cli/test_sync_import_cleanliness.py
@@ -95,6 +95,7 @@ def test_v3_doc_modules_import_no_v2_sync_core():
         import sys
         import clm.slides.bilingual_doc, clm.slides.doc_lenses, clm.slides.sync_diff
         import clm.slides.doc_ledger, clm.slides.doc_apply
+        import clm.slides.doc_identity, clm.slides.doc_write
 
         for mod in (
             "clm.slides.sync_plan",
@@ -102,6 +103,32 @@ def test_v3_doc_modules_import_no_v2_sync_core():
             "clm.slides.sync_code",
         ):
             assert mod not in sys.modules, f"{mod} must not load from the v3 doc modules"
+        print("OK")
+        """
+    )
+    assert probe.returncode == 0, probe.stderr or probe.stdout
+    assert probe.stdout.strip().endswith("OK")
+
+
+def test_doc_identity_and_doc_write_import_no_sync_engine():
+    # Harvest Phase 1 (#546): the identity/snapshot layer and the write
+    # surface are the pieces `clm harvest` builds on, so they must be
+    # importable without pulling in the v3 differ or the ledger (let alone
+    # the v2 core) — otherwise "sync-free consumer of the deck model" is a
+    # fiction. Same fresh-subprocess mechanism as above.
+    probe = _run_probe(
+        """
+        import sys
+        import clm.slides.doc_identity, clm.slides.doc_write
+
+        for mod in (
+            "clm.slides.sync_diff",
+            "clm.slides.doc_ledger",
+            "clm.slides.sync_plan",
+            "clm.slides.sync_apply",
+            "clm.slides.sync_code",
+        ):
+            assert mod not in sys.modules, f"{mod} must not load from doc_identity/doc_write"
         print("OK")
         """
     )

--- a/tests/slides/test_doc_write.py
+++ b/tests/slides/test_doc_write.py
@@ -1,0 +1,127 @@
+"""Tests for :mod:`clm.slides.doc_write` (#546 harvest Phase 1).
+
+The extracted write surface must uphold the two properties the apply
+executor relied on when the code lived inside it: emission of an unmutated
+deck reproduces the on-disk bytes exactly (the lens guarantee lifted into
+the writer), and :func:`~clm.slides.doc_write.write_changed_files` lands
+multiple files atomically, minting a companion path for a file the bundle
+did not have.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from attrs import evolve
+
+from clm.slides.doc_lenses import LoadedBundle, load_bundle, parse_bundle
+from clm.slides.doc_write import DeckEmitter, new_companion_path, write_changed_files
+from clm.slides.voiceover_tools import COMPANION_SUBDIR
+
+HEADER_DE = "# j2 from 'macros.j2' import header_de\n# {{ header_de(\"Titel DE\") }}\n\n"
+HEADER_EN = "# j2 from 'macros.j2' import header_en\n# {{ header_en(\"Title EN\") }}\n\n"
+
+
+def _slide(slug: str, lang: str, title: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{slug}"\n#\n# # {title}\n\n'
+
+
+def _localized(slug: str, lang: str, text: str) -> str:
+    return f'# %% [markdown] lang="{lang}" slide_id="{slug}"\n# {text}\n\n'
+
+
+def _shared_code(name: str, value: int = 1) -> str:
+    return f'# %% tags=["keep"]\n{name} = {value}\n\n'
+
+
+def _build(*parts: str) -> str:
+    return "".join(parts).rstrip("\n") + "\n"
+
+
+def _write_bundle(tmp_path: Path) -> tuple[LoadedBundle, str, str]:
+    de = _build(
+        HEADER_DE,
+        _slide("s0", "de", "Titel"),
+        _shared_code("x"),
+        _localized("s0-m", "de", "DE Text"),
+    )
+    en = _build(
+        HEADER_EN,
+        _slide("s0", "en", "Title"),
+        _shared_code("x"),
+        _localized("s0-m", "en", "EN text"),
+    )
+    de_path = tmp_path / "slides_t.de.py"
+    en_path = tmp_path / "slides_t.en.py"
+    de_path.write_text(de, encoding="utf-8")
+    en_path.write_text(en, encoding="utf-8")
+    return load_bundle(de_path, en_path), de, en
+
+
+def test_emit_reproduces_the_on_disk_bytes(tmp_path: Path) -> None:
+    bundle, de, en = _write_bundle(tmp_path)
+    assert bundle.outcome.deck is not None
+    emitter = DeckEmitter(deck=bundle.outcome.deck)
+    assert emitter.emit("de", "deck") == de
+    assert emitter.emit("en", "deck") == en
+    assert emitter.emit("de", "companion") is None
+    assert emitter.emit_all()[("en", "companion")] is None
+    assert emitter.mutated is False
+
+
+def test_set_side_mutation_round_trips_through_write(tmp_path: Path) -> None:
+    bundle, _de, _en = _write_bundle(tmp_path)
+    deck = bundle.outcome.deck
+    assert deck is not None
+    emitter = DeckEmitter(deck=deck)
+    originals = emitter.emit_all()
+
+    target = next(
+        m for m in deck.members() if m.de is not None and any("DE Text" in x for x in m.de.lines)
+    )
+    new_lines = tuple(line.replace("DE Text", "DE Neu") for line in target.de.lines)
+    emitter.set_side(target, "de", evolve(target.de, lines=new_lines))
+    assert emitter.mutated is True
+
+    finals = emitter.emit_all()
+    changed = {key for key in finals if finals[key] != originals[key]}
+    assert changed == {("de", "deck")}
+
+    # The writer contract: re-parse before write, then land atomically.
+    parse = parse_bundle(
+        finals[("de", "deck")] or "",
+        finals[("en", "deck")] or "",
+        finals[("de", "companion")],
+        finals[("en", "companion")],
+        comment_token=bundle.comment_token,
+    )
+    assert parse.refusal is None
+
+    written = write_changed_files(bundle, finals, changed)
+    assert written == [bundle.de_path]
+    assert "DE Neu" in bundle.de_path.read_text(encoding="utf-8")
+    assert "EN text" in bundle.en_path.read_text(encoding="utf-8")
+
+
+def test_write_changed_files_multi_file_and_minted_companion(tmp_path: Path) -> None:
+    bundle, _de, _en = _write_bundle(tmp_path)
+    assert bundle.de_companion_path is None
+
+    vo = '# %% [markdown] lang="de" tags=["notes"] for_slide="s0"\n# - Punkt\n'
+    finals = {
+        ("de", "deck"): "# de deck\n",
+        ("en", "deck"): "# en deck\n",
+        ("de", "companion"): vo,
+        ("en", "companion"): None,
+    }
+    changed = set(finals)
+    written = write_changed_files(bundle, finals, changed)
+
+    minted = new_companion_path(bundle, "de")
+    assert minted.parent.name == COMPANION_SUBDIR
+    assert set(written) == {bundle.de_path, bundle.en_path, minted}
+    assert bundle.de_path.read_text(encoding="utf-8") == "# de deck\n"
+    assert bundle.en_path.read_text(encoding="utf-8") == "# en deck\n"
+    assert minted.read_text(encoding="utf-8") == vo
+    # The None emission was skipped — a writer never deletes/creates for it.
+    assert not new_companion_path(bundle, "en").exists()


### PR DESCRIPTION
## Summary

Phase 1 of the video-narration-harvest epic #546 (proposal:
`docs/proposals/video-narration-harvest.md`) — a pure code-move with **no
behavior change**, extracting the sync-free pieces of the v3 deck model that
`clm harvest` will build on:

- **`clm.slides.doc_identity`** — the identity/snapshot layer carved out of
  `sync_diff`: `content_fingerprint`, `pair_signature`, `body_fingerprint`,
  `lines_fingerprint`, `MemberBaseline`/`DeckBaseline`, `iter_with_groups`,
  `member_group_token`, `baseline_from_deck`. `sync_diff` imports these back
  (aliasing its old private names) and keeps re-exporting the public four, so
  every existing caller is untouched. `doc_ledger` and `sync_shadow` now
  import from `doc_identity` directly — the ledger no longer imports the
  differ at all.
- **`clm.slides.doc_write`** — the sync-free write surface carved out of
  `doc_apply`: `DeckEmitter` (per-`(lang, part)` stream view, byte-identical
  emission, `set_side`/`stream_remove`/`insert_mirrored` plumbing),
  `DeckWriteError`, `new_companion_path`, `write_changed_files` (atomic ≤4-file
  landing). `doc_apply._Executor` now subclasses `DeckEmitter` (its
  `_ItemError` subclasses `DeckWriteError`) and the apply write tail delegates
  to `write_changed_files`.

Neither new module imports `sync_diff`, `doc_ledger`, or the v2 sync core.

## Tests

- `tests/cli/test_sync_import_cleanliness.py`: new modules added to the
  v2-free probe, plus a new probe pinning that `doc_identity`/`doc_write`
  load neither `sync_diff` nor `doc_ledger`.
- New `tests/slides/test_doc_write.py`: emission reproduces on-disk bytes
  exactly; a `set_side` mutation round-trips through re-parse + write;
  multi-file atomic write mints the companion path and skips `None` emissions.
- Full `tests/slides` + cleanliness suite: 2389 passed. Fast suite ran green
  on the pre-push hook; ruff + mypy clean.

Closes nothing — Phase 1 of epic #546 (epic stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TJvSAbnsLWxcCLJ3SvqoS
