### PR TITLE
fix(sync): frame one-sided id-keyed new cells translate_new, not verify_cold (#566)

### DIFF
--- a/changelog.d/566-one-sided-cold-translate-new.fixed.md
+++ b/changelog.d/566-one-sided-cold-translate-new.fixed.md
@@ -1,0 +1,13 @@
+- **Sync v3: a new one-sided *id-keyed* cell is now framed `translate_new` /
+  `copy_new_shared` in ledger mode, not a dead-end `verify_cold`.** Previously,
+  adding a slide (with a fresh `slide_id`) or an id-keyed shared code cell to one
+  language half of a ledgered deck reported the cell `verify_cold` — whose only
+  answer, `confirm`, `apply` rejects for a one-sided member ("cannot confirm a
+  one-sided member") — so the twin had to be hand-authored. The engine now
+  routes a one-sided un-ledgered *id-keyed* member to `translate_new` (answer
+  with the target-language body; the twin and shared `slide_id` are minted for
+  you) or `copy_new_shared` (mechanical verbatim copy). Two-sided cold members
+  still frame `verify_cold`. Un-id'd positional inserts stay `verify_cold`
+  because ordinal aliasing makes mechanical mirroring unsafe — mint a `slide_id`
+  to resolve. `clm info sync-agents` now documents the add-in-one-language flow
+  and the decision-`body` format. (#566)

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -85,11 +85,25 @@ One JSON document answers any subset of framed items:
 }
 ```
 
-- `body` — the produced text for translate/verify items. It is validated
-  through the accept-gates: a body smuggling a cell delimiter, touching the
-  wrong cell kind, or answering a stale handle is **rejected individually
-  with a reason** while every valid answer still lands. Nothing already
-  applied is lost.
+- `body` — the produced text for translate/verify items. **Format:** the cell
+  body *without* its `# %%` delimiter line, but *with* the jupytext `# `
+  comment prefixes on each line (a markdown cell is prefixed comment lines; a
+  code cell is bare source). A body carrying a delimiter line is rejected. For
+  a localized markdown slide whose source (DE) reads
+
+  ```
+  # %% [markdown] lang="de" slide_id="intro-motivation"
+  #
+  # # Motivation
+  ```
+
+  the `translate_new` answer that mints the EN twin is
+  `{"key": "id:intro-motivation", "body": "#\n# # Motivation (EN)"}` — note the
+  leading `#\n`, matching the source's comment lines, and no `# %%` line. Bodies
+  are validated through the accept-gates: a body smuggling a cell delimiter,
+  touching the wrong cell kind, or answering a stale handle is **rejected
+  individually with a reason** while every valid answer still lands. Nothing
+  already applied is lost.
 - `choice` — one of the item's `answers` (e.g. `confirm`, `de`, `en`).
 
 Feed it to `apply` (`-` reads stdin):
@@ -108,8 +122,9 @@ trusted.
 ## Cold members and `record`
 
 A brand-new checkout, a never-synced deck, or a deck whose ledger entries
-predate a fingerprint-function bump reports members as `verify_cold`. Two
-ways to converge:
+predate a fingerprint-function bump reports **two-sided** members (both halves
+present) as `verify_cold` — the engine will not silently trust a pair it has
+never recorded. Two ways to converge:
 
 - **Per item**: answer `{"key": …, "choice": "confirm"}` in a decision
   document after you have checked the pair is genuinely in sync. Pool-scoped
@@ -122,6 +137,26 @@ ways to converge:
 
 `clm slides split` and `clm slides translate` record freshly-created pairs
 automatically, so a normal authoring flow starts warm.
+
+## Adding a slide in one language (the twin does not exist yet)
+
+Author a new cell on one half only — a new markdown slide (with a fresh
+`slide_id`) or a new **id-keyed** shared code cell — and `report` frames it so
+the engine grows the missing twin; you never hand-author both halves:
+
+- A new **localized** cell (or a per-language header) → `translate_new`. Answer
+  with the target-language `body`; `apply` inserts the twin and mints the
+  shared `slide_id` on it.
+- A new **shared** id-keyed cell → `copy_new_shared` (mechanical). `apply`
+  copies it verbatim to the twin — no answer needed.
+
+This works because the `slide_id` lets `apply` place the twin unambiguously. A
+new **un-id'd positional** cell (a `# %%` code cell with no `slide_id`) inserted
+among existing cells is instead reported `verify_cold`: its ordinal aliases a
+*different* cell on the other half, so the engine cannot mirror it mechanically.
+**Mint a `slide_id`** on the new cell (e.g. `clm slides assign-ids`, or add one
+by hand) and re-`report` — it then frames `translate_new` / `copy_new_shared`
+and the twin is created for you.
 
 ## The forensic window — `report --since`
 

--- a/src/clm/slides/sync_diff.py
+++ b/src/clm/slides/sync_diff.py
@@ -647,7 +647,14 @@ class _Differ:
         """A current member with no base entry: add (snapshot) / cold (ledger)."""
         assert self.base is not None
         handle = member.key.render()
-        if not self.base.complete:
+        if not self.base.complete and not member.is_one_sided:
+            # A two-sided member with no ledger entry is COLD (design §5):
+            # confirm records trust, and both sides are present to confirm.
+            # A ONE-SIDED un-ledgered member is an insert that still needs a
+            # twin, so it must fall through to the translate_new / copy_new_shared
+            # branches below even in ledger mode — verify_cold offers only
+            # `confirm`, which apply rejects for a one-sided member, leaving no
+            # decision-document path to resolve it (issue #566).
             self.emit(
                 handle,
                 "unverified",
@@ -2176,9 +2183,15 @@ class _Differ:
 
         assert self.base is not None
         if not self.base.complete:
-            # Ledger mode: a pos member with no entry is COLD, never a
-            # mechanical add/copy (design §5 — the id-keyed path's rule,
-            # mirrored here).
+            # Ledger mode: a POSITIONAL (un-id'd) member with no entry is COLD,
+            # never a mechanical add/copy (design §5). Unlike the id-keyed path
+            # (which frames a one-sided insert translate_new / copy_new_shared,
+            # issue #566), a positional one-sided insert cannot be mirrored
+            # mechanically: ordinal aliasing pairs it with a *different* twin
+            # cell at the same slot, so the executor cannot locate the empty
+            # target — mint a slide_id to resolve it (the id-keyed path then
+            # grows the twin). Framing it cold keeps apply from emitting an
+            # unappliable mechanical row.
             for member in {id(m): m for m in matched_pairs + de_solo + en_solo}.values():
                 self.emit(
                     member.key.render(),

--- a/tests/slides/test_doc_apply.py
+++ b/tests/slides/test_doc_apply.py
@@ -168,23 +168,82 @@ class TestMechanicalRows:
         assert deck.de_path.read_text(encoding="utf-8") == before
         deck.assert_converged()
 
-    def test_a_brand_new_member_is_cold_in_ledger_mode(self, tmp_path: Path):
-        # Design §5: a member with no ledger entry is UNVERIFIED, never a
-        # mechanical copy — the agent confirms (or records) it explicitly.
+    def test_two_sided_brand_new_member_is_cold_in_ledger_mode(self, tmp_path: Path):
+        # Design §5: a TWO-sided member with no ledger entry is UNVERIFIED, never
+        # a mechanical copy — both sides are present, so the agent confirms (or
+        # records) it explicitly rather than the engine trusting it silently.
         deck = _deck(tmp_path)
+        new = _shared_code("z", 9)  # new, between x and y — added on BOTH sides
         deck.write_de(
             HEADER_DE,
             _slide("s0", "de", "Titel"),
             _shared_code("x"),
-            _shared_code("z", 9),  # new, between x and y
+            new,
             _shared_code("y", 2),
             _localized("s0-m", "de", "DE Text"),
+        )
+        deck.write_en(
+            HEADER_EN,
+            _slide("s0", "en", "Title"),
+            _shared_code("x"),
+            new,
+            _shared_code("y", 2),
+            _localized("s0-m", "en", "EN text"),
         )
         _, diff = deck.diff()
         assert [(i.action) for i in diff.items] == ["verify_cold"]
         outcome = deck.apply()
         assert not outcome.wrote
         assert outcome.count("pending") == 1
+
+    def test_one_sided_new_idd_shared_cell_grows_the_twin_in_ledger_mode(self, tmp_path: Path):
+        # issue #566: a ONE-sided new *id-keyed* shared cell in a ledgered deck
+        # is copy_new_shared (mechanical verbatim copy to the twin), NOT a
+        # verify_cold dead end — verify_cold's only answer, `confirm`, is
+        # rejected for a one-sided member, so it could never be resolved. The
+        # slide_id lets the executor place the twin (positional inserts alias).
+        deck = _deck(tmp_path)
+        idd = '# %% tags=["keep"] slide_id="z-cell"\nz = 9\n\n'
+        deck.write_de(
+            HEADER_DE,
+            _slide("s0", "de", "Titel"),
+            _shared_code("x"),
+            idd,  # new on DE only, between x and y
+            _shared_code("y", 2),
+            _localized("s0-m", "de", "DE Text"),
+        )
+        _, diff = deck.diff()
+        assert [i.action for i in diff.items] == ["copy_new_shared"]
+        outcome = deck.apply()
+        assert outcome.all_applied, outcome.to_payload()
+        en = deck.en_path.read_text(encoding="utf-8")
+        assert en.index("x = 1") < en.index("z = 9") < en.index("y = 2")
+        assert 'slide_id="z-cell"' in en
+        deck.assert_converged()
+
+    def test_one_sided_new_localized_slide_translates_into_the_twin(self, tmp_path: Path):
+        # issue #566 headline path: add a slide in one language, answer
+        # translate_new with the target-language body, and the engine mints the
+        # twin (with the shared slide_id) — no hand-authoring of both halves.
+        deck = _deck(tmp_path)
+        deck.write_de(
+            HEADER_DE,
+            _slide("s0", "de", "Titel"),
+            _shared_code("x"),
+            _shared_code("y", 2),
+            _localized("s0-n", "de", "Neu"),  # new localized slide, DE only
+            _localized("s0-m", "de", "DE Text"),
+        )
+        _, diff = deck.diff()
+        assert [(i.action, i.direction) for i in diff.items] == [("translate_new", "de_to_en")]
+        item = diff.items[0]
+        outcome = deck.apply(decisions={item.key: doc_apply.Decision(item.key, body="# New")})
+        assert outcome.all_applied, outcome.to_payload()
+        en = deck.en_path.read_text(encoding="utf-8")
+        assert 'slide_id="s0-n"' in en
+        assert "# New" in en
+        assert en.index("# New") < en.index("# EN text")
+        deck.assert_converged()
 
     def test_copy_new_shared_completes_a_recorded_pending_twin(self, tmp_path: Path):
         deck = _deck(tmp_path)
@@ -406,12 +465,18 @@ class TestDecisions:
         deck.assert_converged()
 
     def test_confirm_on_a_one_sided_member_is_rejected(self, tmp_path: Path):
+        # issue #566: a one-sided new member is framed translate_new (grow the
+        # twin), not verify_cold — so `confirm` is not a valid answer for it and
+        # is rejected at the vocabulary gate. The agent supplies a `body`
+        # instead; there is no confirm-a-one-sided-member dead end anymore.
         deck = _deck(tmp_path)
         deck.write_de(*DE_PARTS, _localized("s0-new", "de", "Neu"))
+        _, diff = deck.diff()
+        assert [(i.key, i.action) for i in diff.items] == [("id:s0-new", "translate_new")]
         outcome = deck.apply(_decision("id:s0-new", choice="confirm"))
         result = next(r for r in outcome.results if r.key == "id:s0-new")
         assert result.status == "rejected"
-        assert "one-sided" in result.reason
+        assert "translate_new" in result.reason
 
     def test_remove_vs_edit_keep_readds_the_survivor(self, tmp_path: Path):
         deck = _deck(tmp_path)

--- a/tests/slides/test_sync_diff.py
+++ b/tests/slides/test_sync_diff.py
@@ -920,6 +920,48 @@ class TestAdversarialReviewRegressions:
         assert {i.action for i in diff.items} == {"verify_cold"}
         assert {i.outcome for i in diff.items} == {"unverified"}
 
+    def test_ledger_mode_one_sided_localized_add_is_translate_new_not_cold(self):
+        """issue #566: a NEW one-sided localized cell in a ledgered deck must be
+        framed ``translate_new`` (grow the twin), NOT ``verify_cold`` — whose
+        only answer, ``confirm``, apply rejects for a one-sided member, leaving
+        no decision-document path to resolve it. Two-sided cold members stay
+        ``verify_cold`` (both sides present to confirm)."""
+        base = _snapshot(DE0, EN0)
+        base.complete = False
+        de = DE0.replace(
+            '# %% [markdown] lang="de" slide_id="s0-m"',
+            _localized("s0-n", "de", "Neu").rstrip("\n") + "\n\n"
+            '# %% [markdown] lang="de" slide_id="s0-m"',
+        )
+        item = _only_item(_diff(base, de, EN0))  # EN unchanged → one-sided
+        assert (item.outcome, item.action) == ("add", "translate_new")
+        assert item.direction == "de_to_en"
+        assert item.key == "id:s0-n"
+
+    def test_ledger_mode_one_sided_idd_shared_add_is_copy_new_shared_not_cold(self):
+        """issue #566: a NEW one-sided *id-keyed* shared code cell in a ledgered
+        deck is ``copy_new_shared`` (verbatim to the twin), not a ``verify_cold``
+        dead end. (An un-id'd positional insert stays cold — ordinal aliasing
+        makes mechanical mirroring unsafe; mint a slide_id to resolve it.)"""
+        base = _snapshot(DE0, EN0)
+        base.complete = False
+        new = '# %% tags=["keep"] slide_id="z-cell"\nz = 9\n\n'
+        de = DE0.replace('# %% tags=["keep"]\nx = 1', new + '# %% tags=["keep"]\nx = 1')
+        item = _only_item(_diff(base, de, EN0))  # EN unchanged → one-sided
+        assert (item.outcome, item.action) == ("add", "copy_new_shared")
+        assert item.direction == "de_to_en"
+        assert item.key == "id:z-cell"
+
+    def test_ledger_mode_one_sided_unidd_positional_add_stays_cold(self):
+        """Un-id'd positional one-sided insert in a ledgered deck stays
+        ``verify_cold``: it cannot be mechanically mirrored (ordinal aliasing),
+        so the engine keeps it cold rather than emit an unappliable copy."""
+        base = _snapshot(DE0, EN0)
+        base.complete = False
+        de = DE0.replace('# %% tags=["keep"]\nx = 1', '# %%\nnew = 0\n\n# %% tags=["keep"]\nx = 1')
+        item = _only_item(_diff(base, de, EN0))
+        assert item.action == "verify_cold"
+
     def test_slide_id_containing_slash_does_not_crash(self):
         """MAJOR: '/' is legal in slide ids; pos-key parsing must rsplit."""
         de = _build(


### PR DESCRIPTION
Fixes #566.

## Problem

Driving the v3 sync engine in ledger mode, a brand-new cell added to **one**
language half of a ledgered deck was framed `verify_cold` (answers
`['confirm']`). But `apply` categorically rejects a `confirm` on a one-sided
member:

> cannot confirm a one-sided member — supply the twin first (translate/edit)

So the documented headline path — *add a slide in one language, let sync
translate-and-insert it* — was an unresolvable dead end via the decision
document: the human had to hand-author the twin, exactly the manual step the
engine exists to remove.

## Root cause

`_diff_unmatched_current` (`sync_diff.py`) short-circuits on `not base.complete`
and emits `verify_cold` for **every** un-ledgered member, *before* reaching the
`translate_new` / `copy_new_shared` branches (those only ran in snapshot mode).
The §5 "un-ledgered → cold" rule is correct for a **two-sided** member (confirm
records trust; both sides are present to confirm) but a trap for a **one-sided**
one: `verify_cold`'s only answer is `confirm`, which is unsatisfiable for a
one-sided member.

## Fix (Option A, scoped to id-keyed members)

Gate the short-circuit on `not member.is_one_sided`. A one-sided un-ledgered
**id-keyed** member now falls through to the existing, already-correct branches
even in ledger mode:

- new **localized** cell / per-language header → `translate_new` (answer with
  the target-language `body`; `apply` inserts the twin + mints the shared
  `slide_id`);
- new **shared** id-keyed cell → `copy_new_shared` (mechanical verbatim copy).

Two-sided cold members still frame `verify_cold`.

**Positional (un-id'd) inserts deliberately stay `verify_cold`.** An un-id'd
`# %%` cell inserted among existing cells aliases a *different* twin cell at the
same ordinal, so `copy_new_shared` cannot be applied mechanically (the executor
can't locate the empty target). The fix keeps that path cold and the docs now
tell the agent to **mint a `slide_id`** to resolve — which routes it through the
id-keyed path.

## Docs (`clm info sync-agents`)

- New "Adding a slide in one language" section describing the flow and the
  mint-an-id resolution for positional inserts.
- Documented the decision `body` format (no `# %%` delimiter, keeps `# `
  jupytext prefixes) with a worked `translate_new` example — issue's minor #2.
- Clarified the "Cold members" section applies to two-sided members.

The downstream `slide-authoring.md` (course repo, not in clm) should be
reconciled to match; the canonical `clm info sync-agents` topic is updated here.

## Tests

- `test_sync_diff.py`: one-sided localized add → `translate_new`; one-sided
  id-keyed shared add → `copy_new_shared`; one-sided **un-id'd positional** add
  stays `verify_cold`.
- `test_doc_apply.py`: end-to-end round-trips proving the twin is created
  (localized `translate_new` with a body; id-keyed `copy_new_shared`);
  reworked the former `verify_cold` tests into a two-sided (§5-preserving) case
  and updated the one-sided confirm-rejection test to the new framing.

Fast suite green locally; full `tests/slides/` + `test_sync_v3_cli.py` (1627)
green.

## Deferred (issue's minor #1)

The "one-sided edit forces re-supplying the unchanged twin body" ergonomics
item (a `keep_twin` answer for `translate_edit`) is filed as a separate
follow-up rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBnsFy85xjoxgLpEJCaYWB