### PR TITLE
fix: make sync record git-idempotent — preserve confirmed_commit on unchanged members (#555)

### DIFF
--- a/changelog.d/555-record-idempotent.fixed.md
+++ b/changelog.d/555-record-idempotent.fixed.md
@@ -1,0 +1,8 @@
+- `clm slides sync record` no longer rewrites `confirmed_commit` on members
+  whose recorded state is unchanged, and no longer rewrites a ledger file whose
+  content is byte-identical — a repo-wide record sweep over clean pairs now
+  leaves `git status` clean instead of dirtying every committed
+  `<topic>/.clm/sync-ledger.json` (previously ~500-file churn). The same
+  preservation applies to `apply`'s per-item ledger updates. The record `--json`
+  envelope gains a per-pair `ledger_changed` boolean and a top-level `unchanged`
+  count ([#555](https://github.com/hoelzl/clm/issues/555)).

--- a/src/clm/cli/commands/slides/sync_v3.py
+++ b/src/clm/cli/commands/slides/sync_v3.py
@@ -319,6 +319,9 @@ def run_record_v3(
                 "schema": 3,
                 "engine": "v3",
                 "recorded": sum(r.get("recorded", 0) for r in rows),
+                "unchanged": sum(
+                    1 for r in rows if "recorded" in r and not r.get("ledger_changed", True)
+                ),
                 "refused": refused,
                 "errors": errors,
                 "pairs": rows,
@@ -373,9 +376,10 @@ def _record_one(
         commit=_head_commit(bundle.de_path),
         member_keys=set(members) if members else None,
     )
-    doc_ledger.save(ledger, ledger_path)
+    changed = doc_ledger.save(ledger, ledger_path)
     row["recorded"] = recorded
     row["ledger"] = str(ledger_path)
+    row["ledger_changed"] = changed
     if members:
         deck_ledger = ledger.decks.get(deck_key)
         known = deck_ledger.members.keys() if deck_ledger is not None else set()
@@ -403,6 +407,7 @@ def _render_record_row(row: dict) -> None:
         for reason in row.get("reasons", []):
             click.echo(f"  - {reason}")
         return
-    click.echo(f"{name}: recorded {row['recorded']} member(s) -> {row['ledger']}")
+    suffix = "" if row.get("ledger_changed", True) else " (unchanged)"
+    click.echo(f"{name}: recorded {row['recorded']} member(s) -> {row['ledger']}{suffix}")
     for old, new in row.get("key_migrations", {}).items():
         click.echo(f"  key migrated {old} -> {new}")

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1905,6 +1905,17 @@ stale entries and performs the pos→id key migration when a cell gained an id
 who asserted the verification: `record` (default), `agent`, or
 `semantic:<model>`.
 
+**Re-recording is git-idempotent (CLM {version}).** A member whose recorded
+state (fingerprints, provenance, trust state, hash version) is unchanged keeps
+its existing `confirmed_commit`, and a ledger whose canonical serialization is
+byte-identical is not rewritten at all — so a repo-wide
+`clm slides sync record DIR` over clean pairs leaves `git status` clean instead
+of bumping every committed ledger to the current HEAD. `confirmed_commit`
+therefore means "the commit at which this state was last *actually*
+established". The `--json` envelope reports the per-pair `ledger_changed`
+boolean and a top-level `unchanged` pair count; the text output appends
+`(unchanged)` for a write-free pair.
+
 ### `clm slides translate`
 
 *Added in CLM {version}. Alias: `clm slides bootstrap`.*

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -54,6 +54,7 @@ from clm.slides.doc_ledger import (
     DeckLedger,
     LedgerMember,
     TopicLedger,
+    preserve_unchanged_member,
     record_group_order,
     record_order_scope,
     record_preamble_scope,
@@ -800,12 +801,15 @@ def _upsert(target: DeckLedger, fresh: DeckLedger, key: str, provenance: str) ->
     if lm is None:
         target.members.pop(key, None)
         return
-    target.members[key] = LedgerMember(
-        entry=lm.entry,
-        provenance=provenance,
-        state=lm.state,
-        hash_version=lm.hash_version,
-        confirmed_commit=lm.confirmed_commit,
+    target.members[key] = preserve_unchanged_member(
+        target.members.get(key),
+        LedgerMember(
+            entry=lm.entry,
+            provenance=provenance,
+            state=lm.state,
+            hash_version=lm.hash_version,
+            confirmed_commit=lm.confirmed_commit,
+        ),
     )
 
 

--- a/src/clm/slides/doc_ledger.py
+++ b/src/clm/slides/doc_ledger.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from attrs import define, field, frozen
+from attrs import define, evolve, field, frozen
 
 from clm.slides.bilingual_doc import BilingualDeck, Lang
 from clm.slides.doc_identity import DeckBaseline, MemberBaseline, baseline_from_deck
@@ -56,6 +56,7 @@ __all__ = [
     "deck_key_for",
     "ledger_path_for",
     "load",
+    "preserve_unchanged_member",
     "record_deck_snapshot",
     "save",
 ]
@@ -295,12 +296,24 @@ def _to_json(ledger: TopicLedger) -> str:
     return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
 
 
-def save(ledger: TopicLedger, path: Path) -> None:
-    """Write the ledger atomically (canonical JSON), creating ``.clm/``."""
+def save(ledger: TopicLedger, path: Path) -> bool:
+    """Write the ledger atomically (canonical JSON), creating ``.clm/``.
+
+    Skips the write entirely — and returns ``False`` — when the canonical
+    serialization is byte-identical to the file already on disk: a repo-wide
+    ``record`` sweep must be write-free on clean pairs (issue #555).
+    """
     from clm.infrastructure.utils.path_utils import atomic_write_bytes
 
+    payload = _to_json(ledger).encode("utf-8")
+    try:
+        if path.is_file() and path.read_bytes() == payload:
+            return False
+    except OSError:
+        pass  # unreadable existing file: fall through to the atomic write
     path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write_bytes(path, _to_json(ledger).encode("utf-8"))
+    atomic_write_bytes(path, payload)
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -358,6 +371,22 @@ def snapshot_deck(
     )
 
 
+def preserve_unchanged_member(prev: LedgerMember | None, new: LedgerMember) -> LedgerMember:
+    """Keep ``prev`` when re-recording it would change nothing but the commit stamp.
+
+    ``confirmed_commit`` means "the commit at which this state was last
+    *actually* established" — so an entry whose recorded state (baseline,
+    provenance, trust state, hash version) is identical to what a re-record
+    would write keeps its original stamp, and a repo-wide ``record`` sweep of
+    clean pairs rewrites nothing (issue #555). Any real field change — content
+    fingerprints, an explicit ``--provenance`` switch, a hash-version bump —
+    still records fresh.
+    """
+    if prev is not None and evolve(prev, confirmed_commit=new.confirmed_commit) == new:
+        return prev
+    return new
+
+
 def record_deck_snapshot(
     ledger: TopicLedger,
     deck_key: str,
@@ -389,6 +418,11 @@ def record_deck_snapshot(
     old = ledger.decks.get(deck_key)
     migrations = _detect_key_migrations(old, fresh) if old is not None else {}
     if member_keys is None:
+        if old is not None:
+            fresh.members = {
+                key: preserve_unchanged_member(old.members.get(key), lm)
+                for key, lm in fresh.members.items()
+            }
         ledger.decks[deck_key] = fresh
         return len(fresh.members), migrations
     target = old if old is not None else DeckLedger()
@@ -404,7 +438,7 @@ def record_deck_snapshot(
         for old_key, new_key in migrations.items():
             if new_key == key:
                 target.members.pop(old_key, None)
-        target.members[key] = lm
+        target.members[key] = preserve_unchanged_member(target.members.get(key), lm)
         recorded += 1
     ledger.decks[deck_key] = target
     return recorded, {k: v for k, v in migrations.items() if v in member_keys}
@@ -458,12 +492,13 @@ def _detect_key_migrations(old: DeckLedger, fresh: DeckLedger) -> dict[str, str]
 def rerecord_pool(target: DeckLedger, fresh: DeckLedger, group: str, kind: str) -> int:
     """Replace every ``pos:<group>/<kind>/*`` entry with the fresh pool state."""
     prefix = f"pos:{group}/{kind}/"
-    for key in [k for k in target.members if k.startswith(prefix)]:
-        del target.members[key]
+    old_pool = {
+        key: target.members.pop(key) for key in [k for k in target.members if k.startswith(prefix)]
+    }
     copied = 0
     for key, lm in fresh.members.items():
         if key.startswith(prefix):
-            target.members[key] = lm
+            target.members[key] = preserve_unchanged_member(old_pool.get(key), lm)
             copied += 1
     return copied
 

--- a/tests/cli/test_sync_v3_cli.py
+++ b/tests/cli/test_sync_v3_cli.py
@@ -194,6 +194,45 @@ class TestSyncLoop:
         stderr = getattr(result, "stderr", "") or result.output
         assert "no twin half found" in stderr
 
+    def test_rerecord_sweep_is_write_free_on_clean_pairs(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        # Issue #555: a repo-wide re-record must not bump confirmed_commit on
+        # unchanged members — the committed ledger stays byte-identical even
+        # though HEAD has moved since the first record.
+        import subprocess
+
+        de, _en = _write_pair(tmp_path)
+
+        def git(*args: str) -> None:
+            subprocess.run(["git", *args], cwd=tmp_path, check=True, capture_output=True, text=True)
+
+        git("init", "-q")
+        git("config", "user.email", "t@example.com")
+        git("config", "user.name", "T")
+        git("add", ".")
+        git("commit", "-q", "-m", "base")
+
+        first = cli_runner.invoke(slides_sync_group, ["record", str(de), "--json"])
+        assert first.exit_code == 0, first.output
+        ledger_path = tmp_path / ".clm" / "sync-ledger.json"
+        before = ledger_path.read_bytes()
+        assert _head_sha(tmp_path) in before.decode("utf-8")  # first record stamps HEAD
+
+        # Move HEAD without touching the pair, then re-record.
+        git("add", ".")
+        git("commit", "-q", "-m", "record")
+        (tmp_path / "other.txt").write_text("unrelated\n", encoding="utf-8")
+        git("add", ".")
+        git("commit", "-q", "-m", "move HEAD")
+
+        second = cli_runner.invoke(slides_sync_group, ["record", str(de), "--json"])
+        assert second.exit_code == 0, second.output
+        payload = _json_payload(second.output)
+        assert payload["unchanged"] == 1
+        assert payload["pairs"][0]["ledger_changed"] is False
+        assert ledger_path.read_bytes() == before
+
     def test_bare_deck_path_defaults_to_report(self, cli_runner: CliRunner, tmp_path: Path):
         de, _en = _write_pair(tmp_path)
         assert cli_runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0

--- a/tests/slides/test_doc_ledger.py
+++ b/tests/slides/test_doc_ledger.py
@@ -194,6 +194,65 @@ class TestTrustSemantics:
         assert "id:s0-m" not in ledger.decks["slides_x"].members
 
 
+class TestIdempotentRerecord:
+    """Issue #555: re-recording an unchanged state never bumps ``confirmed_commit``.
+
+    ``confirmed_commit`` means "the commit at which this state was last
+    actually established" — a repo-wide ``record`` sweep over clean pairs must
+    leave every entry (and the file) byte-identical, or committed ledgers churn
+    in every PR.
+    """
+
+    def _record(self, ledger, de: str, en: str, *, commit: str, **kwargs) -> None:
+        doc_ledger.record_deck_snapshot(
+            ledger, "slides_x", _parse(de, en), provenance="record", commit=commit, **kwargs
+        )
+
+    def test_full_rerecord_of_an_identical_deck_preserves_every_entry(self):
+        ledger = doc_ledger.TopicLedger()
+        self._record(ledger, DE0, EN0, commit="c1")
+        before = dict(ledger.decks["slides_x"].members)
+        self._record(ledger, DE0, EN0, commit="c2")
+        after = ledger.decks["slides_x"].members
+        assert after == before
+        assert {lm.confirmed_commit for lm in after.values()} == {"c1"}
+
+    def test_changed_member_restamps_while_unchanged_siblings_keep_their_commit(self):
+        ledger = doc_ledger.TopicLedger()
+        self._record(ledger, DE0, EN0, commit="c1")
+        de = DE0.replace("DE Text", "DE Text NEU")
+        self._record(ledger, de, EN0, commit="c2")
+        members = ledger.decks["slides_x"].members
+        assert members["id:s0-m"].confirmed_commit == "c2"
+        assert members["id:s0"].confirmed_commit == "c1"
+
+    def test_provenance_change_is_a_real_change_and_records_fresh(self):
+        ledger = doc_ledger.TopicLedger()
+        self._record(ledger, DE0, EN0, commit="c1")
+        doc_ledger.record_deck_snapshot(
+            ledger, "slides_x", _parse(DE0, EN0), provenance="agent", commit="c2"
+        )
+        members = ledger.decks["slides_x"].members
+        assert all(lm.provenance == "agent" for lm in members.values())
+        assert {lm.confirmed_commit for lm in members.values()} == {"c2"}
+
+    def test_partial_rerecord_of_an_unchanged_member_preserves_its_entry(self):
+        ledger = doc_ledger.TopicLedger()
+        self._record(ledger, DE0, EN0, commit="c1")
+        self._record(ledger, DE0, EN0, commit="c2", member_keys={"id:s0-m"})
+        assert ledger.decks["slides_x"].members["id:s0-m"].confirmed_commit == "c1"
+
+    def test_save_skips_a_byte_identical_write(self, tmp_path: Path):
+        ledger = _recorded_ledger()
+        path = tmp_path / ".clm" / "sync-ledger.json"
+        assert doc_ledger.save(ledger, path) is True
+        assert doc_ledger.save(ledger, path) is False
+        de = _build(HEADER_DE, _slide("s0", "de", "Titel"), _shared_code("x"))
+        en = _build(HEADER_EN, _slide("s0", "en", "Title"), _shared_code("x"))
+        doc_ledger.record_deck_snapshot(ledger, "slides_x", _parse(de, en), provenance="record")
+        assert doc_ledger.save(ledger, path) is True
+
+
 class TestKeyMigration:
     def test_pos_to_id_migration_is_detected_and_logged(self):
         ledger = _recorded_ledger()


### PR DESCRIPTION
## Summary

Fixes #555: a repo-wide `clm slides sync record DIR` bumped `confirmed_commit` to the current HEAD on **every** member of **every** visited ledger, dirtying ~500 committed `sync-ledger.json` files whose fingerprints were byte-identical to what was already recorded.

## Root causes and fixes

1. **`record_deck_snapshot` replaced deck sections wholesale** with a fresh snapshot stamped with the current commit. New `preserve_unchanged_member`: a member whose recorded state (baseline entry, provenance, trust state, hash version) is identical to what a re-record would write keeps its previous `LedgerMember` — including `confirmed_commit`, which thereby keeps its meaning *"the commit at which this state was last actually established"*. The preservation covers full records, partial (`--member`) records, `rerecord_pool`, and `apply`'s per-item `_upsert`.
2. **`doc_ledger.save` wrote unconditionally.** It now skips the write (returning `False`) when the canonical serialization is byte-identical to the file on disk, so a clean sweep is write-free (no mtime churn either).

Any real change — content fingerprints, an explicit `--provenance` switch, a hash-version bump — still records fresh with the current HEAD, so the issue's suggested opt-in `--touch` flag isn't needed: an explicit provenance re-assertion already re-stamps.

## Surface changes

- record `--json`: per-pair `ledger_changed` boolean + top-level `unchanged` count; text output appends `(unchanged)` for a write-free pair.
- `clm info commands` record section documents the git-idempotency contract (downstream agents rely on this).
- Changelog fragment `changelog.d/555-record-idempotent.fixed.md`.

## Testing

- New unit tests (`TestIdempotentRerecord`): full/partial re-record preserves `confirmed_commit`; changed member re-stamps while siblings keep theirs; provenance change records fresh; `save` skips byte-identical writes.
- New CLI regression test replaying the issue's repro: record → move HEAD → re-record → ledger bytes identical, `ledger_changed: false`, `unchanged: 1`.
- Verified end-to-end against the real CLI in a scratch git repo: `git status --porcelain | grep -c sync-ledger.json` → 0 after a sweep at a moved HEAD.
- Full fast suite green on the pre-push hook; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TT19NM4Fz8nKNPpKEaFrHn
