### PR TITLE
fix(workers): isolate Docker/Direct execution modes across concurrent builds

### DIFF
--- a/changelog.d/564-docker-worker-mode-isolation.fixed.md
+++ b/changelog.d/564-docker-worker-mode-isolation.fixed.md
@@ -1,0 +1,13 @@
+- Fixed `--workers=docker` builds silently executing notebook jobs on host
+  (Direct-mode) workers started by a concurrent build sharing the same jobs
+  database, which failed C++ decks with `NoSuchKernel: xcpp20` (the kernel
+  only exists in the Docker image). Three coordinated changes: worker reuse
+  is now execution-mode-aware (a Docker-mode build never counts another
+  build's Direct workers as sufficient), jobs are tagged with the execution
+  mode they require (jobs-DB schema v10) so only matching-mode workers claim
+  them, and the worker-availability check counts only matching-mode workers.
+- A missing Jupyter kernelspec (`NoSuchKernel`) is now reported as a
+  **configuration** error instead of a user error. Besides the correct label
+  and actionable guidance, this keeps the failure out of the persistent
+  error cache, so fixing the environment (e.g. rebuilding the Docker image)
+  is no longer masked by a replayed stale error.

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -1934,6 +1934,15 @@ async def main_build(
                 explain_rebuilds=config.explain_rebuilds,
                 image_registry=course.image_registry,
                 telemetry_store=telemetry_store,
+                # Tag every submitted job with the execution mode this build
+                # resolved for its worker type, so only matching-mode workers
+                # claim it. Without this, a Direct worker from a concurrent
+                # build sharing the jobs DB could take e.g. a C++ notebook
+                # job and fail with NoSuchKernel (xcpp20 lives only in the
+                # Docker image).
+                worker_execution_modes={
+                    c.worker_type: c.execution_mode for c in worker_config.get_all_worker_configs()
+                },
             )
 
             async with backend:

--- a/src/clm/cli/error_categorizer.py
+++ b/src/clm/cli/error_categorizer.py
@@ -202,6 +202,33 @@ class ErrorCategorizer:
         match_text = f"{error_message} {error_class} {cat_error_class} {cat_error_message}"
 
         # Categorize based on error patterns
+        #
+        # A missing Jupyter kernelspec is an environment problem, never the
+        # notebook's fault — the notebook merely names the kernel it needs.
+        # Classifying it as "configuration" also keeps it out of the
+        # processing_issues error cache (user errors are persisted and
+        # replayed on cache hits), so fixing the environment actually fixes
+        # the next build instead of replaying a stale failure. Checked first:
+        # the enhanced message may embed other error-class tokens.
+        if "NoSuchKernel" in match_text or "No such kernel" in match_text:
+            return BuildError(
+                error_type="configuration",
+                category="missing_kernel",
+                severity="error",
+                file_path=input_file,
+                message=error_message,
+                actionable_guidance=(
+                    "The Jupyter kernel this notebook needs is not installed in the "
+                    "environment that executed it. Install the kernelspec there, or "
+                    "run the build with Docker workers ('clm build --workers=docker'), "
+                    "whose image ships the course kernels (e.g. xcpp20 for C++). "
+                    "For a kernel-free build use 'clm build --no-html'."
+                ),
+                job_id=job_id,
+                correlation_id=correlation_id,
+                details=details,
+            )
+
         if any(
             err in match_text
             for err in ["SyntaxError", "NameError", "IndentationError", "TypeError"]

--- a/src/clm/infrastructure/api/client.py
+++ b/src/clm/infrastructure/api/client.py
@@ -216,23 +216,31 @@ class WorkerApiClient:
         logger.info(f"Registered as {worker_type} worker {worker_id} via REST API")
         return worker_id
 
-    def claim_job(self, worker_id: int, job_type: str) -> JobInfo | None:
+    def claim_job(
+        self, worker_id: int, job_type: str, execution_mode: str | None = None
+    ) -> JobInfo | None:
         """Claim next available job.
 
         Args:
             worker_id: ID of the worker claiming the job
             job_type: Type of job to claim
+            execution_mode: Execution mode of the claiming worker ('docker' or
+                'direct'). The server defaults a missing value to 'docker'
+                because only Docker workers use this API.
 
         Returns:
             JobInfo if a job was claimed, None if no jobs available
         """
+        json_data: dict[str, Any] = {
+            "worker_id": worker_id,
+            "job_type": job_type,
+        }
+        if execution_mode is not None:
+            json_data["execution_mode"] = execution_mode
         response = self._request_with_retry(
             "POST",
             "/api/worker/jobs/claim",
-            json_data={
-                "worker_id": worker_id,
-                "job_type": job_type,
-            },
+            json_data=json_data,
         )
 
         data = response.json()

--- a/src/clm/infrastructure/api/job_queue_adapter.py
+++ b/src/clm/infrastructure/api/job_queue_adapter.py
@@ -40,12 +40,20 @@ class ApiJobQueue:
         """Close the API client."""
         self._client.close()
 
-    def get_next_job(self, job_type: str, worker_id: int | None = None) -> Job | None:
+    def get_next_job(
+        self,
+        job_type: str,
+        worker_id: int | None = None,
+        execution_mode: str | None = None,
+    ) -> Job | None:
         """Get next pending job for the given type.
 
         Args:
             job_type: Type of job to retrieve
             worker_id: Worker ID to assign the job to
+            execution_mode: Execution mode of the claiming worker. Forwarded
+                to the API; the server defaults a missing value to 'docker'
+                since only Docker workers use this adapter.
 
         Returns:
             Job object if available, None otherwise
@@ -55,7 +63,7 @@ class ApiJobQueue:
             raise ValueError("worker_id must be set")
 
         try:
-            job_info = self._client.claim_job(wid, job_type)
+            job_info = self._client.claim_job(wid, job_type, execution_mode=execution_mode)
 
             if job_info is None:
                 return None

--- a/src/clm/infrastructure/api/models.py
+++ b/src/clm/infrastructure/api/models.py
@@ -30,6 +30,14 @@ class JobClaimRequest(BaseModel):
 
     worker_id: int = Field(..., description="ID of the worker claiming the job")
     job_type: str = Field(..., description="Type of job to claim: notebook, plantuml, drawio")
+    execution_mode: str | None = Field(
+        default=None,
+        description=(
+            "Execution mode of the claiming worker ('docker' or 'direct'). "
+            "Only the Docker executor points workers at this API, so the "
+            "server treats a missing value (older worker images) as 'docker'."
+        ),
+    )
 
 
 class JobData(BaseModel):

--- a/src/clm/infrastructure/api/worker_routes.py
+++ b/src/clm/infrastructure/api/worker_routes.py
@@ -95,7 +95,15 @@ async def claim_job(request: Request, body: JobClaimRequest):
     job_queue = get_job_queue(request)
 
     try:
-        job = job_queue.get_next_job(body.job_type, body.worker_id)
+        # Only Docker workers reach the queue through this API (Direct workers
+        # open the SQLite file themselves), so default a missing mode — sent
+        # by pre-mode worker images — to "docker". This keeps mode-tagged
+        # claiming effective even with older container images.
+        job = job_queue.get_next_job(
+            body.job_type,
+            body.worker_id,
+            execution_mode=body.execution_mode or "docker",
+        )
 
         if job is None:
             return JobClaimResponse(job=None)

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -82,6 +82,14 @@ class SqliteBackend(LocalOpsBackend):
     # jobs: the structured error JSON) and reports passed-only-after-retry
     # decks to the build summary's flake list.
     telemetry_store: Optional["ExecutionTelemetryStore"] = None
+    # Per-job-type worker execution mode ('docker'/'direct') from this build's
+    # resolved worker config. Jobs are tagged with it on submission so only
+    # workers of that mode claim them — a Direct worker from a concurrent
+    # build sharing the same jobs DB must never take a job that needs the
+    # Docker image's toolchain (e.g. the xeus-cpp kernel; the cause of the
+    # spurious "No such kernel named xcpp20" failures). An empty dict leaves
+    # jobs untagged (legacy behaviour, used by tests).
+    worker_execution_modes: dict[str, str] = field(factory=dict)
 
     # Background result-cache writer (lazy). Retiring a completed job by reading
     # its output back, pickling it, and committing the blob to the cache DB is
@@ -444,6 +452,7 @@ class SqliteBackend(LocalOpsBackend):
             content_hash=payload.content_hash(),
             payload=payload_dict,
             correlation_id=correlation_id,
+            execution_mode=self.worker_execution_modes.get(job_type),
         )
         return ("submitted", job_id)
 
@@ -1130,6 +1139,9 @@ class SqliteBackend(LocalOpsBackend):
 
         A worker is considered available if:
         - It matches the requested job_type
+        - It matches this build's execution mode for the job type (when the
+          backend knows one) — a Direct worker cannot service jobs tagged
+          for Docker, so it must not count as available for them
         - Its status is 'idle' or 'busy' (not 'hung' or 'dead')
         - It has sent a heartbeat within the last 30 seconds
 
@@ -1148,15 +1160,29 @@ class SqliteBackend(LocalOpsBackend):
 
         conn = self.job_queue._get_conn()
 
+        # Same direct/docker discriminator WorkerDiscovery uses: Direct
+        # executor IDs are 'direct-<type>-<uuid>'; anything else (Docker
+        # container IDs, 'docker-<type>-<uuid>' pre-registrations) is Docker.
+        required_mode = self.worker_execution_modes.get(job_type)
+        if required_mode is None:
+            mode_clause = ""
+            mode_params: tuple[str, ...] = ()
+        else:
+            mode_clause = (
+                "AND (CASE WHEN container_id LIKE 'direct-%' THEN 'direct' ELSE 'docker' END) = ?"
+            )
+            mode_params = (required_mode,)
+
         # First check for activated workers (idle or busy with recent heartbeat)
         cursor = conn.execute(
-            """
+            f"""
             SELECT COUNT(*) FROM workers
             WHERE worker_type = ?
             AND status IN ('idle', 'busy')
             AND last_heartbeat > datetime('now', '-30 seconds')
+            {mode_clause}
             """,
-            (job_type,),
+            (job_type, *mode_params),
         )
         row = cursor.fetchone()
         activated_count = row[0] if row else 0
@@ -1167,12 +1193,13 @@ class SqliteBackend(LocalOpsBackend):
         # Check if there are pre-registered workers waiting to activate
         if wait_for_activation:
             cursor = conn.execute(
-                """
+                f"""
                 SELECT COUNT(*) FROM workers
                 WHERE worker_type = ?
                 AND status = 'created'
+                {mode_clause}
                 """,
-                (job_type,),
+                (job_type, *mode_params),
             )
             row = cursor.fetchone()
             created_count = row[0] if row else 0
@@ -1189,13 +1216,14 @@ class SqliteBackend(LocalOpsBackend):
 
                 while (time.time() - start_time) < timeout:
                     cursor = conn.execute(
-                        """
+                        f"""
                         SELECT COUNT(*) FROM workers
                         WHERE worker_type = ?
                         AND status IN ('idle', 'busy')
                         AND last_heartbeat > datetime('now', '-30 seconds')
+                        {mode_clause}
                         """,
-                        (job_type,),
+                        (job_type, *mode_params),
                     )
                     row = cursor.fetchone()
                     activated_count = row[0] if row else 0

--- a/src/clm/infrastructure/database/job_queue.py
+++ b/src/clm/infrastructure/database/job_queue.py
@@ -114,6 +114,7 @@ class JobQueue:
         payload: dict[str, Any],
         priority: int = 0,
         correlation_id: str | None = None,
+        execution_mode: str | None = None,
     ) -> int:
         """Add a new job to the queue.
 
@@ -125,6 +126,12 @@ class JobQueue:
             payload: Job-specific parameters as dictionary
             priority: Job priority (higher = more urgent)
             correlation_id: Optional correlation ID for tracing
+            execution_mode: Worker execution mode this job requires
+                ('docker' or 'direct'); None lets any worker of the matching
+                job_type claim it. A Docker-mode build tags its jobs so a
+                Direct worker from a concurrent build sharing the same jobs
+                DB can never claim them (it may lack the required toolchain,
+                e.g. the xeus-cpp kernel).
 
         Returns:
             Job ID
@@ -134,8 +141,8 @@ class JobQueue:
             """
             INSERT INTO jobs (
                 job_type, status, input_file, output_file,
-                content_hash, payload, priority, correlation_id
-            ) VALUES (?, 'pending', ?, ?, ?, ?, ?, ?)
+                content_hash, payload, priority, correlation_id, execution_mode
+            ) VALUES (?, 'pending', ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 job_type,
@@ -145,6 +152,7 @@ class JobQueue:
                 json.dumps(payload),
                 priority,
                 correlation_id,
+                execution_mode,
             ),
         )
         # No commit() needed - connection is in autocommit mode
