### PR TITLE
feat(sync): add keep_twin answer for translate_edit (#566 follow-up)

### DIFF
--- a/changelog.d/566-keep-twin-translate-edit.added.md
+++ b/changelog.d/566-keep-twin-translate-edit.added.md
@@ -1,0 +1,6 @@
+- **Sync v3: a `translate_edit` item now accepts a `keep_twin` answer.** When a
+  one-sided edit leaves the other language's cell a faithful rendering (e.g. you
+  refined the German prose and the English is already correct), answer
+  `{"key": …, "choice": "keep_twin"}` to record the new baseline and keep the
+  twin verbatim — instead of re-supplying the unchanged twin body as a `body`
+  answer. Documented in `clm info sync-agents`. (#566)

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -64,12 +64,13 @@ for framed items — an **`answers` list naming exactly the decision shapes
 fork/unify/id-stamp transitions. Trust them; review with `git diff`.
 
 **Framed actions** (answer them): `translate_edit` / `translate_new` (produce
-the target-language body), `verify_translation` (both sides moved — confirm
-or supply a body), `conflict_shared` / `remove_vs_edit` / `unify_choose_body`
-/ `order_decision` / `conflict_preamble` (choose a side), `verify_cold`
-(confirm the member is genuinely in sync), `ambiguous_alignment` (mint ids /
-choose), and the normalize-refusal deck item (run `clm slides normalize`,
-then re-report).
+the target-language body — or answer `translate_edit` with `keep_twin` when
+your edit did not change what the twin should say), `verify_translation` (both
+sides moved — confirm or supply a body), `conflict_shared` / `remove_vs_edit`
+/ `unify_choose_body` / `order_decision` / `conflict_preamble` (choose a side),
+`verify_cold` (confirm the member is genuinely in sync), `ambiguous_alignment`
+(mint ids / choose), and the normalize-refusal deck item (run
+`clm slides normalize`, then re-report).
 
 ## The decision document
 
@@ -104,7 +105,10 @@ One JSON document answers any subset of framed items:
   touching the wrong cell kind, or answering a stale handle is **rejected
   individually with a reason** while every valid answer still lands. Nothing
   already applied is lost.
-- `choice` — one of the item's `answers` (e.g. `confirm`, `de`, `en`).
+- `choice` — one of the item's `answers` (e.g. `confirm`, `de`, `en`,
+  `keep_twin`). For a `translate_edit` whose edit left the twin a faithful
+  rendering, `{"key": …, "choice": "keep_twin"}` records the new baseline and
+  keeps the existing twin verbatim — no need to re-supply an unchanged body.
 
 Feed it to `apply` (`-` reads stdin):
 

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -109,7 +109,7 @@ class Decision:
 #: shapes each accepts. Everything else is agent-manual in Phase 3: edit the
 #: files, re-run ``report``, then ``record``.
 _DECISION_VOCABULARY: dict[str, tuple[str, ...]] = {
-    "translate_edit": ("body",),
+    "translate_edit": ("body", "keep_twin"),
     "translate_new": ("body",),
     "verify_translation": ("confirm",),
     "verify_cold": ("confirm",),
@@ -1036,6 +1036,19 @@ def _apply_choice_decision(ex: _Executor, item: DiffItem, choice: str) -> None:
                 f"{item.key} names no removed side — reconcile manually (edit + record)"
             )
         ex.copy_new(item, _other(item.side))
+        return
+    if choice == "keep_twin":
+        # translate_edit only: the edited side did not change what the twin
+        # should say, so record the new (edited) baseline and keep the existing
+        # twin verbatim instead of re-supplying an unchanged body. A
+        # translate_edit member always carries both sides; nothing mutates — a
+        # pure ledger record, like confirm (issue #566, minor #1).
+        de_holder = ex._holder(item, "de")
+        en_holder = ex._holder(item, "en")
+        de_cell = de_holder.side("de") if de_holder is not None else None
+        en_cell = en_holder.side("en") if en_holder is not None else None
+        if de_cell is None or en_cell is None:
+            raise _ItemError("keep_twin needs both sides present — supply the twin body instead")
         return
     raise _ItemError(f"unsupported choice {choice!r}")
 

--- a/tests/slides/test_doc_apply.py
+++ b/tests/slides/test_doc_apply.py
@@ -414,6 +414,21 @@ class TestDecisions:
         assert "# EN text NEW" in deck.en_path.read_text(encoding="utf-8")
         deck.assert_converged()
 
+    def test_translate_edit_keep_twin_records_without_retyping(self, tmp_path: Path):
+        # issue #566 (minor #1): a one-sided prose edit whose twin is still a
+        # faithful rendering is accepted with keep_twin — the new baseline is
+        # recorded and the twin kept verbatim, with no unchanged body re-typed.
+        deck = _deck(tmp_path)
+        deck.edit_de("DE Text", "DE Text (verfeinert)")
+        _, diff = deck.diff()
+        assert [(i.key, i.action) for i in diff.items] == [("id:s0-m", "translate_edit")]
+        en_before = deck.en_path.read_text(encoding="utf-8")
+        outcome = deck.apply(_decision("id:s0-m", choice="keep_twin"))
+        assert outcome.all_applied, outcome.to_payload()
+        assert not outcome.wrote  # the twin is untouched; only the ledger moves
+        assert deck.en_path.read_text(encoding="utf-8") == en_before
+        deck.assert_converged()
+
     def test_conflict_choice_propagates_the_chosen_side(self, tmp_path: Path):
         deck = _deck(tmp_path)
         deck.edit_de("x = 1", "x = 111")


### PR DESCRIPTION
Follow-up to #567 (issue #566, minor item #1).

## Problem

When a one-sided edit leaves the other language's cell a still-faithful
rendering — e.g. you refine the German prose while the English is already
correct — the engine frames `translate_edit direction=de_to_en` and asks for
the EN `body`. The only way to record the new baseline was to paste the
**unchanged** English back, just to re-establish the trusted pair.

## Fix

Add a `keep_twin` choice to `translate_edit`'s decision vocabulary:

```json
{"key": "id:s0-m", "choice": "keep_twin"}
```

It records the new (edited) baseline and keeps the existing twin verbatim — a
pure ledger record, mutating nothing (like `confirm`, but valid for a
one-sided edit). The next report reads clean; no unchanged body is re-typed.

## Docs (`clm info sync-agents`)

- Framed-actions line and the `choice` bullet now name `keep_twin` and explain
  when to use it.

## Tests

- `test_doc_apply.py`: a DE-only prose edit answered with `keep_twin` applies,
  writes nothing, leaves EN byte-identical, and converges.

Full `tests/slides/` + `test_sync_v3_cli.py` + `test_info.py` (1643) green;
fast pre-push suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBnsFy85xjoxgLpEJCaYWB