### PR TITLE
feat(harvest): task/accept/verify — the judgment loop (#546 Phase 3)

### DIFF
--- a/changelog.d/546-harvest-phase3-task-accept.added.md
+++ b/changelog.d/546-harvest-phase3-task-accept.added.md
@@ -1,0 +1,16 @@
+- `clm harvest task` / `accept` / `verify` (epic #546 Phase 3) — the
+  judgment half of the agent-first harvest toolkit. `task` frames one
+  slide's curation or translation as a JSON document (caller instructions,
+  baseline + transcript inputs incl. `revisited_segments`, bullet-list
+  `answer_schema`, per-side `baseline_fingerprint` + `video_fingerprint`
+  freshness tokens). `accept` validates the answer (schema, freshness,
+  single-cell guards, v3 re-parse gate) and writes the id-keyed member edit
+  atomically through the v3 model, creating the voiceover member (minted
+  `slide_id`, `for_slide` owner, deck-convention layout) when absent;
+  `--record` banks it into the sync ledger with provenance
+  `harvest:<video-fingerprint>` under one-sided-trust semantics, so a
+  one-language write surfaces in the next `clm slides sync report` as
+  `translate_new`/`translate_edit` — never as `in_sync` (the stale twin is
+  never blessed) and never as corruption. `verify` runs the v3 lens gate +
+  the shared structural gate, listing one-sided narrative members as
+  `pending_twins` instead of failing them.

--- a/docs/claude/handovers/video-narration-harvest-handover.md
+++ b/docs/claude/handovers/video-narration-harvest-handover.md
@@ -1,7 +1,9 @@
 # Handover: Video Narration Harvest (agent-first rebuild)
 
-**Status**: Phases 1–2 implemented (v3 extraction; `clm harvest report`);
-Phases 3–4 TODO (Phase 3 gated on the v3 dogfood week)
+**Status**: Phases 1–3 implemented (v3 extraction; `clm harvest report`;
+`task`/`accept`/`verify` — Phase 3 landed EARLY as a deliberate v3
+stress-test, back-out tag `pre-harvest-phase3`); Phase 4 (rename+cutover)
+TODO
 **Last updated**: 2026-07-04
 **Canonical design source**: `docs/proposals/video-narration-harvest.md`
 (merged via PR #541, decisions folded in via PR #542). Read that proposal
@@ -114,15 +116,46 @@ pivot), #520 (sync-engine-v3), #501 (separated companions);
     round-trips pinning every class, exit codes, default verb incl. after
     group options, refusal → exit 2, re-homed diagnostics). Docs:
     `commands.md` §`clm harvest`.
-- **Phase 3 [TODO] — `task` / `accept` / `verify`** (gated on v3 confidence
-  — see Blockers). `task --kind curate|translate` framing (instructions =
-  today's `src/clm/voiceover/prompts/merge_*.md` content restated as
-  caller instructions; bullet-list `answer_schema`; named validator).
-  `accept`: validate (schema; baseline-hash freshness vs. what `task`
-  framed; `de_id==en_id`; shared-cell byte-identity — reuse sync
-  validators), then id-keyed member write through the Phase-1 write
-  surface; `--record` with `harvest:<fp>` provenance, one-sided-trust
-  semantics. `verify` delegates to `clm slides sync verify`.
+- **Phase 3 [DONE — landed EARLY, before the v3 dogfood week, as a
+  deliberate stress-test; back-out = revert the PR merge or reset to tag
+  `pre-harvest-phase3`]** — `task` / `accept` / `verify`. Landed as:
+  - `src/clm/voiceover/harvest_task.py` — `build_tasks(report, deck,
+    kind, slide)`: instructions from the new
+    `prompts/harvest_curate.md`/`harvest_translate.md` (merge/propagate
+    rules restated for the caller); bullet-list `ANSWER_SCHEMA`
+    (validator `harvest-bullets`); freshness tokens = per-side
+    `baseline_fingerprint` (the report's per-cell `content_fingerprint`,
+    added to report items) + `video_fingerprint`; >1 narrative cell per
+    side ⇒ `TaskUnavailable` (P8). `revisited_segments` presented as
+    structured groups with instruction 6 explaining their semantics.
+  - `src/clm/voiceover/harvest_accept.py` — `parse_answer` (precise
+    per-field rejections) + `accept_answer`: freshness re-check against
+    the LIVE bundle; bullets rendered `#\n# - …`; existing member body
+    replaced via the doc_apply `_replace_body` rule; missing side added
+    via `swap_lang` + `insert_mirrored`; missing member created (minted
+    `<owner>-vo` id, deck-majority role/layout, companion appends /
+    inline inserts after the owner group) and written via the Phase-1
+    `DeckEmitter`/`write_changed_files` after the re-parse gate.
+  - **The §6 ledger semantics** (`_record_member`, provenance
+    `harvest:<fp>`, gated on `structural_gate`): bilingual answer →
+    fresh both-side entry (next sync report: `in_sync`); one-sided
+    member → fresh one-sided entry (→ framed `translate_new`; without
+    the record it would be unframed `verify_cold`); one-sided write over
+    an existing twin → the written side's fingerprint is NOT advanced
+    (existing entry kept / pre-write state synthesized → framed
+    `translate_edit`). LedgerMember has no per-side trust field — the
+    fingerprint mismatch IS the "twin owes translation" representation;
+    advancing both fps is the forbidden silent-bless state.
+  - `verify` is **v3-native**, NOT a `sync verify` delegate: the v2
+    `verify_pair` projects companions and reads a one-sided narrative
+    member as an `id-asymmetry` ERROR — exactly the corruption
+    misreading §6 forbids. Harvest verify = lens gate + deck-half
+    `structural_gate` + one-sided narrative members listed as
+    `pending_twins` (exit 0).
+  - Tests: `tests/cli/test_harvest_task_accept.py` (report→task→accept→
+    verify loop; the §6 classification tests assert the v3 differ's
+    verdicts against the recorded ledger: `translate_new`,
+    `translate_edit` de→en, bilingual → no item).
 - **Phase 4 [TODO] — rename + cutover**. `clm harvest` absorbs
   `port`/`compare`/`compare-from-inventory`; `voiceover sync` →
   `harvest autopilot`; delete old video-side `voiceover` verbs (no
@@ -136,10 +169,12 @@ pivot), #520 (sync-engine-v3), #501 (separated companions);
 - Proposal written, decisions resolved, merged to master
   (`docs/proposals/video-narration-harvest.md`; PRs #541 merged, #542
   merged/auto-merge armed 2026-07-04).
-- **Phases 1–2 implemented** (`doc_identity.py` + `doc_write.py`;
-  `clm harvest report` + re-homed diagnostics, see §3). Epic issue:
-  **#546** (phases, settled decisions, and the Phase-3 gate mirrored
-  there).
+- **Phases 1–3 implemented** (`doc_identity.py` + `doc_write.py`;
+  `clm harvest report` + re-homed diagnostics; `task`/`accept`/`verify`,
+  see §3). Epic issue: **#546**. Phase 3 landed BEFORE the v3 dogfood week
+  finished (user decision, as a stress-test): master is tagged
+  `pre-harvest-phase3` right before it, and the phase is one PR, so
+  back-out = `git revert -m 1 <merge>` or comparison against the tag.
 - Blocker for Phase 3 (and arguably 4): sync-engine-v3 must survive its
   **dogfood week on PythonCourses** first (see
   `docs/claude/sync-v3-handover.md`; v3 Phase 4 = flip default, delete v2).
@@ -151,15 +186,14 @@ pivot), #520 (sync-engine-v3), #501 (separated companions);
 
 ## 5. Next Steps
 
-Phases 1–2 are done (see §3). Next is **Phase 3 — `task` / `accept` /
-`verify`**, which stays **gated on the v3 dogfood week** (see Blockers in
-§4); do not start it before v3 confidence is established. When it opens:
-`task --kind curate|translate` framing (instructions from
-`src/clm/voiceover/prompts/merge_*.md` restated as caller instructions;
-bullet-list `answer_schema`), `accept` writing through the Phase-1
-`doc_write` surface, `--record` with `harvest:<fp>` provenance (the
-fingerprint `harvest.py:video_fingerprint` already computes), one-sided
-trust semantics (§8 of this doc / proposal §6). Gotchas that remain live:
+Phases 1–3 are done (see §3; Phase 3 was pulled forward deliberately as a
+v3 stress-test — the user's call, hedged by tag `pre-harvest-phase3` on
+master and single-PR landing for easy revert). Next steps: **dogfood the
+harvest loop on real recordings** (this doubles as the v3 dogfood), then
+**Phase 4 — rename + cutover** (absorb `port`/`compare`/
+`compare-from-inventory`, `voiceover sync` → `harvest autopilot`, delete
+old video-side voiceover verbs, MCP renames, `clm info harvest-agents`
+topic, user-guide split). Gotchas that remain live:
 - `tests/cli/test_sync_import_cleanliness.py` pins the v3 import graph
   (model must not import v2; facade imports only v3 core; `doc_identity`/
   `doc_write` must stay differ/ledger-free) — extend, don't fight it.
@@ -174,7 +208,11 @@ Created by Phase 1: `src/clm/slides/doc_identity.py` (identity/snapshot),
 `tests/slides/test_doc_write.py`. Created by Phase 2:
 `src/clm/voiceover/harvest.py` (report engine),
 `src/clm/cli/commands/harvest.py` (group + report + re-homed diagnostics),
