### PR TITLE
feat(harvest): multi-narrative answers + multi-part video caching (#546 Phase 4 extensions)

### DIFF
--- a/src/clm/cli/commands/harvest.py
+++ b/src/clm/cli/commands/harvest.py
@@ -479,7 +479,10 @@ def harvest_accept_cmd(
         click.echo(json.dumps(outcome.to_payload(), indent=2, ensure_ascii=False))
     else:
         state = "dry-run: would write" if dry_run else "wrote"
-        click.echo(f"accepted {outcome.item} → member {outcome.member} ({state})")
+        touched = ", ".join(
+            f"{m['member']}{' (new)' if m['created'] else ''}" for m in outcome.members
+        )
+        click.echo(f"accepted {outcome.item} → {touched} ({state})")
         for path in outcome.written_paths:
             click.echo(f"  {path}")
         if outcome.recorded:

--- a/src/clm/voiceover/cache.py
+++ b/src/clm/voiceover/cache.py
@@ -47,7 +47,7 @@ import json
 import logging
 import os
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Generic, TypeVar
@@ -90,6 +90,37 @@ class VideoKey:
             usedforsecurity=False,
         )
         return h.hexdigest()[:16]
+
+
+@dataclass(frozen=True)
+class MultiVideoKey:
+    """Composite fingerprint for a multi-part recording.
+
+    The hash covers every part's :class:`VideoKey` hash in order — any part
+    changing (or the part order changing) invalidates the entry. The same
+    hash is the harvest ``video_fingerprint`` for multi-part videos, so the
+    cache key and the ledger provenance stay one identity.
+    """
+
+    parts: tuple[VideoKey, ...]
+
+    @classmethod
+    def from_paths(cls, paths: Sequence[str | Path]) -> MultiVideoKey:
+        return cls(parts=tuple(VideoKey.from_path(p) for p in paths))
+
+    @property
+    def hash(self) -> str:
+        joined = "|".join(part.hash for part in self.parts)
+        return hashlib.sha1(joined.encode("utf-8"), usedforsecurity=False).hexdigest()[:16]
+
+
+def video_key_for(paths: str | Path | Sequence[str | Path]) -> VideoKey | MultiVideoKey:
+    """The cache key for one video or an ordered multi-part recording."""
+    if isinstance(paths, (str, Path)):
+        return VideoKey.from_path(paths)
+    if len(paths) == 1:
+        return VideoKey.from_path(paths[0])
+    return MultiVideoKey.from_paths(paths)
 
 
 @dataclass(frozen=True)
@@ -333,10 +364,10 @@ class TimelinesCache(_JsonCache):
         )
 
     @staticmethod
-    def _compose_key(video: VideoKey, slides: SlidesKey) -> str:
+    def _compose_key(video: VideoKey | MultiVideoKey, slides: SlidesKey) -> str:
         return f"{video.hash}_{slides.hash}"
 
-    def get(self, video: VideoKey, slides: SlidesKey, cfg: dict[str, Any]):
+    def get(self, video: VideoKey | MultiVideoKey, slides: SlidesKey, cfg: dict[str, Any]):
         entry = self._load(self._compose_key(video, slides))
         if entry is None:
             return None
@@ -357,7 +388,7 @@ class TimelinesCache(_JsonCache):
 
     def put(
         self,
-        video: VideoKey,
+        video: VideoKey | MultiVideoKey,
         slides: SlidesKey,
         cfg: dict[str, Any],
         timeline,
@@ -386,10 +417,10 @@ class AlignmentsCache(_JsonCache):
         )
 
     @staticmethod
-    def _compose_key(video: VideoKey, slides: SlidesKey) -> str:
+    def _compose_key(video: VideoKey | MultiVideoKey, slides: SlidesKey) -> str:
         return f"{video.hash}_{slides.hash}"
 
-    def get(self, video: VideoKey, slides: SlidesKey, cfg: dict[str, Any]):
+    def get(self, video: VideoKey | MultiVideoKey, slides: SlidesKey, cfg: dict[str, Any]):
         entry = self._load(self._compose_key(video, slides))
         if entry is None:
             return None
