### PR TITLE
fix(validate): run shared-cell + tag parity on single-file validate of a split half

### DIFF
--- a/changelog.d/validate-single-file-pair-parity.fixed.md
+++ b/changelog.d/validate-single-file-pair-parity.fixed.md
@@ -1,0 +1,9 @@
+- **`clm validate` on a single split half now runs the full cross-file pair
+  suite** when the twin exists on disk: shared-cell byte parity and tag-set
+  parity now run alongside the existing `slide_id` / voiceover `for_slide`
+  parity detectives (#162). Previously those two checks ran only at
+  directory/course scope, so `clm validate x.de.py` could report OK while the
+  pair's shared cells had silently diverged — producing divergent DE/EN build
+  output. `--quick` (the PostToolUse-hook path) still skips all cross-file
+  checks by design: it fires mid-edit, where transient pair divergence is
+  expected.

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1299,17 +1299,20 @@ count parity, per-pair tag/type consistency, and DE/EN adjacency) are
 split half legitimately carries cells of only one language, so these
 checks would otherwise report a false `DE/EN cell count mismatch` on every
 converted deck (issue #160). The per-file `slide_id` integrity checks (and
-the `format` / `tags` groups) still run on split files unchanged, and the
-cross-file shared-cell parity diff between a `.de.py` / `.en.py` pair is
-still applied when validating a directory or course spec. Since CLM
-{version} the cross-file **`slide_id` parity** check (issue #162) is applied
-the same way — and additionally on a single-file validate when the twin
-exists on disk, so the pre-commit gate and the PostToolUse path catch a
-divergent join key. The companion **`for_slide` parity** check (the
-both-language voiceover compatibility check) is applied alongside it, so a
-split deck's `voiceover_X.de.py` / `voiceover_X.en.py` companions can't
-silently narrate different slide sets. Bilingual decks (no `.de` / `.en`
-suffix) are unaffected — the full pairing check still runs.
+the `format` / `tags` groups) still run on split files unchanged. The
+cross-file pair checks — **shared-cell byte parity**, **tag-set parity**,
+the **`slide_id` parity** detective (issue #162), and the companion
+**`for_slide` parity** check (the both-language voiceover compatibility
+check) — run when validating a directory or course spec, and since CLM
+{version} the **full suite also runs on a single-file validate** when the
+twin exists on disk (previously only the two #162 detectives did), so a
+standalone `clm validate x.de.py` can no longer report OK while the pair's
+shared cells or tags have silently diverged. **`--quick` deliberately skips
+all cross-file checks**: it is designed for PostToolUse hooks that fire
+mid-edit, where transient pair divergence (DE edited, EN not yet synced) is
+expected — use a non-quick single-file, directory, or course validate to
+check pair parity. Bilingual decks (no `.de` / `.en` suffix) are
+unaffected — the full pairing check still runs.
 
 Since CLM {version}, the `tags` check group also verifies **workshop
 scope** (issue #78). The `partial` output kind leaves a workshop's code
@@ -2200,7 +2203,8 @@ clm slides unify slides_intro.de.py slides_intro.en.py --report-only
 
 Divergent shared cells fail with `error: shared cell content
 diverges …`. The same divergence is surfaced by
-`clm validate <topic_dir>` and refused at build time — see
+`clm validate <topic_dir>` (and, since CLM {version}, by a non-quick
+single-file `clm validate` on either half) and refused at build time — see
 "Split-source build routing" under `clm build` above for the
 build-time gate.
 

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -2171,8 +2171,9 @@ def validate_file(
             marker (#178, see ``marker_opt_in``).
         cross_file_parity: When ``True`` (the default for standalone callers —
             the CLI single-file path, MCP, the pre-commit gate) and ``path`` is
-            a split half whose twin exists on disk, run the #162 cross-file
-            parity detectives against the twin: ``slide_id`` set/order parity on
+            a split half whose twin exists on disk, run the full cross-file
+            pair suite against the twin: shared-cell byte parity and tag-set
+            parity, plus the #162 detectives — ``slide_id`` set/order parity on
             the deck, and ``for_slide`` set parity on the voiceover companions
             (the both-language voiceover compatibility check). Directory/course
             entrypoints pass ``False`` and run those once at their own scope
@@ -2218,8 +2219,8 @@ def validate_file(
     if "pairing" in check_set:
         # Split halves (``*.de.py`` / ``*.en.py``) carry a single language,
         # so the bilingual DE/EN count/adjacency checks don't apply — see
-        # _check_pairing (issue #160). Cross-file parity is validated by the
-        # directory/course entrypoints via _check_shared_cell_parity.
+        # _check_pairing (issue #160). Cross-file parity against the twin
+        # runs below when cross_file_parity is set.
         is_split = split_lang_suffix(path) is not None
         findings.extend(_check_pairing(cells, file_str, is_split=is_split))
         # A voiceover companion duplicated across both layouts (voiceover/ +
@@ -2234,13 +2235,18 @@ def validate_file(
         # has no DE/EN pairs to compare).
         if not is_split:
             findings.extend(_check_workshop_tag_symmetry(cells, file_str))
-        # #162 detective: when validating a split half standalone and its twin
-        # exists on disk, check cross-file slide_id parity (the join key). A
-        # directory/course run handles this once at that scope instead
-        # (cross_file_parity=False) so the finding is not duplicated per file.
+        # When validating a split half standalone and its twin exists on disk,
+        # run the full cross-file pair suite against the twin: shared-cell byte
+        # parity and tag-set parity (the directory/course pair checks), plus
+        # the #162 detectives — slide_id parity (the join key) and companion
+        # for_slide parity. A directory/course run handles all four once at
+        # that scope instead (cross_file_parity=False) so the findings are not
+        # duplicated per file.
         if cross_file_parity and is_split:
             pair = split_twin_pair(path)
             if pair is not None:
+                findings.extend(_check_shared_cell_parity(*pair))
+                findings.extend(_check_split_tag_parity(*pair))
                 findings.extend(_check_split_slide_id_parity(*pair))
                 findings.extend(_check_split_companion_for_slide_parity(*pair))
     if "code_export" in check_set and path.suffix == ".cpp":

--- a/tests/slides/test_validator.py
+++ b/tests/slides/test_validator.py
@@ -1530,6 +1530,134 @@ class TestSplitTagParity:
         result = validate_directory(topic, checks=["pairing"])
         assert self._tag_warnings(result) == []
 
+    def test_single_file_with_twin_catches_tag_mismatch(self, tmp_path):
+        # The single-file path (CLI standalone / MCP / pre-commit gate) runs
+        # tag parity against the twin, same as a directory run.
+        _write_slide(
+            tmp_path,
+            "slides_a.de.py",
+            """\
+            # %% [markdown] lang="de" tags=["subslide", "keep"] slide_id="vec"
+            # ## Vektoren
+            """,
+        )
+        _write_slide(
+            tmp_path,
+            "slides_a.en.py",
+            """\
+            # %% [markdown] lang="en" tags=["subslide"] slide_id="vec"
+            # ## Vectors
+            """,
+        )
+        result = validate_file(tmp_path / "slides_a.de.py", checks=["pairing"])
+        warnings = self._tag_warnings(result)
+        assert len(warnings) == 1
+        assert "only on DE: ['keep']" in warnings[0].message
+        # Symmetric: validating the EN half catches it too.
+        result_en = validate_file(tmp_path / "slides_a.en.py", checks=["pairing"])
+        assert len(self._tag_warnings(result_en)) == 1
+
+
+class TestSingleFileSharedCellParity:
+    """Shared-cell byte parity on the single-file validate path.
+
+    A standalone ``clm validate x.de.py`` (non-quick) runs the full cross-file
+    pair suite against the twin when it exists on disk — including the
+    shared-cell byte-parity check that previously ran only at directory/course
+    scope, so a green single-file validate could hide silently divergent
+    DE/EN build output.
+    """
+
+    @staticmethod
+    def _parity_errors(result):
+        return [
+            f
+            for f in result.findings
+            if f.severity == "error" and "shared cell" in f.message.lower()
+        ]
+
+    def _divergent_pair(self, parent):
+        _write_slide(
+            parent,
+            "slides_intro.de.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Einführung
+
+            # %% tags=["keep"]
+            x = 1
+            """,
+        )
+        _write_slide(
+            parent,
+            "slides_intro.en.py",
+            """\
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Introduction
+
+            # %% tags=["keep"]
+            x = 99
+            """,
+        )
+
+    def test_single_file_with_twin_catches_divergent_shared_cell(self, tmp_path):
+        self._divergent_pair(tmp_path)
+        result = validate_file(tmp_path / "slides_intro.de.py", checks=["pairing"])
+        assert len(self._parity_errors(result)) == 1
+        # Symmetric: validating the EN half catches it too.
+        result_en = validate_file(tmp_path / "slides_intro.en.py", checks=["pairing"])
+        assert len(self._parity_errors(result_en)) == 1
+
+    def test_single_file_identical_shared_cells_are_clean(self, tmp_path):
+        _write_slide(
+            tmp_path,
+            "slides_intro.de.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Einführung
+
+            # %% tags=["keep"]
+            x = 1
+            """,
+        )
+        _write_slide(
+            tmp_path,
+            "slides_intro.en.py",
+            """\
+            # %% [markdown] lang="en" tags=["slide"] slide_id="intro"
+            # ## Introduction
+
+            # %% tags=["keep"]
+            x = 1
+            """,
+        )
+        result = validate_file(tmp_path / "slides_intro.de.py", checks=["pairing"])
+        assert self._parity_errors(result) == []
+
+    def test_single_file_without_twin_is_silent(self, tmp_path):
+        p = _write_slide(
+            tmp_path,
+            "slides_intro.de.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="intro"
+            # ## Einführung
+
+            # %% tags=["keep"]
+            x = 1
+            """,
+        )
+        result = validate_file(p, checks=["pairing"])
+        assert self._parity_errors(result) == []
+
+    def test_quick_mode_still_skips_pair_checks(self, tmp_path):
+        # --quick (the PostToolUse hook path) deliberately excludes cross-file
+        # checks: it fires mid-edit, where transient divergence is expected.
+        from clm.slides.validator import validate_quick
+
+        self._divergent_pair(tmp_path)
+        result = validate_quick(tmp_path / "slides_intro.de.py")
+        assert self._parity_errors(result) == []
+
 
 class TestCheckOrdering:
     """DE/EN adjacency checks (canonical layout)."""


### PR DESCRIPTION
## Summary

A standalone `clm validate x.de.py` located the split twin and ran the #162 cross-file detectives (`slide_id` parity, voiceover `for_slide` parity) — but skipped **shared-cell byte parity** and **tag-set parity**, which only ran at directory/course scope. So a single-file validate could report **OK while the pair's shared cells had silently diverged**, producing divergent DE/EN build output — the exact failure the split format exists to prevent.

## Changes

- `validate_file`'s `cross_file_parity` branch now runs the **full pair suite** against the twin: `_check_shared_cell_parity` and `_check_split_tag_parity` alongside the two existing #162 detectives. The twin was already being read and parsed there, so the added cost is marginal.
- Directory/course runs are unchanged: they still pass `cross_file_parity=False` per file and report each pair finding exactly once at their own scope.
- `--quick` (the PostToolUse-hook path) **still skips all cross-file checks by design** — it fires mid-edit, where transient pair divergence (DE edited, EN not yet synced) is expected; a new test pins this.
- `clm info commands` updated to document the single-file pair suite and the `--quick` exclusion; changelog fragment added.

## Tests

- New `TestSingleFileSharedCellParity`: divergent shared cell caught from either half, identical shared cells clean, lone half silent, `--quick` still skips.
- New tag-parity single-file test mirroring the directory-scope #198 case.
- `tests/slides` + `tests/cli`: 3406 passed. Fast suite passed on the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARk244KWssRYfNGdmmd3pT