-`tests/cli/test_harvest_cli.py`. The rest of the map (from the 2026-07-04
+`tests/cli/test_harvest_cli.py`. Created by Phase 3:
+`src/clm/voiceover/harvest_task.py`, `harvest_accept.py`,
+`prompts/harvest_curate.md`, `prompts/harvest_translate.md`,
+`tests/cli/test_harvest_task_accept.py` (+ `task`/`accept`/`verify` verbs
+in the CLI module). The rest of the map (from the 2026-07-04
 investigation):
 
 - **v3 model (reuse)**: `src/clm/slides/bilingual_doc.py` (model: `Member`,

--- a/src/clm/cli/commands/harvest.py
+++ b/src/clm/cli/commands/harvest.py
@@ -8,11 +8,20 @@ module carries the group plus the Phase-2 surface:
 * ``report`` (the default verb) — run the cached deterministic tier and
   emit per-slide JSON keyed by v3 ``MemberKey``, with a structural novelty
   class per slide. Read-only; no model; no key.
+* ``task`` — frame one slide's curation/translation judgment for the
+  driving agent (instructions + inputs + answer_schema + freshness
+  tokens). Read-only.
+* ``accept`` — validate a bullet-list answer and write it through the v3
+  model (id-keyed member edit, atomic ≤4-file write); ``--record`` banks
+  it into the sync ledger under ``harvest:<video-fingerprint>``
+  provenance with the §6 one-sided-trust semantics. The only write path.
+* ``verify`` — the structural post-check, delegating to the same engine
+  as ``clm slides sync verify``.
 * the re-homed diagnostics ``transcribe`` / ``detect`` / ``identify`` /
   ``identify-rev`` / ``cache`` / ``trace`` (shared with ``clm voiceover``
   until the Phase-4 cutover deletes the old names).
 
-``task`` / ``accept`` / ``verify`` / ``autopilot`` arrive in Phases 3–4.
+``autopilot`` (the embedded-model one-shot) arrives in Phase 4.
 """
 
 from __future__ import annotations
@@ -75,12 +84,20 @@ def harvest_group(ctx, cache_root, no_cache, refresh_cache):
     Bare `clm harvest DECK VIDEO…` == `clm harvest report DECK VIDEO…`.
     Verbs:
       report        what did the recording say, slide by slide? (read-only)
+      task          frame one slide's curation/translation judgment (read-only)
+      accept        validate a bullet-list answer + write it (the only write path)
+      verify        structural post-check on the pair (same engine as sync verify)
       transcribe    ASR only: dump the transcript (diagnostic)
       detect        slide-transition detection only (diagnostic)
       identify      which slides appear in a video? (diagnostic)
       identify-rev  which git revision of a deck was recorded? (diagnostic)
       cache         inspect/prune the artifact cache
       trace         inspect merge trace logs
+
+    \b
+    The agent loop:
+      harvest report → (task → judge → accept [--record])* → verify
+      → clm slides sync report   (twin translation continues there)
 
     The deterministic tier (ASR, transition detection, OCR matching,
     alignment) is engine-owned, cached, and model-free; curation and
@@ -99,6 +116,130 @@ def harvest_group(ctx, cache_root, no_cache, refresh_cache):
 
 
 # ---------------------------------------------------------------------------
+# Shared plumbing for the pipeline-driven verbs (report, task)
+# ---------------------------------------------------------------------------
+
+
+def _pipeline_options(f):
+    """The option stack `report` and `task` share (video → alignment inputs)."""
+    options = [
+        click.option(
+            "--lang",
+            required=True,
+            type=click.Choice(["de", "en"]),
+            help="The recorded (spoken) language; SLIDES must be that half of the pair.",
+        ),
+        click.option(
+            "--transcript",
+            "transcript_override",
+            type=click.Path(exists=True, path_type=Path),
+            default=None,
+            help="Skip ASR and load a precomputed transcript from PATH "
+            "(JSON from `clm harvest transcribe -o`). Single-video only.",
+        ),
+        click.option(
+            "--alignment",
+            "alignment_override",
+            type=click.Path(exists=True, path_type=Path),
+            default=None,
+            help="Skip ASR, detection, and matching; load a precomputed alignment "
+            "from PATH (cache artifact shape). Single-video only.",
+        ),
+        click.option(
+            "--whisper-model",
+            default="large-v3",
+            show_default=True,
+            help="Whisper model size for ASR.",
+        ),
+        click.option(
+            "--backend",
+            "backend_name",
+            default="faster-whisper",
+            show_default=True,
+            help="Transcription backend.",
+        ),
+        click.option(
+            "--device",
+            default="auto",
+            show_default=True,
+            type=click.Choice(["auto", "cuda", "cpu"]),
+            help="Device for ASR.",
+        ),
+    ]
+    for option in reversed(options):
+        f = option(f)
+    return f
+
+
+def _load_bundle_or_exit(slides: Path):
+    """The v3 deck bundle: both languages + companions, the identity source."""
+    from clm.slides.doc_lenses import DocLensError, load_bundle
+
+    try:
+        bundle = load_bundle(slides)
+    except DocLensError as exc:
+        click.echo(f"error: {exc}", err=True)
+        sys.exit(2)
+    if bundle.outcome.deck is None:
+        refusal = bundle.outcome.refusal
+        click.echo("error: the deck bundle is not normalized:", err=True)
+        if refusal is not None:
+            for reason in refusal.reasons:
+                click.echo(f"  [{reason.code}] {reason.detail}", err=True)
+        click.echo("run `clm slides normalize` on the pair first.", err=True)
+        sys.exit(2)
+    return bundle
+
+
+def _build_report_data(
+    ctx,
+    bundle,
+    slides: Path,
+    videos: tuple[str, ...],
+    lang: str,
+    transcript_override: Path | None,
+    alignment_override: Path | None,
+    whisper_model: str,
+    backend_name: str,
+    device: str,
+) -> dict:
+    from clm.cli.commands.voiceover import (
+        _expand_video_args,
+        _load_alignment_override,
+        _load_transcript_override,
+    )
+    from clm.notebooks.slide_parser import parse_slides
+    from clm.voiceover.cache import CachePolicy
+    from clm.voiceover.harvest import HarvestUsageError, build_report, run_pipeline
+
+    policy: CachePolicy = ctx.obj.get("cache_policy", CachePolicy())
+    video_paths = _expand_video_args(videos)
+
+    # The recorded-language view the OCR matcher and aligner key on.
+    slide_groups = parse_slides(slides, lang)
+
+    transcript = _load_transcript_override(transcript_override) if transcript_override else None
+    alignment = _load_alignment_override(alignment_override) if alignment_override else None
+    try:
+        artifacts = run_pipeline(
+            slides,
+            video_paths,
+            lang,
+            slide_groups,
+            policy=policy,
+            backend_name=backend_name,
+            whisper_model=whisper_model,
+            device=device,
+            transcript_override=transcript,
+            alignment_override=alignment,
+        )
+    except HarvestUsageError as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    return build_report(bundle, slide_groups, artifacts, lang=lang, video_paths=video_paths)
+
+
+# ---------------------------------------------------------------------------
 # report — the read-only default verb
 # ---------------------------------------------------------------------------
 
@@ -106,49 +247,8 @@ def harvest_group(ctx, cache_root, no_cache, refresh_cache):
 @harvest_group.command("report")
 @click.argument("slides", type=click.Path(exists=True, path_type=Path))
 @click.argument("videos", nargs=-1, required=True, type=str)
-@click.option(
-    "--lang",
-    required=True,
-    type=click.Choice(["de", "en"]),
-    help="The recorded (spoken) language; SLIDES must be that half of the pair.",
-)
+@_pipeline_options
 @click.option("--json", "as_json", is_flag=True, help="Emit the JSON report envelope.")
-@click.option(
-    "--transcript",
-    "transcript_override",
-    type=click.Path(exists=True, path_type=Path),
-    default=None,
-    help="Skip ASR and load a precomputed transcript from PATH "
-    "(JSON from `clm harvest transcribe -o`). Single-video only.",
-)
-@click.option(
-    "--alignment",
-    "alignment_override",
-    type=click.Path(exists=True, path_type=Path),
-    default=None,
-    help="Skip ASR, detection, and matching; load a precomputed alignment "
-    "from PATH (cache artifact shape). Single-video only.",
-)
-@click.option(
-    "--whisper-model",
-    default="large-v3",
-    show_default=True,
-    help="Whisper model size for ASR.",
-)
-@click.option(
-    "--backend",
-    "backend_name",
-    default="faster-whisper",
-    show_default=True,
-    help="Transcription backend.",
-)
-@click.option(
-    "--device",
-    default="auto",
-    show_default=True,
-    type=click.Choice(["auto", "cuda", "cpu"]),
-    help="Device for ASR.",
-)
 @click.pass_context
 def harvest_report_cmd(
     ctx,
@@ -180,66 +280,303 @@ def harvest_report_cmd(
 
     No model, no key, no writes — also the human dry-run.
     """
-    from clm.cli.commands.voiceover import (
-        _expand_video_args,
-        _load_alignment_override,
-        _load_transcript_override,
+    from clm.voiceover.harvest import report_exit_code
+
+    bundle = _load_bundle_or_exit(slides)
+    report = _build_report_data(
+        ctx,
+        bundle,
+        slides,
+        videos,
+        lang,
+        transcript_override,
+        alignment_override,
+        whisper_model,
+        backend_name,
+        device,
     )
-    from clm.notebooks.slide_parser import parse_slides
-    from clm.slides.doc_lenses import DocLensError, load_bundle
-    from clm.voiceover.cache import CachePolicy
-    from clm.voiceover.harvest import (
-        HarvestUsageError,
-        build_report,
-        report_exit_code,
-        run_pipeline,
-    )
-
-    policy: CachePolicy = ctx.obj.get("cache_policy", CachePolicy())
-    video_paths = _expand_video_args(videos)
-
-    # The v3 deck bundle: both languages + companions, the identity source.
-    try:
-        bundle = load_bundle(slides)
-    except DocLensError as exc:
-        click.echo(f"error: {exc}", err=True)
-        sys.exit(2)
-    if bundle.outcome.deck is None:
-        refusal = bundle.outcome.refusal
-        click.echo("error: the deck bundle is not normalized:", err=True)
-        if refusal is not None:
-            for reason in refusal.reasons:
-                click.echo(f"  [{reason.code}] {reason.detail}", err=True)
-        click.echo("run `clm slides normalize` on the pair first.", err=True)
-        sys.exit(2)
-
-    # The recorded-language view the OCR matcher and aligner key on.
-    slide_groups = parse_slides(slides, lang)
-
-    transcript = _load_transcript_override(transcript_override) if transcript_override else None
-    alignment = _load_alignment_override(alignment_override) if alignment_override else None
-    try:
-        artifacts = run_pipeline(
-            slides,
-            video_paths,
-            lang,
-            slide_groups,
-            policy=policy,
-            backend_name=backend_name,
-            whisper_model=whisper_model,
-            device=device,
-            transcript_override=transcript,
-            alignment_override=alignment,
-        )
-    except HarvestUsageError as exc:
-        raise click.UsageError(str(exc)) from exc
-
-    report = build_report(bundle, slide_groups, artifacts, lang=lang, video_paths=video_paths)
     if as_json:
         click.echo(json.dumps(report, indent=2, ensure_ascii=False))
     else:
         _print_human_report(report)
     sys.exit(report_exit_code(report))
+
+
+# ---------------------------------------------------------------------------
+# task — frame the judgment for the driving agent (read-only)
+# ---------------------------------------------------------------------------
+
+
+@harvest_group.command("task")
+@click.argument("slides", type=click.Path(exists=True, path_type=Path))
+@click.argument("videos", nargs=-1, required=True, type=str)
+@_pipeline_options
+@click.option(
+    "--slide",
+    default=None,
+    help="Frame one slide (bare id or id:… handle). Omit to frame every actionable item.",
+)
+@click.option(
+    "--kind",
+    type=click.Choice(["curate", "translate"]),
+    default="curate",
+    show_default=True,
+    help="curate = merge the recorded language; translate = frame the twin side.",
+)
+@click.pass_context
+def harvest_task_cmd(
+    ctx,
+    slides: Path,
+    videos: tuple[str, ...],
+    lang: str,
+    slide: str | None,
+    kind: str,
+    transcript_override: Path | None,
+    alignment_override: Path | None,
+    whisper_model: str,
+    backend_name: str,
+    device: str,
+):
+    """Frame one slide's judgment as a task document (read-only).
+
+    Emits JSON task document(s): caller instructions (the curation rules the
+    old embedded-model merge applied), structured inputs (baseline voiceover
+    on both sides, the aligned transcript with its revisited groups, slide
+    content), the bullet-list `answer_schema`, and the freshness tokens
+    (`baseline_fingerprint`, `video_fingerprint`) that `accept` re-checks.
+
+    \b
+    Exit codes: 0 tasks emitted (possibly zero in the sweep) · 2 error /
+    the named slide cannot be framed.
+    """
+    from clm.voiceover.harvest_task import TaskUnavailable, build_tasks
+
+    bundle = _load_bundle_or_exit(slides)
+    report = _build_report_data(
+        ctx,
+        bundle,
+        slides,
+        videos,
+        lang,
+        transcript_override,
+        alignment_override,
+        whisper_model,
+        backend_name,
+        device,
+    )
+    deck = bundle.outcome.deck
+    assert deck is not None
+    try:
+        tasks = build_tasks(report, deck, kind=kind, slide=slide)
+    except TaskUnavailable as exc:
+        click.echo(f"error: {exc}", err=True)
+        sys.exit(2)
+    click.echo(
+        json.dumps(
+            {
+                "schema": 1,
+                "tool": "harvest",
+                "verb": "task",
+                "video_fingerprint": report["video_fingerprint"],
+                "tasks": tasks,
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    )
+    sys.exit(0)
+
+
+# ---------------------------------------------------------------------------
+# accept — the only write path
+# ---------------------------------------------------------------------------
+
+
+@harvest_group.command("accept")
+@click.argument("slides", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--answer",
+    "answer_src",
+    required=True,
+    help="The answer document: a file path, or '-' for stdin.",
+)
+@click.option("--slide", default=None, help="Safety check: must match the answer's item.")
+@click.option(
+    "--record",
+    is_flag=True,
+    help="Bank the written member into the sync ledger under "
+    "harvest:<video-fingerprint> provenance (one-sided trust semantics).",
+)
+@click.option("--dry-run", is_flag=True, help="Validate and report; write nothing.")
+@click.option("--json", "as_json", is_flag=True, help="Emit the JSON outcome envelope.")
+def harvest_accept_cmd(
+    slides: Path,
+    answer_src: str,
+    slide: str | None,
+    record: bool,
+    dry_run: bool,
+    as_json: bool,
+):
+    """Validate a bullet-list answer and write it through the v3 model.
+
+    Validates the answer against the task's schema and the LIVE deck
+    (baseline-fingerprint freshness — a concurrent edit rejects, never
+    overwrites), renders the bullets into the voiceover cell body, and lands
+    the member edit atomically (both halves + companions as needed). A
+    one-language answer writes that side only — the pair becomes a
+    deliberate divergence the `clm slides sync` loop resolves as translation
+    work. Writes nothing on any validation failure.
+
+    \b
+    Exit codes: 0 applied (and recorded, if requested) · 1 applied but the
+    ledger record was refused by the structural gate · 2 rejected / error.
+    """
+    from clm.voiceover.harvest_accept import AcceptRejected, accept_answer, parse_answer
+
+    if answer_src == "-":
+        raw = click.get_text_stream("stdin").read()
+    else:
+        answer_path = Path(answer_src)
+        if not answer_path.exists():
+            raise click.UsageError(f"answer file not found: {answer_src}")
+        raw = answer_path.read_text(encoding="utf-8")
+    try:
+        payload = json.loads(raw)
+    except ValueError as exc:
+        raise click.UsageError(f"the answer is not valid JSON: {exc}") from exc
+
+    bundle = _load_bundle_or_exit(slides)
+    try:
+        parsed = parse_answer(payload)
+        if slide is not None:
+            handle = slide if slide.startswith("id:") else f"id:{slide}"
+            if handle != parsed.item:
+                raise AcceptRejected(
+                    f"--slide {handle} does not match the answer's item {parsed.item}"
+                )
+        outcome = accept_answer(bundle, parsed, record=record, dry_run=dry_run)
+    except AcceptRejected as exc:
+        if as_json:
+            click.echo(
+                json.dumps(
+                    {
+                        "schema": 1,
+                        "tool": "harvest",
+                        "verb": "accept",
+                        "applied": False,
+                        "outcome": "rejected",
+                        "reason": str(exc),
+                    },
+                    indent=2,
+                    ensure_ascii=False,
+                )
+            )
+        else:
+            click.echo(f"rejected: {exc}", err=True)
+        sys.exit(2)
+
+    if as_json:
+        click.echo(json.dumps(outcome.to_payload(), indent=2, ensure_ascii=False))
+    else:
+        state = "dry-run: would write" if dry_run else "wrote"
+        click.echo(f"accepted {outcome.item} → member {outcome.member} ({state})")
+        for path in outcome.written_paths:
+            click.echo(f"  {path}")
+        if outcome.recorded:
+            click.echo("  ledger: recorded")
+        for message in outcome.record_refused:
+            click.echo(f"  ledger withheld: {message}", err=True)
+    sys.exit(1 if outcome.record_refused else 0)
+
+
+# ---------------------------------------------------------------------------
+# verify — the structural post-check
+# ---------------------------------------------------------------------------
+
+
+@harvest_group.command("verify")
+@click.argument("slides", type=click.Path(exists=True, path_type=Path))
+@click.option("--json", "as_json", is_flag=True, help="Emit the JSON verdict.")
+def harvest_verify_cmd(slides: Path, as_json: bool):
+    """Structural post-check on the pair (v3 lens + the shared write gate).
+
+    Runs the v3 lens gate (the whole bundle must parse back — refusals are
+    corruption) plus the deck-half structural gate `sync record`/`apply`
+    use. One-sided narrative members are NOT failures: a harvest write to
+    one language side is a representable pending state the `clm slides
+    sync` loop resolves as translation work — they are listed as
+    `pending_twin` items. (The v2 `sync verify` projects companions and
+    reads that same state as an id-asymmetry error, which is exactly the
+    "corruption" misreading harvest must avoid — §6.)
+
+    \b
+    Exit codes: 0 pass (pending twins allowed) · 2 structural errors.
+    """
+    from clm.slides.doc_lenses import DocLensError, load_bundle
+    from clm.slides.sync_verify import structural_gate
+
+    try:
+        bundle = load_bundle(slides)
+    except DocLensError as exc:
+        click.echo(f"error: {exc}", err=True)
+        sys.exit(2)
+
+    errors: list[str] = []
+    pending: list[dict] = []
+    if bundle.outcome.deck is None:
+        refusal = bundle.outcome.refusal
+        if refusal is not None:
+            errors.extend(f"[{r.code}] {r.detail}" for r in refusal.reasons)
+        else:  # pragma: no cover - a refusal always carries reasons
+            errors.append("the bundle did not parse")
+    else:
+        errors.extend(
+            f"[{v.kind}] {v.message}"
+            for v in structural_gate(
+                bundle.de_path.read_text(encoding="utf-8"),
+                bundle.en_path.read_text(encoding="utf-8"),
+                bundle.comment_token,
+            )
+        )
+        for member in bundle.outcome.deck.members():
+            if member.role in ("voiceover", "notes") and member.is_one_sided:
+                present = "de" if member.de is not None else "en"
+                pending.append(
+                    {
+                        "member": member.key.render(),
+                        "present": present,
+                        "missing": "en" if present == "de" else "de",
+                    }
+                )
+
+    ok = not errors
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "tool": "harvest",
+                    "verb": "verify",
+                    "de": str(bundle.de_path),
+                    "en": str(bundle.en_path),
+                    "ok": ok,
+                    "errors": errors,
+                    "pending_twins": pending,
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+    else:
+        click.echo(f"{'PASS' if ok else 'FAIL'}  {bundle.de_path} / {bundle.en_path}")
+        for message in errors:
+            click.echo(f"  [error] {message}")
+        for item in pending:
+            click.echo(
+                f"  [pending] {item['member']}: {item['missing']} twin awaits "
+                "translation (run the `clm slides sync` loop)"
+            )
+    sys.exit(0 if ok else 2)
 
 
 def _print_human_report(report: dict) -> None:

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -3850,6 +3850,12 @@ engine-owned, cached, and model-free; curation and translation judgment
 belong to the driving agent. Requires `clm[voiceover]` extra.
 
 Bare `clm harvest DECK VIDEO…` runs the read-only default verb `report`.
+The canonical agent loop:
+
+```
+harvest report → (task → judge → accept [--record])* → verify
+              → clm slides sync report      (twin translation continues there)
+```
 
 **Group-level cache flags** (same artifact cache as `clm voiceover`):
 
@@ -3912,6 +3918,75 @@ ledger provenance `harvest:<fingerprint>`).
 **Exit codes:** `0` nothing to harvest (all covered/silent) · `1`
 actionable items (new material or unmatched speech) · `2` error
 (unreadable deck, non-normalized bundle, bad inputs).
+
+#### `clm harvest task` (CLM {version}+)
+
+Frame one slide's judgment as a JSON task document for the driving agent.
+Read-only; no model.
+
+```
+clm harvest task SLIDES VIDEO... --lang {de|en} [--slide ID] [--kind curate|translate]
+```
+
+Takes the same pipeline/cache/injection options as `report`. Each task
+carries: caller `instructions` (the curation rules the old embedded-model
+merge applied — preserve baseline bullets, integrate substantive additions,
+filter recording noise into the `dropped` audit list), structured `inputs`
+(baseline voiceover on both sides, the aligned transcript with its
+`revisited_segments` backtracking groups, slide content), the bullet-list
+`answer_schema` (validator `harvest-bullets`), and the freshness tokens the
+answer must echo: per-side `baseline_fingerprint` plus `video_fingerprint`.
+`--kind curate` merges the recorded language; `--kind translate` frames the
+twin side from the already-curated source. Omitting `--slide` frames every
+actionable item. A slide with more than one narrative cell per side is
+refused (ambiguous — edit the files directly).
+
+**Exit codes:** `0` tasks emitted (possibly zero in the sweep) · `2` error /
+the named slide cannot be framed.
+
+#### `clm harvest accept` (CLM {version}+)
+
+Validate a bullet-list answer and write it through the v3 model — the
+**only** write path of the harvest toolkit.
+
+```
+clm harvest accept SLIDES --answer FILE|- [--slide ID] [--record] [--dry-run] [--json]
+```
+
+Validation (all-or-nothing; nothing is written on failure): answer schema
+shape; per-side `baseline_fingerprint` freshness against the live deck (a
+concurrent edit rejects, never overwrites); single-cell body guards; the
+mutated bundle must re-parse through the v3 lens. Bullets render into the
+deck's `#\n# - …` narrative cell style; a missing voiceover member is
+created (own minted `slide_id`, `for_slide` owner, companion or inline
+following the deck's convention) and the ≤4 files land atomically.
+
+A one-language answer writes that side only: the pair becomes a deliberate,
+representable divergence that the next `clm slides sync report` frames as
+translation work. `--record` banks the touched member into the sync ledger
+(`.clm/sync-ledger.json`) with provenance `harvest:<video-fingerprint>`
+under one-sided-trust semantics: a bilingual answer records the clean pair;
+a one-sided member records its one-sided entry (framing `translate_new`);
+a one-sided write over an existing twin never advances the written side's
+fingerprint (framing `translate_edit`) — the stale twin is never silently
+blessed. The ledger save is gated on the structural verify; a refused gate
+leaves the files written and reports the reasons.
+
+**Exit codes:** `0` applied (and recorded if requested) · `1` applied but
+the ledger record was refused by the structural gate · `2` rejected/error.
+
+#### `clm harvest verify` (CLM {version}+)
+
+Structural post-check on the pair: the v3 lens gate (the whole bundle must
+parse back) plus the deck-half structural gate the sync write verbs use.
+One-sided narrative members are **not** failures — they are listed as
+`pending_twins` (translation work for the `clm slides sync` loop).
+
+```
+clm harvest verify SLIDES [--json]
+```
+
+**Exit codes:** `0` pass (pending twins allowed) · `2` structural errors.
 
 ### `clm voiceover`
 

--- a/src/clm/voiceover/harvest.py
+++ b/src/clm/voiceover/harvest.py
@@ -281,6 +281,8 @@ def _narrative_by_group(deck) -> dict[str, list[Member]]:
 
 
 def _voiceover_payload(members: list[Member], side: Lang) -> dict[str, Any]:
+    from clm.slides.doc_identity import content_fingerprint
+
     cells = []
     for member in members:
         cell = member.side(side)
@@ -292,6 +294,8 @@ def _voiceover_payload(members: list[Member], side: Lang) -> dict[str, Any]:
                 "role": member.role,
                 "layout": member.layout,
                 "text": cell.body,
+                # The freshness token `task` frames and `accept` re-checks.
+                "fingerprint": content_fingerprint(cell),
             }
         )
     present = any(c["text"].strip() for c in cells)

--- a/src/clm/voiceover/harvest_accept.py
+++ b/src/clm/voiceover/harvest_accept.py
@@ -1,0 +1,581 @@
+"""``clm harvest accept`` — validate an answer and write it (#546 Phase 3).
+
+The only write path of the harvest toolkit. An answer (the bullet-list
+document a ``harvest task`` framed, `validator "harvest-bullets"`) is
+validated — schema shape, single-cell body guards, baseline-fingerprint
+freshness against what ``task`` framed — and then lands through the v3
+model: an id-keyed member edit emitted and written atomically via the
+Phase-1 write surface (:mod:`clm.slides.doc_write`). Nothing is written on
+any validation failure; the mutated bundle is re-parsed before anything
+touches disk (the lens gate).
+
+``--record`` banks the write into the sync consistency ledger with
+provenance ``harvest:<video-fingerprint>`` under the §6 one-sided-trust
+semantics (proposal §6, the load-bearing invariant):
+
+* **bilingual answer** → the member's fresh both-side snapshot is recorded
+  (the pair is clean; next ``slides sync report`` reads ``in_sync``);
+* **one-sided answer, member ends one-sided** → the fresh one-sided
+  snapshot is recorded — that entry is precisely what makes the next sync
+  report frame ``translate_new`` for the twin (an unrecorded new member
+  would only surface as an unframed ``verify_cold``);
+* **one-sided answer, twin body exists** → the written side's ledger
+  fingerprint is **not** advanced (the existing entry is kept, or the
+  pre-write state is recorded): the harvested side reads as "edited off
+  base" and the next sync report frames ``translate_edit`` toward the twin.
+  Advancing both fingerprints would read ``in_sync`` and silently bless the
+  stale twin — the §6 forbidden state.
+
+The ledger save is additionally gated on the structural verify
+(:func:`clm.slides.sync_verify.structural_gate`), mirroring the sync verbs.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from attrs import define, evolve, field
+
+from clm.slides.bilingual_doc import (
+    BilingualDeck,
+    Lang,
+    Member,
+    MemberKey,
+    Part,
+    SideCell,
+)
+from clm.slides.doc_identity import (
+    body_fingerprint,
+    content_fingerprint,
+    pair_signature,
+)
+from clm.slides.doc_lenses import LoadedBundle, parse_bundle
+from clm.slides.doc_write import DeckEmitter, write_changed_files
+from clm.slides.raw_cells import is_cell_boundary
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = [
+    "AcceptOutcome",
+    "AcceptRejected",
+    "Answer",
+    "accept_answer",
+    "parse_answer",
+]
+
+_SIDES: tuple[Lang, Lang] = ("de", "en")
+_NARRATIVE_ROLES = ("voiceover", "notes")
+_BULLET_PREFIX = re.compile(r"^-\s+")
+
+
+class AcceptRejected(Exception):
+    """The answer was rejected; the message names the reason. Nothing was written."""
+
+
+@define
+class Answer:
+    """The validated bullet-list answer document."""
+
+    item: str
+    kind: str
+    baseline_fingerprint: dict[str, str | None]
+    bullets: dict[str, list[str]]  # side -> ordered bullet strings
+    dropped: list[str]
+    video_fingerprint: str | None
+
+
+@define
+class AcceptOutcome:
+    item: str
+    applied: bool = False
+    created: bool = False
+    member: str | None = None  # the vo member's rendered key
+    written_paths: list[Path] = field(factory=list)
+    recorded: bool = False
+    record_refused: list[str] = field(factory=list)
+    dry_run: bool = False
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "schema": 1,
+            "tool": "harvest",
+            "verb": "accept",
+            "item": self.item,
+            "applied": self.applied,
+            "created": self.created,
+            "member": self.member,
+            "written": [str(p) for p in self.written_paths],
+            "recorded": self.recorded,
+            "record_refused": self.record_refused,
+            "dry_run": self.dry_run,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Answer validation (validator "harvest-bullets")
+# ---------------------------------------------------------------------------
+
+
+def parse_answer(payload: Any) -> Answer:
+    """Validate the answer document shape; raise :class:`AcceptRejected` with
+    a precise reason on the first violation."""
+    if not isinstance(payload, dict):
+        raise AcceptRejected("the answer must be a JSON object (see the task's answer_schema)")
+    item = payload.get("item")
+    if not isinstance(item, str) or not item.startswith("id:"):
+        raise AcceptRejected("'item' must be the slide handle string, e.g. \"id:intro\"")
+    kind = payload.get("kind")
+    if kind not in ("curate", "translate"):
+        raise AcceptRejected('\'kind\' must be "curate" or "translate"')
+    fingerprint = payload.get("baseline_fingerprint")
+    if not isinstance(fingerprint, dict) or set(fingerprint) - {"de", "en"}:
+        raise AcceptRejected(
+            "'baseline_fingerprint' must be the {de, en} object echoed from the task"
+        )
+    for side, value in fingerprint.items():
+        if value is not None and not isinstance(value, str):
+            raise AcceptRejected(f"baseline_fingerprint.{side} must be a string or null")
+    bullets = payload.get("bullets")
+    if not isinstance(bullets, dict) or not bullets or set(bullets) - {"de", "en"}:
+        raise AcceptRejected("'bullets' must map at least one of de/en to a bullet list")
+    parsed_bullets: dict[str, list[str]] = {}
+    for side, entries in bullets.items():
+        if not isinstance(entries, list) or not entries:
+            raise AcceptRejected(f"bullets.{side} must be a non-empty list of bullet strings")
+        cleaned: list[str] = []
+        for i, bullet in enumerate(entries):
+            if not isinstance(bullet, str) or not bullet.strip():
+                raise AcceptRejected(f"bullets.{side}[{i}] must be a non-empty string")
+            if "\n" in bullet:
+                raise AcceptRejected(
+                    f"bullets.{side}[{i}] contains a newline — one bullet per string, "
+                    "markdown inline formatting only"
+                )
+            cleaned.append(_BULLET_PREFIX.sub("", bullet.strip()))
+        parsed_bullets[side] = cleaned
+    dropped = payload.get("dropped")
+    if not isinstance(dropped, list) or any(not isinstance(d, str) for d in dropped):
+        raise AcceptRejected("'dropped' must be a list of strings (the audit trail; may be empty)")
+    video_fingerprint = payload.get("video_fingerprint")
+    if video_fingerprint is not None and not isinstance(video_fingerprint, str):
+        raise AcceptRejected("'video_fingerprint' must be a string when present")
+    return Answer(
+        item=item,
+        kind=kind,
+        baseline_fingerprint={s: fingerprint.get(s) for s in _SIDES},
+        bullets=parsed_bullets,
+        dropped=list(dropped),
+        video_fingerprint=video_fingerprint,
+    )
+
+
+def _render_body(bullets: list[str], comment_token: str) -> str:
+    """Bullets → the cell body (the deck's `#\\n# - …` narrative style)."""
+    lines = [comment_token]
+    lines.extend(f"{comment_token} - {b}" for b in bullets)
+    return "\n".join(lines)
+
+
+def _guard_body(body: str, comment_token: str) -> None:
+    for line in body.split("\n"):
+        if is_cell_boundary(line, comment_token):
+            raise AcceptRejected(
+                f"a rendered bullet line would form a '{comment_token} %%' cell "
+                "boundary and re-split on read-back — remove the delimiter from the bullet"
+            )
+
+
+def _replace_body(cell: SideCell, body: str) -> tuple[str, ...]:
+    """The cell's lines with a new body, preserving its trailing separator
+    (the :mod:`clm.slides.doc_apply` rule)."""
+    old_body = cell.lines[1:]
+    trailing = 0
+    for line in reversed(old_body):
+        if line == "":
+            trailing += 1
+        else:
+            break
+    new_body = body.split("\n")
+    while new_body and new_body[-1] == "":
+        new_body.pop()
+    return (cell.lines[0], *new_body, *([""] * trailing))
+
+
+# ---------------------------------------------------------------------------
+# Locating and mutating the voiceover member
+# ---------------------------------------------------------------------------
+
+
+def _narrative_members(deck: BilingualDeck, slide_id: str) -> list[Member] | None:
+    for group in deck.groups:
+        if group.anchor_id == slide_id:
+            return [m for m in group.members if m.role in _NARRATIVE_ROLES]
+    return None
+
+
+def _check_freshness(answer: Answer, members: list[Member]) -> None:
+    for side in _SIDES:
+        cells = [c for m in members if (c := m.side(side)) is not None]
+        current = content_fingerprint(cells[0]) if cells else None
+        framed = answer.baseline_fingerprint.get(side)
+        if current != framed:
+            raise AcceptRejected(
+                f"the {side} voiceover baseline changed since the task was framed "
+                "(fingerprint mismatch) — re-run `harvest task` and re-judge"
+            )
+
+
+def _deck_slide_ids(deck: BilingualDeck) -> set[str]:
+    ids: set[str] = set()
+    for member in deck.members():
+        for side in _SIDES:
+            cell = member.side(side)
+            if cell is not None and cell.slide_id is not None:
+                ids.add(cell.slide_id.rstrip("!"))
+    return ids
+
+
+def _mint_vo_id(deck: BilingualDeck, owner: str) -> str:
+    taken = _deck_slide_ids(deck)
+    candidate = f"{owner}-vo"
+    n = 2
+    while candidate in taken:
+        candidate = f"{owner}-vo{n}"
+        n += 1
+    return candidate
+
+
+def _narrative_conventions(deck: BilingualDeck) -> tuple[str, str]:
+    """(role, layout) for a new vo member: follow the deck's majority
+    convention; default ("voiceover", "companion")."""
+    roles: dict[str, int] = {}
+    layouts: dict[str, int] = {}
+    for member in deck.members():
+        if member.role in _NARRATIVE_ROLES:
+            roles[member.role] = roles.get(member.role, 0) + 1
+            layouts[member.layout] = layouts.get(member.layout, 0) + 1
+    role = max(roles, key=roles.__getitem__) if roles else "voiceover"
+    layout = max(layouts, key=layouts.__getitem__) if layouts else "companion"
+    return role, layout
+
+
+def _new_side_cell(
+    *,
+    side: Lang,
+    body: str,
+    role: str,
+    part: Part,
+    vo_id: str,
+    owner: str,
+    comment_token: str,
+) -> SideCell:
+    header = (
+        f'{comment_token} %% [markdown] lang="{side}" tags=["{role}"] '
+        f'slide_id="{vo_id}" for_slide="{owner}"'
+    )
+    lines = (header, *body.split("\n"), "")
+    return SideCell(
+        lines=lines,
+        index=0,  # streams are already built; emission follows stream order
+        line_number=0,
+        part=part,
+        lang_attr=side,
+        tags=(role,),
+        slide_id=vo_id,
+        for_slide=owner,
+        vo_anchor=None,
+        cell_type="markdown",
+    )
+
+
+def _insert_new_member(
+    emitter: DeckEmitter,
+    deck: BilingualDeck,
+    member: Member,
+    owner: str,
+    part: Part,
+) -> None:
+    """Place the new member's cells: companion cells append to the companion
+    stream; inline cells go right after the owner group's last cell."""
+    for side in _SIDES:
+        cell = member.side(side)
+        if cell is None:
+            continue
+        stream = emitter.streams.setdefault((side, part), [])
+        if part == "companion":
+            stream.append(member)
+        else:
+            anchor_pos = -1
+            for group in deck.groups:
+                if group.anchor_id != owner:
+                    continue
+                group_members = [
+                    m
+                    for m in group.all_members()
+                    if (c := m.side(side)) is not None and c.part == part
+                ]
+                positions = [
+                    i for i, m in enumerate(stream) if any(m is gm for gm in group_members)
+                ]
+                anchor_pos = max(positions) if positions else -1
+            stream.insert(anchor_pos + 1, member)
+        emitter.mutated = True
+
+
+# ---------------------------------------------------------------------------
+# The §6 ledger record
+# ---------------------------------------------------------------------------
+
+
+def _entry_from_member(member: Member):
+    """One member's :class:`~clm.slides.doc_identity.MemberBaseline` snapshot
+    (the per-member core of ``baseline_from_deck``)."""
+    from clm.slides.doc_identity import MemberBaseline
+
+    return MemberBaseline(
+        key=member.key.render(),
+        langness=member.langness,
+        layout=member.layout,
+        kind=member.kind,
+        role=member.role,
+        owner=member.owner.render() if member.owner else None,
+        de_fp=content_fingerprint(member.de) if member.de else None,
+        en_fp=content_fingerprint(member.en) if member.en else None,
+        de_body_fp=body_fingerprint(member.de) if member.de else None,
+        en_body_fp=body_fingerprint(member.en) if member.en else None,
+        de_tags=member.de.tags if member.de else None,
+        en_tags=member.en.tags if member.en else None,
+        de_sig=pair_signature(member.de) if member.de else None,
+        en_sig=pair_signature(member.en) if member.en else None,
+    )
+
+
+def _record_member(
+    bundle: LoadedBundle,
+    *,
+    key: str,
+    final_member: Member,
+    pre_member: Member | None,
+    bilingual: bool,
+    video_fingerprint: str,
+) -> list[str]:
+    """Bank the write under ``harvest:<fp>`` provenance (§6 semantics).
+
+    Returns structural-gate violation messages; non-empty means the ledger
+    save was withheld (the files stay as written — fail-safe, like apply).
+    """
+    from clm.slides import doc_ledger
+    from clm.slides.sync_verify import structural_gate
+
+    violations = structural_gate(
+        bundle.de_path.read_text(encoding="utf-8"),
+        bundle.en_path.read_text(encoding="utf-8"),
+        bundle.comment_token,
+    )
+    if violations:
+        return [v.message for v in violations]
+
+    ledger_path = doc_ledger.ledger_path_for(bundle.de_path)
+    ledger = doc_ledger.load(ledger_path)
+    target = ledger.decks.setdefault(
+        doc_ledger.deck_key_for(bundle.de_path), doc_ledger.DeckLedger()
+    )
+    provenance = f"harvest:{video_fingerprint}"
+
+    if bilingual or final_member.is_one_sided:
+        # Fresh snapshot: a bilingual answer records a clean pair (in_sync
+        # next report); a one-sided member records the one-sided entry that
+        # frames translate_new for the twin.
+        entry = _entry_from_member(final_member)
+    else:
+        # One side written while a twin body exists: never advance the
+        # written side's fingerprint — the mismatch IS the translate_edit
+        # framing; advancing it would silently bless the stale twin.
+        existing = target.members.get(key)
+        if existing is not None:
+            entry = existing.entry
+        elif pre_member is not None:
+            entry = _entry_from_member(pre_member)
+        else:  # pragma: no cover - created members are one-sided or bilingual
+            return ["cannot synthesize a pre-write baseline for the member"]
+
+    target.members[key] = doc_ledger.LedgerMember(entry=entry, provenance=provenance)
+    doc_ledger.save(ledger, ledger_path)
+    return []
+
+
+# ---------------------------------------------------------------------------
+# accept
+# ---------------------------------------------------------------------------
+
+
+def accept_answer(
+    bundle: LoadedBundle,
+    answer: Answer,
+    *,
+    record: bool = False,
+    dry_run: bool = False,
+) -> AcceptOutcome:
+    """Validate ``answer`` against the live bundle and land it atomically.
+
+    Raises :class:`AcceptRejected` (nothing written) on any validation
+    failure. With ``record``, banks the touched member into the sync ledger
+    under ``harvest:<video-fingerprint>`` provenance (§6 semantics).
+    """
+    deck = bundle.outcome.deck
+    if deck is None:
+        raise AcceptRejected("the deck bundle is not normalized — run `clm slides normalize` first")
+    if record and answer.video_fingerprint is None:
+        raise AcceptRejected(
+            "--record needs the answer's 'video_fingerprint' (echo it from the task document)"
+        )
+    slide_id = answer.item.split(":", 1)[1]
+    members = _narrative_members(deck, slide_id)
+    if members is None:
+        raise AcceptRejected(f"no slide {answer.item} in the deck")
+    for side in _SIDES:
+        if side in answer.bullets and len([m for m in members if m.side(side) is not None]) > 1:
+            raise AcceptRejected(
+                f"slide {answer.item} has more than one narrative cell on the {side} "
+                "side — edit the files directly, then re-run report"
+            )
+    _check_freshness(answer, members)
+
+    comment_token = bundle.comment_token
+    bodies: dict[Lang, str] = {
+        side: _render_body(answer.bullets[side], comment_token)
+        for side in _SIDES
+        if side in answer.bullets
+    }
+    for body in bodies.values():
+        _guard_body(body, comment_token)
+
+    emitter = DeckEmitter(deck=deck)
+    originals = emitter.emit_all()
+
+    target_member = members[0] if members else None
+    pre_member = None
+    created = False
+    if target_member is not None:
+        pre_member = evolve_copy(target_member)
+        for side, body in bodies.items():
+            cell = target_member.side(side)
+            if cell is not None:
+                emitter.set_side(target_member, side, evolve(cell, lines=_replace_body(cell, body)))
+            else:
+                source: Lang = "en" if side == "de" else "de"
+                source_cell = target_member.side(source)
+                if source_cell is None:  # pragma: no cover - members carry >=1 side
+                    raise AcceptRejected(f"the member for {answer.item} carries no cells")
+                from clm.slides.sync_writeback import swap_lang
+
+                header = (
+                    swap_lang(source_cell.header, side)
+                    if source_cell.lang_attr
+                    else source_cell.header
+                )
+                base = evolve(source_cell, lines=(header, *source_cell.lines[1:]))
+                new_cell = evolve(base, lines=_replace_body(base, body), lang_attr=side)
+                emitter.insert_mirrored(target_member, source, side, source_cell.part, new_cell)
+        member_key = target_member.key
+    else:
+        created = True
+        role, layout = _narrative_conventions(deck)
+        part: Part = "companion" if layout == "companion" else "deck"
+        vo_id = _mint_vo_id(deck, slide_id)
+        member_key = MemberKey.for_id(vo_id)
+        new_member = Member(
+            key=member_key,
+            kind="markdown",
+            role=role,
+            langness="localized",
+            layout=layout,
+            owner=MemberKey.for_id(slide_id),
+            de=None,
+            en=None,
+        )
+        for side, body in bodies.items():
+            emitter.set_side(
+                new_member,
+                side,
+                _new_side_cell(
+                    side=side,
+                    body=body,
+                    role=role,
+                    part=part,
+                    vo_id=vo_id,
+                    owner=slide_id,
+                    comment_token=comment_token,
+                ),
+            )
+        _insert_new_member(emitter, deck, new_member, slide_id, part)
+
+    finals = emitter.emit_all()
+    changed = {file_key for file_key in finals if finals[file_key] != originals[file_key]}
+    outcome = AcceptOutcome(
+        item=answer.item, created=created, member=member_key.render(), dry_run=dry_run
+    )
+    if not changed:
+        outcome.applied = True  # a byte-identical answer is a valid no-op
+        return outcome
+
+    parse = parse_bundle(
+        finals[("de", "deck")] or "",
+        finals[("en", "deck")] or "",
+        finals[("de", "companion")],
+        finals[("en", "companion")],
+        comment_token=comment_token,
+    )
+    if parse.refusal is not None or parse.deck is None:
+        reasons = (
+            "; ".join(f"[{r.code}] {r.detail}" for r in parse.refusal.reasons)
+            if parse.refusal
+            else "no deck"
+        )
+        raise AcceptRejected(
+            f"the mutated bundle failed the re-parse gate ({reasons}) — nothing was written"
+        )
+    final_member = next(
+        (m for m in parse.deck.members() if m.key.render() == member_key.render()), None
+    )
+    if final_member is None:
+        raise AcceptRejected(
+            "the written member did not survive the re-parse (writer bug) — nothing was written"
+        )
+
+    if dry_run:
+        outcome.applied = True
+        return outcome
+
+    outcome.written_paths = write_changed_files(bundle, finals, changed)
+    outcome.applied = True
+
+    if record:
+        assert answer.video_fingerprint is not None
+        outcome.record_refused = _record_member(
+            bundle,
+            key=member_key.render(),
+            final_member=final_member,
+            pre_member=pre_member,
+            bilingual=len(answer.bullets) == 2,
+            video_fingerprint=answer.video_fingerprint,
+        )
+        outcome.recorded = not outcome.record_refused
+    return outcome
+
+
+def evolve_copy(member: Member) -> Member:
+    """A detached snapshot of a member's pre-write state (cells are frozen,
+    the member shell is mutable — copy the shell)."""
+    return Member(
+        key=member.key,
+        kind=member.kind,
+        role=member.role,
+        langness=member.langness,
+        layout=member.layout,
+        owner=member.owner,
+        de=member.de,
+        en=member.en,
+    )

--- a/src/clm/voiceover/harvest_task.py
+++ b/src/clm/voiceover/harvest_task.py
@@ -1,0 +1,194 @@
+"""``clm harvest task`` — frame judgment work for the driving agent (#546 Phase 3).
+
+A task document packages ONE slide's curation (or translation) judgment:
+the caller instructions (the old embedded-model merge rules restated for an
+agent), the structured inputs (baseline voiceover on both sides, the aligned
+transcript with its ``revisited_segments`` backtracking groups, the slide
+content for context), the ``answer_schema``, and the freshness tokens
+(per-side ``baseline_fingerprint`` of the voiceover member plus the
+``video_fingerprint``) that ``accept`` validates before writing. Read-only;
+the engine emits, it never invokes a model.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from clm.slides.bilingual_doc import BilingualDeck
+
+__all__ = [
+    "ANSWER_SCHEMA",
+    "TASK_KINDS",
+    "TaskUnavailable",
+    "build_tasks",
+]
+
+TASK_KINDS = ("curate", "translate")
+
+#: The bullet-list answer contract (proposal §4/§8): per-language ordered
+#: bullet strings plus the `dropped` audit list, echoing the freshness
+#: tokens the task framed. Validated by `harvest accept` (validator
+#: "harvest-bullets").
+ANSWER_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "required": ["item", "kind", "baseline_fingerprint", "bullets", "dropped"],
+    "properties": {
+        "item": {"type": "string", "description": "the slide handle, e.g. id:intro"},
+        "kind": {"enum": list(TASK_KINDS)},
+        "video_fingerprint": {"type": "string"},
+        "baseline_fingerprint": {
+            "type": "object",
+            "description": "echoed verbatim from the task document",
+            "properties": {
+                "de": {"type": ["string", "null"]},
+                "en": {"type": ["string", "null"]},
+            },
+        },
+        "bullets": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": False,
+            "properties": {
+                "de": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+                "en": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+            },
+        },
+        "dropped": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "transcript passages deliberately discarded (audit trail)",
+        },
+    },
+}
+
+
+class TaskUnavailable(Exception):
+    """This slide cannot be framed (with the reason as the message)."""
+
+
+def _instructions(kind: str) -> str:
+    name = "harvest_curate.md" if kind == "curate" else "harvest_translate.md"
+    return (Path(__file__).parent / "prompts" / name).read_text(encoding="utf-8")
+
+
+def _baseline_fingerprint(item: dict[str, Any]) -> dict[str, str | None]:
+    """The per-side freshness token: the single vo member's fingerprint.
+
+    A slide with more than one narrative member per side is ambiguous —
+    ``accept`` could not know which cell the answer replaces (P8: never
+    guess), so the task is refused with a pointer at manual editing.
+    """
+    fingerprint: dict[str, str | None] = {}
+    for side in ("de", "en"):
+        cells = item["voiceover"][side]["cells"]
+        if len(cells) > 1:
+            keys = ", ".join(c["key"] for c in cells)
+            raise TaskUnavailable(
+                f"slide {item['key']} has {len(cells)} narrative cells on the "
+                f"{side} side ({keys}) — edit the files directly, then re-run report"
+            )
+        fingerprint[side] = cells[0]["fingerprint"] if cells else None
+    return fingerprint
+
+
+def _slide_content(deck: BilingualDeck, slide_id: str, lang: str) -> str:
+    for group in deck.groups:
+        if group.anchor_id != slide_id:
+            continue
+        parts = []
+        for member in group.all_members():
+            if member.role in ("voiceover", "notes"):
+                continue
+            cell = member.side(lang)  # type: ignore[arg-type]
+            if cell is not None:
+                parts.append(cell.body)
+        return "\n".join(parts)
+    return ""
+
+
+def _frame_one(
+    item: dict[str, Any], report: dict[str, Any], deck: BilingualDeck, kind: str
+) -> dict[str, Any]:
+    lang = report["video_language"]
+    slide_id = item["key"].split(":", 1)[1]
+    if kind == "curate":
+        if item["class"] in ("covered", "unmatched_slide"):
+            raise TaskUnavailable(
+                f"slide {item['key']} is '{item['class']}' — the recording "
+                "contributed no speech for it; nothing to curate"
+            )
+        inputs: dict[str, Any] = {
+            "language": lang,
+            "baseline": {
+                side: [c["text"] for c in item["voiceover"][side]["cells"]] for side in ("de", "en")
+            },
+            "transcript": item.get("transcript"),
+            "slide": {"title": item["title"], "content": _slide_content(deck, slide_id, lang)},
+        }
+    else:  # translate
+        twin = "en" if lang == "de" else "de"
+        if not item["voiceover"][lang]["present"]:
+            raise TaskUnavailable(
+                f"slide {item['key']} has no {lang} voiceover to translate — curate it first"
+            )
+        inputs = {
+            "source_language": lang,
+            "target_language": twin,
+            "source": [c["text"] for c in item["voiceover"][lang]["cells"]],
+            "target_baseline": [c["text"] for c in item["voiceover"][twin]["cells"]],
+            "slide": {"title": item["title"]},
+        }
+    return {
+        "item": item["key"],
+        "kind": kind,
+        "class": item["class"],
+        "validator": "harvest-bullets",
+        "video_language": lang,
+        "video_fingerprint": report["video_fingerprint"],
+        "baseline_fingerprint": _baseline_fingerprint(item),
+        "instructions": _instructions(kind),
+        "inputs": inputs,
+        "answer_schema": ANSWER_SCHEMA,
+    }
+
+
+def build_tasks(
+    report: dict[str, Any],
+    deck: BilingualDeck,
+    *,
+    kind: str = "curate",
+    slide: str | None = None,
+) -> list[dict[str, Any]]:
+    """Frame the judgment tasks for ``slide`` (or every actionable item).
+
+    ``slide`` accepts the bare slide id or the ``id:...`` handle. Raises
+    :class:`TaskUnavailable` when the named slide cannot be framed; in the
+    all-items sweep, unframeable items are skipped (report shows why).
+    """
+    if kind not in TASK_KINDS:
+        raise TaskUnavailable(f"unknown task kind '{kind}' (choose from {', '.join(TASK_KINDS)})")
+    items = report["items"]
+    if slide is not None:
+        handle = slide if slide.startswith(("id:", "pos:")) else f"id:{slide}"
+        matches = [i for i in items if i["key"] == handle]
+        if not matches:
+            raise TaskUnavailable(f"no slide {handle} in the report")
+        return [_frame_one(matches[0], report, deck, kind)]
+    tasks = []
+    for item in items:
+        if item["key"] is None:
+            continue  # id-less slides carry their own normalize note
+        if kind == "curate" and item["class"] not in (
+            "no_existing_vo",
+            "transcript_adds_material",
+        ):
+            continue
+        if kind == "translate" and not item["voiceover"][report["video_language"]]["present"]:
+            continue
+        try:
+            tasks.append(_frame_one(item, report, deck, kind))
+        except TaskUnavailable:
+            continue
+    return tasks

--- a/src/clm/voiceover/prompts/harvest_curate.md
+++ b/src/clm/voiceover/prompts/harvest_curate.md
@@ -1,0 +1,37 @@
+# Harvest curation task
+
+You are curating spoken narration from a recorded video into a slide's
+voiceover. The inputs give you the slide's existing voiceover baseline (both
+language sides), the transcript passages the aligner assigned to this slide,
+and the slide content for context. Produce the slide's new voiceover as an
+ordered bullet list in the recorded language.
+
+Rules (these replace the old embedded-model merge — apply them yourself):
+
+1. **Preserve every substantive baseline bullet.** The existing voiceover is
+   curated content; never silently drop a baseline point. The only permitted
+   baseline edit is rewriting a bullet the transcript *factually
+   contradicts* — not a stylistic preference.
+2. **Integrate new substantive transcript content** at its natural narrative
+   position among the baseline bullets, not appended as an afterthought.
+3. **Filter transcript noise aggressively.** Drop greetings and sign-offs,
+   self-corrections, remarks about the recording environment or tooling,
+   operator asides ("let me scroll down"), live-coding dictation of code the
+   slide already shows, and off-topic tangents. Every dropped passage goes
+   into the answer's `dropped` list — that is the audit trail.
+4. **No hallucination.** Add nothing the transcript or baseline does not
+   support.
+5. **Bullet form**: one thought per bullet, markdown inline formatting
+   allowed within a bullet, no nested block structure. Stay in the recorded
+   language (translation is a separate `translate` task — but you MAY
+   answer bilingually if you also translate every bullet for the twin side).
+6. **`revisited_segments`** are passages spoken when the presenter navigated
+   *back* to this slide after having moved past it (aligner backtracking
+   groups, in order of return). They often revisit or correct earlier
+   statements — weigh them accordingly; a later revisit wins over an earlier
+   statement it contradicts.
+
+Answer with the JSON shape given in `answer_schema`, echoing `item`, `kind`,
+`baseline_fingerprint`, and `video_fingerprint` from this task document.
+Then submit it with `clm harvest accept DECK --answer FILE` (add `--record`
+to bank the write into the sync ledger).

--- a/src/clm/voiceover/prompts/harvest_translate.md
+++ b/src/clm/voiceover/prompts/harvest_translate.md
@@ -1,0 +1,23 @@
+# Harvest translation task
+
+You are translating a slide's curated voiceover to its twin language side.
+The inputs give you the source-side voiceover (the recorded language,
+already curated) and the target side's existing voiceover, if any.
+
+Rules:
+
+1. **Translate the source bullets faithfully**, one target bullet per source
+   bullet, preserving order and inline markdown formatting.
+2. **Preserve target bullets that already say the same thing** — prefer
+   minimally editing an existing good translation over re-translating from
+   scratch; keep established terminology consistent with the target deck.
+3. **No content changes in flight**: do not add, drop, or reorder points
+   relative to the source side. Curation happened in the `curate` task; this
+   task is translation only.
+4. Stay idiomatic in the target language; technical terms follow the deck's
+   existing conventions.
+
+Answer with the JSON shape given in `answer_schema`, providing bullets for
+the **target** language side only, echoing `item`, `kind`,
+`baseline_fingerprint`, and `video_fingerprint` from this task document.
+Then submit it with `clm harvest accept DECK --answer FILE [--record]`.

--- a/tests/cli/test_harvest_task_accept.py
+++ b/tests/cli/test_harvest_task_accept.py
@@ -1,0 +1,307 @@
+"""Tests for ``clm harvest task`` / ``accept`` / ``verify`` (#546 Phase 3).
+
+Drives the full agent loop through the real CLI with an injected alignment
+(no ASR/GPU): report → task → (synthesized judgment) → accept [--record] →
+verify. The §6 hard requirement is pinned at the engine level: after a
+one-sided ``accept --record``, the v3 sync differ (ledger baseline) must
+frame the twin as *translation work* (``translate_new``/``translate_edit``)
+— never ``in_sync`` (silently blessing the stale twin) and never a cold or
+corrupt state.
+
+Fixture decks come from ``test_harvest_cli`` (s0 has bilingual companion
+voiceover, s1 has none, s2 has DE-only voiceover, s3 is silent).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from clm.cli.commands.harvest import harvest_group
+from tests.cli.test_harvest_cli import _write_alignment, _write_fixture
+
+
+def _invoke(args: list[str]):
+    return CliRunner().invoke(harvest_group, args, catch_exceptions=False)
+
+
+def _json_from(result) -> dict:
+    text = result.output
+    return json.loads(text[text.index("{") :])
+
+
+def _task_for(tmp_path: Path, de_path: Path, video: Path, slide: str, kind: str = "curate") -> dict:
+    alignment = _write_alignment(tmp_path, de_path)
+    result = _invoke(
+        [
+            "task",
+            str(de_path),
+            str(video),
+            "--lang",
+            "de",
+            "--alignment",
+            str(alignment),
+            "--slide",
+            slide,
+            "--kind",
+            kind,
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    envelope = _json_from(result)
+    assert len(envelope["tasks"]) == 1
+    return envelope["tasks"][0]
+
+
+def _answer_from_task(task: dict, bullets: dict[str, list[str]]) -> dict:
+    return {
+        "item": task["item"],
+        "kind": task["kind"],
+        "video_fingerprint": task["video_fingerprint"],
+        "baseline_fingerprint": task["baseline_fingerprint"],
+        "bullets": bullets,
+        "dropped": ["Mikrofontest."],
+    }
+
+
+def _accept(tmp_path: Path, de_path: Path, answer: dict, *extra: str):
+    answer_path = tmp_path / "answer.json"
+    answer_path.write_text(json.dumps(answer, ensure_ascii=False), encoding="utf-8")
+    return _invoke(["accept", str(de_path), "--answer", str(answer_path), "--json", *extra])
+
+
+def _ledger_diff(de_path: Path):
+    """The v3 differ's verdicts against the committed ledger baseline."""
+    from clm.slides import doc_ledger
+    from clm.slides.doc_lenses import load_bundle
+    from clm.slides.sync_diff import diff_outcome
+
+    bundle = load_bundle(de_path)
+    ledger = doc_ledger.load(doc_ledger.ledger_path_for(de_path))
+    deck_ledger = ledger.decks.get(doc_ledger.deck_key_for(de_path))
+    assert deck_ledger is not None, "the ledger has no deck section"
+    base = doc_ledger.baseline_from_ledger(deck_ledger)
+    return diff_outcome(bundle.outcome, base)
+
+
+class TestHarvestTask:
+    def test_curate_task_frames_instructions_inputs_and_tokens(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        task = _task_for(tmp_path, de_path, video, "s1")
+        assert task["item"] == "id:s1"
+        assert task["kind"] == "curate"
+        assert task["validator"] == "harvest-bullets"
+        assert task["baseline_fingerprint"] == {"de": None, "en": None}
+        assert task["video_fingerprint"]
+        assert "Preserve every substantive baseline bullet" in task["instructions"]
+        assert task["inputs"]["transcript"]["segments"] == ["Alles über Beta."]
+        assert "# Beta" in task["inputs"]["slide"]["content"]
+        assert task["answer_schema"]["required"] == [
+            "item",
+            "kind",
+            "baseline_fingerprint",
+            "bullets",
+            "dropped",
+        ]
+
+    def test_sweep_frames_every_actionable_item(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        alignment = _write_alignment(tmp_path, de_path)
+        result = _invoke(
+            ["task", str(de_path), str(video), "--lang", "de", "--alignment", str(alignment)]
+        )
+        assert result.exit_code == 0, result.output
+        envelope = _json_from(result)
+        assert sorted(t["item"] for t in envelope["tasks"]) == ["id:s0", "id:s1"]
+
+    def test_silent_slide_cannot_be_framed(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        alignment = _write_alignment(tmp_path, de_path)
+        result = _invoke(
+            [
+                "task",
+                str(de_path),
+                str(video),
+                "--lang",
+                "de",
+                "--alignment",
+                str(alignment),
+                "--slide",
+                "s3",
+            ]
+        )
+        assert result.exit_code == 2
+        assert "nothing to curate" in result.output
+
+    def test_translate_task_frames_the_twin(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        task = _task_for(tmp_path, de_path, video, "s2", kind="translate")
+        assert task["inputs"]["source_language"] == "de"
+        assert task["inputs"]["target_language"] == "en"
+        assert "Bestand Gamma." in task["inputs"]["source"][0]
+        assert task["inputs"]["target_baseline"] == []
+        assert task["baseline_fingerprint"]["de"] is not None
+        assert task["baseline_fingerprint"]["en"] is None
+
+
+class TestHarvestAccept:
+    def test_creates_a_new_vo_member_for_no_existing_vo(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        task = _task_for(tmp_path, de_path, video, "s1")
+        answer = _answer_from_task(task, {"de": ["Beta ist wichtig.", "Beta hat Kanten."]})
+        result = _accept(tmp_path, de_path, answer)
+        assert result.exit_code == 0, result.output
+        payload = _json_from(result)
+        assert payload["applied"] is True
+        assert payload["created"] is True
+        assert payload["member"] == "id:s1-vo"
+
+        companion = tmp_path / "voiceover" / "voiceover_t.de.py"
+        text = companion.read_text(encoding="utf-8")
+        assert 'for_slide="s1"' in text
+        assert 'slide_id="s1-vo"' in text
+        assert "# - Beta ist wichtig." in text
+
+        # The written bundle re-parses and shows the member (lens gate held).
+        from clm.slides.doc_lenses import load_bundle
+
+        bundle = load_bundle(de_path)
+        assert bundle.outcome.deck is not None
+        keys = {m.key.render() for m in bundle.outcome.deck.members()}
+        assert "id:s1-vo" in keys
+
+    def test_one_sided_create_with_record_frames_translate_new(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        task = _task_for(tmp_path, de_path, video, "s1")
+        answer = _answer_from_task(task, {"de": ["Beta ist wichtig."]})
+        result = _accept(tmp_path, de_path, answer, "--record")
+        assert result.exit_code == 0, result.output
+        assert _json_from(result)["recorded"] is True
+
+        ledger_text = (tmp_path / ".clm" / "sync-ledger.json").read_text(encoding="utf-8")
+        assert f"harvest:{task['video_fingerprint']}" in ledger_text
+
+        diff = _ledger_diff(de_path)
+        verdicts = {i.key: i.action for i in diff.items}
+        # The §6 invariant: the recorded one-sided member frames the twin as
+        # translation work — not cold, not in_sync.
+        assert verdicts.get("id:s1-vo") == "translate_new"
+
+    def test_one_sided_edit_with_record_frames_translate_edit(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        task = _task_for(tmp_path, de_path, video, "s0")
+        answer = _answer_from_task(task, {"de": ["Alpha, neu kuratiert."]})
+        result = _accept(tmp_path, de_path, answer, "--record")
+        assert result.exit_code == 0, result.output
+        payload = _json_from(result)
+        assert payload["created"] is False
+        assert payload["member"] == "id:s0-vo"
+        assert payload["recorded"] is True
+
+        diff = _ledger_diff(de_path)
+        items = {i.key: i for i in diff.items}
+        assert "id:s0-vo" in items, "the one-sided edit must stay visible as translate work"
+        assert items["id:s0-vo"].action == "translate_edit"
+        assert items["id:s0-vo"].direction == "de_to_en"
+
+    def test_bilingual_answer_with_record_is_in_sync(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        task = _task_for(tmp_path, de_path, video, "s0")
+        answer = _answer_from_task(
+            task,
+            {"de": ["Alpha, neu kuratiert."], "en": ["Alpha, freshly curated."]},
+        )
+        result = _accept(tmp_path, de_path, answer, "--record")
+        assert result.exit_code == 0, result.output
+
+        en_companion = tmp_path / "voiceover" / "voiceover_t.en.py"
+        assert "# - Alpha, freshly curated." in en_companion.read_text(encoding="utf-8")
+
+        diff = _ledger_diff(de_path)
+        verdicts = {i.key: i.action for i in diff.items}
+        assert "id:s0-vo" not in verdicts, "a bilingual accept records a clean pair"
+
+    def test_stale_baseline_fingerprint_rejects(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        task = _task_for(tmp_path, de_path, video, "s0")
+        answer = _answer_from_task(task, {"de": ["Alpha."]})
+        answer["baseline_fingerprint"] = {
+            "de": "0" * 64,
+            "en": answer["baseline_fingerprint"]["en"],
+        }
+        result = _accept(tmp_path, de_path, answer)
+        assert result.exit_code == 2
+        assert "changed since the task" in result.output
+
+    def test_schema_violations_reject_without_writing(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        task = _task_for(tmp_path, de_path, video, "s1")
+        before = de_path.read_text(encoding="utf-8")
+        for bad_bullets in ({}, {"de": []}, {"de": ["a\nb"]}, {"fr": ["x"]}):
+            answer = _answer_from_task(task, {"de": ["ok"]})
+            answer["bullets"] = bad_bullets
+            result = _accept(tmp_path, de_path, answer)
+            assert result.exit_code == 2, f"{bad_bullets}: {result.output}"
+        assert de_path.read_text(encoding="utf-8") == before
+
+    def test_record_needs_the_video_fingerprint(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        task = _task_for(tmp_path, de_path, video, "s1")
+        answer = _answer_from_task(task, {"de": ["Beta."]})
+        del answer["video_fingerprint"]
+        result = _accept(tmp_path, de_path, answer, "--record")
+        assert result.exit_code == 2
+        assert "video_fingerprint" in result.output
+
+    def test_slide_option_must_match_the_answer(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        task = _task_for(tmp_path, de_path, video, "s1")
+        answer = _answer_from_task(task, {"de": ["Beta."]})
+        result = _accept(tmp_path, de_path, answer, "--slide", "s0")
+        assert result.exit_code == 2
+        assert "does not match" in result.output
+
+    def test_dry_run_writes_nothing(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        companion = tmp_path / "voiceover" / "voiceover_t.de.py"
+        before = companion.read_text(encoding="utf-8")
+        task = _task_for(tmp_path, de_path, video, "s1")
+        answer = _answer_from_task(task, {"de": ["Beta."]})
+        result = _accept(tmp_path, de_path, answer, "--dry-run")
+        assert result.exit_code == 0, result.output
+        assert _json_from(result)["dry_run"] is True
+        assert companion.read_text(encoding="utf-8") == before
+        assert not (tmp_path / ".clm" / "sync-ledger.json").exists()
+
+    def test_unknown_slide_rejects(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        task = _task_for(tmp_path, de_path, video, "s1")
+        answer = _answer_from_task(task, {"de": ["Beta."]})
+        answer["item"] = "id:missing"
+        result = _accept(tmp_path, de_path, answer)
+        assert result.exit_code == 2
+        assert "no slide id:missing" in result.output
+
+
+class TestHarvestVerify:
+    def test_clean_pair_passes_with_pending_twin_listed(self, tmp_path: Path) -> None:
+        de_path, _video = _write_fixture(tmp_path)
+        result = _invoke(["verify", str(de_path), "--json"])
+        assert result.exit_code == 0, result.output
+        payload = _json_from(result)
+        assert payload["ok"] is True
+        # The fixture's s2-vo exists in DE only: a representable pending
+        # state, never a structural failure (§6).
+        assert {"member": "id:s2-vo", "present": "de", "missing": "en"} in payload["pending_twins"]
+
+    def test_pair_stays_verifiable_after_accept(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        task = _task_for(tmp_path, de_path, video, "s1")
+        answer = _answer_from_task(task, {"de": ["Beta ist wichtig."]})
+        assert _accept(tmp_path, de_path, answer, "--record").exit_code == 0
+        result = _invoke(["verify", str(de_path)])
+        assert result.exit_code == 0, result.output
+        assert "PASS" in result.output
+        assert "id:s1-vo" in result.output  # the fresh harvest write is pending


### PR DESCRIPTION
## Summary

Phase 3 of the video-narration-harvest epic #546: the judgment half of the
agent-first toolkit — `clm harvest task` / `accept` / `verify`.

**Landed ahead of the v3 dogfood week as a deliberate stress-test (user
decision). Back-out: master is tagged `pre-harvest-phase3` immediately
before this phase, and the whole phase is this one PR — `git revert -m 1`
of the merge commit drops it cleanly.**

### `clm harvest task DECK VIDEO… --lang de|en [--slide ID] [--kind curate|translate]`

Frames one slide's judgment as a JSON document: caller instructions (the
old embedded-model merge/propagate rules restated for the driving agent in
`prompts/harvest_curate.md` / `harvest_translate.md`, including the
`**[Revisited]**` backtracking semantics — resolving the one open design
detail), structured inputs (baseline VO on both sides, aligned transcript,
slide content), the bullet-list `answer_schema` (validator
`harvest-bullets`), and freshness tokens: per-side `baseline_fingerprint`
(report items now carry per-cell content fingerprints) plus
`video_fingerprint`. A slide with >1 narrative cell per side is refused
(P8: never guess).

### `clm harvest accept DECK --answer FILE|- [--record]`

The toolkit's only write path. Validates with precise per-field reasons —
schema, fingerprint freshness against the **live** deck (a concurrent edit
rejects, never overwrites), single-cell body guards, and the v3 re-parse
gate — then lands the id-keyed member edit atomically through the Phase-1
`DeckEmitter`/`write_changed_files` surface. A missing voiceover member is
created: minted `<owner>-vo` id, `for_slide` owner, deck-majority
role/layout, companion append or inline insert after the owner group.

**The §6 one-sided-trust semantics** (`--record`, provenance
`harvest:<video-fingerprint>`, gated on the shared structural gate):

- bilingual answer → fresh both-side ledger entry → next `slides sync
  report` reads `in_sync` (the pair is genuinely clean);
- one-sided member → fresh one-sided entry → frames **`translate_new`**
  (without the record it would only surface as unframed `verify_cold`);
- one-sided write over an existing twin → the written side's fingerprint is
  **not** advanced → frames **`translate_edit`** toward the twin.

`LedgerMember` has no per-side trust field — the fingerprint mismatch *is*
the "twin owes translation" representation; advancing both fingerprints
would read `in_sync` and silently bless the stale twin, the forbidden
state.

### `clm harvest verify DECK`

V3-native: the lens gate (bundle must re-parse) plus the deck-half
structural gate the sync write verbs use. One-sided narrative members are
listed as `pending_twins` (exit 0), not failures — the v2 `verify_pair`
projects companions and reads that representable pending state as an
`id-asymmetry` **error**, which is precisely the corruption misreading §6
forbids.

## Tests

`tests/cli/test_harvest_task_accept.py` drives the full loop through the
real CLI with injected alignments (no ASR/GPU, fast suite): task framing
(instructions, tokens, translate kind, unavailable slides), accept
round-trips (create / replace / bilingual / dry-run / every rejection
path), and the **§6 hard-requirement tests** asserting the actual v3
differ's verdicts against the recorded ledger: `translate_new` for a
recorded one-sided create, `translate_edit` (de→en) for a one-sided edit,
and no item at all for a bilingual accept. Suites: tests/cli + tests/slides
+ tests/voiceover = 4744 passed; ruff + mypy clean; fast suite green on the
pre-push hook.

## Docs

`clm info commands` gains `task`/`accept`/`verify` subsections (envelope,
exit codes, §6 semantics); changelog fragment; harvest handover updated
(Phase 3 done, early-landing rationale + back-out recorded). The
`clm info harvest-agents` topic and MCP wrappers remain Phase 4.

Part of epic #546. After merge, the result will be tagged `harvest-phase3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TJvSAbnsLWxcCLJ3SvqoS
