### PR TITLE
feat(harvest): clm harvest group with read-only report verb (#546 Phase 2)

### DIFF
--- a/changelog.d/546-harvest-phase2-report.added.md
+++ b/changelog.d/546-harvest-phase2-report.added.md
@@ -1,0 +1,13 @@
+- New `clm harvest` command group (epic #546 Phase 2) — the agent-first
+  rebuild of the video→voiceover feature. Its read-only default verb
+  `clm harvest report DECK VIDEO… --lang de|en` runs the cached
+  deterministic pipeline (transcribe → transition detect → OCR match →
+  align) and emits per-slide JSON keyed by the v3 member handle
+  (`id:<slide_id>`), with the aligned transcript, the existing voiceover
+  baseline on both language sides, and a structural novelty class
+  (`no_existing_vo` | `transcript_adds_material` | `covered` |
+  `unmatched_slide`, plus `unmatched_speech` per unassigned segment).
+  Exit codes 0/1/2; `--transcript`/`--alignment` injection skips ASR. The
+  diagnostics `transcribe`/`detect`/`identify`/`identify-rev`/`cache`/
+  `trace` are re-homed under the group (the `clm voiceover` names remain
+  until the Phase-4 cutover).

--- a/docs/claude/handovers/video-narration-harvest-handover.md
+++ b/docs/claude/handovers/video-narration-harvest-handover.md
@@ -1,6 +1,7 @@
 # Handover: Video Narration Harvest (agent-first rebuild)
 
-**Status**: Phase 1 implemented (v3 utility extraction); Phases 2–4 TODO
+**Status**: Phases 1–2 implemented (v3 extraction; `clm harvest report`);
+Phases 3–4 TODO (Phase 3 gated on the v3 dogfood week)
 **Last updated**: 2026-07-04
 **Canonical design source**: `docs/proposals/video-narration-harvest.md`
 (merged via PR #541, decisions folded in via PR #542). Read that proposal
@@ -89,16 +90,30 @@ pivot), #520 (sync-engine-v3), #501 (separated companions);
     mutation round-trip, atomic multi-file + minted companion);
     `tests/cli/test_sync_import_cleanliness.py` extended — the new modules
     must import neither `sync_diff` nor `doc_ledger` nor the v2 core.
-- **Phase 2 [TODO] — `clm harvest report`** (read-only; can land during v3
-  dogfooding). New group + verb wrapping the deterministic pipeline
-  (`transcribe`→`detect`→`match`→`align`, cached via
-  `src/clm/voiceover/cache.py`), emitting per-slide JSON: `MemberKey`,
-  video language, transcript segment(s), both-language VO baseline,
-  structural novelty class (`no_existing_vo` | `transcript_adds_material`
-  → *structural only, see decision 6* | `covered` | `unmatched_speech` |
-  `unmatched_slide`). Reads the deck through `load_bundle`
-  (`doc_lenses.py`). Existing diagnostics (`transcribe`/`detect`/
-  `identify`/`identify-rev`/`cache`/`trace`) re-home under the group.
+- **Phase 2 [DONE] — `clm harvest report`** (read-only). Landed as:
+  - `src/clm/voiceover/harvest.py` — engine: `run_pipeline` (the cached
+    deterministic tier, mirroring `voiceover sync`'s stage order + cache
+    scoping, with `--transcript`/`--alignment` short-circuits),
+    `build_report` (joins alignment×deck; the index→`slide_id`→
+    `id:<slide_id>` identity seam), `classify_slide` (structural 2×2:
+    speech assigned × VO present on the recorded side), `video_fingerprint`
+    (single = `VideoKey.hash`; multi-part = sha1 over ordered part hashes —
+    this is the future `harvest:<fp>` provenance), `report_exit_code`.
+  - `src/clm/cli/commands/harvest.py` — lazily registered top-level group
+    (`main.py` `lazy_subcommands` + `optional_subcommands` +
+    `_OPTIONAL_COMPAT_EXPORTS`); `report` is the default verb (resolved in
+    `resolve_command`, NOT sync's `parse_args` prepend — the group carries
+    cache flags and a prepend would fire on `--no-cache`); group-level
+    cache flags mirror `voiceover_group`; diagnostics re-registered as the
+    SAME Click command objects imported from `voiceover.py` (old names stay
+    until Phase 4).
+  - Aligned notes pointing at slide indices absent from the parsed deck
+    (stale injected alignment / slides deleted since recording) fold into
+    `unmatched_speech` — never dropped silently.
+  - Tests: `tests/cli/test_harvest_cli.py` (injected-alignment CLI
+    round-trips pinning every class, exit codes, default verb incl. after
+    group options, refusal → exit 2, re-homed diagnostics). Docs:
+    `commands.md` §`clm harvest`.
 - **Phase 3 [TODO] — `task` / `accept` / `verify`** (gated on v3 confidence
   — see Blockers). `task --kind curate|translate` framing (instructions =
   today's `src/clm/voiceover/prompts/merge_*.md` content restated as
@@ -121,9 +136,10 @@ pivot), #520 (sync-engine-v3), #501 (separated companions);
 - Proposal written, decisions resolved, merged to master
   (`docs/proposals/video-narration-harvest.md`; PRs #541 merged, #542
   merged/auto-merge armed 2026-07-04).
-- **Phase 1 implemented** (`doc_identity.py` + `doc_write.py`, see §3); no
-  harvest-facing code yet. Epic issue: **#546** (phases, settled decisions,
-  and the Phase-3 gate mirrored there).
+- **Phases 1–2 implemented** (`doc_identity.py` + `doc_write.py`;
+  `clm harvest report` + re-homed diagnostics, see §3). Epic issue:
+  **#546** (phases, settled decisions, and the Phase-3 gate mirrored
+  there).
 - Blocker for Phase 3 (and arguably 4): sync-engine-v3 must survive its
   **dogfood week on PythonCourses** first (see
   `docs/claude/sync-v3-handover.md`; v3 Phase 4 = flip default, delete v2).
@@ -135,11 +151,15 @@ pivot), #520 (sync-engine-v3), #501 (separated companions);
 
 ## 5. Next Steps
 
