### PR TITLE
fix(build): dedupe dir-group copies and skip unchanged files

### DIFF
--- a/changelog.d/dirgroup-duplicate-copy-race.fixed.md
+++ b/changelog.d/dirgroup-duplicate-copy-race.fixed.md
@@ -1,0 +1,8 @@
+- Fixed a build crash (`shutil.Error` / WinError 32 sharing violation on
+  Windows) in the final dir-group copy: for explicit output targets whose
+  kinds span both public and speaker (e.g. `{code-along, trainer}`), the
+  public/speaker split collapses to a single output path, but two copy
+  operations were still launched and raced `shutil.copytree` against each
+  other on the same destination files. Dir-group copy operations are now
+  deduplicated by (destination, sources) across the whole build, which also
+  covers dir-groups repeated in a course spec.

--- a/changelog.d/dirgroup-skip-unchanged-writes.changed.md
+++ b/changelog.d/dirgroup-skip-unchanged-writes.changed.md
@@ -1,0 +1,4 @@
+- Dir-group copies now skip files whose size and mtime already match the
+  source (rsync-style quick check) instead of rewriting the whole tree on
+  every build. Large vendored trees (e.g. Catch2) no longer cause needless
+  SSD writes on rebuilds.

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -882,6 +882,13 @@ class Course(NotebookMixin):
         that should be available in all output directories, including both
         public and speaker directories as appropriate for each target.
         """
+        # Shared across all dir-groups and targets so that copies of the
+        # same sources to the same destination are launched only once —
+        # e.g. an explicit target with both public and speaker kinds, where
+        # the two is_speaker variants collapse to one output path, or a
+        # dir-group repeated in the spec. Concurrent duplicate copytrees
+        # race on Windows (WinError 32 sharing violations).
+        seen_copy_keys: set = set()
         async with TaskGroup() as tg:
             for dir_group in self.dir_groups:
                 for target in self.output_targets:
@@ -908,6 +915,7 @@ class Course(NotebookMixin):
                         languages=target.languages,
                         is_speaker_options=is_speaker_options,
                         skip_toplevel=target.is_explicit,
+                        seen_copy_keys=seen_copy_keys,
                     )
                     tg.create_task(op.execute(backend))
 

--- a/src/clm/core/dir_group.py
+++ b/src/clm/core/dir_group.py
@@ -95,12 +95,38 @@ class DirGroup:
             for dir_ in self.relative_paths
         )
 
+    def _copy_key(
+        self,
+        is_speaker: bool,
+        lang: str,
+        output_root: Path | None,
+        skip_toplevel: bool,
+    ) -> tuple:
+        """Identity of a copy operation's effect on disk.
+
+        Two operations with the same key copy the same sources to the same
+        destination, so all but one are redundant — and running them
+        concurrently makes ``shutil.copytree`` race against itself, which on
+        Windows raises WinError 32 (sharing violation). The key deliberately
+        includes the sources: operations writing *different* content to the
+        same destination are a spec conflict, not a duplicate, and must stay
+        visible to the output-write registry's conflict detection.
+        """
+        return (
+            self.output_path(is_speaker, lang, output_root, skip_toplevel=skip_toplevel),
+            self.source_dirs,
+            self.relative_paths,
+            self.base_path,
+            self.recursive,
+        )
+
     async def get_processing_operation(
         self,
         output_root: Path | None = None,
         languages: frozenset[str] | None = None,
         is_speaker_options: list[bool] | None = None,
         skip_toplevel: bool = False,
+        seen_copy_keys: set | None = None,
     ) -> "Operation":
         """Get the operation to copy this directory group.
 
@@ -113,6 +139,16 @@ class DirGroup:
                                If None, defaults to [False, True] for both public and speaker.
             skip_toplevel: If True, skip the "public"/"speaker" directory prefix.
                           Used for explicitly specified output targets.