@@ -221,7 +229,12 @@ class JobQueue:
             (output_file, content_hash, json.dumps(result_metadata)),
         )
 
-    def get_next_job(self, job_type: str, worker_id: int | None = None) -> Job | None:
+    def get_next_job(
+        self,
+        job_type: str,
+        worker_id: int | None = None,
+        execution_mode: str | None = None,
+    ) -> Job | None:
         """Get next pending job for the given type.
 
         This method atomically retrieves and marks a job as processing.
@@ -229,6 +242,11 @@ class JobQueue:
         Args:
             job_type: Type of job to retrieve
             worker_id: Optional worker ID to assign the job to
+            execution_mode: Execution mode of the claiming worker ('docker' or
+                'direct'). When given, only jobs tagged with the same mode (or
+                untagged jobs) are claimed, so a Direct worker never picks up
+                a job that requires the Docker image's toolchain and vice
+                versa. None preserves the legacy claim-anything behaviour.
 
         Returns:
             Job object if available, None otherwise
@@ -238,15 +256,27 @@ class JobQueue:
         # Use explicit transaction to atomically get and update job
         conn.execute("BEGIN IMMEDIATE")
         try:
-            cursor = conn.execute(
-                """
-                SELECT * FROM jobs
-                WHERE status = 'pending' AND job_type = ? AND attempts < max_attempts
-                ORDER BY priority DESC, created_at ASC
-                LIMIT 1
-                """,
-                (job_type,),
-            )
+            if execution_mode is None:
+                cursor = conn.execute(
+                    """
+                    SELECT * FROM jobs
+                    WHERE status = 'pending' AND job_type = ? AND attempts < max_attempts
+                    ORDER BY priority DESC, created_at ASC
+                    LIMIT 1
+                    """,
+                    (job_type,),
+                )
+            else:
+                cursor = conn.execute(
+                    """
+                    SELECT * FROM jobs
+                    WHERE status = 'pending' AND job_type = ? AND attempts < max_attempts
+                    AND (execution_mode IS NULL OR execution_mode = ?)
+                    ORDER BY priority DESC, created_at ASC
+                    LIMIT 1
+                    """,
+                    (job_type, execution_mode),
+                )
             row = cursor.fetchone()
 
             if not row:

--- a/src/clm/infrastructure/database/schema.py
+++ b/src/clm/infrastructure/database/schema.py
@@ -8,7 +8,7 @@ workers.
 import sqlite3
 from pathlib import Path
 
-DATABASE_VERSION = 9
+DATABASE_VERSION = 10
 
 SCHEMA_SQL = """
 -- Jobs table (replaces message queue)
