### PR TITLE
fix(sync): mint missing EN voiceover companion from translate_new (#570)

### DIFF
--- a/changelog.d/570-companion-translate-new-writepath.fixed.md
+++ b/changelog.d/570-companion-translate-new-writepath.fixed.md
@@ -1,0 +1,13 @@
+- `clm slides sync apply` can now create a missing separated **EN voiceover
+  companion** from a `translate_new` decision. A one-sided (DE-only) companion
+  — the state `clm harvest accept` leaves when the EN twin is deferred — is
+  framed `translate_new` by `report`, but `apply` previously rejected every
+  member with `the en source cell of id:<slide-id> is missing`: the executor
+  derived the translation *target* from the framed item's `side`, whose meaning
+  differed between the reporters (a *standing* one-sided member reports the
+  *missing* side, a fresh add reports the *present* side), inverting the
+  direction. `translate_new` now mints the absent twin from the member itself,
+  so answering with the EN `body` writes `voiceover/voiceover_x.en.py` (minting
+  the shared `slide_id`/`for_slide`) and leaves the EN deck untouched — the
+  documented harvest → sync handoff closes through the ordinary loop instead of
+  requiring the companion to be hand-authored ([#570](https://github.com/hoelzl/clm/issues/570)).

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -187,6 +187,16 @@ inconsistently across languages) is **refused** with a normalize hint
 (`clm voiceover inline` / `extract`). An orphaned companion cell is refused
 rather than dropped.
 
+A **one-sided (DE-only) separated voiceover companion** — the state left by
+`clm harvest accept` when the EN twin is deferred, i.e. the deck twin
+(`slides_x.en.py`) already exists but `voiceover/voiceover_x.en.py` does not —
+is framed `translate_new` (`direction: de_to_en`, answer with the EN `body`).
+Answering `apply` with that `body` **creates the missing EN companion file**
+and writes the cell (minting the shared `slide_id`/`for_slide`, same as harvest
+mints cells); the EN deck stays untouched — narration remains in the companion.
+No hand-authoring of `voiceover_x.en.py` is needed: the documented harvest →
+sync handoff closes through the ordinary loop.
+
 ## Non-shell agents — the MCP tool
 
 `slides_sync_report` (MCP) returns the same schema-3 pair payload as

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -875,7 +875,10 @@ def _drop_unresolved_from_pools(
 
 
 def _decision_target_side(item: DiffItem) -> Lang:
-    """The side a body answer lands on: the twin of the moved/present side."""
+    """The side a ``translate_edit`` body answer lands on: the twin of the
+    moved/present side. (``translate_new`` derives its target from the
+    one-sided member directly — see :func:`_apply_body_decision` — because the
+    reporters set ``side`` inconsistently for that action, #570.)"""
     if item.side is not None:
         return _other(item.side)
     if item.member is not None and item.member.is_one_sided:
@@ -920,13 +923,20 @@ def _apply_body_decision(ex: _Executor, item: DiffItem, body: str) -> None:
     if item.action == "translate_new":
         if member is None:
             raise _ItemError("item carries no member")
-        target = _decision_target_side(item)
+        # A ``translate_new`` mints the *absent* twin, so the target is the
+        # member's missing side — derived from the member itself, never from
+        # ``item.side``. The reporters disagree on what ``side`` means here
+        # (``_classify_new`` sets the present side; ``_classify_localized`` /
+        # ``_classify_fork`` set the missing side), so trusting it inverts the
+        # direction for a standing one-sided member — the harvest → sync handoff
+        # for a separated voiceover companion (issue #570).
+        if not member.is_one_sided:
+            raise _ItemError("cannot mint a twin: both sides already exist — answer with a choice")
+        target = "de" if member.de is None else "en"
         source = _other(target)
         source_cell = member.side(source)
         if source_cell is None:
             raise _ItemError(f"the {source} source cell of {item.key} is missing")
-        if member.side(target) is not None:
-            raise _ItemError(f"the {target} side of {item.key} already exists")
         header = (
             swap_lang(source_cell.header, target) if source_cell.lang_attr else (source_cell.header)
         )

--- a/src/clm/slides/sync_diff.py
+++ b/src/clm/slides/sync_diff.py
@@ -1282,7 +1282,11 @@ class _Differ:
             return
         if member.is_one_sided:
             # The side was already missing at base: still a pending twin.
+            # ``side`` names the side that *exists* (the translate source),
+            # consistent with the other ``translate_new`` emitters; the
+            # executor mints the absent twin from the member itself (#570).
             missing: Lang = "de" if member.de is None else "en"
+            present: Lang = "en" if missing == "de" else "de"
             self.emit(
                 handle,
                 "add",
@@ -1290,7 +1294,7 @@ class _Differ:
                 "en_to_de" if missing == "de" else "de_to_en",
                 f"the {missing} twin body is still pending",
                 group=group,
-                side=missing,
+                side=present,
                 member=member,
                 base=entry,
             )
@@ -1511,7 +1515,9 @@ class _Differ:
                 "en_to_de" if missing == "de" else "de_to_en",
                 f"fork of a shared member: the {missing} variant body is missing",
                 group=group,
-                side=missing,
+                # ``side`` names the side that exists (the translate source),
+                # consistent with the other ``translate_new`` emitters (#570).
+                side=marked,
                 member=member,
                 base=entry,
             )

--- a/tests/slides/test_doc_apply.py
+++ b/tests/slides/test_doc_apply.py
@@ -347,6 +347,73 @@ class TestMechanicalRows:
 
 
 # ---------------------------------------------------------------------------
+# Separated voiceover companions (issue #570)
+# ---------------------------------------------------------------------------
+
+
+def _vo_cell(slug: str, for_slide: str, lang: str, text: str) -> str:
+    return (
+        f'# %% [markdown] lang="{lang}" tags=["voiceover"] '
+        f'slide_id="{slug}" for_slide="{for_slide}"\n#\n# - {text}\n\n'
+    )
+
+
+class TestSeparatedVoiceoverCompanion:
+    """The harvest → sync handoff: ``clm harvest accept`` writes a one-sided
+    (DE-only) separated voiceover companion and records it, deferring the EN
+    twin. The ordinary sync loop must then be able to *create* the missing EN
+    companion — ``report`` frames each DE-only cell ``translate_new`` and
+    ``apply`` with a target-language body mints the companion file. Before the
+    fix the executor inverted the direction and rejected every member with
+    ``the en source cell … is missing``.
+    """
+
+    def _companion_deck(self, tmp_path: Path) -> _Deck:
+        """A split deck whose only voiceover lives in a DE-only companion in the
+        ``voiceover/`` subdir — the state left by ``harvest accept`` DE-only."""
+        de = _build(HEADER_DE, _slide("s0", "de", "Titel"))
+        en = _build(HEADER_EN, _slide("s0", "en", "Title"))
+        deck = _Deck(tmp_path, de, en)
+        vo_dir = tmp_path / "voiceover"
+        vo_dir.mkdir()
+        (vo_dir / "voiceover_t.de.py").write_text(
+            _build(_vo_cell("s0-vo", "s0", "de", "Hallo Welt")), encoding="utf-8"
+        )
+        deck.record()  # baseline knows the standing one-sided companion cell
+        return deck
+
+    def test_report_frames_de_only_companion_translate_new(self, tmp_path: Path):
+        deck = self._companion_deck(tmp_path)
+        _, diff = deck.diff()
+        assert [(i.action, i.direction, i.key) for i in diff.items] == [
+            ("translate_new", "de_to_en", "id:s0-vo")
+        ]
+        # ``side`` names the side that exists (the translate source), uniformly
+        # across the translate_new emitters (the normalized convention).
+        assert diff.items[0].side == "de"
+
+    def test_apply_mints_the_missing_en_companion(self, tmp_path: Path):
+        deck = self._companion_deck(tmp_path)
+        _, diff = deck.diff()
+        item = diff.items[0]
+        outcome = deck.apply(
+            decisions={item.key: doc_apply.Decision(item.key, body="# - Hello World")}
+        )
+        assert outcome.all_applied, outcome.to_payload()
+
+        en_comp = tmp_path / "voiceover" / "voiceover_t.en.py"
+        assert en_comp.exists(), "the EN companion file was not created"
+        en_text = en_comp.read_text(encoding="utf-8")
+        assert 'lang="en"' in en_text
+        assert 'slide_id="s0-vo"' in en_text
+        assert 'for_slide="s0"' in en_text
+        assert "Hello World" in en_text
+        # The EN *deck* is untouched — narration stays in the companion.
+        assert "voiceover" not in deck.en_path.read_text(encoding="utf-8")
+        deck.assert_converged()
+
+
+# ---------------------------------------------------------------------------
 # Per-item independence and safety
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #570. After `clm harvest accept` writes a **one-sided (DE-only) separated
voiceover companion**, `clm slides sync` had no working write-path to create the
EN companion: `report` framed each DE-only voiceover cell `translate_new`, but
`apply --decisions` rejected every member with
`the en source cell of id:<slide-id> is missing`.

## Root cause

The executor derived the translation *target* from the framed item's `side`,
whose meaning **differs across the reporters**:

| Reporter | `side` set to |
|---|---|
| `_classify_new` (fresh add) | the **present** side |
| `_classify_localized` (standing pending twin) | the **missing** side |
| `_classify_fork` (one-sided fork) | the **missing** side |

`_decision_target_side` assumed the present-side convention (`return _other(side)`),
so for a **standing** one-sided member — exactly the harvest → sync handoff, where
the baseline already records the DE cell — it aimed the EN body at the DE side and
then failed looking for a non-existent EN source cell.

The existing headline test passed only because it exercises the *fresh-add*
(`_classify_new`) path; the bug is invisible until a one-sided member has been
blessed once, which is what `harvest accept` does.

## Fix

- `translate_new` now mints the absent twin from the **member itself** (target =
  the member's missing side), never from the ambiguous `side`. Answering with the
  EN `body` creates `voiceover/voiceover_x.en.py` (minting the shared
  `slide_id`/`for_slide`, same as harvest mints cells) and leaves the EN deck
  untouched — narration stays in the companion. A `translate_new` on a two-sided
  member is refused with a clear message.
- The three `translate_new` emitters are **normalized** to set `side` to the side
  that *exists*, so the field carries one coherent meaning (the executor no longer
  depends on it for this action).

## Tests / docs

- New `TestSeparatedVoiceoverCompanion` in `test_doc_apply.py`: report frames the
  DE-only companion `translate_new`; apply mints the EN companion file with the
  right `slide_id`/`for_slide`/`lang`, leaves the EN deck untouched, and a fresh
  diff **converges clean**.
- `clm info sync-agents` companion section documents the harvest → sync handoff
  now closing through the ordinary loop.
- Changelog fragment `changelog.d/570-companion-translate-new-writepath.fixed.md`.

Verified locally: `tests/slides/` + the sync CLI suites — 1695 passed, 5 skipped.
ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UzS8a3VTrfnH8eM38ckndg