-Phase 1 is done (see §3). Next is **Phase 2 — `clm harvest report`**
-(read-only; can land during v3 dogfooding): new CLI group wrapping the
-deterministic pipeline, per-slide JSON keyed by `MemberKey`, reading decks
-through `load_bundle`. Phase 3 stays gated on the v3 dogfood week.
-Gotchas that remain live:
+Phases 1–2 are done (see §3). Next is **Phase 3 — `task` / `accept` /
+`verify`**, which stays **gated on the v3 dogfood week** (see Blockers in
+§4); do not start it before v3 confidence is established. When it opens:
+`task --kind curate|translate` framing (instructions from
+`src/clm/voiceover/prompts/merge_*.md` restated as caller instructions;
+bullet-list `answer_schema`), `accept` writing through the Phase-1
+`doc_write` surface, `--record` with `harvest:<fp>` provenance (the
+fingerprint `harvest.py:video_fingerprint` already computes), one-sided
+trust semantics (§8 of this doc / proposal §6). Gotchas that remain live:
 - `tests/cli/test_sync_import_cleanliness.py` pins the v3 import graph
   (model must not import v2; facade imports only v3 core; `doc_identity`/
   `doc_write` must stay differ/ledger-free) — extend, don't fight it.
@@ -151,7 +171,10 @@ Gotchas that remain live:
 
 Created by Phase 1: `src/clm/slides/doc_identity.py` (identity/snapshot),
 `src/clm/slides/doc_write.py` (emitter + atomic write surface),