@@ -40,6 +40,13 @@ CREATE TABLE IF NOT EXISTS jobs (
 
     -- Result data (v6) - stores warnings and other result metadata as JSON
     result TEXT,
+
+    -- Required worker execution mode (v10): 'docker' or 'direct'. NULL means
+    -- any worker of the matching job_type may claim the job. Prevents a
+    -- Direct-mode worker (e.g. from a concurrent build sharing this jobs DB)
+    -- from stealing jobs that need a toolchain only the Docker image has,
+    -- such as the xeus-cpp C++ kernel.
+    execution_mode TEXT,
 
     FOREIGN KEY (worker_id) REFERENCES workers(id)
 );
@@ -424,4 +431,17 @@ def migrate_database(conn: sqlite3.Connection, from_version: int, to_version: in
 
             INSERT OR IGNORE INTO schema_version (version) VALUES (9);
         """)
+        conn.commit()
+
+    # Migration from v9 to v10: jobs carry the execution mode they require
+    # ('docker'/'direct', NULL = any) so workers of the other mode never
+    # claim them. See the column comment in SCHEMA_SQL.
+    if from_version < 10 <= to_version:
+        try:
+            conn.execute("ALTER TABLE jobs ADD COLUMN execution_mode TEXT")
+        except sqlite3.OperationalError as e:
+            # Column might already exist (fresh SCHEMA_SQL ran first)
+            if "duplicate column name" not in str(e).lower():
+                raise
+        conn.execute("INSERT OR IGNORE INTO schema_version (version) VALUES (10)")
         conn.commit()

--- a/src/clm/infrastructure/workers/discovery.py
+++ b/src/clm/infrastructure/workers/discovery.py
@@ -180,18 +180,30 @@ class WorkerDiscovery:
 
         return True
 
-    def count_healthy_workers(self, worker_type: str) -> int:
+    def count_healthy_workers(self, worker_type: str, execution_mode: str | None = None) -> int:
         """Count healthy workers of a specific type.
 
         Args:
             worker_type: Worker type to count
+            execution_mode: When given ('docker' or 'direct'), count only
+                workers running in that mode. A build that wants Docker
+                workers must not treat another build's Direct workers as
+                satisfying its requirement — they lack the Docker image's
+                toolchain (e.g. the xeus-cpp kernel).
 
         Returns:
             Number of healthy workers
         """
         workers = self.discover_workers(worker_type=worker_type, status_filter=["idle", "busy"])
 
-        return sum(1 for w in workers if w.is_healthy)
+        return sum(
+            1
+            for w in workers
+            if w.is_healthy
+            and (
+                execution_mode is None or ("docker" if w.is_docker else "direct") == execution_mode
+            )
+        )
 
     def get_worker_summary(self) -> dict[str, dict[str, int]]:
         """Get summary of workers by type and status.

--- a/src/clm/infrastructure/workers/lifecycle_manager.py
+++ b/src/clm/infrastructure/workers/lifecycle_manager.py
@@ -154,12 +154,17 @@ class WorkerLifecycleManager:
             required_config = self.config.get_worker_config(worker_type)
             required_count = required_config.count
 
-            healthy_count = self.discovery.count_healthy_workers(worker_type)
+            # Only workers of the required execution mode count: a Docker-mode
+            # build must not be satisfied by Direct workers another build
+            # registered in a shared jobs DB (they lack the image's toolchain).
+            healthy_count = self.discovery.count_healthy_workers(
+                worker_type, execution_mode=required_config.execution_mode
+            )
 
             if healthy_count < required_count:
                 logger.info(
-                    f"Need {required_count} {worker_type} worker(s), "
-                    f"found {healthy_count} healthy worker(s)"
+                    f"Need {required_count} {required_config.execution_mode} {worker_type} "
+                    f"worker(s), found {healthy_count} healthy worker(s)"
                 )
                 return True
 
@@ -298,7 +303,11 @@ class WorkerLifecycleManager:
         adjusted = []
 
         for config in configs:
-            healthy_count = self.discovery.count_healthy_workers(config.worker_type)
+            # Mode-aware: only same-mode workers can be reused (see
+            # should_start_workers).
+            healthy_count = self.discovery.count_healthy_workers(
+                config.worker_type, execution_mode=config.execution_mode
+            )
             needed_count = max(0, config.count - healthy_count)
 
             if needed_count > 0:
@@ -375,8 +384,14 @@ class WorkerLifecycleManager:
                 worker_type=config.worker_type, status_filter=["idle", "busy"]
             )
 