+            seen_copy_keys: Mutable set used to deduplicate copy operations
+                           that would write the same sources to the same
+                           destination. Pass one shared set across all
+                           dir-groups of a build to also collapse duplicates
+                           between dir-groups; if None, deduplication is
+                           limited to this call. Deduplication matters for
+                           explicit output targets, where the public/speaker
+                           split collapses to a single path and both
+                           is_speaker variants would otherwise copy the same
+                           tree concurrently.
         """
         from clm.core.operations.copy_dir_group import CopyDirGroupOperation
         from clm.infrastructure.operation import Concurrently, NoOperation
@@ -123,19 +159,30 @@ class DirGroup:
         # Default to both public and speaker if not specified
         speaker_options = is_speaker_options if is_speaker_options is not None else [False, True]
 
-        operations = tuple(
-            CopyDirGroupOperation(
-                dir_group=self,
-                lang=lang,
-                is_speaker=is_speaker,
-                output_root=output_root,
-                skip_toplevel=skip_toplevel,
-            )
-            for lang in langs_to_copy
-            for is_speaker in speaker_options
-        )
+        if seen_copy_keys is None:
+            seen_copy_keys = set()
+
+        operations = []
+        for lang in sorted(langs_to_copy):
+            for is_speaker in speaker_options:
+                key = self._copy_key(is_speaker, lang, output_root, skip_toplevel)
+                if key in seen_copy_keys:
+                    logger.debug(
+                        f"Skipping duplicate dir-group copy of '{self.name[lang]}' to {key[0]}"
+                    )
+                    continue
+                seen_copy_keys.add(key)
+                operations.append(
+                    CopyDirGroupOperation(
+                        dir_group=self,
+                        lang=lang,
+                        is_speaker=is_speaker,
+                        output_root=output_root,
+                        skip_toplevel=skip_toplevel,
+                    )
+                )
 
         if not operations:
             return NoOperation()
 
-        return Concurrently(operations)
+        return Concurrently(tuple(operations))

--- a/src/clm/infrastructure/backends/local_ops_backend.py
+++ b/src/clm/infrastructure/backends/local_ops_backend.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import shutil
 import sys
 from abc import ABC
@@ -49,6 +50,32 @@ from clm.infrastructure.utils.path_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _copy2_if_changed(src, dst, *, follow_symlinks=True):
+    """``shutil.copy2`` that skips the write when ``dst`` already matches ``src``.
+
+    "Matches" means equal size and equal mtime (nanosecond resolution) —
+    the rsync-style quick check. Because ``copy2`` preserves the source
+    mtime via ``copystat``, an unchanged source compares equal on every
+    subsequent build, so rebuilds don't rewrite identical dir-group trees
+    (needless SSD wear for e.g. a vendored Catch2). Content is not hashed:
+    a file whose bytes changed without touching size or mtime is not
+    detected, the same trade-off rsync's default mode makes.
+
+    Signature is ``copytree``-compatible so it can be passed as
+    ``copy_function``.
+    """
+    try:
+        src_stat = os.stat(src, follow_symlinks=follow_symlinks)
+        dst_stat = os.stat(dst, follow_symlinks=follow_symlinks)
+    except OSError:
+        pass
+    else:
+        if src_stat.st_size == dst_stat.st_size and src_stat.st_mtime_ns == dst_stat.st_mtime_ns:
+            logger.debug(f"Skipping unchanged file '{src}' -> {dst}")
+            return dst
+    return shutil.copy2(src, dst, follow_symlinks=follow_symlinks)
 
 
 @define
@@ -235,7 +262,7 @@ class LocalOpsBackend(Backend, ABC):
                     if item.is_file():
                         dest = copy_data.output_dir / item.name
                         logger.debug(f"Copying root file '{item}' to {dest}")
-                        shutil.copy2(item, dest)
+                        _copy2_if_changed(item, dest)
             else:
                 warning_msg = (
                     f"Base directory does not exist: {copy_data.base_path}\n"
@@ -281,6 +308,7 @@ class LocalOpsBackend(Backend, ABC):
                     source_dir,
                     output_dir,
                     dirs_exist_ok=True,
+                    copy_function=_copy2_if_changed,
                     ignore=shutil.ignore_patterns(
                         *SKIP_DIRS_FOR_OUTPUT, *SKIP_DIRS_PATTERNS, *SKIP_OUTPUT_FILE_GLOBS
                     ),
@@ -291,7 +319,7 @@ class LocalOpsBackend(Backend, ABC):
                     if item.is_file():
                         dest = output_dir / item.name
                         logger.debug(f"Copying file '{item}' to {dest}")
-                        shutil.copy2(item, dest)
+                        _copy2_if_changed(item, dest)
 
         return warnings
 

--- a/tests/core/course_test.py
+++ b/tests/core/course_test.py
@@ -16,7 +16,7 @@ from clm.core.utils.execution_utils import (
 from clm.core.utils.text_utils import Text
 from clm.infrastructure.backends.local_ops_backend import LocalOpsBackend
 from clm.infrastructure.messaging.base_classes import Payload
-from clm.infrastructure.operation import Operation
+from clm.infrastructure.operation import Concurrently, NoOperation, Operation
 
 # DATA_DIR is defined in tests/conftest.py and available as a fixture
 # For direct use, we compute it here
@@ -266,6 +266,52 @@ async def test_course_dir_groups_copy(course_1_spec, tmp_path):
             )
 
     assert set(tmp_path.glob("**/*")) == expected
+
+
+async def test_dir_group_copy_deduped_for_explicit_targets(course_1_spec, tmp_path):
+    """Explicit targets collapse the public/speaker split to a single path.
+
+    With both is_speaker variants requested (a target whose kinds span
+    public and speaker, e.g. {code-along, trainer}), only one copy
+    operation may remain — two concurrent copytrees of the same tree to
+    the same destination race and fail with WinError 32 on Windows.
+    """
+    course = Course.from_spec(course_1_spec, DATA_DIR, tmp_path)
+    dir_group = course.dir_groups[0]
+
+    op = await dir_group.get_processing_operation(
+        output_root=tmp_path,
+        languages=frozenset({"de"}),
+        is_speaker_options=[False, True],
+        skip_toplevel=True,
+    )
+    assert isinstance(op, Concurrently)
+    assert len(op.operations) == 1
+
+    # Without skip_toplevel the public/speaker paths differ, so both
+    # operations are kept.
+    op = await dir_group.get_processing_operation(
+        output_root=tmp_path,
+        languages=frozenset({"de"}),
+        is_speaker_options=[False, True],
+        skip_toplevel=False,
+    )
+    assert isinstance(op, Concurrently)
+    assert len(op.operations) == 2
+
+
+async def test_dir_group_copy_deduped_across_calls_with_shared_keys(course_1_spec, tmp_path):
+    """A shared seen_copy_keys set collapses repeated dir-groups entirely."""
+    course = Course.from_spec(course_1_spec, DATA_DIR, tmp_path)
+    dir_group = course.dir_groups[0]
+    seen: set = set()
+
+    first = await dir_group.get_processing_operation(output_root=tmp_path, seen_copy_keys=seen)
+    second = await dir_group.get_processing_operation(output_root=tmp_path, seen_copy_keys=seen)
+
+    assert isinstance(first, Concurrently)
+    assert len(first.operations) == 4  # 2 languages x public/speaker
+    assert isinstance(second, NoOperation)
 
 
 async def test_count_stage_operations_returns_correct_counts(course_1_spec, tmp_path):

--- a/tests/infrastructure/backends/local_ops_backend_test.py
+++ b/tests/infrastructure/backends/local_ops_backend_test.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 
 from clm.infrastructure.backends.local_ops_backend import LocalOpsBackend
@@ -62,6 +63,43 @@ async def test_copy_dir_group(tmp_path):
     assert not (output_dir / "dir_1/build/foo.txt").exists()
     assert not (output_dir / "dir_1/.git/data.bin").exists()
     assert not (output_dir / "dir_1/.clm").exists()
+
+
+async def test_copy_dir_group_skips_unchanged_files(tmp_path, monkeypatch):
+    """A rebuild must not rewrite dir-group files whose size and mtime match.
+
+    Rewriting an unchanged vendored tree (e.g. Catch2) on every build is
+    needless SSD wear; copy2 preserves the source mtime, so the size+mtime
+    quick check holds on every subsequent build.
+    """
+    input_files = ["dir_1/file_1.txt", "dir_2/subdir/file_2.txt"]
+    copy_data, output_dir = build_copy_data(tmp_path, input_files)
+
+    async with PytestLocalOpsBackend() as unit:
+        await unit.copy_dir_group_to_output(copy_data)
+    assert (output_dir / "dir_1/file_1.txt").exists()
+
+    real_copy2 = shutil.copy2
+    copied: list[str] = []
+
+    def counting_copy2(src, dst, *, follow_symlinks=True):
+        copied.append(Path(src).name)
+        return real_copy2(src, dst, follow_symlinks=follow_symlinks)
+
+    monkeypatch.setattr(shutil, "copy2", counting_copy2)
+
+    # Second run over identical sources: no file is written again.
+    async with PytestLocalOpsBackend() as unit:
+        await unit.copy_dir_group_to_output(copy_data)
+    assert copied == []
+
+    # A modified source is copied again.
+    changed = tmp_path / "input/dir_1/file_1.txt"
+    changed.write_text("changed content")
+    async with PytestLocalOpsBackend() as unit:
+        await unit.copy_dir_group_to_output(copy_data)
+    assert copied == ["file_1.txt"]
+    assert (output_dir / "dir_1/file_1.txt").read_text() == "changed content"
 
 
 def build_copy_data(tmp_dir, input_files):


### PR DESCRIPTION
## Problem

Builds crash intermittently at the end of the dir-group copy stage on Windows with:

```
shutil.Error: [('...\code\external\Catch2\...\catch_to_string.hpp', '...\output\trainer\cpp-tdd-de\code\...', '[WinError 32] The process cannot access the file because it is being used by another process')]
```

Root cause: for an **explicit output target whose kinds span both public and speaker buckets** (e.g. `{code-along, trainer}`), `process_dir_group_for_targets` builds `is_speaker_options=[False, True]` and launches one `CopyDirGroupOperation` per variant. But explicit targets use `skip_toplevel=True`, and `output_path_for` then ignores `is_speaker` entirely — so both operations `shutil.copytree` the identical source tree to the identical destination **concurrently** (`Concurrently(...)`), racing on every file. On Windows this is a sharing violation (WinError 32); large vendored trees like Catch2 make the collision near-certain.

## Fix

- `DirGroup.get_processing_operation` deduplicates copy operations by `(destination path, source_dirs, relative_paths, base_path, recursive)`. The key includes the sources on purpose: different sources writing to the same destination are a spec conflict, not a duplicate, and stay visible to the output-write registry's conflict detection.
- `Course.process_dir_group_for_targets` shares one seen-set across all dir-groups and targets, so dir-groups repeated in a spec are also collapsed.
- **Skip-unchanged writes:** dir-group copies now use an rsync-style quick check (equal size + `st_mtime_ns` → skip) instead of unconditionally rewriting every file. Since `copy2` preserves the source mtime, rebuilds over an unchanged tree perform zero writes — no more rewriting all of Catch2 on every build (SSD wear).

## Testing

- New tests: dedupe for explicit targets (1 op instead of 2; still 2 without `skip_toplevel`), cross-call dedupe via shared seen-set, and skip-unchanged behavior (second copy performs zero `copy2` calls; modified source is recopied).
- Full fast suite: 8267 passed, 7 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WNAUKTGuayEJcTw4XZywfc