@@ -410,7 +441,7 @@ class AlignmentsCache(_JsonCache):
 
     def put(
         self,
-        video: VideoKey,
+        video: VideoKey | MultiVideoKey,
         slides: SlidesKey,
         cfg: dict[str, Any],
         alignment,
@@ -712,7 +743,7 @@ def cached_detect(
 
 
 def cached_timeline(
-    video_path: str | Path,
+    video_path: str | Path | Sequence[str | Path],
     slide_path: str | Path,
     *,
     policy: CachePolicy,
@@ -728,14 +759,14 @@ def cached_timeline(
     if not policy.enabled:
         return timeline_fn(), False
 
-    video_key = VideoKey.from_path(video_path)
+    video_key = video_key_for(video_path)
     slides_key = SlidesKey.from_path(slide_path)
     cache = TimelinesCache(policy.resolve_root(base_dir))
 
     if not policy.refresh:
         hit = cache.get(video_key, slides_key, cfg)
         if hit is not None:
-            logger.info("Timeline cache hit for %s", Path(video_path).name)
+            logger.info("Timeline cache hit (%s)", video_key.hash)
             return hit, True
 
     timeline = timeline_fn()
@@ -744,7 +775,7 @@ def cached_timeline(
 
 
 def cached_alignment(
-    video_path: str | Path,
+    video_path: str | Path | Sequence[str | Path],
     slide_path: str | Path,
     *,
     policy: CachePolicy,
@@ -756,14 +787,14 @@ def cached_alignment(
     if not policy.enabled:
         return alignment_fn(), False
 
-    video_key = VideoKey.from_path(video_path)
+    video_key = video_key_for(video_path)
     slides_key = SlidesKey.from_path(slide_path)
     cache = AlignmentsCache(policy.resolve_root(base_dir))
 
     if not policy.refresh:
         hit = cache.get(video_key, slides_key, cfg)
         if hit is not None:
-            logger.info("Alignment cache hit for %s", Path(video_path).name)
+            logger.info("Alignment cache hit (%s)", video_key.hash)
             return hit, True
 
     alignment = alignment_fn()

--- a/src/clm/voiceover/harvest.py
+++ b/src/clm/voiceover/harvest.py
@@ -37,7 +37,6 @@ This module is engine-only: it emits, it never invokes a model.
 
 from __future__ import annotations
 
-import hashlib
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -101,19 +100,18 @@ class PipelineArtifacts:
 
 
 def video_fingerprint(video_paths: list[Path]) -> str:
-    """The fingerprint keying the artifact cache — and, later, the ledger
-    provenance ``harvest:<fingerprint>`` (proposal §6).
+    """The fingerprint keying the artifact cache — and the ledger provenance
+    ``harvest:<fingerprint>`` (proposal §6).
 
     Single video: the cache's :class:`~clm.voiceover.cache.VideoKey` hash
-    (path + mtime + size). Multiple parts: a stable hash over the ordered
-    per-part hashes.
+    (path + mtime + size). Multiple parts: the composite
+    :class:`~clm.voiceover.cache.MultiVideoKey` hash over the ordered
+    per-part hashes — the same key the timeline/alignment caches use, so
+    cache identity and provenance stay one thing.
     """
-    from clm.voiceover.cache import VideoKey
+    from clm.voiceover.cache import video_key_for
 
-    hashes = [VideoKey.from_path(p).hash for p in video_paths]
-    if len(hashes) == 1:
-        return hashes[0]
-    return hashlib.sha1("|".join(hashes).encode("utf-8")).hexdigest()[:16]
+    return video_key_for(video_paths).hash
 
 
 def run_pipeline(
@@ -131,11 +129,12 @@ def run_pipeline(
 ) -> PipelineArtifacts:
     """Run the deterministic tier (cached) up to the alignment.
 
-    The same stage order and cache wrappers ``clm voiceover sync`` uses:
-    per part transcribe + detect (cached), offset and merge, OCR match
-    (cached, single-part only), align (cached, single-part only). An
-    ``alignment_override`` short-circuits everything; a
-    ``transcript_override`` skips only ASR. Both are single-part only.
+    Per part: transcribe + detect (cached per part), offset and merge; then
+    OCR match and align, cached under the composite multi-part key when the
+    recording has several parts. An ``alignment_override`` short-circuits
+    everything (it encodes the final stitched alignment, so it applies to
+    multi-part recordings too); a ``transcript_override`` skips only ASR
+    and stays single-video only (it encodes one part's ASR output).
     """
     from clm.voiceover.aligner import align_transcript
     from clm.voiceover.cache import (
@@ -156,11 +155,8 @@ def run_pipeline(
 
     multi_part = len(video_paths) > 1
     if alignment_override is not None:
-        if multi_part:
-            raise HarvestUsageError(
-                "--alignment is incompatible with multi-part videos; "
-                "the override encodes a single pre-computed alignment."
-            )
+        # The override is the final per-slide alignment — it already encodes
+        # the stitched timeline, so it applies to multi-part recordings too.
         return PipelineArtifacts(
             alignment=alignment_override, timeline=None, transcript_language=None
         )
@@ -227,34 +223,28 @@ def run_pipeline(
             lang=lang,
         ).timeline
 
-    # Timeline/alignment caching is single-part only (composite multi-part
-    # keys are not modelled) — the same scoping `voiceover sync` applies.
-    if multi_part:
-        timeline = _run_match()
-    else:
-        timeline, _ = cached_timeline(
-            video_paths[0],
-            slides_path,
-            policy=policy,
-            base_dir=slides_path.parent,
-            timeline_fn=_run_match,
-            cfg={"lang": lang, "frame_offset": 1.0, "multi_part": multi_part},
-        )
+    # Timeline/alignment caching covers multi-part recordings via the
+    # composite MultiVideoKey (any part change/reorder invalidates).
+    timeline, _ = cached_timeline(
+        video_paths,
+        slides_path,
+        policy=policy,
+        base_dir=slides_path.parent,
+        timeline_fn=_run_match,
+        cfg={"lang": lang, "frame_offset": 1.0, "multi_part": multi_part},
+    )
 
     def _run_align():
         return align_transcript(merged_transcript, timeline)
 
-    if multi_part:
-        alignment = _run_align()
-    else:
-        alignment, _ = cached_alignment(
-            video_paths[0],
-            slides_path,
-            policy=policy,
-            base_dir=slides_path.parent,
-            alignment_fn=_run_align,
-            cfg={"lang": lang, "multi_part": multi_part},
-        )
+    alignment, _ = cached_alignment(
+        video_paths,
+        slides_path,
+        policy=policy,
+        base_dir=slides_path.parent,
+        alignment_fn=_run_align,
+        cfg={"lang": lang, "multi_part": multi_part},
+    )
 
     return PipelineArtifacts(
         alignment=alignment,

--- a/src/clm/voiceover/harvest_accept.py
+++ b/src/clm/voiceover/harvest_accept.py
@@ -1,25 +1,31 @@
-"""``clm harvest accept`` — validate an answer and write it (#546 Phase 3).
+"""``clm harvest accept`` — validate an answer and write it (#546 Phase 3/4).
 
 The only write path of the harvest toolkit. An answer (the bullet-list
-document a ``harvest task`` framed, `validator "harvest-bullets"`) is
-validated — schema shape, single-cell body guards, baseline-fingerprint
-freshness against what ``task`` framed — and then lands through the v3
-model: an id-keyed member edit emitted and written atomically via the
-Phase-1 write surface (:mod:`clm.slides.doc_write`). Nothing is written on
-any validation failure; the mutated bundle is re-parsed before anything
-touches disk (the lens gate).
+document a ``harvest task`` framed, validator ``harvest-bullets``) is
+validated — schema shape, single-cell body guards, per-member
+baseline-fingerprint freshness against what ``task`` framed — and then
+lands through the v3 model: id-keyed member edits emitted and written
+atomically via the Phase-1 write surface (:mod:`clm.slides.doc_write`).
+Nothing is written on any validation failure; the mutated bundle is
+re-parsed before anything touches disk (the lens gate).
 
-``--record`` banks the write into the sync consistency ledger with
-provenance ``harvest:<video-fingerprint>`` under the §6 one-sided-trust
-semantics (proposal §6, the load-bearing invariant):
+Slides routinely carry several narrative cells (one per code cell), so an
+answer is a list of per-member ``updates``: each names an existing
+narrative member of the slide, or creates a new one (``"member": null``,
+optionally placed ``"after"`` an existing narrative member; default at the
+end of the slide group).
 
-* **bilingual answer** → the member's fresh both-side snapshot is recorded
+``--record`` banks each written member into the sync consistency ledger
+with provenance ``harvest:<video-fingerprint>`` under the §6
+one-sided-trust semantics (proposal §6, the load-bearing invariant):
+
+* **bilingual update** → the member's fresh both-side snapshot is recorded
   (the pair is clean; next ``slides sync report`` reads ``in_sync``);
-* **one-sided answer, member ends one-sided** → the fresh one-sided
+* **one-sided update, member ends one-sided** → the fresh one-sided
   snapshot is recorded — that entry is precisely what makes the next sync
   report frame ``translate_new`` for the twin (an unrecorded new member
   would only surface as an unframed ``verify_cold``);
-* **one-sided answer, twin body exists** → the written side's ledger
+* **one-sided update, twin body exists** → the written side's ledger
   fingerprint is **not** advanced (the existing entry is kept, or the
   pre-write state is recorded): the harvested side reads as "edited off
   base" and the next sync report frames ``translate_edit`` toward the twin.
@@ -61,6 +67,7 @@ __all__ = [
     "AcceptOutcome",
     "AcceptRejected",
     "Answer",
+    "Update",
     "accept_answer",
     "parse_answer",
 ]
@@ -75,13 +82,22 @@ class AcceptRejected(Exception):
 
 
 @define
+class Update:
+    """One per-member edit: an existing member's new bullets, or a new cell."""
+
+    member: str | None  # id:… handle, or None = create
+    bullets: dict[str, list[str]]  # side -> ordered bullet strings
+    after: str | None = None  # create only: place after this narrative member
+
+
+@define
 class Answer:
     """The validated bullet-list answer document."""
 
     item: str
     kind: str
-    baseline_fingerprint: dict[str, str | None]
-    bullets: dict[str, list[str]]  # side -> ordered bullet strings
+    baseline_fingerprints: dict[str, dict[str, str | None]]
+    updates: list[Update]
     dropped: list[str]
     video_fingerprint: str | None
 
@@ -90,8 +106,7 @@ class Answer:
 class AcceptOutcome:
     item: str
     applied: bool = False
-    created: bool = False
-    member: str | None = None  # the vo member's rendered key
+    members: list[dict[str, Any]] = field(factory=list)  # {"member","created"}
     written_paths: list[Path] = field(factory=list)
     recorded: bool = False
     record_refused: list[str] = field(factory=list)
@@ -104,8 +119,7 @@ class AcceptOutcome:
             "verb": "accept",
             "item": self.item,
             "applied": self.applied,
-            "created": self.created,
-            "member": self.member,
+            "members": self.members,
             "written": [str(p) for p in self.written_paths],
             "recorded": self.recorded,
             "record_refused": self.record_refused,
@@ -116,6 +130,27 @@ class AcceptOutcome:
 # ---------------------------------------------------------------------------
 # Answer validation (validator "harvest-bullets")
 # ---------------------------------------------------------------------------
+
+
+def _parse_bullets(bullets: Any, where: str) -> dict[str, list[str]]:
+    if not isinstance(bullets, dict) or not bullets or set(bullets) - {"de", "en"}:
+        raise AcceptRejected(f"{where}.bullets must map at least one of de/en to a bullet list")
+    parsed: dict[str, list[str]] = {}
+    for side, entries in bullets.items():
+        if not isinstance(entries, list) or not entries:
+            raise AcceptRejected(f"{where}.bullets.{side} must be a non-empty list of strings")
+        cleaned: list[str] = []
+        for i, bullet in enumerate(entries):
+            if not isinstance(bullet, str) or not bullet.strip():
+                raise AcceptRejected(f"{where}.bullets.{side}[{i}] must be a non-empty string")
+            if "\n" in bullet:
+                raise AcceptRejected(
+                    f"{where}.bullets.{side}[{i}] contains a newline — one bullet per "
+                    "string, markdown inline formatting only"
+                )
+            cleaned.append(_BULLET_PREFIX.sub("", bullet.strip()))
+        parsed[side] = cleaned
+    return parsed
 
 
 def parse_answer(payload: Any) -> Answer:
@@ -129,32 +164,46 @@ def parse_answer(payload: Any) -> Answer:
     kind = payload.get("kind")
     if kind not in ("curate", "translate"):
         raise AcceptRejected('\'kind\' must be "curate" or "translate"')
-    fingerprint = payload.get("baseline_fingerprint")
-    if not isinstance(fingerprint, dict) or set(fingerprint) - {"de", "en"}:
+    tokens = payload.get("baseline_fingerprints")
+    if not isinstance(tokens, dict):
         raise AcceptRejected(
-            "'baseline_fingerprint' must be the {de, en} object echoed from the task"
+            "'baseline_fingerprints' must be the per-member object echoed from the task"
         )
-    for side, value in fingerprint.items():
-        if value is not None and not isinstance(value, str):
-            raise AcceptRejected(f"baseline_fingerprint.{side} must be a string or null")
-    bullets = payload.get("bullets")
-    if not isinstance(bullets, dict) or not bullets or set(bullets) - {"de", "en"}:
-        raise AcceptRejected("'bullets' must map at least one of de/en to a bullet list")
-    parsed_bullets: dict[str, list[str]] = {}
-    for side, entries in bullets.items():
-        if not isinstance(entries, list) or not entries:
-            raise AcceptRejected(f"bullets.{side} must be a non-empty list of bullet strings")
-        cleaned: list[str] = []
-        for i, bullet in enumerate(entries):
-            if not isinstance(bullet, str) or not bullet.strip():
-                raise AcceptRejected(f"bullets.{side}[{i}] must be a non-empty string")
-            if "\n" in bullet:
+    fingerprints: dict[str, dict[str, str | None]] = {}
+    for key, sides in tokens.items():
+        if not isinstance(sides, dict) or set(sides) - {"de", "en"}:
+            raise AcceptRejected(f"baseline_fingerprints[{key!r}] must be a {{de, en}} object")
+        for side, value in sides.items():
+            if value is not None and not isinstance(value, str):
                 raise AcceptRejected(
-                    f"bullets.{side}[{i}] contains a newline — one bullet per string, "
-                    "markdown inline formatting only"
+                    f"baseline_fingerprints[{key!r}].{side} must be a string or null"
                 )
-            cleaned.append(_BULLET_PREFIX.sub("", bullet.strip()))
-        parsed_bullets[side] = cleaned
+        fingerprints[key] = {s: sides.get(s) for s in _SIDES}
+    raw_updates = payload.get("updates")
+    if not isinstance(raw_updates, list) or not raw_updates:
+        raise AcceptRejected("'updates' must be a non-empty list of per-member entries")
+    updates: list[Update] = []
+    seen_members: set[str] = set()
+    for i, entry in enumerate(raw_updates):
+        where = f"updates[{i}]"
+        if not isinstance(entry, dict):
+            raise AcceptRejected(f"{where} must be an object with 'member' and 'bullets'")
+        member = entry.get("member")
+        if member is not None and (not isinstance(member, str) or not member.startswith("id:")):
+            raise AcceptRejected(f"{where}.member must be an id:… handle or null (= create)")
+        if member is not None:
+            if member in seen_members:
+                raise AcceptRejected(f"{where}: duplicate update for member {member}")
+            seen_members.add(member)
+        after = entry.get("after")
+        if after is not None:
+            if member is not None:
+                raise AcceptRejected(f"{where}: 'after' is only valid when member is null")
+            if not isinstance(after, str) or not after.startswith("id:"):
+                raise AcceptRejected(f"{where}.after must be an existing member's id:… handle")
+        updates.append(
+            Update(member=member, bullets=_parse_bullets(entry.get("bullets"), where), after=after)
+        )
     dropped = payload.get("dropped")
     if not isinstance(dropped, list) or any(not isinstance(d, str) for d in dropped):
         raise AcceptRejected("'dropped' must be a list of strings (the audit trail; may be empty)")
@@ -164,8 +213,8 @@ def parse_answer(payload: Any) -> Answer:
     return Answer(
         item=item,
         kind=kind,
-        baseline_fingerprint={s: fingerprint.get(s) for s in _SIDES},
-        bullets=parsed_bullets,
+        baseline_fingerprints=fingerprints,
+        updates=updates,
         dropped=list(dropped),
         video_fingerprint=video_fingerprint,
     )
@@ -204,7 +253,7 @@ def _replace_body(cell: SideCell, body: str) -> tuple[str, ...]:
 
 
 # ---------------------------------------------------------------------------
-# Locating and mutating the voiceover member
+# Locating and mutating the voiceover members
 # ---------------------------------------------------------------------------
 
 
@@ -216,15 +265,20 @@ def _narrative_members(deck: BilingualDeck, slide_id: str) -> list[Member] | Non
 
 
 def _check_freshness(answer: Answer, members: list[Member]) -> None:
-    for side in _SIDES:
-        cells = [c for m in members if (c := m.side(side)) is not None]
-        current = content_fingerprint(cells[0]) if cells else None
-        framed = answer.baseline_fingerprint.get(side)
-        if current != framed:
-            raise AcceptRejected(
-                f"the {side} voiceover baseline changed since the task was framed "
-                "(fingerprint mismatch) — re-run `harvest task` and re-judge"
-            )
+    """The echoed per-member tokens must match the LIVE deck exactly —
+    including the member set itself (a narrative cell added or removed
+    since the task was framed is staleness, not a merge opportunity)."""
+    current: dict[str, dict[str, str | None]] = {}
+    for member in members:
+        current[member.key.render()] = {
+            side: content_fingerprint(cell) if (cell := member.side(side)) is not None else None
+            for side in _SIDES
+        }
+    if current != answer.baseline_fingerprints:
+        raise AcceptRejected(
+            "the slide's narrative cells changed since the task was framed "
+            "(baseline_fingerprints mismatch) — re-run `harvest task` and re-judge"
+        )
 
 
 def _deck_slide_ids(deck: BilingualDeck) -> set[str]:
@@ -237,13 +291,13 @@ def _deck_slide_ids(deck: BilingualDeck) -> set[str]:
     return ids
 
 
-def _mint_vo_id(deck: BilingualDeck, owner: str) -> str:
-    taken = _deck_slide_ids(deck)
+def _mint_vo_id(taken: set[str], owner: str) -> str:
     candidate = f"{owner}-vo"
     n = 2
     while candidate in taken:
         candidate = f"{owner}-vo{n}"
         n += 1
+    taken.add(candidate)
     return candidate
 
 
@@ -296,31 +350,40 @@ def _insert_new_member(
     member: Member,
     owner: str,
     part: Part,
+    after: Member | None,
 ) -> None:
-    """Place the new member's cells: companion cells append to the companion
-    stream; inline cells go right after the owner group's last cell."""
+    """Place the new member's cells per side: right after ``after`` when it
+    is present in that side's stream; otherwise after the owner group's last
+    cell (deck part) / appended (companion part)."""
     for side in _SIDES:
         cell = member.side(side)
         if cell is None:
             continue
         stream = emitter.streams.setdefault((side, part), [])
-        if part == "companion":
-            stream.append(member)
-        else:
-            anchor_pos = -1
-            for group in deck.groups:
-                if group.anchor_id != owner:
-                    continue
-                group_members = [
-                    m
-                    for m in group.all_members()
-                    if (c := m.side(side)) is not None and c.part == part
-                ]
-                positions = [
-                    i for i, m in enumerate(stream) if any(m is gm for gm in group_members)
-                ]
-                anchor_pos = max(positions) if positions else -1
-            stream.insert(anchor_pos + 1, member)
+        insert_at: int | None = None
+        if after is not None:
+            for i, m in enumerate(stream):
+                if m is after:
+                    insert_at = i + 1
+                    break
+        if insert_at is None:
+            if part == "companion":
+                insert_at = len(stream)
+            else:
+                insert_at = 0
+                for group in deck.groups:
+                    if group.anchor_id != owner:
+                        continue
+                    group_members = [
+                        m
+                        for m in group.all_members()
+                        if (c := m.side(side)) is not None and c.part == part
+                    ]
+                    positions = [
+                        i for i, m in enumerate(stream) if any(m is gm for gm in group_members)
+                    ]
+                    insert_at = (max(positions) + 1) if positions else 0
+        stream.insert(insert_at, member)
         emitter.mutated = True
 
 
@@ -352,16 +415,23 @@ def _entry_from_member(member: Member):
     )
 
 
-def _record_member(
+@define
+class _WrittenMember:
+    """What the record step needs about one landed update."""
+
+    key: str
+    final_member: Member
+    pre_member: Member | None  # None = created
+    bilingual: bool
+
+
+def _record_members(
     bundle: LoadedBundle,
+    written: list[_WrittenMember],
     *,
-    key: str,
-    final_member: Member,
-    pre_member: Member | None,
-    bilingual: bool,
     video_fingerprint: str,
 ) -> list[str]:
-    """Bank the write under ``harvest:<fp>`` provenance (§6 semantics).
+    """Bank the writes under ``harvest:<fp>`` provenance (§6 semantics).
 
     Returns structural-gate violation messages; non-empty means the ledger
     save was withheld (the files stay as written — fail-safe, like apply).
@@ -384,24 +454,26 @@ def _record_member(
     )
     provenance = f"harvest:{video_fingerprint}"
 
-    if bilingual or final_member.is_one_sided:
-        # Fresh snapshot: a bilingual answer records a clean pair (in_sync
-        # next report); a one-sided member records the one-sided entry that
-        # frames translate_new for the twin.
-        entry = _entry_from_member(final_member)
-    else:
-        # One side written while a twin body exists: never advance the
-        # written side's fingerprint — the mismatch IS the translate_edit
-        # framing; advancing it would silently bless the stale twin.
-        existing = target.members.get(key)
-        if existing is not None:
-            entry = existing.entry
-        elif pre_member is not None:
-            entry = _entry_from_member(pre_member)
-        else:  # pragma: no cover - created members are one-sided or bilingual
-            return ["cannot synthesize a pre-write baseline for the member"]
+    for item in written:
+        if item.bilingual or item.final_member.is_one_sided:
+            # Fresh snapshot: a bilingual update records a clean pair
+            # (in_sync next report); a one-sided member records the
+            # one-sided entry that frames translate_new for the twin.
+            entry = _entry_from_member(item.final_member)
+        else:
+            # One side written while a twin body exists: never advance the
+            # written side's fingerprint — the mismatch IS the
+            # translate_edit framing; advancing it would silently bless the
+            # stale twin.
+            existing = target.members.get(item.key)
+            if existing is not None:
+                entry = existing.entry
+            elif item.pre_member is not None:
+                entry = _entry_from_member(item.pre_member)
+            else:  # pragma: no cover - created members are one-sided or bilingual
+                return ["cannot synthesize a pre-write baseline for the member"]
+        target.members[item.key] = doc_ledger.LedgerMember(entry=entry, provenance=provenance)
 
-    target.members[key] = doc_ledger.LedgerMember(entry=entry, provenance=provenance)
     doc_ledger.save(ledger, ledger_path)
     return []
 
@@ -421,8 +493,8 @@ def accept_answer(
     """Validate ``answer`` against the live bundle and land it atomically.
 
     Raises :class:`AcceptRejected` (nothing written) on any validation
-    failure. With ``record``, banks the touched member into the sync ledger
-    under ``harvest:<video-fingerprint>`` provenance (§6 semantics).
+    failure. With ``record``, banks every touched member into the sync
+    ledger under ``harvest:<video-fingerprint>`` provenance (§6 semantics).
     """
     deck = bundle.outcome.deck
     if deck is None:
@@ -435,88 +507,113 @@ def accept_answer(
     members = _narrative_members(deck, slide_id)
     if members is None:
         raise AcceptRejected(f"no slide {answer.item} in the deck")
-    for side in _SIDES:
-        if side in answer.bullets and len([m for m in members if m.side(side) is not None]) > 1:
+    by_key = {m.key.render(): m for m in members}
+    for update in answer.updates:
+        if update.member is not None and update.member not in by_key:
             raise AcceptRejected(
-                f"slide {answer.item} has more than one narrative cell on the {side} "
-                "side — edit the files directly, then re-run report"
+                f"{update.member} is not a narrative member of slide {answer.item} "
+                f"(known: {', '.join(sorted(by_key)) or 'none'})"
+            )
+        if update.after is not None and update.after not in by_key:
+            raise AcceptRejected(
+                f"'after' target {update.after} is not a narrative member of slide {answer.item}"
             )
     _check_freshness(answer, members)
 
     comment_token = bundle.comment_token
-    bodies: dict[Lang, str] = {
-        side: _render_body(answer.bullets[side], comment_token)
-        for side in _SIDES
-        if side in answer.bullets
-    }
-    for body in bodies.values():
-        _guard_body(body, comment_token)
-
     emitter = DeckEmitter(deck=deck)
     originals = emitter.emit_all()
 
-    target_member = members[0] if members else None
-    pre_member = None
-    created = False
-    if target_member is not None:
-        pre_member = evolve_copy(target_member)
-        for side, body in bodies.items():
-            cell = target_member.side(side)
-            if cell is not None:
-                emitter.set_side(target_member, side, evolve(cell, lines=_replace_body(cell, body)))
-            else:
-                source: Lang = "en" if side == "de" else "de"
-                source_cell = target_member.side(source)
-                if source_cell is None:  # pragma: no cover - members carry >=1 side
-                    raise AcceptRejected(f"the member for {answer.item} carries no cells")
-                from clm.slides.sync_writeback import swap_lang
+    role, layout = _narrative_conventions(deck)
+    part: Part = "companion" if layout == "companion" else "deck"
+    taken = _deck_slide_ids(deck)
+    written: list[_WrittenMember] = []
+    outcome = AcceptOutcome(item=answer.item, dry_run=dry_run)
 
-                header = (
-                    swap_lang(source_cell.header, side)
-                    if source_cell.lang_attr
-                    else source_cell.header
+    for update in answer.updates:
+        bodies: dict[Lang, str] = {
+            side: _render_body(update.bullets[side], comment_token)
+            for side in _SIDES
+            if side in update.bullets
+        }
+        for body in bodies.values():
+            _guard_body(body, comment_token)
+        bilingual = len(bodies) == 2
+
+        if update.member is not None:
+            target_member = by_key[update.member]
+            pre_member = _detached_copy(target_member)
+            for side, body in bodies.items():
+                cell = target_member.side(side)
+                if cell is not None:
+                    emitter.set_side(
+                        target_member, side, evolve(cell, lines=_replace_body(cell, body))
+                    )
+                else:
+                    source: Lang = "en" if side == "de" else "de"
+                    source_cell = target_member.side(source)
+                    if source_cell is None:  # pragma: no cover - members carry >=1 side
+                        raise AcceptRejected(f"the member {update.member} carries no cells")
+                    from clm.slides.sync_writeback import swap_lang
+
+                    header = (
+                        swap_lang(source_cell.header, side)
+                        if source_cell.lang_attr
+                        else source_cell.header
+                    )
+                    base = evolve(source_cell, lines=(header, *source_cell.lines[1:]))
+                    new_cell = evolve(base, lines=_replace_body(base, body), lang_attr=side)
+                    emitter.insert_mirrored(target_member, source, side, source_cell.part, new_cell)
+            written.append(
+                _WrittenMember(
+                    key=target_member.key.render(),
+                    final_member=target_member,  # re-resolved after the re-parse
+                    pre_member=pre_member,
+                    bilingual=bilingual,
                 )
-                base = evolve(source_cell, lines=(header, *source_cell.lines[1:]))
-                new_cell = evolve(base, lines=_replace_body(base, body), lang_attr=side)
-                emitter.insert_mirrored(target_member, source, side, source_cell.part, new_cell)
-        member_key = target_member.key
-    else:
-        created = True
-        role, layout = _narrative_conventions(deck)
-        part: Part = "companion" if layout == "companion" else "deck"
-        vo_id = _mint_vo_id(deck, slide_id)
-        member_key = MemberKey.for_id(vo_id)
-        new_member = Member(
-            key=member_key,
-            kind="markdown",
-            role=role,
-            langness="localized",
-            layout=layout,
-            owner=MemberKey.for_id(slide_id),
-            de=None,
-            en=None,
-        )
-        for side, body in bodies.items():
-            emitter.set_side(
-                new_member,
-                side,
-                _new_side_cell(
-                    side=side,
-                    body=body,
-                    role=role,
-                    part=part,
-                    vo_id=vo_id,
-                    owner=slide_id,
-                    comment_token=comment_token,
-                ),
             )
-        _insert_new_member(emitter, deck, new_member, slide_id, part)
+            outcome.members.append({"member": target_member.key.render(), "created": False})
+        else:
+            vo_id = _mint_vo_id(taken, slide_id)
+            member_key = MemberKey.for_id(vo_id)
+            new_member = Member(
+                key=member_key,
+                kind="markdown",
+                role=role,
+                langness="localized",
+                layout=layout,
+                owner=MemberKey.for_id(slide_id),
+                de=None,
+                en=None,
+            )
+            for side, body in bodies.items():
+                emitter.set_side(
+                    new_member,
+                    side,
+                    _new_side_cell(
+                        side=side,
+                        body=body,
+                        role=role,
+                        part=part,
+                        vo_id=vo_id,
+                        owner=slide_id,
+                        comment_token=comment_token,
+                    ),
+                )
+            after = by_key[update.after] if update.after is not None else None
+            _insert_new_member(emitter, deck, new_member, slide_id, part, after)
+            written.append(
+                _WrittenMember(
+                    key=member_key.render(),
+                    final_member=new_member,
+                    pre_member=None,
+                    bilingual=bilingual,
+                )
+            )
+            outcome.members.append({"member": member_key.render(), "created": True})
 
     finals = emitter.emit_all()
     changed = {file_key for file_key in finals if finals[file_key] != originals[file_key]}
-    outcome = AcceptOutcome(
-        item=answer.item, created=created, member=member_key.render(), dry_run=dry_run
-    )
     if not changed:
         outcome.applied = True  # a byte-identical answer is a valid no-op
         return outcome
@@ -537,13 +634,15 @@ def accept_answer(
         raise AcceptRejected(
             f"the mutated bundle failed the re-parse gate ({reasons}) — nothing was written"
         )
-    final_member = next(
-        (m for m in parse.deck.members() if m.key.render() == member_key.render()), None
-    )
-    if final_member is None:
-        raise AcceptRejected(
-            "the written member did not survive the re-parse (writer bug) — nothing was written"
-        )
+    final_by_key = {m.key.render(): m for m in parse.deck.members()}
+    for item in written:
+        final = final_by_key.get(item.key)
+        if final is None:
+            raise AcceptRejected(
+                f"the written member {item.key} did not survive the re-parse "
+                "(writer bug) — nothing was written"
+            )
+        item.final_member = final
 
     if dry_run:
         outcome.applied = True
@@ -554,19 +653,14 @@ def accept_answer(
 
     if record:
         assert answer.video_fingerprint is not None
-        outcome.record_refused = _record_member(
-            bundle,
-            key=member_key.render(),
-            final_member=final_member,
-            pre_member=pre_member,
-            bilingual=len(answer.bullets) == 2,
-            video_fingerprint=answer.video_fingerprint,
+        outcome.record_refused = _record_members(
+            bundle, written, video_fingerprint=answer.video_fingerprint
         )
         outcome.recorded = not outcome.record_refused
     return outcome
 
 
-def evolve_copy(member: Member) -> Member:
+def _detached_copy(member: Member) -> Member:
     """A detached snapshot of a member's pre-write state (cells are frozen,
     the member shell is mutable — copy the shell)."""
     return Member(

--- a/src/clm/voiceover/harvest_task.py
+++ b/src/clm/voiceover/harvest_task.py
@@ -1,13 +1,19 @@
-"""``clm harvest task`` — frame judgment work for the driving agent (#546 Phase 3).
+"""``clm harvest task`` — frame judgment work for the driving agent (#546 Phase 3/4).
 
 A task document packages ONE slide's curation (or translation) judgment:
 the caller instructions (the old embedded-model merge rules restated for an
-agent), the structured inputs (baseline voiceover on both sides, the aligned
-transcript with its ``revisited_segments`` backtracking groups, the slide
-content for context), the ``answer_schema``, and the freshness tokens
-(per-side ``baseline_fingerprint`` of the voiceover member plus the
-``video_fingerprint``) that ``accept`` validates before writing. Read-only;
-the engine emits, it never invokes a model.
+agent), the structured inputs (every narrative cell of the slide with both
+language sides, the aligned transcript with its ``revisited_segments``
+backtracking groups, the slide content for context), the ``answer_schema``,
+and the freshness tokens (per-member ``baseline_fingerprints`` plus the
+``video_fingerprint``) that ``accept`` validates before writing.
+
+Slides routinely carry **several** narrative cells (one per code cell, each
+anchored near what it narrates), so the answer addresses narrative members
+individually: each ``updates`` entry names an existing member (by its
+``id:…`` handle) or creates a new one (``"member": null``, optionally
+placed ``"after"`` an existing narrative member). Read-only; the engine
+emits, it never invokes a model.
 """
 
 from __future__ import annotations
@@ -27,32 +33,66 @@ __all__ = [
 
 TASK_KINDS = ("curate", "translate")
 
-#: The bullet-list answer contract (proposal §4/§8): per-language ordered
-#: bullet strings plus the `dropped` audit list, echoing the freshness
-#: tokens the task framed. Validated by `harvest accept` (validator
-#: "harvest-bullets").
+#: The bullet-list answer contract (proposal §4/§8, extended for
+#: multi-narrative slides): a list of per-member updates, each carrying
+#: per-language ordered bullet strings, plus the `dropped` audit list,
+#: echoing the freshness tokens the task framed. Validated by
+#: `harvest accept` (validator "harvest-bullets").
 ANSWER_SCHEMA: dict[str, Any] = {
     "type": "object",
-    "required": ["item", "kind", "baseline_fingerprint", "bullets", "dropped"],
+    "required": ["item", "kind", "baseline_fingerprints", "updates", "dropped"],
     "properties": {
         "item": {"type": "string", "description": "the slide handle, e.g. id:intro"},
         "kind": {"enum": list(TASK_KINDS)},
         "video_fingerprint": {"type": "string"},
-        "baseline_fingerprint": {
+        "baseline_fingerprints": {
             "type": "object",
-            "description": "echoed verbatim from the task document",
-            "properties": {
-                "de": {"type": ["string", "null"]},
-                "en": {"type": ["string", "null"]},
+            "description": "echoed verbatim from the task document: per narrative "
+            "member, its per-side content fingerprints",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "de": {"type": ["string", "null"]},
+                    "en": {"type": ["string", "null"]},
+                },
             },
         },
-        "bullets": {
-            "type": "object",
-            "minProperties": 1,
-            "additionalProperties": False,
-            "properties": {
-                "de": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
-                "en": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "updates": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": ["member", "bullets"],
+                "properties": {
+                    "member": {
+                        "type": ["string", "null"],
+                        "description": "an existing narrative member's id:… handle, "
+                        "or null to create a new narrative cell",
+                    },
+                    "after": {
+                        "type": ["string", "null"],
+                        "description": "for member=null only: place the new cell "
+                        "right after this existing narrative member "
+                        "(default: at the end of the slide group)",
+                    },
+                    "bullets": {
+                        "type": "object",
+                        "minProperties": 1,
+                        "additionalProperties": False,
+                        "properties": {
+                            "de": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {"type": "string", "minLength": 1},
+                            },
+                            "en": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {"type": "string", "minLength": 1},
+                            },
+                        },
+                    },
+                },
             },
         },
         "dropped": {
@@ -73,24 +113,32 @@ def _instructions(kind: str) -> str:
     return (Path(__file__).parent / "prompts" / name).read_text(encoding="utf-8")
 
 
-def _baseline_fingerprint(item: dict[str, Any]) -> dict[str, str | None]:
-    """The per-side freshness token: the single vo member's fingerprint.
-
-    A slide with more than one narrative member per side is ambiguous —
-    ``accept`` could not know which cell the answer replaces (P8: never
-    guess), so the task is refused with a pointer at manual editing.
-    """
-    fingerprint: dict[str, str | None] = {}
+def _narrative_cells(item: dict[str, Any]) -> list[dict[str, Any]]:
+    """The slide's narrative members, both sides merged, in document order."""
+    merged: dict[str, dict[str, Any]] = {}
     for side in ("de", "en"):
-        cells = item["voiceover"][side]["cells"]
-        if len(cells) > 1:
-            keys = ", ".join(c["key"] for c in cells)
-            raise TaskUnavailable(
-                f"slide {item['key']} has {len(cells)} narrative cells on the "
-                f"{side} side ({keys}) — edit the files directly, then re-run report"
+        for cell in item["voiceover"][side]["cells"]:
+            entry = merged.setdefault(
+                cell["key"],
+                {
+                    "member": cell["key"],
+                    "role": cell["role"],
+                    "layout": cell["layout"],
+                    "de": None,
+                    "en": None,
+                },
             )
-        fingerprint[side] = cells[0]["fingerprint"] if cells else None
-    return fingerprint
+            entry[side] = cell["text"]
+    return list(merged.values())
+
+
+def _baseline_fingerprints(item: dict[str, Any]) -> dict[str, dict[str, str | None]]:
+    """The per-member freshness tokens: each narrative member's per-side fps."""
+    tokens: dict[str, dict[str, str | None]] = {}
+    for side in ("de", "en"):
+        for cell in item["voiceover"][side]["cells"]:
+            tokens.setdefault(cell["key"], {"de": None, "en": None})[side] = cell["fingerprint"]
+    return tokens
 
 
 def _slide_content(deck: BilingualDeck, slide_id: str, lang: str) -> str:
@@ -113,6 +161,7 @@ def _frame_one(
 ) -> dict[str, Any]:
     lang = report["video_language"]
     slide_id = item["key"].split(":", 1)[1]
+    cells = _narrative_cells(item)
     if kind == "curate":
         if item["class"] in ("covered", "unmatched_slide"):
             raise TaskUnavailable(
@@ -121,9 +170,7 @@ def _frame_one(
             )
         inputs: dict[str, Any] = {
             "language": lang,
-            "baseline": {
-                side: [c["text"] for c in item["voiceover"][side]["cells"]] for side in ("de", "en")
-            },
+            "baseline": cells,
             "transcript": item.get("transcript"),
             "slide": {"title": item["title"], "content": _slide_content(deck, slide_id, lang)},
         }
@@ -136,8 +183,7 @@ def _frame_one(
         inputs = {
             "source_language": lang,
             "target_language": twin,
-            "source": [c["text"] for c in item["voiceover"][lang]["cells"]],
-            "target_baseline": [c["text"] for c in item["voiceover"][twin]["cells"]],
+            "baseline": cells,
             "slide": {"title": item["title"]},
         }
     return {
@@ -147,7 +193,7 @@ def _frame_one(
         "validator": "harvest-bullets",
         "video_language": lang,
         "video_fingerprint": report["video_fingerprint"],
-        "baseline_fingerprint": _baseline_fingerprint(item),
+        "baseline_fingerprints": _baseline_fingerprints(item),
         "instructions": _instructions(kind),
         "inputs": inputs,
         "answer_schema": ANSWER_SCHEMA,

--- a/src/clm/voiceover/prompts/harvest_curate.md
+++ b/src/clm/voiceover/prompts/harvest_curate.md
@@ -30,8 +30,17 @@ Rules (these replace the old embedded-model merge — apply them yourself):
    groups, in order of return). They often revisit or correct earlier
    statements — weigh them accordingly; a later revisit wins over an earlier
    statement it contradicts.
+7. **Multiple narrative cells.** A slide often carries several narrative
+   cells — typically one per code cell, each sitting next to what it
+   narrates (`inputs.baseline` lists them in document order with their
+   `member` handles). Distribute the narration accordingly: address each
+   existing cell by its `member` handle in a separate `updates` entry, and
+   only touch the cells the transcript actually concerns. To add a new
+   narrative cell, use `"member": null` — with `"after": "<member handle>"`
+   to place it right after an existing narrative cell, or omit `after` to
+   append it at the end of the slide group.
 
 Answer with the JSON shape given in `answer_schema`, echoing `item`, `kind`,
-`baseline_fingerprint`, and `video_fingerprint` from this task document.
+`baseline_fingerprints`, and `video_fingerprint` from this task document.
 Then submit it with `clm harvest accept DECK --answer FILE` (add `--record`
 to bank the write into the sync ledger).

--- a/src/clm/voiceover/prompts/harvest_translate.md
+++ b/src/clm/voiceover/prompts/harvest_translate.md
@@ -17,7 +17,13 @@ Rules:
 4. Stay idiomatic in the target language; technical terms follow the deck's
    existing conventions.
 
+5. **Multiple narrative cells.** `inputs.baseline` lists every narrative
+   cell of the slide (document order) with its `member` handle and both
+   language sides. Translate each source cell in its own `updates` entry
+   addressed at that `member`; skip cells whose target side is already a
+   faithful translation.
+
 Answer with the JSON shape given in `answer_schema`, providing bullets for
 the **target** language side only, echoing `item`, `kind`,
-`baseline_fingerprint`, and `video_fingerprint` from this task document.
+`baseline_fingerprints`, and `video_fingerprint` from this task document.
 Then submit it with `clm harvest accept DECK --answer FILE [--record]`.

--- a/tests/cli/test_harvest_task_accept.py
+++ b/tests/cli/test_harvest_task_accept.py
@@ -1,4 +1,4 @@
-"""Tests for ``clm harvest task`` / ``accept`` / ``verify`` (#546 Phase 3).
+"""Tests for ``clm harvest task`` / ``accept`` / ``verify`` (#546 Phase 3/4).
 
 Drives the full agent loop through the real CLI with an injected alignment
 (no ASR/GPU): report → task → (synthesized judgment) → accept [--record] →
@@ -7,6 +7,10 @@ one-sided ``accept --record``, the v3 sync differ (ledger baseline) must
 frame the twin as *translation work* (``translate_new``/``translate_edit``)
 — never ``in_sync`` (silently blessing the stale twin) and never a cold or
 corrupt state.
+
+Answers address narrative members individually (slides routinely carry one
+narrative cell per code cell): ``updates`` entries name an existing member
+or create a new one (optionally placed ``after`` an existing member).
 
 Fixture decks come from ``test_harvest_cli`` (s0 has bilingual companion
 voiceover, s1 has none, s2 has DE-only voiceover, s3 is silent).
@@ -20,7 +24,11 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from clm.cli.commands.harvest import harvest_group
-from tests.cli.test_harvest_cli import _write_alignment, _write_fixture
+from tests.cli.test_harvest_cli import (
+    _companion_cell,
+    _write_alignment,
+    _write_fixture,
+)
 
 
 def _invoke(args: list[str]):
@@ -55,15 +63,19 @@ def _task_for(tmp_path: Path, de_path: Path, video: Path, slide: str, kind: str 
     return envelope["tasks"][0]
 
 
-def _answer_from_task(task: dict, bullets: dict[str, list[str]]) -> dict:
+def _answer_from_task(task: dict, updates: list[dict]) -> dict:
     return {
         "item": task["item"],
         "kind": task["kind"],
         "video_fingerprint": task["video_fingerprint"],
-        "baseline_fingerprint": task["baseline_fingerprint"],
-        "bullets": bullets,
+        "baseline_fingerprints": task["baseline_fingerprints"],
+        "updates": updates,
         "dropped": ["Mikrofontest."],
     }
+
+
+def _single_update_answer(task: dict, bullets: dict[str, list[str]], member: str | None) -> dict:
+    return _answer_from_task(task, [{"member": member, "bullets": bullets}])
 
 
 def _accept(tmp_path: Path, de_path: Path, answer: dict, *extra: str):
@@ -93,18 +105,29 @@ class TestHarvestTask:
         assert task["item"] == "id:s1"
         assert task["kind"] == "curate"
         assert task["validator"] == "harvest-bullets"
-        assert task["baseline_fingerprint"] == {"de": None, "en": None}
+        assert task["baseline_fingerprints"] == {}
         assert task["video_fingerprint"]
         assert "Preserve every substantive baseline bullet" in task["instructions"]
+        assert task["inputs"]["baseline"] == []
         assert task["inputs"]["transcript"]["segments"] == ["Alles über Beta."]
         assert "# Beta" in task["inputs"]["slide"]["content"]
         assert task["answer_schema"]["required"] == [
             "item",
             "kind",
-            "baseline_fingerprint",
-            "bullets",
+            "baseline_fingerprints",
+            "updates",
             "dropped",
         ]
+
+    def test_task_lists_every_narrative_cell_with_tokens(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        task = _task_for(tmp_path, de_path, video, "s0")
+        assert [c["member"] for c in task["inputs"]["baseline"]] == ["id:s0-vo"]
+        cell = task["inputs"]["baseline"][0]
+        assert "Bestand Alpha." in cell["de"]
+        assert "Existing alpha." in cell["en"]
+        tokens = task["baseline_fingerprints"]["id:s0-vo"]
+        assert tokens["de"] and tokens["en"] and tokens["de"] != tokens["en"]
 
     def test_sweep_frames_every_actionable_item(self, tmp_path: Path) -> None:
         de_path, video = _write_fixture(tmp_path)
@@ -140,23 +163,26 @@ class TestHarvestTask:
         task = _task_for(tmp_path, de_path, video, "s2", kind="translate")
         assert task["inputs"]["source_language"] == "de"
         assert task["inputs"]["target_language"] == "en"
-        assert "Bestand Gamma." in task["inputs"]["source"][0]
-        assert task["inputs"]["target_baseline"] == []
-        assert task["baseline_fingerprint"]["de"] is not None
-        assert task["baseline_fingerprint"]["en"] is None
+        cell = task["inputs"]["baseline"][0]
+        assert cell["member"] == "id:s2-vo"
+        assert "Bestand Gamma." in cell["de"]
+        assert cell["en"] is None
+        assert task["baseline_fingerprints"]["id:s2-vo"]["de"] is not None
+        assert task["baseline_fingerprints"]["id:s2-vo"]["en"] is None
 
 
 class TestHarvestAccept:
     def test_creates_a_new_vo_member_for_no_existing_vo(self, tmp_path: Path) -> None:
         de_path, video = _write_fixture(tmp_path)
         task = _task_for(tmp_path, de_path, video, "s1")
-        answer = _answer_from_task(task, {"de": ["Beta ist wichtig.", "Beta hat Kanten."]})
+        answer = _single_update_answer(
+            task, {"de": ["Beta ist wichtig.", "Beta hat Kanten."]}, member=None
+        )
         result = _accept(tmp_path, de_path, answer)
         assert result.exit_code == 0, result.output
         payload = _json_from(result)
         assert payload["applied"] is True
-        assert payload["created"] is True
-        assert payload["member"] == "id:s1-vo"
+        assert payload["members"] == [{"member": "id:s1-vo", "created": True}]
 
         companion = tmp_path / "voiceover" / "voiceover_t.de.py"
         text = companion.read_text(encoding="utf-8")
@@ -175,7 +201,7 @@ class TestHarvestAccept:
     def test_one_sided_create_with_record_frames_translate_new(self, tmp_path: Path) -> None:
         de_path, video = _write_fixture(tmp_path)
         task = _task_for(tmp_path, de_path, video, "s1")
-        answer = _answer_from_task(task, {"de": ["Beta ist wichtig."]})
+        answer = _single_update_answer(task, {"de": ["Beta ist wichtig."]}, member=None)
         result = _accept(tmp_path, de_path, answer, "--record")
         assert result.exit_code == 0, result.output
         assert _json_from(result)["recorded"] is True
@@ -192,12 +218,11 @@ class TestHarvestAccept:
     def test_one_sided_edit_with_record_frames_translate_edit(self, tmp_path: Path) -> None:
         de_path, video = _write_fixture(tmp_path)
         task = _task_for(tmp_path, de_path, video, "s0")
-        answer = _answer_from_task(task, {"de": ["Alpha, neu kuratiert."]})
+        answer = _single_update_answer(task, {"de": ["Alpha, neu kuratiert."]}, member="id:s0-vo")
         result = _accept(tmp_path, de_path, answer, "--record")
         assert result.exit_code == 0, result.output
         payload = _json_from(result)
-        assert payload["created"] is False
-        assert payload["member"] == "id:s0-vo"
+        assert payload["members"] == [{"member": "id:s0-vo", "created": False}]
         assert payload["recorded"] is True
 
         diff = _ledger_diff(de_path)
@@ -209,9 +234,10 @@ class TestHarvestAccept:
     def test_bilingual_answer_with_record_is_in_sync(self, tmp_path: Path) -> None:
         de_path, video = _write_fixture(tmp_path)
         task = _task_for(tmp_path, de_path, video, "s0")
-        answer = _answer_from_task(
+        answer = _single_update_answer(
             task,
             {"de": ["Alpha, neu kuratiert."], "en": ["Alpha, freshly curated."]},
+            member="id:s0-vo",
         )
         result = _accept(tmp_path, de_path, answer, "--record")
         assert result.exit_code == 0, result.output
@@ -226,11 +252,8 @@ class TestHarvestAccept:
     def test_stale_baseline_fingerprint_rejects(self, tmp_path: Path) -> None:
         de_path, video = _write_fixture(tmp_path)
         task = _task_for(tmp_path, de_path, video, "s0")
-        answer = _answer_from_task(task, {"de": ["Alpha."]})
-        answer["baseline_fingerprint"] = {
-            "de": "0" * 64,
-            "en": answer["baseline_fingerprint"]["en"],
-        }
+        answer = _single_update_answer(task, {"de": ["Alpha."]}, member="id:s0-vo")
+        answer["baseline_fingerprints"]["id:s0-vo"]["de"] = "0" * 64
         result = _accept(tmp_path, de_path, answer)
         assert result.exit_code == 2
         assert "changed since the task" in result.output
@@ -239,17 +262,29 @@ class TestHarvestAccept:
         de_path, video = _write_fixture(tmp_path)
         task = _task_for(tmp_path, de_path, video, "s1")
         before = de_path.read_text(encoding="utf-8")
-        for bad_bullets in ({}, {"de": []}, {"de": ["a\nb"]}, {"fr": ["x"]}):
-            answer = _answer_from_task(task, {"de": ["ok"]})
-            answer["bullets"] = bad_bullets
+        bad_updates = [
+            [],  # no updates
+            [{"member": None, "bullets": {}}],  # no sides
+            [{"member": None, "bullets": {"de": []}}],  # empty side
+            [{"member": None, "bullets": {"de": ["a\nb"]}}],  # newline
+            [{"member": None, "bullets": {"fr": ["x"]}}],  # unknown side
+            [{"member": "id:nope", "bullets": {"de": ["x"]}}],  # unknown member
+            [{"member": None, "after": "id:nope", "bullets": {"de": ["x"]}}],  # bad after
+            [  # duplicate member updates
+                {"member": "id:s0-vo", "bullets": {"de": ["x"]}},
+                {"member": "id:s0-vo", "bullets": {"de": ["y"]}},
+            ],
+        ]
+        for updates in bad_updates:
+            answer = _answer_from_task(task, updates)
             result = _accept(tmp_path, de_path, answer)
-            assert result.exit_code == 2, f"{bad_bullets}: {result.output}"
+            assert result.exit_code == 2, f"{updates}: {result.output}"
         assert de_path.read_text(encoding="utf-8") == before
 
     def test_record_needs_the_video_fingerprint(self, tmp_path: Path) -> None:
         de_path, video = _write_fixture(tmp_path)
         task = _task_for(tmp_path, de_path, video, "s1")
-        answer = _answer_from_task(task, {"de": ["Beta."]})
+        answer = _single_update_answer(task, {"de": ["Beta."]}, member=None)
         del answer["video_fingerprint"]
         result = _accept(tmp_path, de_path, answer, "--record")
         assert result.exit_code == 2
@@ -258,7 +293,7 @@ class TestHarvestAccept:
     def test_slide_option_must_match_the_answer(self, tmp_path: Path) -> None:
         de_path, video = _write_fixture(tmp_path)
         task = _task_for(tmp_path, de_path, video, "s1")
-        answer = _answer_from_task(task, {"de": ["Beta."]})
+        answer = _single_update_answer(task, {"de": ["Beta."]}, member=None)
         result = _accept(tmp_path, de_path, answer, "--slide", "s0")
         assert result.exit_code == 2
         assert "does not match" in result.output
@@ -268,7 +303,7 @@ class TestHarvestAccept:
         companion = tmp_path / "voiceover" / "voiceover_t.de.py"
         before = companion.read_text(encoding="utf-8")
         task = _task_for(tmp_path, de_path, video, "s1")
-        answer = _answer_from_task(task, {"de": ["Beta."]})
+        answer = _single_update_answer(task, {"de": ["Beta."]}, member=None)
         result = _accept(tmp_path, de_path, answer, "--dry-run")
         assert result.exit_code == 0, result.output
         assert _json_from(result)["dry_run"] is True
@@ -278,11 +313,147 @@ class TestHarvestAccept:
     def test_unknown_slide_rejects(self, tmp_path: Path) -> None:
         de_path, video = _write_fixture(tmp_path)
         task = _task_for(tmp_path, de_path, video, "s1")
-        answer = _answer_from_task(task, {"de": ["Beta."]})
+        answer = _single_update_answer(task, {"de": ["Beta."]}, member=None)
         answer["item"] = "id:missing"
         result = _accept(tmp_path, de_path, answer)
         assert result.exit_code == 2
         assert "no slide id:missing" in result.output
+
+
+class TestMultiNarrativeSlides:
+    """Slides with several narrative cells (one per code cell) — the
+    ubiquitous shape the answer's per-member ``updates`` exist for."""
+
+    def _fixture(self, tmp_path: Path) -> tuple[Path, Path]:
+        de_path, video = _write_fixture(tmp_path)
+        companion_dir = tmp_path / "voiceover"
+        # A second narrative cell for s0 on both sides.
+        extra_de = _companion_cell("s0-vo-code", "de", "s0", "Bestand Code-Zelle.")
+        extra_en = _companion_cell("s0-vo-code", "en", "s0", "Existing code cell.")
+        de_comp = companion_dir / "voiceover_t.de.py"
+        en_comp = companion_dir / "voiceover_t.en.py"
+        de_comp.write_text(
+            de_comp.read_text(encoding="utf-8").rstrip("\n")
+            + "\n\n"
+            + extra_de.rstrip("\n")
+            + "\n",
+            encoding="utf-8",
+        )
+        en_comp.write_text(
+            en_comp.read_text(encoding="utf-8").rstrip("\n")
+            + "\n\n"
+            + extra_en.rstrip("\n")
+            + "\n",
+            encoding="utf-8",
+        )
+        return de_path, video
+
+    def test_task_frames_all_cells_and_accept_updates_each(self, tmp_path: Path) -> None:
+        de_path, video = self._fixture(tmp_path)
+        task = _task_for(tmp_path, de_path, video, "s0")
+        assert [c["member"] for c in task["inputs"]["baseline"]] == ["id:s0-vo", "id:s0-vo-code"]
+        assert set(task["baseline_fingerprints"]) == {"id:s0-vo", "id:s0-vo-code"}
+
+        answer = _answer_from_task(
+            task,
+            [
+                {"member": "id:s0-vo", "bullets": {"de": ["Alpha-Intro, neu."]}},
+                {"member": "id:s0-vo-code", "bullets": {"de": ["Code-Zelle, neu."]}},
+                {
+                    "member": None,
+                    "after": "id:s0-vo",
+                    "bullets": {"de": ["Neue Zelle nach dem Intro."]},
+                },
+            ],
+        )
+        result = _accept(tmp_path, de_path, answer)
+        assert result.exit_code == 0, result.output
+        payload = _json_from(result)
+        assert payload["members"] == [
+            {"member": "id:s0-vo", "created": False},
+            {"member": "id:s0-vo-code", "created": False},
+            {"member": "id:s0-vo2", "created": True},
+        ]
+
+        text = (tmp_path / "voiceover" / "voiceover_t.de.py").read_text(encoding="utf-8")
+        assert "# - Alpha-Intro, neu." in text
+        assert "# - Code-Zelle, neu." in text
+        # `after` placement: the new cell sits between the two existing ones.
+        assert (
+            text.index("Alpha-Intro, neu.")
+            < text.index("Neue Zelle nach dem Intro.")
+            < text.index("Code-Zelle, neu.")
+        )
+
+    def test_mixed_record_keeps_per_member_semantics(self, tmp_path: Path) -> None:
+        de_path, video = self._fixture(tmp_path)
+        task = _task_for(tmp_path, de_path, video, "s0")
+        answer = _answer_from_task(
+            task,
+            [
+                # one-sided edit over an existing twin -> translate_edit
+                {"member": "id:s0-vo", "bullets": {"de": ["Nur DE geändert."]}},
+                # bilingual edit -> clean pair, no diff item
+                {
+                    "member": "id:s0-vo-code",
+                    "bullets": {"de": ["Beide Seiten."], "en": ["Both sides."]},
+                },
+            ],
+        )
+        result = _accept(tmp_path, de_path, answer, "--record")
+        assert result.exit_code == 0, result.output
+        assert _json_from(result)["recorded"] is True
+
+        diff = _ledger_diff(de_path)
+        verdicts = {i.key: i.action for i in diff.items}
+        assert verdicts.get("id:s0-vo") == "translate_edit"
+        assert "id:s0-vo-code" not in verdicts
+
+    def test_new_cell_since_task_is_staleness(self, tmp_path: Path) -> None:
+        de_path, video = self._fixture(tmp_path)
+        task = _task_for(tmp_path, de_path, video, "s0")
+        # A narrative cell appears after the task was framed.
+        companion = tmp_path / "voiceover" / "voiceover_t.de.py"
+        companion.write_text(
+            companion.read_text(encoding="utf-8").rstrip("\n")
+            + "\n\n"
+            + _companion_cell("s0-vo-late", "de", "s0", "Nachzügler.").rstrip("\n")
+            + "\n",
+            encoding="utf-8",
+        )
+        answer = _answer_from_task(task, [{"member": "id:s0-vo", "bullets": {"de": ["Egal."]}}])
+        result = _accept(tmp_path, de_path, answer)
+        assert result.exit_code == 2
+        assert "changed since the task" in result.output
+
+
+class TestMultiPartVideos:
+    def test_report_accepts_alignment_override_for_multi_part(self, tmp_path: Path) -> None:
+        de_path, video = _write_fixture(tmp_path)
+        video2 = tmp_path / "video-part2.mp4"
+        video2.write_bytes(b"also not a real video")
+        alignment = _write_alignment(tmp_path, de_path)
+        result = _invoke(
+            [
+                "report",
+                str(de_path),
+                str(video),
+                str(video2),
+                "--lang",
+                "de",
+                "--alignment",
+                str(alignment),
+                "--json",
+            ]
+        )
+        assert result.exit_code == 1, result.output
+        report = _json_from(result)
+        assert len(report["videos"]) == 2
+
+        from clm.voiceover.cache import MultiVideoKey
+
+        expected = MultiVideoKey.from_paths([video, video2]).hash
+        assert report["video_fingerprint"] == expected
 
 
 class TestHarvestVerify:
@@ -299,7 +470,7 @@ class TestHarvestVerify:
     def test_pair_stays_verifiable_after_accept(self, tmp_path: Path) -> None:
         de_path, video = _write_fixture(tmp_path)
         task = _task_for(tmp_path, de_path, video, "s1")
-        answer = _answer_from_task(task, {"de": ["Beta ist wichtig."]})
+        answer = _single_update_answer(task, {"de": ["Beta ist wichtig."]}, member=None)
         assert _accept(tmp_path, de_path, answer, "--record").exit_code == 0
         result = _invoke(["verify", str(de_path)])
         assert result.exit_code == 0, result.output

--- a/tests/voiceover/test_cache.py
+++ b/tests/voiceover/test_cache.py
@@ -11,6 +11,7 @@ from clm.voiceover.cache import (
     AlignmentsCache,
     CachePolicy,
     DetectConfig,
+    MultiVideoKey,
     SlidesKey,
     TimelinesCache,
     TranscribeConfig,
@@ -25,6 +26,7 @@ from clm.voiceover.cache import (
     iter_entries,
     prune,
     resolve_cache_root,
+    video_key_for,
 )
 
 
@@ -73,6 +75,73 @@ class TestSlidesKey:
         p.write_text("x = 1\n", encoding="utf-8")
         key = SlidesKey.from_path(p)
         assert key == SlidesKey.from_text("x = 1\n")
+
+
+class TestMultiVideoKey:
+    def test_hash_covers_every_part_in_order(self, tmp_path):
+        a = tmp_path / "a.mp4"
+        b = tmp_path / "b.mp4"
+        a.write_bytes(b"part a")
+        b.write_bytes(b"part b")
+        key_ab = MultiVideoKey.from_paths([a, b])
+        key_ba = MultiVideoKey.from_paths([b, a])
+        assert key_ab.hash == MultiVideoKey.from_paths([a, b]).hash  # stable
+        assert key_ab.hash != key_ba.hash  # order-sensitive
+        assert len(key_ab.hash) == 16
+
+    def test_hash_changes_when_any_part_changes(self, tmp_path):
+        import os
+
+        a = tmp_path / "a.mp4"
+        b = tmp_path / "b.mp4"
+        a.write_bytes(b"part a")
+        b.write_bytes(b"part b")
+        before = MultiVideoKey.from_paths([a, b]).hash
+        b.write_bytes(b"part b, re-rendered longer")
+        os.utime(b, ns=(1, 1))
+        assert MultiVideoKey.from_paths([a, b]).hash != before
+
+    def test_video_key_for_dispatch(self, tmp_path):
+        a = tmp_path / "a.mp4"
+        b = tmp_path / "b.mp4"
+        a.write_bytes(b"part a")
+        b.write_bytes(b"part b")
+        assert isinstance(video_key_for(a), VideoKey)
+        assert isinstance(video_key_for([a]), VideoKey)
+        assert isinstance(video_key_for([a, b]), MultiVideoKey)
+
+    def test_multi_part_timeline_cache_round_trip(self, tmp_path):
+        from clm.voiceover.cache import CachePolicy, cached_timeline
+        from clm.voiceover.matcher import TimelineEntry
+
+        a = tmp_path / "a.mp4"
+        b = tmp_path / "b.mp4"
+        a.write_bytes(b"part a")
+        b.write_bytes(b"part b")
+        slides = tmp_path / "slides_t.de.py"
+        slides.write_text("# %% [markdown]\n# x\n", encoding="utf-8")
+        policy = CachePolicy(cache_root=tmp_path / "cache")
+        timeline = [TimelineEntry(slide_index=1, start_time=0.0, end_time=5.0, match_score=90.0)]
+        calls = []
+
+        def compute():
+            calls.append(1)
+            return timeline
+
+        first, hit1 = cached_timeline(
+            [a, b], slides, policy=policy, timeline_fn=compute, cfg={"lang": "de"}
+        )
+        second, hit2 = cached_timeline(
+            [a, b], slides, policy=policy, timeline_fn=compute, cfg={"lang": "de"}
+        )
+        assert (hit1, hit2) == (False, True)
+        assert len(calls) == 1
+        assert second[0].slide_index == 1
+        # A different part order is a different recording -> a miss.
+        _, hit3 = cached_timeline(
+            [b, a], slides, policy=policy, timeline_fn=compute, cfg={"lang": "de"}
+        )
+        assert hit3 is False
 
 
 class TestTranscribeConfig:


### PR DESCRIPTION
## Summary

Two extensions folded into Phase 4 of epic #546, landing ahead of the
cutover PR.

### Multi-narrative slides (the ubiquitous case)

Slides routinely carry several narrative cells — typically one per code
cell, each next to what it narrates. The Phase-3 one-cell-per-side refusal
is gone:

- **`task`** lists every narrative cell of the slide in `inputs.baseline`
  (document order, with member handles and both language sides) and frames
  per-member freshness tokens (`baseline_fingerprints`).
- **Answers** become a list of per-member `updates`: each entry names an
  existing narrative member, or creates a new one (`"member": null`, with
  optional `"after": "<member>"` placement; default at the end of the
  slide group).
- **`accept`** validates member addressing (unknown/duplicate members
  reject), enforces *set-level* freshness (a narrative cell added or
  removed since the task was framed is staleness, not a merge
  opportunity), mints distinct `<owner>-vo`/`-vo2`/… ids across multiple
  creates, and applies the §6 ledger semantics **per written member** — a
  mixed answer can land a `translate_edit` divergence on one cell and a
  clean bilingual pair on another (pinned by test).

### Multi-part videos

- New `cache.MultiVideoKey`: an ordered composite over the per-part
  `VideoKey` hashes — any part changing or reordering invalidates — with
  `video_key_for()` dispatch. `cached_timeline`/`cached_alignment` accept
  the part list, so multi-part timelines and alignments are now **cached**
  instead of bypassed.
- `harvest.video_fingerprint` delegates to the same key: cache identity
  and the `harvest:<fp>` ledger provenance remain one thing for
  multi-part recordings too.
- `--alignment` overrides now work for multi-part recordings (the override
  encodes the final stitched alignment); `--transcript` stays single-video
  (it encodes one part's ASR output).

## Tests

- `tests/cli/test_harvest_task_accept.py` reworked to the `updates` schema
  plus new suites: multi-narrative framing/updating/`after` placement,
  per-member mixed `--record` semantics, new-cell-since-task staleness,
  multi-part report with alignment override + composite fingerprint.
- `tests/voiceover/test_cache.py`: `MultiVideoKey` stability/order/part
  invalidation, dispatch, multi-part timeline cache round-trip.
- 67 harvest+cache tests pass; fast suite green on the pre-push hook;
  ruff + mypy clean.

Part of epic #546; the Phase 4 cutover PR (autopilot, verb moves, MCP
renames, docs) follows on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TJvSAbnsLWxcCLJ3SvqoS