-            # Take up to config.count healthy workers
-            healthy_workers = [w for w in discovered if w.is_healthy][: config.count]
+            # Take up to config.count healthy workers of the REQUIRED
+            # execution mode — mirroring should_start_workers, a Direct
+            # worker never counts as a reused Docker worker or vice versa.
+            healthy_workers = [
+                w
+                for w in discovered
+                if w.is_healthy and ("docker" if w.is_docker else "direct") == config.execution_mode
+            ][: config.count]
 
             for worker in healthy_workers:
                 info = WorkerInfo(

--- a/src/clm/infrastructure/workers/worker_base.py
+++ b/src/clm/infrastructure/workers/worker_base.py
@@ -223,6 +223,10 @@ class Worker(ABC):
 
         # Determine mode and create appropriate job queue
         self._api_mode = api_url is not None
+        # The worker's own execution mode, used to claim only jobs tagged for
+        # it (or untagged ones). REST API mode is used exclusively by Docker
+        # workers; everything else runs directly on the host.
+        self.execution_mode = "docker" if self._api_mode else "direct"
         if self._api_mode:
             from clm.infrastructure.api.job_queue_adapter import ApiJobQueue
 
@@ -645,8 +649,12 @@ class Worker(ABC):
                 if self._check_parent_and_exit_if_dead():
                     break
 
-                # Get next job
-                job = self.job_queue.get_next_job(self.worker_type, self.worker_id)
+                # Get next job (claiming only jobs untagged or tagged with
+                # this worker's execution mode, so e.g. a Direct worker never
+                # takes a job that needs the Docker image's toolchain)
+                job = self.job_queue.get_next_job(
+                    self.worker_type, self.worker_id, execution_mode=self.execution_mode
+                )
 
                 if job is None:
                     # No jobs available, update heartbeat (throttled) and wait

--- a/tests/cli/test_error_categorizer.py
+++ b/tests/cli/test_error_categorizer.py
@@ -214,6 +214,47 @@ class TestNotebookErrorCategorization:
         assert error.error_type == "user"
         assert error.category == "missing_module"
 
+    def test_missing_kernel_is_configuration_error(self):
+        """A missing Jupyter kernelspec is an environment problem, not a
+        notebook bug — it must be a configuration error so it is neither
+        blamed on the file nor persisted to the error cache (user errors
+        replay on every cached build until the cache is wiped)."""
+        error = ErrorCategorizer.categorize_job_error(
+            job_type="notebook",
+            input_file="slides_020_workshop.en.cpp",
+            error_message=(
+                "Notebook execution failed: slides_020_workshop.en.cpp\n"
+                "  Cell: #3\n"
+                "  Error: NoSuchKernel: No such kernel named xcpp20"
+            ),
+            job_payload={},
+        )
+
+        assert error.error_type == "configuration"
+        assert error.category == "missing_kernel"
+        assert "kernel" in error.actionable_guidance.lower()
+
+    def test_missing_kernel_structured_error_is_configuration_error(self):
+        """NoSuchKernel arriving via the structured notebook_error_class field
+        (worker-enhanced JSON errors) is categorized the same way."""
+        import json
+
+        error = ErrorCategorizer.categorize_job_error(
+            job_type="notebook",
+            input_file="deck.cpp",
+            error_message=json.dumps(
+                {
+                    "error_message": "Notebook execution failed: deck.cpp",
+                    "notebook_error_class": "NoSuchKernel",
+                    "notebook_error_message": "No such kernel named xcpp20",
+                }
+            ),
+            job_payload={},
+        )
+
+        assert error.error_type == "configuration"
+        assert error.category == "missing_kernel"
+
 
 class TestPlantumlErrorCategorization:
     """Tests for PlantUML error categorization."""

--- a/tests/infrastructure/api/test_job_queue_adapter.py
+++ b/tests/infrastructure/api/test_job_queue_adapter.py
@@ -72,7 +72,7 @@ class TestGetNextJob:
 
         adapter.get_next_job("notebook", worker_id=99)
 
-        fake_client.claim_job.assert_called_once_with(99, "notebook")
+        fake_client.claim_job.assert_called_once_with(99, "notebook", execution_mode=None)
 
     def test_raises_if_no_worker_id(self, fake_client: MagicMock) -> None:
         q = ApiJobQueue("http://host", worker_id=None)

--- a/tests/infrastructure/api/test_worker_routes_endpoints.py
+++ b/tests/infrastructure/api/test_worker_routes_endpoints.py
@@ -144,6 +144,52 @@ class TestClaimJobEndpoint:
         assert data["job"] is not None
         assert data["job"]["id"] == job_id
 
+    def test_claim_defaults_to_docker_mode(self, client: TestClient, db_path: Path) -> None:
+        """The route claims as a Docker worker when the body omits the mode.
+
+        Only Docker workers use this API, so a job tagged 'direct' (another
+        build's host-only job) must never be handed out here, while a job
+        tagged 'docker' is claimable even by older worker images that do
+        not send execution_mode yet.
+        """
+        queue = JobQueue(db_path)
+        try:
+            conn = queue._get_conn()
+            conn.execute(
+                """
+                INSERT INTO jobs (
+                    job_type, input_file, output_file, content_hash,
+                    payload, status, priority, attempts, execution_mode
+                ) VALUES ('notebook', 'a.py', 'a.html', 'h1', '{}', 'pending', 0, 0, 'direct')
+                """
+            )
+            cursor = conn.execute(
+                """
+                INSERT INTO jobs (
+                    job_type, input_file, output_file, content_hash,
+                    payload, status, priority, attempts, execution_mode
+                ) VALUES ('notebook', 'b.cpp', 'b.html', 'h2', '{}', 'pending', 0, 0, 'docker')
+                """
+            )
+            docker_job_id = cursor.lastrowid
+            cursor = conn.execute(
+                "INSERT INTO workers (worker_type, container_id, status) VALUES (?, ?, 'idle')",
+                ("notebook", "c1"),
+            )
+            worker_id = cursor.lastrowid
+        finally:
+            queue.close()
+
+        response = client.post(
+            "/api/worker/jobs/claim",
+            json={"worker_id": worker_id, "job_type": "notebook"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["job"] is not None
+        assert data["job"]["id"] == docker_job_id  # docker-tagged, not the direct one
+
     def test_claim_returns_500_on_error(self, client: TestClient) -> None:
         with patch(
             "clm.infrastructure.database.job_queue.JobQueue.get_next_job",

--- a/tests/infrastructure/database/test_job_queue.py
+++ b/tests/infrastructure/database/test_job_queue.py
@@ -113,6 +113,66 @@ def test_get_next_job_by_type(job_queue):
     assert job.job_type == "drawio"
 
 
+def test_get_next_job_execution_mode_filtering(job_queue):
+    """Mode-tagged jobs are only claimed by workers of the same mode.
+
+    A job tagged 'docker' must never be handed to a Direct worker — the
+    scenario behind the spurious NoSuchKernel(xcpp20) failures, where a
+    concurrent Direct-mode build's workers stole a Docker build's C++ jobs.
+    """
+    docker_job_id = job_queue.add_job(
+        job_type="notebook",
+        input_file="deck.cpp",
+        output_file="deck.html",
+        content_hash="abc123",
+        payload={},
+        execution_mode="docker",
+    )
+
+    # A Direct worker asking for notebook jobs must NOT get the docker job
+    assert job_queue.get_next_job("notebook", execution_mode="direct") is None
+
+    # A Docker worker gets it
+    job = job_queue.get_next_job("notebook", execution_mode="docker")
+    assert job is not None
+    assert job.id == docker_job_id
+
+
+def test_get_next_job_untagged_claimable_by_any_mode(job_queue):
+    """Untagged jobs (legacy / mode-agnostic) go to workers of any mode."""
+    job_queue.add_job(
+        job_type="notebook",
+        input_file="a.py",
+        output_file="a.html",
+        content_hash="h1",
+        payload={},
+    )
+    job_queue.add_job(
+        job_type="notebook",
+        input_file="b.py",
+        output_file="b.html",
+        content_hash="h2",
+        payload={},
+    )
+
+    assert job_queue.get_next_job("notebook", execution_mode="direct") is not None
+    assert job_queue.get_next_job("notebook", execution_mode="docker") is not None
+
+
+def test_get_next_job_without_mode_claims_tagged_jobs(job_queue):
+    """A claimer that passes no mode keeps the legacy claim-anything behaviour."""
+    job_queue.add_job(
+        job_type="notebook",
+        input_file="deck.cpp",
+        output_file="deck.html",
+        content_hash="abc123",
+        payload={},
+        execution_mode="docker",
+    )
+
+    assert job_queue.get_next_job("notebook") is not None
+
+
 def test_get_next_job_priority(job_queue):
     """Test that jobs are retrieved by priority."""
     # Add low priority job

--- a/tests/infrastructure/database/test_schema.py
+++ b/tests/infrastructure/database/test_schema.py
@@ -694,6 +694,53 @@ class TestMigrateDatabase:
 
         conn.close()
 
+    def test_migrate_v9_to_v10_adds_execution_mode_column(self, tmp_path):
+        """Migration from v9 to v10 adds the jobs.execution_mode column.
+
+        The column tags a job with the worker execution mode it requires
+        ('docker'/'direct'), so a Direct worker never claims a job that
+        needs the Docker image's toolchain.
+        """
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db_path))
+
+        # Minimal v9 jobs table without execution_mode.
+        conn.execute("""
+            CREATE TABLE jobs (
+                id INTEGER PRIMARY KEY,
+                job_type TEXT NOT NULL,
+                status TEXT NOT NULL,
+                completed_at TIMESTAMP
+            )
+        """)
+        conn.execute(
+            "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TIMESTAMP)"
+        )
+        conn.execute("INSERT INTO schema_version (version) VALUES (9)")
+        conn.commit()
+
+        migrate_database(conn, 9, 10)
+
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(jobs)").fetchall()}
+        assert "execution_mode" in columns
+        assert get_schema_version(conn) == 10
+
+        conn.close()
+
+    def test_migrate_v9_to_v10_handles_existing_column(self, tmp_path):
+        """v9→v10 migration is a no-op when execution_mode already exists."""
+        db_path = tmp_path / "test.db"
+        # A freshly initialized DB already has the column via SCHEMA_SQL.
+        init_database(db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            migrate_database(conn, 9, 10)  # Should not raise
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(jobs)").fetchall()}
+            assert "execution_mode" in columns
+        finally:
+            conn.close()
+
     def test_init_database_adds_v9_indexes_to_existing_v8_db(self, tmp_path):
         """init_database upgrades a pre-v9 database in place.
 

--- a/tests/infrastructure/database/test_worker_heartbeats.py
+++ b/tests/infrastructure/database/test_worker_heartbeats.py
@@ -116,7 +116,7 @@ def _read_heartbeat(db_path: Path, worker_id: int) -> dict | None:
 class TestHeartbeatSchema:
     def test_schema_version_is_current(self, db_path: Path) -> None:
         """After init the schema is at the documented latest version."""
-        assert DATABASE_VERSION == 9
+        assert DATABASE_VERSION == 10
 
     def test_table_exists_with_expected_columns(self, db_path: Path) -> None:
         conn = sqlite3.connect(str(db_path))

--- a/tests/infrastructure/workers/test_discovery.py
+++ b/tests/infrastructure/workers/test_discovery.py
@@ -435,6 +435,49 @@ class TestCountHealthyWorkers:
 
         assert count == 1  # Only the one with recent heartbeat
 
+    def test_count_filters_by_execution_mode(self, worker_discovery, mock_job_queue, make_db_row):
+        """Only workers of the requested execution mode count.
+
+        A Docker-mode build must not treat another build's Direct workers
+        (registered in a shared jobs DB) as satisfying its requirement —
+        they lack the Docker image's toolchain (e.g. the xcpp20 kernel).
+        """
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        now = datetime.now(timezone.utc)
+        mock_cursor.fetchall.return_value = [
+            # Direct workers use the 'direct-' executor-ID prefix
+            make_db_row(
+                db_id=1,
+                worker_type="notebook",
+                container_id="direct-notebook-1-abc",
+                status="idle",
+                last_heartbeat=now,
+            ),
+            make_db_row(
+                db_id=2,
+                worker_type="notebook",
+                container_id="direct-notebook-2-def",
+                status="idle",
+                last_heartbeat=now,
+            ),
+            # Docker worker (container hash, no 'direct-' prefix)
+            make_db_row(
+                db_id=3,
+                worker_type="notebook",
+                container_id="0a1b2c3d4e5f",
+                status="idle",
+                last_heartbeat=now,
+            ),
+        ]
+        mock_conn.execute.return_value = mock_cursor
+        mock_job_queue._get_conn.return_value = mock_conn
+
+        assert worker_discovery.count_healthy_workers("notebook", execution_mode="docker") == 1
+        assert worker_discovery.count_healthy_workers("notebook", execution_mode="direct") == 2
+        # No mode → legacy count-everything behaviour
+        assert worker_discovery.count_healthy_workers("notebook") == 3
+
 
 class TestDatetimeCompatibility:
     """Test datetime compatibility between DiscoveredWorker and CLI operations.


### PR DESCRIPTION
## Problem

`clm build --workers=docker` for the C++ TDD course failed every executed deck with:

```
✗ [User Error]  Error: NoSuchKernel — No such kernel named xcpp20
```

even right after rebuilding the Docker images (which demonstrably contain the `xcpp20` kernel).

## Root cause

The failing build ran **concurrently with another (Direct-mode) build sharing the same jobs DB** (`CLM_JOBS_DB_PATH`). The jobs-DB worker events show the C++ jobs (#27600/#27601) were executed by `direct`-mode notebook workers started by the other build seconds earlier — on the Windows host, where `xcpp20` cannot exist. Two independent gaps allowed this:

1. **Worker reuse counted by type only.** The Docker-mode build saw the other build's 8 healthy Direct notebook workers as "sufficient" and started no containers at all.
2. **Job claiming filtered by `job_type` only.** Even with its own Docker workers, the other build's Direct workers could still steal the C++ jobs from the shared queue.

On top of that, `NoSuchKernel` was categorized as a **user** error, so it was persisted to the error cache and would replay on cache hits — masking a fixed environment.

## Fix (coordinated)

- **Mode-aware worker reuse**: `count_healthy_workers` takes an `execution_mode`; `should_start_workers`, `_adjust_configs_for_reuse`, and `_collect_reused_worker_info` only accept same-mode workers.
- **Mode-tagged job claiming** (jobs-DB **schema v10**, nullable `jobs.execution_mode`): builds tag submitted jobs with the mode resolved for that worker type; workers claim only untagged jobs or jobs tagged with their own mode. The REST claim route defaults a missing mode to `docker` (only Docker workers use the API), so **older worker images keep working unchanged**.
- **Mode-aware availability check**: the backend counts only matching-mode workers, so a missing Docker pool fails fast instead of pointing at another build's Direct workers.
- **`NoSuchKernel` is now a configuration error** (`missing_kernel`) with actionable guidance, and is therefore never persisted/replayed from the error cache.

## Testing

- New tests: mode-filtered claiming (incl. legacy no-mode behaviour), v9→v10 migration (+idempotence), REST claim-route docker default, mode-filtered healthy-worker counting, `NoSuchKernel` categorization (plain + structured error).
- `tests/infrastructure` + `tests/cli` pass locally (~3000 tests); fast suite ran on the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SuSx44XggvW7m9Mjih3tkB
