### PR TITLE
fix(build): print sweep notice after the build summary

### DIFF
--- a/changelog.d/sweep-message-after-summary.fixed.md
+++ b/changelog.d/sweep-message-after-summary.fixed.md
@@ -1,0 +1,1 @@
+- Fixed the "Sweeping stale output files..." notice printing above the still-active stage progress bar: the stray-file sweep now runs after the build summary, so the notice appears below it.

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -1471,6 +1471,11 @@ async def process_course_with_backend(
             # totals (and any output_path_conflict warnings) appear
             # exactly once per build.
             build_reporter.report_output_writes(backend.output_write_registry)
+            summary = build_reporter.finish_build()
+            # Run the sweep after finish_build: show_summary stops the
+            # Rich live progress display, so the "Sweeping stale output
+            # files..." notice prints below the summary instead of being
+            # pushed above the still-active progress bar.
             _maybe_run_sweep(
                 config=config,
                 root_dirs=root_dirs,
@@ -1478,7 +1483,6 @@ async def process_course_with_backend(
                 build_reporter=build_reporter,
                 only_sections_mode=only_sections_mode,
             )
-            summary = build_reporter.finish_build()
             build_reporter.cleanup()
         return summary
 


### PR DESCRIPTION
## Summary

`clm build` printed `Sweeping stale output files...` above the Stage 4/4 progress bar:

```
Sweeping stale output files...
  Stage 4/4: HTML Completed/Partial ━━━━━━━━ 204/204 100% 0:00:00

✓ Build completed successfully in 67.5s
```

The message was emitted while the Rich live progress display was still active, and Rich renders regular console prints *above* a live display, so the notice landed before the pinned progress bar in scrollback.

## Fix

Run `_maybe_run_sweep` after `build_reporter.finish_build()` in `process_course_with_backend`'s `finally` block. `finish_build` → `show_summary` stops the live progress display, so the sweep notice now prints below the summary (where the pause it announces actually happens, right before "Cleaning up job and cache databases..."). Side benefit: the build summary is now produced even if the sweep raises.

The sweep's skip logic is unaffected — it reads `build_reporter.errors`, which `finish_build` does not clear.

## Testing

- `pytest tests/cli/test_build_command.py tests/cli/test_output_sweep.py` — 158 passed
- Fast suite via pre-push hook — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvCYo2FkaUkEhGZzBjfmpb
