### PR TITLE
fix(build): emit the result-cache drain notice after the build summary

### DIFF
--- a/changelog.d/result-cache-drain-message-order.fixed.md
+++ b/changelog.d/result-cache-drain-message-order.fixed.md
@@ -1,0 +1,1 @@
+- The "Finishing N result-cache write(s)..." notice no longer interleaves with the live stage progress bar mid-build; it is now emitted during backend shutdown (after the build summary), consistent with the other cleanup notices. The end-of-stage drain itself is unchanged and is covered by the progress bar's spinner.

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -885,8 +885,8 @@ class SqliteBackend(LocalOpsBackend):
         # tests) read processed_files right after wait_for_completion. The
         # writer thread stays alive for the next stage; it is stopped in
         # shutdown. This is where any backlog the writer could not keep up with
-        # during the stage is absorbed, with a progress line so it is not a
-        # silent pause.
+        # during the stage is absorbed; the live progress bar's spinner covers
+        # the pause (a console notice here would render above the pinned bar).
         await self._drain_result_cache_writes()
 
         # Stop progress tracking and log summary
@@ -1373,13 +1373,20 @@ class SqliteBackend(LocalOpsBackend):
         if the background writer fell behind, joining inline here would freeze
         the loop — and therefore the progress bar — at the end of every stage
         (three times per stage with the default shared/trainer/speaker targets).
+
+        No console notice here: the Rich live progress display is still active
+        at this point, so a print would render above the pinned stage bar and
+        interleave with the build output (same bug as the sweep notice, fixed
+        in build.py). The bar's spinner covers the pause; the "Finishing N
+        result-cache write(s)..." notice is shown by _stop_result_cache_writer
+        instead, which runs in the shutdown phase after the summary.
         """
         q = self._result_cache_queue
         if q is None:
             return
         pending = q.qsize()
         if pending:
-            self._show_progress(f"Finishing {pending} result-cache write(s)...")
+            logger.info(f"Draining {pending} queued result-cache write(s)")
         await asyncio.to_thread(q.join)
 
     def _stop_result_cache_writer(self) -> None:
@@ -1388,6 +1395,11 @@ class SqliteBackend(LocalOpsBackend):
         q = self._result_cache_queue
         if thread is None or q is None:
             return
+        pending = q.qsize()
+        if pending:
+            # Shutdown phase: the build summary is already on screen, so this
+            # prints below it like the other cleanup notices.
+            self._show_progress(f"Finishing {pending} result-cache write(s)...")
         q.join()
         q.put(None)  # sentinel: tells the loop to exit
         thread.join(timeout=30.0)


### PR DESCRIPTION
## Summary

The `Finishing N result-cache write(s)...` notice was printed by the end-of-stage queue drain in `wait_for_completion`, while the Rich live progress display was still active — so it rendered above the pinned stage bar, interleaved with the build output:

```
Finishing 13 result-cache write(s)...
  Stage 4/4: HTML Completed/Partial (1122 cached) ━━━━ 1254/1254 100% 0:00:00

✓ Build completed successfully in 94.9s
```

Same root cause as the sweep-notice fix (#558 / 622ee91f).

## Fix

The drain itself must stay at the end of each `wait_for_completion` (the next stage's cache replay reads those rows), so only the user-visible notice moves:

- The mid-build drain in `_drain_result_cache_writes` is now silent on the console — the live bar's spinner covers the pause, and a `logger.info` records the backlog.
- `_stop_result_cache_writer` prints the notice during backend shutdown when a backlog remains there — after the summary, consistent with the other cleanup-phase `_show_progress` messages ("Cleaning up job and cache databases...", "Compacting databases...").

## Testing

- `pytest tests -k "result_cache or sqlite_backend"` — 68 passed
- Fast suite via pre-push hook — one unrelated flake on the first run (`test_two_overlapping_dir_groups_detect_conflict`, passes in isolation); clean on retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMRDS8Bd9peM4DL1HjG8uE
