### PR TITLE
fix: scope section notebook numbering to the parent directory

### DIFF
--- a/changelog.d/section-numbering-duplicate-names.fixed.md
+++ b/changelog.d/section-numbering-duplicate-names.fixed.md
@@ -1,0 +1,5 @@
+- Fixed section notebook numbering assigning the same number to notebooks
+  with identical file names from different topic folders (e.g. several
+  `workshop.*.py` decks in one section all rendered as `03 …`). The numbering
+  key is now scoped to the notebook's parent directory; split companions
+  (`*.de.py` / `*.en.py`) in the same folder still share one slot.

--- a/src/clm/core/section.py
+++ b/src/clm/core/section.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from attr import Factory
@@ -34,13 +35,18 @@ class Section(NotebookMixin):
         key derived from :func:`clm.infrastructure.utils.path_utils.slide_family_key`
         keys each split pair under its bilingual companion's filename so
         the assignment is stable regardless of iteration order.
+
+        The key is scoped to the notebook's parent directory: split
+        companions always live next to each other, but unrelated topics
+        may reuse the same file name (e.g. several ``workshop.py``
+        folders in one section), and those must each get their own slot.
         """
         from clm.infrastructure.utils.path_utils import slide_family_key
 
-        family_number: dict[str, int] = {}
+        family_number: dict[tuple[Path, str], int] = {}
         next_index = 1
         for nb in self.notebooks:
-            key = slide_family_key(nb.path) or nb.path.name
+            key = (nb.path.parent, slide_family_key(nb.path) or nb.path.name)
             if key not in family_number:
                 family_number[key] = next_index
                 next_index += 1

--- a/tests/core/section_numbering_test.py
+++ b/tests/core/section_numbering_test.py
@@ -1,0 +1,54 @@
+"""Tests for :meth:`clm.core.section.Section.add_notebook_numbers`."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from clm.core.course_files.notebook_file import NotebookFile
+from clm.core.section import Section
+from clm.core.utils.text_utils import Text
+
+
+def _section_with_notebooks(paths: list[Path]) -> tuple[Section, list[NotebookFile]]:
+    notebooks = [NotebookFile(path=path, course=None, topic=None) for path in paths]
+    topic = SimpleNamespace(files=notebooks)
+    section = Section(name=Text(de="s", en="s"), course=None, topics=[topic])
+    return section, notebooks
+
+
+def test_same_file_name_in_different_folders_gets_distinct_numbers():
+    # Regression: five topic folders each containing a `workshop.py` all
+    # received number 1 because the fallback key was the bare file name.
+    section, notebooks = _section_with_notebooks(
+        [
+            Path("course/intro/workshop.py"),
+            Path("course/basics/workshop.py"),
+            Path("course/advanced/workshop.py"),
+        ]
+    )
+    section.add_notebook_numbers()
+    assert [nb.number_in_section for nb in notebooks] == [1, 2, 3]
+
+
+def test_split_companions_in_same_folder_share_one_slot():
+    section, notebooks = _section_with_notebooks(
+        [
+            Path("course/intro/slides_foo.de.py"),
+            Path("course/intro/slides_foo.en.py"),
+            Path("course/intro/slides_bar.py"),
+        ]
+    )
+    section.add_notebook_numbers()
+    assert [nb.number_in_section for nb in notebooks] == [1, 1, 2]
+
+
+def test_same_split_family_name_in_different_folders_gets_distinct_slots():
+    section, notebooks = _section_with_notebooks(
+        [
+            Path("course/intro/slides_workshop.de.py"),
+            Path("course/intro/slides_workshop.en.py"),
+            Path("course/basics/slides_workshop.de.py"),
+            Path("course/basics/slides_workshop.en.py"),
+        ]
+    )
+    section.add_notebook_numbers()
+    assert [nb.number_in_section for nb in notebooks] == [1, 1, 2, 2]


### PR DESCRIPTION
## Summary

In `CppCourses`, building `course-specs/cpp-tdd.xml` produced **five output files all numbered `03`** — every workshop deck in the section. The cause: `Section.add_notebook_numbers` keyed its numbering map by file name only (or the slide-family name derived from it), so same-named decks (`workshop.*.py`) from different topic folders collapsed into a single slot.

## Fix

Key the family map by `(parent directory, family name)`:

- Same-named files in different topic folders now each get their own `number_in_section`.
- Split companions (`*.de.py` / `*.en.py`) still share one slot — they always live in the same folder as each other, so parent-dir scoping preserves the Phase 6 shared-slot behavior byte-for-byte.

## Testing

- New `tests/core/section_numbering_test.py`: distinct numbers for same-named files across folders (regression), split companions share a slot, and same-named split families across folders get distinct slots.
- Full `tests/core` suite passes (831 tests); fast suite passed on the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMRDS8Bd9peM4DL1HjG8uE