-`tests/slides/test_doc_write.py`. The rest of the map (from the 2026-07-04
+`tests/slides/test_doc_write.py`. Created by Phase 2:
+`src/clm/voiceover/harvest.py` (report engine),
+`src/clm/cli/commands/harvest.py` (group + report + re-homed diagnostics),
+`tests/cli/test_harvest_cli.py`. The rest of the map (from the 2026-07-04
 investigation):
 
 - **v3 model (reuse)**: `src/clm/slides/bilingual_doc.py` (model: `Member`,

--- a/src/clm/cli/commands/harvest.py
+++ b/src/clm/cli/commands/harvest.py
@@ -1,0 +1,292 @@
+"""``clm harvest`` — recover narration from recorded videos (#546 Phase 2).
+
+The agent-first rebuild of the video→voiceover feature (epic #546,
+`docs/proposals/video-narration-harvest.md`): the deterministic pipeline
+lives behind read-only verbs, judgment stays with the driving agent. This
+module carries the group plus the Phase-2 surface:
+
+* ``report`` (the default verb) — run the cached deterministic tier and
+  emit per-slide JSON keyed by v3 ``MemberKey``, with a structural novelty
+  class per slide. Read-only; no model; no key.
+* the re-homed diagnostics ``transcribe`` / ``detect`` / ``identify`` /
+  ``identify-rev`` / ``cache`` / ``trace`` (shared with ``clm voiceover``
+  until the Phase-4 cutover deletes the old names).
+
+``task`` / ``accept`` / ``verify`` / ``autopilot`` arrive in Phases 3–4.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from clm.cli._lazy_group import LazyGroup
+
+_DEFAULT_VERB = "report"
+
+
+class _DefaultVerbGroup(LazyGroup):
+    """A group whose bare ``clm harvest DECK VIDEO`` runs ``report``.
+
+    Unlike the ``slides sync`` variant this one resolves the default verb in
+    :meth:`resolve_command` (after group options are parsed), because the
+    harvest group carries the cache flags — a ``parse_args`` prepend would
+    fire on ``--no-cache`` before Click ever saw it as a group option.
+    """
+
+    def resolve_command(self, ctx: click.Context, args: list[str]):
+        try:
+            return super().resolve_command(ctx, args)
+        except click.UsageError:
+            if args and not args[0].startswith("-"):
+                cmd = self.get_command(ctx, _DEFAULT_VERB)
+                if cmd is not None:
+                    return _DEFAULT_VERB, cmd, args
+            raise
+
+
+@click.group("harvest", cls=_DefaultVerbGroup)
+@click.option(
+    "--cache-root",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Override the cache location (default: <deck dir>/.clm/voiceover-cache).",
+)
+@click.option(
+    "--no-cache",
+    is_flag=True,
+    default=False,
+    help="Disable the artifact cache for this invocation.",
+)
+@click.option(
+    "--refresh-cache",
+    is_flag=True,
+    default=False,
+    help="Force recomputation and overwrite existing cache entries.",
+)
+@click.pass_context
+def harvest_group(ctx, cache_root, no_cache, refresh_cache):
+    """Recover spoken narration from recorded videos into slide decks.
+
+    \b
+    Bare `clm harvest DECK VIDEO…` == `clm harvest report DECK VIDEO…`.
+    Verbs:
+      report        what did the recording say, slide by slide? (read-only)
+      transcribe    ASR only: dump the transcript (diagnostic)
+      detect        slide-transition detection only (diagnostic)
+      identify      which slides appear in a video? (diagnostic)
+      identify-rev  which git revision of a deck was recorded? (diagnostic)
+      cache         inspect/prune the artifact cache
+      trace         inspect merge trace logs
+
+    The deterministic tier (ASR, transition detection, OCR matching,
+    alignment) is engine-owned, cached, and model-free; curation and
+    translation judgment belong to the driving agent (epic #546).
+
+    Requires: pip install clm[voiceover]
+    """
+    from clm.voiceover.cache import CachePolicy
+
+    ctx.ensure_object(dict)
+    ctx.obj["cache_policy"] = CachePolicy(
+        enabled=not no_cache,
+        refresh=refresh_cache,
+        cache_root=cache_root,
+    )
+
+
+# ---------------------------------------------------------------------------
+# report — the read-only default verb
+# ---------------------------------------------------------------------------
+
+
+@harvest_group.command("report")
+@click.argument("slides", type=click.Path(exists=True, path_type=Path))
+@click.argument("videos", nargs=-1, required=True, type=str)
+@click.option(
+    "--lang",
+    required=True,
+    type=click.Choice(["de", "en"]),
+    help="The recorded (spoken) language; SLIDES must be that half of the pair.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit the JSON report envelope.")
+@click.option(
+    "--transcript",
+    "transcript_override",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="Skip ASR and load a precomputed transcript from PATH "
+    "(JSON from `clm harvest transcribe -o`). Single-video only.",
+)
+@click.option(
+    "--alignment",
+    "alignment_override",
+    type=click.Path(exists=True, path_type=Path),
+    default=None,
+    help="Skip ASR, detection, and matching; load a precomputed alignment "
+    "from PATH (cache artifact shape). Single-video only.",
+)
+@click.option(
+    "--whisper-model",
+    default="large-v3",
+    show_default=True,
+    help="Whisper model size for ASR.",
+)
+@click.option(
+    "--backend",
+    "backend_name",
+    default="faster-whisper",
+    show_default=True,
+    help="Transcription backend.",
+)
+@click.option(
+    "--device",
+    default="auto",
+    show_default=True,
+    type=click.Choice(["auto", "cuda", "cpu"]),
+    help="Device for ASR.",
+)
+@click.pass_context
+def harvest_report_cmd(
+    ctx,
+    slides: Path,
+    videos: tuple[str, ...],
+    lang: str,
+    as_json: bool,
+    transcript_override: Path | None,
+    alignment_override: Path | None,
+    whisper_model: str,
+    backend_name: str,
+    device: str,
+):
+    """What did the recording say, slide by slide? (read-only)
+
+    Runs the cached deterministic tier (transcribe → detect transitions →
+    OCR-match → align) over VIDEOS and joins the result with the deck
+    bundle: one item per slide, keyed by the v3 member handle
+    (`id:<slide_id>`), carrying the aligned transcript, the existing
+    voiceover baseline on both language sides, and a structural novelty
+    class: no_existing_vo | transcript_adds_material | covered |
+    unmatched_slide (plus unmatched_speech per unassigned segment).
+
+    \b
+    Exit codes:
+      0  nothing to harvest (all covered / silent)
+      1  actionable items (new material or unmatched speech)
+      2  error (unreadable deck, non-normalized bundle, bad inputs)
+
+    No model, no key, no writes — also the human dry-run.
+    """
+    from clm.cli.commands.voiceover import (
+        _expand_video_args,
+        _load_alignment_override,
+        _load_transcript_override,
+    )
+    from clm.notebooks.slide_parser import parse_slides
+    from clm.slides.doc_lenses import DocLensError, load_bundle
+    from clm.voiceover.cache import CachePolicy
+    from clm.voiceover.harvest import (
+        HarvestUsageError,
+        build_report,
+        report_exit_code,
+        run_pipeline,
+    )
+
+    policy: CachePolicy = ctx.obj.get("cache_policy", CachePolicy())
+    video_paths = _expand_video_args(videos)
+
+    # The v3 deck bundle: both languages + companions, the identity source.
+    try:
+        bundle = load_bundle(slides)
+    except DocLensError as exc:
+        click.echo(f"error: {exc}", err=True)
+        sys.exit(2)
+    if bundle.outcome.deck is None:
+        refusal = bundle.outcome.refusal
+        click.echo("error: the deck bundle is not normalized:", err=True)
+        if refusal is not None:
+            for reason in refusal.reasons:
+                click.echo(f"  [{reason.code}] {reason.detail}", err=True)
+        click.echo("run `clm slides normalize` on the pair first.", err=True)
+        sys.exit(2)
+
+    # The recorded-language view the OCR matcher and aligner key on.
+    slide_groups = parse_slides(slides, lang)
+
+    transcript = _load_transcript_override(transcript_override) if transcript_override else None
+    alignment = _load_alignment_override(alignment_override) if alignment_override else None
+    try:
+        artifacts = run_pipeline(
+            slides,
+            video_paths,
+            lang,
+            slide_groups,
+            policy=policy,
+            backend_name=backend_name,
+            whisper_model=whisper_model,
+            device=device,
+            transcript_override=transcript,
+            alignment_override=alignment,
+        )
+    except HarvestUsageError as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    report = build_report(bundle, slide_groups, artifacts, lang=lang, video_paths=video_paths)
+    if as_json:
+        click.echo(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        _print_human_report(report)
+    sys.exit(report_exit_code(report))
+
+
+def _print_human_report(report: dict) -> None:
+    summary = report["summary"]
+    click.echo(
+        f"harvest report: {summary['slides']} slide(s), "
+        f"video language {report['video_language']}, "
+        f"fingerprint {report['video_fingerprint']}"
+    )
+    for cls, count in summary["classes"].items():
+        if count:
+            click.echo(f"  {cls}: {count}")
+    if summary["unmatched_speech"]:
+        click.echo(f"  unmatched_speech: {summary['unmatched_speech']} segment(s)")
+    for item in report["items"]:
+        if item["class"] in ("covered", "unmatched_slide"):
+            continue
+        key = item["key"] or f"(no id, slide_index {item['slide_index']})"
+        click.echo(f"  {item['class']:26} {key}  {item['title']}")
+    click.echo(
+        "actionable — run with --json for the full per-slide payload"
+        if summary["actionable"]
+        else "nothing to harvest"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Re-homed diagnostics (shared with `clm voiceover` until the Phase-4 cutover)
+# ---------------------------------------------------------------------------
+
+
+def _register_diagnostics() -> None:
+    from clm.cli.commands.voiceover import (
+        cache_group,
+        detect,
+        identify,
+        identify_rev_cmd,
+        trace_group,
+        transcribe,
+    )
+
+    harvest_group.add_command(transcribe)
+    harvest_group.add_command(detect)
+    harvest_group.add_command(identify)
+    harvest_group.add_command(identify_rev_cmd, name="identify-rev")
+    harvest_group.add_command(cache_group, name="cache")
+    harvest_group.add_command(trace_group, name="trace")
+
+
+_register_diagnostics()

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -20,7 +20,8 @@ The CLI is organised into a small top-level surface (the everyday verbs:
 authoring tools), `course` (course/spec structure: decks, targets, topics,
 includes, readiness gate), `query` (read-only introspection for scripting),
 `export` (rendered course documents), `calendar`
-(cohort viewing calendars), `voiceover`, and the infrastructure groups
+(cohort viewing calendars), `voiceover`, `harvest` (recover narration from
+recorded videos), and the infrastructure groups
 (`db`, `docker`, `git`, `jobs`, `workers`, `zip`, ...). The reference below
 uses the canonical (group-qualified) names. Older flat names were removed
 in CLM 1.8 and the remaining single-command groups (`topic`, `spec`,
@@ -3839,6 +3840,78 @@ clm export agent-guide --stdout             # preview without writing
 clm export agent-guide --with-issues        # also embed open agent-impact issues
 clm export agent-guide --check              # staleness gate (CI / pre-commit)
 ```
+
+### `clm harvest` (CLM {version}+)
+
+Recover spoken narration from recorded videos into slide decks — the
+agent-first rebuild of the video side of `clm voiceover` (epic #546). The
+deterministic tier (ASR, transition detection, OCR matching, alignment) is
+engine-owned, cached, and model-free; curation and translation judgment
+belong to the driving agent. Requires `clm[voiceover]` extra.
+
+Bare `clm harvest DECK VIDEO…` runs the read-only default verb `report`.
+
+**Group-level cache flags** (same artifact cache as `clm voiceover`):
+
+| Option | Description |
+|--------|-------------|
+| `--cache-root PATH` | Override the cache location (default: `<deck dir>/.clm/voiceover-cache`) |
+| `--no-cache` | Disable the artifact cache for this invocation |
+| `--refresh-cache` | Force recomputation and overwrite existing cache entries |
+
+The diagnostics `transcribe`, `detect`, `identify`, `identify-rev`,
+`cache`, and `trace` are also registered under `clm harvest` — they are the
+same commands documented under `clm voiceover` below (the old names remain
+until the harvest cutover phase deletes them).
+
+#### `clm harvest report`
+
+Run the full deterministic tier (cached) and report, slide by slide, what
+the recording said and how it relates to the deck's existing voiceover.
+Read-only; no model; no API key. Also the human dry-run.
+
+```
+clm harvest report SLIDES VIDEO... --lang {de|en} [OPTIONS]
+```
+
+`SLIDES` must be the recorded-language half of a split pair; the whole
+bundle (both deck halves + voiceover companions) is loaded through the v3
+document model, so every item is keyed by the slide's member handle
+(`id:<slide_id>`). A non-normalized bundle (e.g. id-less slides) is refused
+with exit 2 and a `clm slides normalize` hint.
+
+| Option | Description |
+|--------|-------------|
+| `--lang TEXT` | The recorded (spoken) language, `de` or `en` (required) |
+| `--json` | Emit the JSON report envelope instead of the human summary |
+| `--transcript PATH` | Skip ASR; load a precomputed transcript JSON (single-video only) |
+| `--alignment PATH` | Skip ASR, detection, and matching; load a precomputed alignment (single-video only) |
+| `--whisper-model TEXT` | Whisper model size (default: `large-v3`) |
+| `--backend TEXT` | Transcription backend (default: `faster-whisper`) |
+| `--device [auto\|cuda\|cpu]` | Device for ASR (default: `auto`) |
+
+Each per-slide item carries: the member `key` (`id:<slide_id>`, or `null`
+with a normalize note), the slide `title` and pipeline `slide_index`, the
+aligned `transcript` (segments plus `**[Revisited]**` backtracking groups),
+the existing `voiceover` baseline on **both** language sides (inline or
+companion, with per-cell member keys), and a purely **structural** novelty
+`class`:
+
+| Class | Meaning |
+|-------|---------|
+| `no_existing_vo` | Speech was assigned to the slide and the recorded side has no voiceover yet |
+| `transcript_adds_material` | Speech assigned AND a voiceover exists — whether it truly adds anything is the agent's judgment |
+| `covered` | A voiceover exists; the recording contributed no speech for this slide |
+| `unmatched_slide` | No voiceover and no speech (shown silently, or never shown) |
+
+Transcript segments the aligner could not assign to any slide are listed
+separately under `unmatched_speech`. The envelope also records the video
+`fingerprint` that keys the artifact cache (and, in later phases, the
+ledger provenance `harvest:<fingerprint>`).
+
+**Exit codes:** `0` nothing to harvest (all covered/silent) · `1`
+actionable items (new material or unmatched speech) · `2` error
+(unreadable deck, non-normalized bundle, bad inputs).
 
 ### `clm voiceover`
 

--- a/src/clm/cli/main.py
+++ b/src/clm/cli/main.py
@@ -84,10 +84,11 @@ _COMMANDS = "clm.cli.commands"
         # Optional commands gated behind extras.
         # -------------------------------------------------------------
         "voiceover": f"{_COMMANDS}.voiceover:voiceover_group",
+        "harvest": f"{_COMMANDS}.harvest:harvest_group",
         "recordings": f"{_COMMANDS}.recordings:recordings_group",
         "mcp": f"{_COMMANDS}.mcp:mcp_cmd",
     },
-    optional_subcommands=("voiceover", "recordings", "mcp"),
+    optional_subcommands=("voiceover", "harvest", "recordings", "mcp"),
 )
 @click.version_option(version=__version__, prog_name="clm")
 @click.option(
@@ -217,6 +218,7 @@ _COMPAT_EXPORTS: dict[str, tuple[str, str]] = {
 
 _OPTIONAL_COMPAT_EXPORTS: dict[str, tuple[str, str]] = {
     "voiceover_group": (f"{_COMMANDS}.voiceover", "voiceover_group"),
+    "harvest_group": (f"{_COMMANDS}.harvest", "harvest_group"),
     "recordings_group": (f"{_COMMANDS}.recordings", "recordings_group"),
     "mcp_cmd": (f"{_COMMANDS}.mcp", "mcp_cmd"),
 }

--- a/src/clm/voiceover/harvest.py
+++ b/src/clm/voiceover/harvest.py
@@ -1,0 +1,407 @@
+"""The read-only harvest report engine (#546 Phase 2).
+
+``clm harvest report`` = the deterministic tier of the video→voiceover
+pipeline (transcribe → transition detect → OCR match → align, cached via
+:mod:`clm.voiceover.cache`) joined with the v3 deck model: every slide of
+the recorded-language deck becomes one report item keyed by its
+:class:`~clm.slides.bilingual_doc.MemberKey`, carrying the video's
+transcript segment(s), the existing voiceover baseline on **both** language
+sides (inline or companion), and a *structural* novelty class. No model, no
+key, no writes — this is the input a driving agent (or a human dry-run)
+reads before deciding what to curate.
+
+Novelty classification is purely structural (proposal §8 / epic #546
+decision 6): it combines only *VO present/absent on the recorded side* with
+*transcript speech assigned/unassigned* — never textual similarity:
+
+* ``no_existing_vo`` — speech was assigned to the slide and the recorded
+  side has no voiceover yet: harvest material, nothing to merge into.
+* ``transcript_adds_material`` — speech assigned AND a voiceover exists:
+  candidate additions; whether the speech truly adds anything is wholly
+  the agent's judgment.
+* ``covered`` — a voiceover exists and the recording contributed no
+  speech for this slide.
+* ``unmatched_slide`` — no voiceover and no speech (the slide was shown
+  silently, or never shown).
+* ``unmatched_speech`` — transcript segments the aligner could not assign
+  to any slide; reported per segment, not per slide.
+
+The identity seam: the deterministic stages key everything by positional
+``SlideGroup.index`` (the OCR matcher and the aligner know nothing about
+ids); this module maps each index to the slide's ``slide_id`` and renders
+the v3 handle ``id:<slide_id>``. A slide without an id gets a ``null`` key
+and a normalize hint — never a guessed identity.
+
+This module is engine-only: it emits, it never invokes a model.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from clm.notebooks.slide_parser import SlideGroup
+    from clm.slides.bilingual_doc import Lang, Member
+    from clm.slides.doc_lenses import LoadedBundle
+    from clm.voiceover.aligner import AlignmentResult
+    from clm.voiceover.cache import CachePolicy
+    from clm.voiceover.matcher import TimelineEntry
+    from clm.voiceover.transcribe import Transcript
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ACTIONABLE_CLASSES",
+    "NOVELTY_CLASSES",
+    "HarvestUsageError",
+    "PipelineArtifacts",
+    "build_report",
+    "classify_slide",
+    "report_exit_code",
+    "run_pipeline",
+    "video_fingerprint",
+]
+
+#: The closed per-slide vocabulary (``unmatched_speech`` is per segment).
+NOVELTY_CLASSES = (
+    "no_existing_vo",
+    "transcript_adds_material",
+    "covered",
+    "unmatched_slide",
+)
+
+#: Classes that mean there is harvest work for an agent to judge.
+ACTIONABLE_CLASSES = frozenset({"no_existing_vo", "transcript_adds_material"})
+
+#: The narrative member roles of the v3 model (voiceover/notes cells).
+_NARRATIVE_ROLES = ("voiceover", "notes")
+
+_SIDES: tuple[Lang, Lang] = ("de", "en")
+
+
+class HarvestUsageError(ValueError):
+    """A caller-input problem (the CLI renders it as a usage error)."""
+
+
+@dataclass(frozen=True)
+class PipelineArtifacts:
+    """What the deterministic tier produced for one report run.
+
+    ``timeline`` is ``None`` when an alignment override skipped the
+    match stage; ``transcript_language`` is ``None`` in the same case.
+    """
+
+    alignment: AlignmentResult
+    timeline: list[TimelineEntry] | None
+    transcript_language: str | None
+
+
+def video_fingerprint(video_paths: list[Path]) -> str:
+    """The fingerprint keying the artifact cache — and, later, the ledger
+    provenance ``harvest:<fingerprint>`` (proposal §6).
+
+    Single video: the cache's :class:`~clm.voiceover.cache.VideoKey` hash
+    (path + mtime + size). Multiple parts: a stable hash over the ordered
+    per-part hashes.
+    """
+    from clm.voiceover.cache import VideoKey
+
+    hashes = [VideoKey.from_path(p).hash for p in video_paths]
+    if len(hashes) == 1:
+        return hashes[0]
+    return hashlib.sha1("|".join(hashes).encode("utf-8")).hexdigest()[:16]
+
+
+def run_pipeline(
+    slides_path: Path,
+    video_paths: list[Path],
+    lang: str,
+    slide_groups: list[SlideGroup],
+    *,
+    policy: CachePolicy,
+    backend_name: str = "faster-whisper",
+    whisper_model: str = "large-v3",
+    device: str = "auto",
+    transcript_override: Transcript | None = None,
+    alignment_override: AlignmentResult | None = None,
+) -> PipelineArtifacts:
+    """Run the deterministic tier (cached) up to the alignment.
+
+    The same stage order and cache wrappers ``clm voiceover sync`` uses:
+    per part transcribe + detect (cached), offset and merge, OCR match
+    (cached, single-part only), align (cached, single-part only). An
+    ``alignment_override`` short-circuits everything; a
+    ``transcript_override`` skips only ASR. Both are single-part only.
+    """
+    from clm.voiceover.aligner import align_transcript
+    from clm.voiceover.cache import (
+        cached_alignment,
+        cached_detect,
+        cached_timeline,
+        cached_transcribe,
+    )
+    from clm.voiceover.keyframes import TransitionEvent, detect_transitions
+    from clm.voiceover.matcher import match_events_to_slides
+    from clm.voiceover.timeline import (
+        build_parts,
+        merge_transcripts,
+        offset_events,
+        offset_transcript,
+    )
+    from clm.voiceover.transcribe import transcribe_video
+
+    multi_part = len(video_paths) > 1
+    if alignment_override is not None:
+        if multi_part:
+            raise HarvestUsageError(
+                "--alignment is incompatible with multi-part videos; "
+                "the override encodes a single pre-computed alignment."
+            )
+        return PipelineArtifacts(
+            alignment=alignment_override, timeline=None, transcript_language=None
+        )
+    if transcript_override is not None and multi_part:
+        raise HarvestUsageError(
+            "--transcript is incompatible with multi-part videos; "
+            "supply a precomputed single-part transcript only."
+        )
+
+    parts = build_parts(video_paths)
+    total_duration = sum(p.duration for p in parts)
+
+    all_transcripts = []
+    all_events: list[TransitionEvent] = []
+    for part in parts:
+        if transcript_override is not None:
+            transcript = transcript_override
+        else:
+
+            def _do_transcribe(part=part):
+                return transcribe_video(
+                    part.path,
+                    language=lang,
+                    backend_name=backend_name,
+                    model_size=whisper_model,
+                    device=device,
+                )
+
+            transcript, tx_hit = cached_transcribe(
+                part.path,
+                policy=policy,
+                base_dir=slides_path.parent,
+                transcribe_fn=_do_transcribe,
+                backend_name=backend_name,
+                model_size=whisper_model,
+                language=lang,
+                device=device,
+            )
+            logger.info("transcript for %s: cache %s", part.path.name, "hit" if tx_hit else "miss")
+
+        def _do_detect(part=part):
+            return detect_transitions(part.path)[0]
+
+        events, det_hit = cached_detect(
+            part.path,
+            policy=policy,
+            base_dir=slides_path.parent,
+            detect_fn=_do_detect,
+        )
+        logger.info("transitions for %s: cache %s", part.path.name, "hit" if det_hit else "miss")
+
+        all_transcripts.append(offset_transcript(transcript, part))
+        all_events.extend(offset_events(events, part))
+
+    merged_transcript = merge_transcripts(all_transcripts)
+
+    def _run_match():
+        return match_events_to_slides(
+            all_events,
+            slide_groups,
+            video_paths[0],
+            video_paths=video_paths if multi_part else None,
+            total_duration=total_duration,
+            lang=lang,
+        ).timeline
+
+    # Timeline/alignment caching is single-part only (composite multi-part
+    # keys are not modelled) — the same scoping `voiceover sync` applies.
+    if multi_part:
+        timeline = _run_match()
+    else:
+        timeline, _ = cached_timeline(
+            video_paths[0],
+            slides_path,
+            policy=policy,
+            base_dir=slides_path.parent,
+            timeline_fn=_run_match,
+            cfg={"lang": lang, "frame_offset": 1.0, "multi_part": multi_part},
+        )
+
+    def _run_align():
+        return align_transcript(merged_transcript, timeline)
+
+    if multi_part:
+        alignment = _run_align()
+    else:
+        alignment, _ = cached_alignment(
+            video_paths[0],
+            slides_path,
+            policy=policy,
+            base_dir=slides_path.parent,
+            alignment_fn=_run_align,
+            cfg={"lang": lang, "multi_part": multi_part},
+        )
+
+    return PipelineArtifacts(
+        alignment=alignment,
+        timeline=timeline,
+        transcript_language=merged_transcript.language,
+    )
+
+
+def classify_slide(*, has_transcript: bool, vo_present: bool) -> str:
+    """The structural novelty class of one slide (see the module docstring)."""
+    if has_transcript:
+        return "transcript_adds_material" if vo_present else "no_existing_vo"
+    return "covered" if vo_present else "unmatched_slide"
+
+
+def _narrative_by_group(deck) -> dict[str, list[Member]]:
+    """The narrative (voiceover/notes) members of each slide group."""
+    result: dict[str, list[Member]] = {}
+    for group in deck.groups:
+        members = [m for m in group.members if m.role in _NARRATIVE_ROLES]
+        if members:
+            result[group.anchor_id] = members
+    return result
+
+
+def _voiceover_payload(members: list[Member], side: Lang) -> dict[str, Any]:
+    cells = []
+    for member in members:
+        cell = member.side(side)
+        if cell is None:
+            continue
+        cells.append(
+            {
+                "key": member.key.render(),
+                "role": member.role,
+                "layout": member.layout,
+                "text": cell.body,
+            }
+        )
+    present = any(c["text"].strip() for c in cells)
+    return {"present": present, "cells": cells}
+
+
+def build_report(
+    bundle: LoadedBundle,
+    slide_groups: list[SlideGroup],
+    artifacts: PipelineArtifacts,
+    *,
+    lang: str,
+    video_paths: list[Path],
+) -> dict[str, Any]:
+    """Join the pipeline artifacts with the v3 deck into the report envelope.
+
+    ``bundle.outcome.deck`` must be set (the CLI turns a refusal into exit 2
+    before calling this).
+    """
+    deck = bundle.outcome.deck
+    assert deck is not None
+    alignment = artifacts.alignment
+    timeline = artifacts.timeline
+    narrative = _narrative_by_group(deck)
+
+    items: list[dict[str, Any]] = []
+    counts: dict[str, int] = dict.fromkeys(NOVELTY_CLASSES, 0)
+    known_indices: set[int] = set()
+    for sg in slide_groups:
+        if sg.slide_type == "header":
+            known_indices.add(sg.index)
+            continue
+        known_indices.add(sg.index)
+        slide_id = sg.cells[0].slide_id if sg.cells else None
+        notes = alignment.slide_notes.get(sg.index)
+        transcript_text = alignment.get_notes_text(sg.index)
+        vo_members = narrative.get(slide_id, []) if slide_id else []
+        voiceover: dict[str, dict[str, Any]] = {
+            side: _voiceover_payload(vo_members, side) for side in _SIDES
+        }
+        cls = classify_slide(
+            has_transcript=transcript_text is not None,
+            vo_present=voiceover[lang]["present"],
+        )
+        counts[cls] += 1
+        item: dict[str, Any] = {
+            "key": f"id:{slide_id}" if slide_id else None,
+            "slide_index": sg.index,
+            "title": sg.title,
+            "class": cls,
+            "voiceover": voiceover,
+        }
+        if timeline is not None:
+            item["in_timeline"] = any(e.slide_index == sg.index for e in timeline)
+        if notes is not None and transcript_text is not None:
+            item["transcript"] = {
+                "text": transcript_text,
+                "segments": list(notes.segments),
+                "revisited_segments": [list(r) for r in notes.revisited_segments],
+            }
+        if slide_id is None:
+            item["note"] = (
+                "slide has no slide_id — run `clm slides normalize --stamp-ids` "
+                "before harvesting into it"
+            )
+        items.append(item)
+
+    unmatched_speech: list[dict[str, Any]] = [
+        {
+            "start": seg.start,
+            "end": seg.end,
+            "text": seg.text,
+            "source_part_index": seg.source_part_index,
+        }
+        for seg in alignment.unassigned_segments
+    ]
+    # Aligned notes pointing at indices outside the parsed deck (a stale
+    # injected alignment, or slides removed since the recording) are speech
+    # without a slide — surface them, never drop them silently.
+    for idx in sorted(set(alignment.slide_notes) - known_indices):
+        text = alignment.get_notes_text(idx)
+        if text is not None:
+            unmatched_speech.append({"slide_index": idx, "text": text})
+
+    actionable = bool(unmatched_speech) or any(counts[c] for c in ACTIONABLE_CLASSES)
+    return {
+        "schema": 1,
+        "tool": "harvest",
+        "verb": "report",
+        "deck": {
+            "de": str(bundle.de_path),
+            "en": str(bundle.en_path),
+            "de_companion": str(bundle.de_companion_path) if bundle.de_companion_path else None,
+            "en_companion": str(bundle.en_companion_path) if bundle.en_companion_path else None,
+        },
+        "videos": [str(p) for p in video_paths],
+        "video_language": lang,
+        "transcript_language": artifacts.transcript_language,
+        "video_fingerprint": video_fingerprint(video_paths),
+        "summary": {
+            "slides": len(items),
+            "classes": counts,
+            "unmatched_speech": len(unmatched_speech),
+            "actionable": actionable,
+        },
+        "items": items,
+        "unmatched_speech": unmatched_speech,
+    }
+
+
+def report_exit_code(report: dict[str, Any]) -> int:
+    """0 = nothing to harvest, 1 = actionable items (2 = error, CLI-side)."""
+    return 1 if report["summary"]["actionable"] else 0

--- a/tests/cli/test_harvest_cli.py
+++ b/tests/cli/test_harvest_cli.py
@@ -1,0 +1,325 @@
+"""Tests for ``clm harvest report`` (#546 Phase 2).
+
+The report joins an injected alignment (no ASR/ffmpeg/GPU — the
+``--alignment`` short-circuit) with a tiny inline deck bundle, so the
+structural novelty classification and the JSON envelope are pinned end to
+end through the real CLI. One slide per class:
+
+* ``s0`` — voiceover present + speech assigned → ``transcript_adds_material``
+* ``s1`` — no voiceover + speech assigned     → ``no_existing_vo``
+* ``s2`` — voiceover present (DE only) + silent → ``covered``
+* ``s3`` — nothing                             → ``unmatched_slide``
+
+plus an unassigned segment and a stale slide index → ``unmatched_speech``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from clm.cli.commands.harvest import harvest_group
+
+HEADER_DE = "# j2 from 'macros.j2' import header_de\n# {{ header_de(\"Titel DE\") }}\n\n"
+HEADER_EN = "# j2 from 'macros.j2' import header_en\n# {{ header_en(\"Title EN\") }}\n\n"
+
+
+def _slide(slug: str, lang: str, title: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{slug}"\n#\n# # {title}\n\n'
+
+
+def _companion_cell(slug: str, lang: str, owner: str, text: str) -> str:
+    return (
+        f'# %% [markdown] lang="{lang}" tags=["notes"] for_slide="{owner}" '
+        f'vo_anchor="id:{owner}#0" slide_id="{slug}"\n#\n# - {text}\n\n'
+    )
+
+
+def _build(*parts: str) -> str:
+    return "".join(parts).rstrip("\n") + "\n"
+
+
+def _write_fixture(tmp_path: Path) -> tuple[Path, Path]:
+    """The deck pair + companions + a dummy video; returns (de_path, video)."""
+    de = _build(
+        HEADER_DE,
+        _slide("s0", "de", "Alpha"),
+        _slide("s1", "de", "Beta"),
+        _slide("s2", "de", "Gamma"),
+        _slide("s3", "de", "Delta"),
+    )
+    en = _build(
+        HEADER_EN,
+        _slide("s0", "en", "Alpha"),
+        _slide("s1", "en", "Beta"),
+        _slide("s2", "en", "Gamma"),
+        _slide("s3", "en", "Delta"),
+    )
+    de_path = tmp_path / "slides_t.de.py"
+    en_path = tmp_path / "slides_t.en.py"
+    de_path.write_text(de, encoding="utf-8")
+    en_path.write_text(en, encoding="utf-8")
+
+    companion_dir = tmp_path / "voiceover"
+    companion_dir.mkdir()
+    de_comp = _build(
+        _companion_cell("s0-vo", "de", "s0", "Bestand Alpha."),
+        _companion_cell("s2-vo", "de", "s2", "Bestand Gamma."),
+    )
+    en_comp = _build(_companion_cell("s0-vo", "en", "s0", "Existing alpha."))
+    (companion_dir / "voiceover_t.de.py").write_text(de_comp, encoding="utf-8")
+    (companion_dir / "voiceover_t.en.py").write_text(en_comp, encoding="utf-8")
+
+    video = tmp_path / "video.mp4"
+    video.write_bytes(b"not a real video")
+    return de_path, video
+
+
+def _slide_indices(de_path: Path) -> dict[str, int]:
+    from clm.notebooks.slide_parser import parse_slides
+
+    groups = parse_slides(de_path, "de")
+    return {
+        sg.cells[0].slide_id: sg.index
+        for sg in groups
+        if sg.slide_type != "header" and sg.cells and sg.cells[0].slide_id
+    }
+
+
+def _write_alignment(tmp_path: Path, de_path: Path) -> Path:
+    idx = _slide_indices(de_path)
+    payload = {
+        "slide_notes": {
+            str(idx["s0"]): {
+                "slide_index": idx["s0"],
+                "segments": ["Neues zu Alpha."],
+                "revisited_segments": [["Nachtrag zu Alpha."]],
+            },
+            str(idx["s1"]): {
+                "slide_index": idx["s1"],
+                "segments": ["Alles über Beta."],
+                "revisited_segments": [],
+            },
+            "99": {
+                "slide_index": 99,
+                "segments": ["Geist einer gelöschten Folie."],
+                "revisited_segments": [],
+            },
+        },
+        "unassigned_segments": [{"start": 0.0, "end": 2.0, "text": "Mikrofontest."}],
+    }
+    path = tmp_path / "alignment.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _invoke(args: list[str]):
+    return CliRunner().invoke(harvest_group, args, catch_exceptions=False)
+
+
+def _report_from(result) -> dict:
+    text = result.output
+    return json.loads(text[text.index("{") :])
+
+
+class TestHarvestReport:
+    def test_classifies_every_slide_and_exits_1(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        alignment = _write_alignment(tmp_path, de_path)
+        result = _invoke(
+            [
+                "report",
+                str(de_path),
+                str(video),
+                "--lang",
+                "de",
+                "--alignment",
+                str(alignment),
+                "--json",
+            ]
+        )
+        assert result.exit_code == 1, result.output
+        report = _report_from(result)
+
+        by_key = {item["key"]: item for item in report["items"]}
+        assert by_key["id:s0"]["class"] == "transcript_adds_material"
+        assert by_key["id:s1"]["class"] == "no_existing_vo"
+        assert by_key["id:s2"]["class"] == "covered"
+        assert by_key["id:s3"]["class"] == "unmatched_slide"
+
+        assert report["schema"] == 1
+        assert report["video_language"] == "de"
+        assert report["video_fingerprint"]
+        assert report["summary"]["actionable"] is True
+        assert report["summary"]["classes"] == {
+            "no_existing_vo": 1,
+            "transcript_adds_material": 1,
+            "covered": 1,
+            "unmatched_slide": 1,
+        }
+
+    def test_transcript_and_voiceover_payloads(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        alignment = _write_alignment(tmp_path, de_path)
+        result = _invoke(
+            [
+                "report",
+                str(de_path),
+                str(video),
+                "--lang",
+                "de",
+                "--alignment",
+                str(alignment),
+                "--json",
+            ]
+        )
+        report = _report_from(result)
+        by_key = {item["key"]: item for item in report["items"]}
+
+        s0 = by_key["id:s0"]
+        assert s0["transcript"]["segments"] == ["Neues zu Alpha."]
+        assert s0["transcript"]["revisited_segments"] == [["Nachtrag zu Alpha."]]
+        assert "**[Revisited]**" in s0["transcript"]["text"]
+        # Both language sides of the baseline are visible to the agent.
+        assert s0["voiceover"]["de"]["present"] is True
+        assert s0["voiceover"]["en"]["present"] is True
+        assert s0["voiceover"]["de"]["cells"][0]["key"] == "id:s0-vo"
+        assert s0["voiceover"]["de"]["cells"][0]["layout"] == "companion"
+
+        # s2's twin has no voiceover — a one-sided baseline is representable.
+        s2 = by_key["id:s2"]
+        assert s2["voiceover"]["de"]["present"] is True
+        assert s2["voiceover"]["en"]["present"] is False
+
+        # The silent slides carry no transcript payload.
+        assert "transcript" not in by_key["id:s3"]
+
+    def test_unmatched_speech_collects_unassigned_and_stale_indices(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        alignment = _write_alignment(tmp_path, de_path)
+        result = _invoke(
+            [
+                "report",
+                str(de_path),
+                str(video),
+                "--lang",
+                "de",
+                "--alignment",
+                str(alignment),
+                "--json",
+            ]
+        )
+        report = _report_from(result)
+        texts = [entry["text"] for entry in report["unmatched_speech"]]
+        assert "Mikrofontest." in texts
+        assert "Geist einer gelöschten Folie." in texts
+        assert report["summary"]["unmatched_speech"] == 2
+
+    def test_silent_recording_exits_0(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        empty = tmp_path / "empty-alignment.json"
+        empty.write_text(json.dumps({"slide_notes": {}, "unassigned_segments": []}), "utf-8")
+        result = _invoke(
+            [
+                "report",
+                str(de_path),
+                str(video),
+                "--lang",
+                "de",
+                "--alignment",
+                str(empty),
+                "--json",
+            ]
+        )
+        assert result.exit_code == 0, result.output
+        report = _report_from(result)
+        assert report["summary"]["actionable"] is False
+        classes = {item["class"] for item in report["items"]}
+        assert classes == {"covered", "unmatched_slide"}
+
+    def test_bare_deck_video_defaults_to_report(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        alignment = _write_alignment(tmp_path, de_path)
+        result = _invoke(
+            [str(de_path), str(video), "--lang", "de", "--alignment", str(alignment), "--json"]
+        )
+        assert result.exit_code == 1, result.output
+        assert _report_from(result)["verb"] == "report"
+
+    def test_default_verb_works_after_group_options(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        alignment = _write_alignment(tmp_path, de_path)
+        result = _invoke(
+            [
+                "--no-cache",
+                str(de_path),
+                str(video),
+                "--lang",
+                "de",
+                "--alignment",
+                str(alignment),
+                "--json",
+            ]
+        )
+        assert result.exit_code == 1, result.output
+
+    def test_non_normalized_deck_exits_2(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        # An id-less slide makes the v3 lens refuse the bundle.
+        idless = '# %% [markdown] lang="de" tags=["slide"]\n#\n# # Ohne Id\n\n'
+        de_path.write_text(de_path.read_text(encoding="utf-8") + idless, encoding="utf-8")
+        alignment = _write_alignment(tmp_path, de_path)
+        result = _invoke(
+            [
+                "report",
+                str(de_path),
+                str(video),
+                "--lang",
+                "de",
+                "--alignment",
+                str(alignment),
+                "--json",
+            ]
+        )
+        assert result.exit_code == 2, result.output
+
+    def test_human_output_lists_actionable_items(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        alignment = _write_alignment(tmp_path, de_path)
+        result = _invoke(
+            ["report", str(de_path), str(video), "--lang", "de", "--alignment", str(alignment)]
+        )
+        assert result.exit_code == 1
+        assert "no_existing_vo" in result.output
+        assert "id:s1" in result.output
+        assert "id:s3" not in result.output  # non-actionable rows stay out
+
+
+class TestHarvestGroup:
+    def test_help_lists_verbs(self) -> None:
+        result = _invoke(["--help"])
+        assert result.exit_code == 0
+        for verb in (
+            "report",
+            "transcribe",
+            "detect",
+            "identify",
+            "identify-rev",
+            "cache",
+            "trace",
+        ):
+            assert verb in result.output
+
+    def test_rehomed_diagnostics_resolve(self) -> None:
+        for verb in ("transcribe", "detect", "identify", "identify-rev", "trace"):
+            result = _invoke([verb, "--help"])
+            assert result.exit_code == 0, f"{verb}: {result.output}"
+
+    def test_report_help_documents_exit_codes(self) -> None:
+        result = _invoke(["report", "--help"])
+        assert result.exit_code == 0
+        assert "--lang" in result.output
+        assert "--alignment" in result.output
+        assert "Exit codes" in result.output


### PR DESCRIPTION
## Summary

Phase 2 of the video-narration-harvest epic #546 (proposal:
`docs/proposals/video-narration-harvest.md`): the read-only, agent-first
entry point of the new `clm harvest` toolkit. No writes, no model, no key.

### `clm harvest report DECK VIDEO… --lang de|en`

- Runs the cached deterministic tier — transcribe → transition detect →
  OCR match → align — with the exact stage order, `cached_*` wrappers, and
  single-part cache scoping `clm voiceover sync` uses
  (`src/clm/voiceover/harvest.py:run_pipeline`).
- Joins the alignment with the v3 deck bundle (`load_bundle`): one item per
  slide, keyed by the member handle `id:<slide_id>` (the positional
  `slide_index` → `slide_id` identity seam), carrying the aligned
  transcript (including `**[Revisited]**` backtracking groups) and the
  existing voiceover baseline on **both** language sides (inline or
  companion, with per-cell member keys) — so a driving agent sees twin
  staleness directly.
- Purely **structural** novelty classification (epic decision 6 — no
  textual-similarity heuristics): speech-assigned × VO-present →
  `no_existing_vo` | `transcript_adds_material` | `covered` |
  `unmatched_slide`; unassignable segments (and aligned notes pointing at
  slide indices absent from the deck) surface under `unmatched_speech`,
  never dropped silently.
- Exit codes 0 (nothing to harvest) / 1 (actionable) / 2 (error, incl.
  non-normalized bundle with a `clm slides normalize` hint);
  `--transcript` / `--alignment` injection skips ASR (single-video only);
  the envelope records the video fingerprint that keys the cache (and the
  future `harvest:<fp>` ledger provenance).
- `report` is the group's **default verb**, resolved in `resolve_command`
  (not sync's `parse_args` prepend, which would misfire on the group's
  cache flags), so `clm harvest DECK VIDEO…` and
  `clm harvest --no-cache DECK VIDEO…` both work.

### Re-homed diagnostics

`transcribe` / `detect` / `identify` / `identify-rev` / `cache` / `trace`
are registered under `clm harvest` as the same Click command objects; the
`clm voiceover` names stay until the Phase-4 cutover deletes them (no
aliases policy applies at cutover, not mid-epic).

### Registration

Lazily registered top-level group (`main.py` `lazy_subcommands`,
`optional_subcommands`, `_OPTIONAL_COMPAT_EXPORTS`) — no eager imports,
per the PR #312 LazyGroup rule.

## Tests & docs

- `tests/cli/test_harvest_cli.py`: injected-alignment CLI round-trips
  pinning every novelty class, transcript/voiceover payloads, unmatched
  speech (incl. stale indices), exit codes 0/1/2, default verb (bare and
  after group options), re-homed diagnostics. No ASR/ffmpeg/GPU — fast
  suite.
- Suites run locally: tests/cli (1918 passed), tests/voiceover +
  test_voiceover_cli (465 passed); ruff + mypy clean; fast suite green on
  the pre-push hook.
- `clm info commands` topic updated (`### clm harvest` section + group
  overview); changelog fragment in `changelog.d/`; harvest handover marks
  Phase 2 done (Phase 3 stays gated on the v3 dogfood week).

Part of epic #546 (stays open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TJvSAbnsLWxcCLJ3SvqoS
