### PR TITLE
feat(sync): add clm slides rename-id for warm slide_id renames (#572)

### DIFF
--- a/changelog.d/572-rename-id.added.md
+++ b/changelog.d/572-rename-id.added.md
@@ -1,0 +1,12 @@
+- **`clm slides rename-id DECK OLD NEW`** — rename a `slide_id` across both
+  halves of a split deck **and** the committed sync ledger, atomically. Renaming
+  a `slide_id` by hand dropped the member's v3 ledger baseline to *cold* (the
+  engine keys trust by `id:<slide_id>` and only recovers `pos: → id:`
+  migrations), so a cell renamed **and** edited in one go reported `verify_cold`
+  — whose only answer, `confirm`, banks the existing, now-stale twin. The new
+  command rewrites the id (and every `for_slide` owner reference) on both halves
+  and *migrates* the ledger baseline key (carrying the recorded fingerprints,
+  never re-hashing): a pure rename then reports clean, and a rename done
+  alongside an edit reports `translate_edit` against the carried baseline, so the
+  stale twin can never be confirmed unnoticed. Refuses a rename that would create
+  a duplicate id. See `clm info commands` / `clm info sync-agents`. (#572)

--- a/docs/claude/handovers/issue-572-cold-ledger-handover.md
+++ b/docs/claude/handovers/issue-572-cold-ledger-handover.md
@@ -1,0 +1,82 @@
+# Issue #572 — cold-ledger stale-twin — handover
+
+**Status:** plan approved; implementing as two PRs. PR 1 = Phase A
+(`clm slides rename-id`). PR 2 = Phase B (`body`/`keep_twin` on id-keyed
+two-sided `verify_cold`) + Phase C-3a (reworded cold detail).
+
+**Issue:** On a split DE/EN deck whose per-topic ledger is cold for the current
+`slide_id`s, an id-keyed cell whose EN source was **edited** is framed
+`verify_cold` (only answer `confirm`). `confirm` banks the stale DE twin as the
+baseline; `sync verify` + `clm validate` pass. Silent stale-translation ship.
+
+## Decision (post 3-way adversarial review)
+
+The tempting fix — teach the differ to auto-migrate an `id→id` rename by
+content fingerprint — was **rejected**. It fights v3's *total identity /
+monotone ids* invariant (the only sanctioned key migration is `pos→id`, on
+purpose; "inference is out"), and fingerprint collisions on boilerplate/blank/
+short cells (which are the norm in CLM decks) make a single-side match
+mis-migrate genuinely-new cells — a *new* silent-failure class. A freshness
+check cannot exist on a cold cell anyway (no baseline by construction).
+
+**Approved approach:**
+
+- **Phase A (PR 1) — `clm slides rename-id <old> <new>`**: atomically rewrite
+  the `slide_id` on both halves AND migrate the ledger baseline key
+  (`id:old → id:new`). Design-consistent: keeps identity total across a
+  deliberate rename, so a later edit frames `translate_edit` against a live
+  baseline. This removes the footgun the issue's repro walks into.
+- **Phase B (PR 2) — `body`/`keep_twin` on id-keyed two-sided `verify_cold`**:
+  one-pass recovery for decks *already* cold. Scoped to id-keyed only
+  (positional path can't target a body — it drops the EN partner). Requires a
+  `Decision.side` schema addition and a fix to the pool-coherence guard.
+- **Phase C-3a (PR 2) — reword the cold detail** to state `confirm`/`keep_twin`
+  banks the twin as-is, no freshness guarantee. Drop `--strict-cold` (it buys
+  nothing: `keep_twin ≡ confirm` in ledger effect).
+- **NOT shipping:** fingerprint auto-migration (old Phase 1 / Phase D) and
+  `--strict-cold`.
+
+## Key file:line anchors
+
+- Cold framing: `sync_diff.py:646-666` (`_diff_unmatched_current`, id-keyed
+  two-sided → `verify_cold`); `:2202-2210` (`_classify_pool_news`, positional).
+- Cold vocabulary: `doc_apply.py:115` (`verify_cold: ("confirm",)`).
+- `confirm` = pure record, no freshness compare: `doc_apply.py:979-995`.
+- Ledger always cold in ledger mode: `doc_ledger.py:332` (`complete=False`);
+  hash-version drop-to-cold `:334`.
+- Sanctioned migration is pos→id only: `sync_diff.py:504-522`,
+  `doc_ledger.py:447-458`.
+- Record-side rename plumbing (reused by Phase A): `_record_item` for
+  `record_key_migration` pops `item.base.key` (id or pos) + upserts new key —
+  `doc_apply.py:742-746`; `rename_group_scopes` exists in doc_ledger.
+- Warm bootstrap already records a baseline: `translate_bootstrap.py:316-371`.
+
+## Phase B blockers surfaced by review (must fix in PR 2)
+
+1. **Pool-coherence hole:** `_incoherent_pool_confirms` keys only on
+   `choice == "confirm"` (`doc_apply.py:1284`) and the guard fires only on
+   `confirm` (`:1163`). `keep_twin` (choice set) / `body` (choice None) bypass
+   it, yet a `pos:` item runs `rerecord_pool` wholesale (`:791-794`). Widen the
+   guard to treat `keep_twin`/`body` on cold members as pool-recording answers.
+2. **Positional can't take a body:** `_classify_pool_news` drops the EN partner
+   (`:2185`) and yields one-sided members with `twin` unset, so `_holder(item,
+   "en")` returns a `.en=None` member. Scope Phase B to id-keyed `verify_cold`;
+   positional stays confirm / mint-`slide_id` (`sync-agents.md:158-163`).
+3. **`side` is a real wire change:** `parse_decisions` reads only
+   `key`/`choice`/`body` and silently ignores unknown fields
+   (`doc_apply.py:143-161`); `Decision` is `@frozen` with three fields
+   (`:99-105`). Add `Decision.side` + extraction + validation; reject `side`
+   where meaningless. No existing side-targeted-body convention to reuse.
+4. **Handle/tags (only relevant if the dropped Phase D is ever revisited):**
+   `_classify_matched` handle derivation `sync_diff.py:767`; `_tags_only_change`
+   re-reads `entry.key` at `:1370`.
+
+## Docs / changelog to touch
+
+- `src/clm/cli/info_topics/sync-agents.md`, `commands.md`.
+- `changelog.d/572-*.added.md` / `.changed.md`.
+- Info Topics Maintenance Rule: `rename-id` is a new CLI command → update
+  `commands.md`.
+
+Full plan: this repo did not commit the working plan; the reasoning is captured
+above and in the PR descriptions.

--- a/src/clm/cli/commands/slides/__init__.py
+++ b/src/clm/cli/commands/slides/__init__.py
@@ -23,6 +23,7 @@ from clm.cli.commands.slides.language_view import language_view_cmd  # noqa: E40
 from clm.cli.commands.slides.normalize import normalize_slides_cmd  # noqa: E402
 from clm.cli.commands.slides.reconcile_vo_ids import reconcile_vo_ids_cmd  # noqa: E402
 from clm.cli.commands.slides.referenced_by import referenced_by_cmd  # noqa: E402
+from clm.cli.commands.slides.rename_id import rename_id_cmd  # noqa: E402
 from clm.cli.commands.slides.rules import authoring_rules_cmd  # noqa: E402
 from clm.cli.commands.slides.search import search_slides_cmd  # noqa: E402
 from clm.cli.commands.slides.slug_report import slug_report_cmd  # noqa: E402
@@ -42,6 +43,7 @@ slides_group.add_command(language_view_cmd, name="language-view")
 slides_group.add_command(suggest_sync_cmd, name="suggest-sync")
 slides_group.add_command(slides_sync_group, name="sync")
 slides_group.add_command(reconcile_vo_ids_cmd, name="reconcile-vo-ids")
+slides_group.add_command(rename_id_cmd, name="rename-id")
 slides_group.add_command(slides_translate_cmd, name="translate")
 # `bootstrap` is the cold-start direction of `translate`; keep it
 # invocable but list the command only once in --help.

--- a/src/clm/cli/commands/slides/rename_id.py
+++ b/src/clm/cli/commands/slides/rename_id.py
@@ -1,0 +1,214 @@
+"""``clm slides rename-id`` — rename a ``slide_id`` across a split pair + ledger.
+
+Issue #572. Renaming a ``slide_id`` by hand on a split DE/EN deck drops the
+pair's per-topic sync ledger baseline to *cold* for that id — the v3 differ
+keys trust by ``id:<slide_id>`` and only ``pos: → id:`` migrations are
+recovered, so an ``id: → id:`` rename reads as a cold add. A later edit of the
+renamed cell then frames ``verify_cold`` (only answer ``confirm``), which banks
+the possibly-stale twin unnoticed.
+
+This command does the rename atomically and design-consistently: it rewrites
+the id on **both** halves (and every ``for_slide`` owner reference) and
+**migrates** the ledger baseline key — preserving the recorded fingerprints, so
+a simultaneous content edit surfaces as ``translate_edit`` on the next report,
+never a silent cold-``confirm``. See :mod:`clm.slides.rename_id`.
+
+Exit codes: ``0`` renamed (or would-rename in ``--report-only``); ``2`` usage
+error (no such id, collision, no twin, bad path).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from clm.notebooks.slide_parser import comment_token_for_path
+from clm.slides import doc_ledger
+from clm.slides.doc_ledger import deck_key_for, ledger_path_for
+from clm.slides.pairing import derive_split_pair, order_split_pair, split_lang_tag
+from clm.slides.rename_id import (
+    RenameResult,
+    is_valid_slide_id,
+    migrate_ledger_key,
+    rename_in_half,
+    slide_ids_in,
+)
+
+
+@click.command("rename-id")
+@click.argument("path", type=click.Path(exists=True, dir_okay=False, path_type=Path))
+@click.argument("old")
+@click.argument("new")
+@click.argument(
+    "en_path", required=False, type=click.Path(exists=True, dir_okay=False, path_type=Path)
+)
+@click.option(
+    "--report-only",
+    "--dry-run",
+    "report_only",
+    is_flag=True,
+    help="Report what would change without modifying files or the ledger.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit a JSON report.")
+def rename_id_cmd(
+    path: Path,
+    old: str,
+    new: str,
+    en_path: Path | None,
+    report_only: bool,
+    as_json: bool,
+) -> None:
+    """Rename a slide_id from OLD to NEW across both halves of a split deck.
+
+    \b
+    PATH is one half of a split pair (``<deck>.de.<ext>`` / ``<deck>.en.<ext>``
+    — the twin is found on disk) or both halves passed explicitly. OLD is the
+    current slide_id; NEW is the replacement.
+
+    \b
+    The rename is atomic across the pair AND the committed sync ledger: it
+    rewrites the id (and every ``for_slide`` owner reference) on both halves and
+    migrates the ledger baseline key, keeping the member's identity total. The
+    baseline is migrated, never re-fingerprinted — so if you renamed *and*
+    edited the same cell, the next ``clm slides sync report`` frames a
+    ``translate_edit`` against the carried baseline instead of banking the stale
+    twin under a cold ``verify_cold`` (issue #572). A manual rename that resets
+    the deck to cold is exactly the footgun this command removes.
+    """
+    try:
+        de, en = _resolve_pair(path, en_path)
+        old_bare, new_bare = _validate(old, new)
+        result = _rename_pair(de, en, old_bare, new_bare, write=not report_only)
+    except click.UsageError as exc:
+        # Honor the --json contract for usage errors too: emit {"error": …}
+        # (exit 2) rather than click's plain text; else re-raise for click.
+        if as_json:
+            _fail(exc.format_message())
+        raise
+
+    if as_json:
+        click.echo(json.dumps(_to_dict(de, en, result, report_only=report_only), indent=2))
+    else:
+        _print_human(de, en, result, report_only=report_only)
+    sys.exit(0)
+
+
+def _resolve_pair(path: Path, en_path: Path | None) -> tuple[Path, Path]:
+    """Resolve the argument(s) to an ordered ``(de, en)`` split pair."""
+    if en_path is not None:
+        pair = order_split_pair(path.resolve(), en_path.resolve())
+        if pair is None:
+            raise click.UsageError(
+                f"{path.name} and {en_path.name} are not the two halves of one split deck."
+            )
+        return pair
+    tag = split_lang_tag(path)
+    if tag is None:
+        raise click.UsageError(
+            f"{path.name} has no .de/.en language tag; pass a split half "
+            "(<deck>.de.<ext>) or both halves explicitly."
+        )
+    pair = derive_split_pair(path)
+    if pair is None:
+        other = "EN" if tag == "de" else "DE"
+        raise click.UsageError(
+            f"no {other} twin found next to {path.name}; pass both halves explicitly."
+        )
+    return pair
+
+
+def _validate(old: str, new: str) -> tuple[str, str]:
+    """Bare-id, sanity-check the OLD/NEW arguments."""
+    old_bare = old[1:] if old.startswith("!") else old
+    new_bare = new[1:] if new.startswith("!") else new
+    if not old_bare or not new_bare:
+        raise click.UsageError("OLD and NEW must be non-empty slide_ids.")
+    if old_bare == new_bare:
+        raise click.UsageError(f'OLD and NEW are the same id ("{old_bare}") — nothing to rename.')
+    if not is_valid_slide_id(new_bare):
+        raise click.UsageError(
+            f'"{new_bare}" is not a usable slide_id (no whitespace or double-quotes).'
+        )
+    return old_bare, new_bare
+
+
+def _rename_pair(de: Path, en: Path, old: str, new: str, *, write: bool) -> RenameResult:
+    """Rewrite both halves + migrate the ledger for one id rename."""
+    de_text = de.read_text(encoding="utf-8")
+    en_text = en.read_text(encoding="utf-8")
+    de_token = comment_token_for_path(de)
+    en_token = comment_token_for_path(en)
+
+    present = slide_ids_in(de_text, de_token) | slide_ids_in(en_text, en_token)
+    if old not in present:
+        raise click.UsageError(
+            f'no cell carries slide_id="{old}" in either half of {de.name} / {en.name}.'
+        )
+    if new in present:
+        raise click.UsageError(
+            f'slide_id "{new}" already exists in the pair — renaming to it would create a '
+            "duplicate id. Choose an unused id."
+        )
+
+    de_out, de_sid, de_fs = rename_in_half(de_text, de_token, old, new)
+    en_out, en_sid, en_fs = rename_in_half(en_text, en_token, old, new)
+
+    # Ledger migration is keyed off the DE half's topic; a deck with no recorded
+    # baseline (cold / never recorded) simply has nothing to migrate.
+    ledger_path = ledger_path_for(de)
+    ledger = doc_ledger.load(ledger_path)
+    deck_ledger = ledger.decks.get(deck_key_for(de))
+    ledger_migrated = deck_ledger is not None and migrate_ledger_key(deck_ledger, old, new)
+
+    if write:
+        if de_out != de_text:
+            de.write_text(de_out, encoding="utf-8", newline="\n")
+        if en_out != en_text:
+            en.write_text(en_out, encoding="utf-8", newline="\n")
+        if ledger_migrated:
+            doc_ledger.save(ledger, ledger_path)
+
+    return RenameResult(
+        old=old,
+        new=new,
+        de_slide_id_hits=de_sid,
+        en_slide_id_hits=en_sid,
+        de_for_slide_hits=de_fs,
+        en_for_slide_hits=en_fs,
+        ledger_migrated=ledger_migrated,
+    )
+
+
+def _to_dict(de: Path, en: Path, result: RenameResult, *, report_only: bool) -> dict:
+    return {
+        "deck": deck_key_for(de),
+        "de_path": str(de),
+        "en_path": str(en),
+        "old": result.old,
+        "new": result.new,
+        "slide_id_hits": {"de": result.de_slide_id_hits, "en": result.en_slide_id_hits},
+        "for_slide_hits": {"de": result.de_for_slide_hits, "en": result.en_for_slide_hits},
+        "ledger_migrated": result.ledger_migrated,
+        "report_only": report_only,
+    }
+
+
+def _print_human(de: Path, en: Path, result: RenameResult, *, report_only: bool) -> None:
+    verb = "would rename" if report_only else "renamed"
+    click.echo(f'{deck_key_for(de)}: {verb} slide_id "{result.old}" → "{result.new}"')
+    click.echo(
+        f"  slide_id: DE {result.de_slide_id_hits}, EN {result.en_slide_id_hits}"
+        f"  |  for_slide: DE {result.de_for_slide_hits}, EN {result.en_for_slide_hits}"
+    )
+    if result.ledger_migrated:
+        click.echo(f"  ledger: baseline migrated{' (dry-run)' if report_only else ''}")
+    else:
+        click.echo("  ledger: no baseline for this id (cold / not recorded) — nothing to migrate")
+
+
+def _fail(message: str) -> None:
+    click.echo(json.dumps({"error": message}, indent=2))
+    sys.exit(2)

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1654,6 +1654,51 @@ clm slides reconcile-vo-ids slides_pe_03b_few_shot.de.py --to ids
 clm slides reconcile-vo-ids slides/module_410_ai_dev/
 ```
 
+### `clm slides rename-id`
+
+*Added in CLM {version}.*
+
+Rename a `slide_id` from `OLD` to `NEW` across **both** halves of a split deck
+**and** the committed sync ledger, atomically. Renaming a `slide_id` by hand is a
+footgun: the v3 sync engine keys trust by `id:<slide_id>` and only recovers a
+`pos: → id:` (id-less → id'd) migration, so a hand `id: → id:` rename drops the
+member's ledger baseline to **cold**. A later edit of the renamed cell then reports
+`verify_cold` (whose only answer, `confirm`, banks the *existing* — possibly stale —
+twin), instead of a `translate_edit` that would re-translate it. This command does
+the rename the safe way so the deck never resets to cold (issue #572).
+
+```bash
+clm slides rename-id PATH OLD NEW [EN_PATH]
+```
+
+`PATH` is one half of a split pair (`<deck>.de.<ext>` / `<deck>.en.<ext>` — the twin
+is found on disk) or both halves passed explicitly. It rewrites the `slide_id` (and
+every `for_slide` owner reference) on both halves and **migrates** the ledger
+baseline key — *migrates*, never re-fingerprints, so the recorded content hashes are
+carried under the new key. Consequently:
+
+- A pure rename (no content change) reports **clean** afterward — not cold.
+- A rename you did *together with* an edit reports `translate_edit` on the next
+  `clm slides sync report` (the carried baseline no longer matches the edited body),
+  so the stale twin can never be banked unnoticed by a cold `confirm`.
+
+| Option | Effect |
+|---|---|
+| `--report-only`, `--dry-run` | Report what would change without modifying files or the ledger. |
+| `--json` | Emit a JSON report. |
+
+It refuses (exit 2) if `NEW` already exists as a `slide_id` in the pair (that would
+create a duplicate id), if no cell carries `OLD`, if `OLD == NEW`, or if `NEW`
+contains whitespace or a double-quote. A deck with no recorded baseline (never
+`record`ed) still has its files rewritten — there is simply nothing to migrate.
+
+```bash
+# Preview the rename across both halves + the ledger
+clm slides rename-id slides_pe_03a_chain_of_thought.de.py old-slug new-slug --dry-run
+# Apply it
+clm slides rename-id slides_pe_03a_chain_of_thought.de.py old-slug new-slug
+```
+
 ### `clm slides slug-report`
 
 *Added in CLM {version}.*

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -142,6 +142,18 @@ never recorded. Two ways to converge:
 `clm slides split` and `clm slides translate` record freshly-created pairs
 automatically, so a normal authoring flow starts warm.
 
+**Renaming a `slide_id` is a common way to fall cold — do not do it by hand.**
+The ledger keys trust by `id:<slide_id>`, and the only key migration the engine
+recovers is `pos: → id:` (an id-less cell gaining an id). A hand `id: → id:`
+rename therefore reads as a cold add on the new id (and a `record_remove` on the
+old one), so a cell you *renamed and edited* in one go reports `verify_cold` —
+whose `confirm` would bank the existing, now-stale twin. Use
+`clm slides rename-id DECK OLD NEW`: it rewrites the id (and every `for_slide`
+owner reference) on both halves and **migrates** the ledger baseline key
+(carrying the recorded fingerprints, never re-hashing). A pure rename then
+reports clean; a rename you did alongside an edit reports `translate_edit`
+against the carried baseline — so the stale twin is never silently confirmed.
+
 ## Adding a slide in one language (the twin does not exist yet)
 
 Author a new cell on one half only — a new markdown slide (with a fresh

--- a/src/clm/slides/rename_id.py
+++ b/src/clm/slides/rename_id.py
@@ -1,0 +1,182 @@
+"""Rename a ``slide_id`` across both halves of a split deck **and** its ledger.
+
+Issue #572. A manual ``slide_id`` rename (``foo-old`` → ``foo-new``) on a split
+DE/EN pair silently drops the pair's per-topic sync ledger baseline to *cold*
+for that id: the v3 differ keys trust by ``id:<slide_id>`` and the **only**
+sanctioned key migration is ``pos: → id:`` (id-less → id'd), so an
+``id: → id:`` rename is not recovered — every renamed member reads as a cold
+add (:func:`clm.slides.sync_diff` ``verify_cold``). A subsequent edit of the
+renamed cell then frames ``verify_cold`` (whose only answer, ``confirm``, banks
+the — possibly stale — existing twin) instead of ``translate_edit``.
+
+This module does the rename the design-consistent way: it rewrites the id on
+**both** halves and migrates the ledger baseline key in one step, keeping the
+member's identity *total* across the rename. Crucially it **migrates, never
+re-fingerprints** the baseline — the carried entry keeps the old content
+fingerprints under the new key. So if the cell was *also* edited in the same
+breath, the next ``clm slides sync report`` compares the edited bytes against
+the carried baseline and frames a proper ``translate_edit`` — never a
+stale-``confirm``. (Content fingerprints are computed modulo ``slide_id`` /
+``for_slide``, so the id rewrite itself never perturbs them.)
+
+The two pieces are pure and independently testable:
+
+* :func:`rename_in_half` rewrites one half's text (``slide_id`` on the renamed
+  cell, ``for_slide`` on every companion that owns it).
+* :func:`migrate_ledger_key` re-keys the ledger entry, its owner references,
+  the id-keyed member-order handles, and — when the renamed id anchors a slide
+  group — the whole positional-key / order cascade (via
+  :func:`clm.slides.doc_ledger.rename_group_scopes`).
+"""
+
+from __future__ import annotations
+
+import re
+
+from attrs import evolve, frozen
+
+from clm.notebooks.slide_parser import parse_cell_header
+from clm.slides.doc_ledger import DeckLedger, rename_group_scopes
+from clm.slides.raw_cells import reconstruct, split_cells
+
+#: A usable ``slide_id``: non-empty, no whitespace, no ``"`` (which would break
+#: the header attribute). Deliberately permissive — slug *quality* is a separate
+#: concern; this only rejects ids that cannot be written into a cell header.
+_VALID_ID_RE = re.compile(r'^[^\s"]+$')
+
+
+@frozen
+class RenameResult:
+    """The outcome of renaming one id across a pair (+ ledger)."""
+
+    old: str
+    new: str
+    de_slide_id_hits: int  # slide_id occurrences rewritten on the DE half
+    en_slide_id_hits: int
+    de_for_slide_hits: int  # for_slide (owner) references rewritten on DE
+    en_for_slide_hits: int
+    ledger_migrated: bool  # a ledger baseline entry was re-keyed
+
+    @property
+    def slide_id_hits(self) -> int:
+        return self.de_slide_id_hits + self.en_slide_id_hits
+
+    @property
+    def for_slide_hits(self) -> int:
+        return self.de_for_slide_hits + self.en_for_slide_hits
+
+
+def is_valid_slide_id(slide_id: str) -> bool:
+    """A ``slide_id`` that can be written into a cell header without breaking it."""
+    return bool(_VALID_ID_RE.match(slide_id))
+
+
+def _split_marker(slide_id: str) -> tuple[str, str]:
+    """Split a leading ``!`` preserve marker off a verbatim ``slide_id``.
+
+    ``"!intro"`` → ``("!", "intro")``; ``"intro"`` → ``("", "intro")``. The
+    marker (§ assign-ids "don't re-slug") is carried through a rename.
+    """
+    return ("!", slide_id[1:]) if slide_id.startswith("!") else ("", slide_id)
+
+
+def _bare(slide_id: str) -> str:
+    return _split_marker(slide_id)[1]
+
+
+def _rewrite_attr(header: str, attr: str, value: str) -> str:
+    """Replace the first ``attr="…"`` value in a cell header line."""
+    return re.sub(rf'{attr}="[^"]*"', f'{attr}="{value}"', header, count=1)
+
+
+def slide_ids_in(text: str, comment_token: str) -> set[str]:
+    """Every bare ``slide_id`` present in one half (markers stripped)."""
+    _pre, cells = split_cells(text, comment_token)
+    return {_bare(c.metadata.slide_id) for c in cells if c.metadata.slide_id is not None}
+
+
+def rename_in_half(text: str, comment_token: str, old: str, new: str) -> tuple[str, int, int]:
+    """Rewrite ``old`` → ``new`` on one half; return ``(text', slide_id_hits, for_slide_hits)``.
+
+    Rewrites the ``slide_id`` of the renamed cell **and** the ``for_slide`` of
+    every companion that owns it (a group rename cascades into ``for_slide``
+    references, exactly as the fingerprint's owner-free signature anticipates).
+    Any ``!`` preserve marker on the matched attribute is carried through. The
+    text is returned byte-identical when nothing matched. ``old``/``new`` are
+    bare ids (no marker).
+    """
+    pre, cells = split_cells(text, comment_token)
+    slide_id_hits = 0
+    for_slide_hits = 0
+    for cell in cells:
+        meta = cell.metadata
+        header = cell.lines[0]
+        rewritten = header
+        if meta.slide_id is not None and _bare(meta.slide_id) == old:
+            marker, _ = _split_marker(meta.slide_id)
+            rewritten = _rewrite_attr(rewritten, "slide_id", marker + new)
+            slide_id_hits += 1
+        if meta.for_slide is not None and _bare(meta.for_slide) == old:
+            marker, _ = _split_marker(meta.for_slide)
+            rewritten = _rewrite_attr(rewritten, "for_slide", marker + new)
+            for_slide_hits += 1
+        if rewritten != header:
+            cell.lines[0] = rewritten
+            cell.metadata = parse_cell_header(rewritten, comment_token)
+    out = reconstruct(pre, cells) if (slide_id_hits or for_slide_hits) else text
+    return out, slide_id_hits, for_slide_hits
+
+
+def migrate_ledger_key(deck: DeckLedger, old: str, new: str) -> bool:
+    """Re-key the ledger baseline for a renamed ``slide_id`` (``old`` → ``new``).
+
+    Migrates — never re-fingerprints — so a simultaneous content edit surfaces
+    as ``translate_edit`` on the next report, not a silent cold-confirm. Touches
+    every place the id is encoded:
+
+    * the ``id:<old>`` member entry (re-keyed, entry ``key`` rewritten);
+    * ``owner`` references on companion entries the renamed slide owns;
+    * id-keyed handles inside every member-order scope's list;
+    * when ``old`` anchors a slide group, the whole positional-key / member-order
+      / group-order cascade (its bare id tokens every ``pos:`` key of the group)
+      via :func:`~clm.slides.doc_ledger.rename_group_scopes`.
+
+    Returns ``True`` when anything changed (``False`` = the id was cold / absent,
+    a no-op the caller reports as "ledger not updated").
+    """
+    old_key = f"id:{old}"
+    new_key = f"id:{new}"
+    changed = False
+
+    # A slide group anchored by ``old`` tokens every pos: key + order scope of
+    # the group with its bare id — cascade those first. group_order is the
+    # canonical anchor list; the pos-key / by-side checks are belt-and-braces.
+    is_anchor = (
+        old in deck.group_order
+        or any(old in order for order in deck.group_order_by_side.values())
+        or any(k.startswith(f"pos:{old}/") for k in deck.members)
+    )
+    if is_anchor:
+        rename_group_scopes(deck, old, new)
+        changed = True
+
+    # The member entry itself (rename_group_scopes leaves the id: entry to us).
+    lm = deck.members.pop(old_key, None)
+    if lm is not None:
+        deck.members[new_key] = evolve(lm, entry=evolve(lm.entry, key=new_key))
+        changed = True
+
+    # Owner references: a companion owned by the renamed slide points at it.
+    for key, member in list(deck.members.items()):
+        if member.entry.owner == old_key:
+            deck.members[key] = evolve(member, entry=evolve(member.entry, owner=new_key))
+            changed = True
+
+    # Member-order value lists carry id: handles (the anchor's own handle among
+    # them for the group-rename case) — swap them regardless of scope key.
+    for scope_key, handles in list(deck.member_order.items()):
+        if old_key in handles:
+            deck.member_order[scope_key] = [new_key if h == old_key else h for h in handles]
+            changed = True
+
+    return changed

--- a/tests/cli/test_rename_id_cli.py
+++ b/tests/cli/test_rename_id_cli.py
@@ -1,0 +1,172 @@
+"""CLI + end-to-end tests for ``clm slides rename-id`` (issue #572).
+
+The money test (:meth:`TestRenameThenEdit.test_rename_then_edit_frames_translate_edit`)
+reproduces the reported footgun and proves the fix: after a manual id rename the
+ledger stays warm, so a subsequent edit of the renamed cell frames
+``translate_edit`` (with a fresh twin body answer) — never the silent
+``verify_cold`` that would bank the stale twin on ``confirm``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands.slides.rename_id import rename_id_cmd
+from clm.cli.commands.slides.sync import slides_sync_group
+
+
+@pytest.fixture
+def cli_runner():
+    try:
+        return CliRunner(mix_stderr=False)
+    except TypeError:
+        return CliRunner()
+
+
+HEADER_DE = "# j2 from 'macros.j2' import header_de\n# {{ header_de(\"Titel DE\") }}\n\n"
+HEADER_EN = "# j2 from 'macros.j2' import header_en\n# {{ header_en(\"Title EN\") }}\n\n"
+
+DE = (
+    HEADER_DE
+    + '# %% [markdown] lang="de" tags=["slide"] slide_id="s0"\n#\n# # Titel\n\n'
+    + '# %% tags=["keep"]\nx = 1\n\n'
+    + '# %% [markdown] lang="de" slide_id="s0-m"\n# DE Text\n'
+)
+EN = (
+    HEADER_EN
+    + '# %% [markdown] lang="en" tags=["slide"] slide_id="s0"\n#\n# # Title\n\n'
+    + '# %% tags=["keep"]\nx = 1\n\n'
+    + '# %% [markdown] lang="en" slide_id="s0-m"\n# EN text\n'
+)
+
+
+def _write_pair(tmp_path: Path) -> tuple[Path, Path]:
+    de = tmp_path / "slides_t.de.py"
+    en = tmp_path / "slides_t.en.py"
+    de.write_text(DE, encoding="utf-8")
+    en.write_text(EN, encoding="utf-8")
+    return de, en
+
+
+def _json_payload(output: str) -> dict:
+    return json.loads(output[output.index("{") :])
+
+
+def _record(cli_runner, de: Path) -> None:
+    assert cli_runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0
+
+
+def _report(cli_runner, de: Path) -> dict:
+    res = cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"])
+    return _json_payload(res.output)
+
+
+class TestRenameThenEdit:
+    def test_rename_then_edit_frames_translate_edit(self, cli_runner: CliRunner, tmp_path: Path):
+        de, en = _write_pair(tmp_path)
+        _record(cli_runner, de)
+        assert _report(cli_runner, de)["is_clean"] is True
+
+        # Rename the non-anchor member id on BOTH halves + the ledger.
+        res = cli_runner.invoke(rename_id_cmd, [str(de), "s0-m", "s0-x", "--json"])
+        assert res.exit_code == 0, res.output
+        payload = _json_payload(res.output)
+        assert payload["ledger_migrated"] is True
+        assert payload["slide_id_hits"] == {"de": 1, "en": 1}
+        assert 'slide_id="s0-x"' in de.read_text(encoding="utf-8")
+        assert 'slide_id="s0-x"' in en.read_text(encoding="utf-8")
+
+        # The ledger stayed warm: a pure rename reports clean, NOT cold.
+        after_rename = _report(cli_runner, de)
+        assert after_rename["is_clean"] is True, after_rename
+        assert not any(i["action"] == "verify_cold" for i in after_rename["items"])
+
+        # Now edit the EN body of the renamed cell. Because the baseline was
+        # migrated (not dropped to cold), this frames translate_edit — the twin
+        # can be re-translated — instead of a verify_cold that would confirm the
+        # stale German.
+        en.write_text(
+            en.read_text(encoding="utf-8").replace("EN text", "EN text rewritten"), "utf-8"
+        )
+        after_edit = _report(cli_runner, de)
+        actions = {i["action"] for i in after_edit["items"]}
+        assert "verify_cold" not in actions, after_edit
+        edited = next(i for i in after_edit["items"] if i["key"] == "id:s0-x")
+        assert edited["action"] == "translate_edit"
+        assert "body" in edited["answers"]
+
+        # And the loop closes: supplying the fresh DE twin resolves it to clean.
+        decisions = json.dumps({"decisions": [{"key": "id:s0-x", "body": "# DE neu"}]})
+        applied = cli_runner.invoke(
+            slides_sync_group, ["apply", str(de), "--decisions", "-", "--json"], input=decisions
+        )
+        assert applied.exit_code == 0, applied.output
+        assert "# DE neu" in de.read_text(encoding="utf-8")
+        assert _report(cli_runner, de)["is_clean"] is True
+
+    def test_rename_anchor_stays_clean(self, cli_runner: CliRunner, tmp_path: Path):
+        de, en = _write_pair(tmp_path)
+        _record(cli_runner, de)
+
+        res = cli_runner.invoke(rename_id_cmd, [str(de), "s0", "s0-new"])
+        assert res.exit_code == 0, res.output
+        assert 'slide_id="s0-new"' in de.read_text(encoding="utf-8")
+
+        # The positional `x = 1` under the s0 group cascaded its group token —
+        # the deck is still fully in sync.
+        report = _report(cli_runner, de)
+        assert report["is_clean"] is True, report
+
+
+class TestRenameGuards:
+    def test_missing_old_id_rejected(self, cli_runner: CliRunner, tmp_path: Path):
+        de, _ = _write_pair(tmp_path)
+        res = cli_runner.invoke(rename_id_cmd, [str(de), "nope", "whatever", "--json"])
+        assert res.exit_code == 2
+        assert "no cell carries" in _json_payload(res.output)["error"]
+
+    def test_collision_with_existing_id_rejected(self, cli_runner: CliRunner, tmp_path: Path):
+        de, _ = _write_pair(tmp_path)
+        res = cli_runner.invoke(rename_id_cmd, [str(de), "s0-m", "s0", "--json"])
+        assert res.exit_code == 2
+        assert "already exists" in _json_payload(res.output)["error"]
+
+    def test_same_old_new_rejected(self, cli_runner: CliRunner, tmp_path: Path):
+        de, _ = _write_pair(tmp_path)
+        res = cli_runner.invoke(rename_id_cmd, [str(de), "s0-m", "s0-m", "--json"])
+        assert res.exit_code == 2
+        assert "same id" in _json_payload(res.output)["error"]
+
+    def test_invalid_new_id_rejected(self, cli_runner: CliRunner, tmp_path: Path):
+        de, _ = _write_pair(tmp_path)
+        res = cli_runner.invoke(rename_id_cmd, [str(de), "s0-m", "bad id", "--json"])
+        assert res.exit_code == 2
+        assert "not a usable slide_id" in _json_payload(res.output)["error"]
+
+    def test_dry_run_writes_nothing(self, cli_runner: CliRunner, tmp_path: Path):
+        de, en = _write_pair(tmp_path)
+        _record(cli_runner, de)
+        before_de, before_en = de.read_text(encoding="utf-8"), en.read_text(encoding="utf-8")
+        ledger_before = (tmp_path / ".clm" / "sync-ledger.json").read_text(encoding="utf-8")
+
+        res = cli_runner.invoke(rename_id_cmd, [str(de), "s0-m", "s0-x", "--report-only", "--json"])
+        assert res.exit_code == 0, res.output
+        assert _json_payload(res.output)["report_only"] is True
+
+        assert de.read_text(encoding="utf-8") == before_de
+        assert en.read_text(encoding="utf-8") == before_en
+        assert (tmp_path / ".clm" / "sync-ledger.json").read_text(encoding="utf-8") == ledger_before
+
+    def test_rename_without_ledger_still_rewrites_files(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        de, en = _write_pair(tmp_path)  # never recorded — no ledger
+        res = cli_runner.invoke(rename_id_cmd, [str(de), "s0-m", "s0-x", "--json"])
+        assert res.exit_code == 0, res.output
+        payload = _json_payload(res.output)
+        assert payload["ledger_migrated"] is False
+        assert 'slide_id="s0-x"' in de.read_text(encoding="utf-8")

--- a/tests/slides/test_rename_id.py
+++ b/tests/slides/test_rename_id.py
@@ -1,0 +1,172 @@
+"""Unit tests for :mod:`clm.slides.rename_id` (issue #572).
+
+Covers the two pure pieces: the per-half text rewrite (``slide_id`` + owner
+``for_slide``, marker-preserving, byte-stable on a no-op) and the ledger
+key migration (member re-key, owner references, member-order handles, and the
+group-anchor positional cascade) — asserting throughout that fingerprints are
+*carried*, never recomputed.
+"""
+
+from __future__ import annotations
+
+from attrs import evolve
+
+from clm.slides import doc_ledger
+from clm.slides.bilingual_doc import BilingualDeck
+from clm.slides.doc_lenses import parse_bundle
+from clm.slides.rename_id import (
+    is_valid_slide_id,
+    migrate_ledger_key,
+    rename_in_half,
+    slide_ids_in,
+)
+
+HEADER_DE = "# j2 from 'macros.j2' import header_de\n# {{ header_de(\"Titel DE\") }}\n\n"
+HEADER_EN = "# j2 from 'macros.j2' import header_en\n# {{ header_en(\"Title EN\") }}\n\n"
+
+
+def _slide(slug: str, lang: str, title: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{slug}"\n#\n# # {title}\n\n'
+
+
+def _localized(slug: str, lang: str, text: str) -> str:
+    return f'# %% [markdown] lang="{lang}" slide_id="{slug}"\n# {text}\n\n'
+
+
+def _shared_code(name: str, value: int = 1) -> str:
+    return f'# %% tags=["keep"]\n{name} = {value}\n\n'
+
+
+def _build(*parts: str) -> str:
+    return "".join(parts).rstrip("\n") + "\n"
+
+
+DE0 = _build(
+    HEADER_DE, _slide("s0", "de", "Titel"), _shared_code("x"), _localized("s0-m", "de", "DE Text")
+)
+EN0 = _build(
+    HEADER_EN, _slide("s0", "en", "Title"), _shared_code("x"), _localized("s0-m", "en", "EN text")
+)
+
+
+def _parse(de: str, en: str) -> BilingualDeck:
+    outcome = parse_bundle(de, en)
+    assert outcome.deck is not None
+    return outcome.deck
+
+
+def _deck_ledger(de: str = DE0, en: str = EN0) -> doc_ledger.DeckLedger:
+    ledger = doc_ledger.TopicLedger()
+    doc_ledger.record_deck_snapshot(ledger, "slides_x", _parse(de, en), provenance="record")
+    return ledger.decks["slides_x"]
+
+
+class TestValidId:
+    def test_rejects_whitespace_and_quotes_and_empty(self):
+        assert not is_valid_slide_id("")
+        assert not is_valid_slide_id("a b")
+        assert not is_valid_slide_id('a"b')
+        assert is_valid_slide_id("foo-new")
+        assert is_valid_slide_id("s0_m.2")
+
+
+class TestSlideIdsIn:
+    def test_collects_bare_ids(self):
+        assert slide_ids_in(DE0, "#") == {"s0", "s0-m"}
+
+    def test_strips_preserve_marker(self):
+        text = _build(HEADER_DE, _slide("!kept", "de", "Titel"))
+        assert slide_ids_in(text, "#") == {"kept"}
+
+
+class TestRenameInHalf:
+    def test_rewrites_slide_id(self):
+        out, sid, fs = rename_in_half(DE0, "#", "s0-m", "s0-x")
+        assert (sid, fs) == (1, 0)
+        assert 'slide_id="s0-x"' in out
+        assert 'slide_id="s0-m"' not in out
+        # the OTHER id and all bodies are untouched
+        assert 'slide_id="s0"' in out and "DE Text" in out
+
+    def test_noop_returns_byte_identical(self):
+        out, sid, fs = rename_in_half(DE0, "#", "absent", "whatever")
+        assert (sid, fs) == (0, 0)
+        assert out == DE0
+
+    def test_preserves_preserve_marker(self):
+        text = _build(HEADER_DE, _slide("!keep-me", "de", "Titel"))
+        out, sid, _ = rename_in_half(text, "#", "keep-me", "renamed")
+        assert sid == 1
+        assert 'slide_id="!renamed"' in out
+
+    def test_rewrites_for_slide_owner_reference(self):
+        text = _build(
+            HEADER_DE,
+            _slide("s0", "de", "Titel"),
+            '# %% [markdown] lang="de" tags=["voiceover"] for_slide="s0"\n# VO\n\n',
+        )
+        out, sid, fs = rename_in_half(text, "#", "s0", "s0-new")
+        assert (sid, fs) == (1, 1)
+        assert 'slide_id="s0-new"' in out
+        assert 'for_slide="s0-new"' in out
+        assert 'for_slide="s0"' not in out
+
+
+class TestMigrateLedgerNonAnchor:
+    def test_rekeys_member_preserving_fingerprints(self):
+        deck = _deck_ledger()
+        before = deck.members["id:s0-m"].entry
+        assert migrate_ledger_key(deck, "s0-m", "s0-x") is True
+        assert "id:s0-m" not in deck.members
+        after = deck.members["id:s0-x"]
+        # migrated, NOT re-fingerprinted: fps carried, key rewritten
+        assert after.entry.key == "id:s0-x"
+        assert (after.entry.de_fp, after.entry.en_fp) == (before.de_fp, before.en_fp)
+        assert after.provenance == deck.members["id:s0-x"].provenance
+
+    def test_swaps_member_order_handle(self):
+        deck = _deck_ledger()
+        migrate_ledger_key(deck, "s0-m", "s0-x")
+        handles = [h for lst in deck.member_order.values() for h in lst]
+        assert "id:s0-m" not in handles
+        assert "id:s0-x" in handles
+
+    def test_absent_id_is_noop(self):
+        deck = _deck_ledger()
+        assert migrate_ledger_key(deck, "not-here", "whatever") is False
+
+    def test_migrates_owner_reference(self):
+        deck = _deck_ledger()
+        # Graft an explicit owner ref onto an existing entry (a companion the
+        # renamed slide owns) and confirm the rename follows it.
+        orig = deck.members["id:s0-m"]
+        deck.members["id:s0-m"] = evolve(orig, entry=evolve(orig.entry, owner="id:s0"))
+        migrate_ledger_key(deck, "s0", "s0-new")
+        assert deck.members["id:s0-m"].entry.owner == "id:s0-new"
+
+
+class TestMigrateLedgerAnchorCascade:
+    def test_positional_keys_and_group_order_migrate(self):
+        deck = _deck_ledger()
+        pos_before = [k for k in deck.members if k.startswith("pos:s0/")]
+        assert pos_before, "fixture should have a positional member under the s0 group"
+        assert "s0" in deck.group_order
+
+        assert migrate_ledger_key(deck, "s0", "s0-new") is True
+
+        # anchor re-keyed; its group token cascaded into every pos: key
+        assert "id:s0" not in deck.members and "id:s0-new" in deck.members
+        assert not any(k.startswith("pos:s0/") for k in deck.members)
+        migrated_pos = [k for k in deck.members if k.startswith("pos:s0-new/")]
+        assert len(migrated_pos) == len(pos_before)
+        assert "s0" not in deck.group_order and "s0-new" in deck.group_order
+        # member-order scope keys re-grouped to the new anchor token
+        assert not any(g == "s0" for (_lang, g, _part) in deck.member_order)
+
+    def test_anchor_cascade_preserves_positional_fingerprints(self):
+        deck = _deck_ledger()
+        pos_key = next(k for k in deck.members if k.startswith("pos:s0/"))
+        fp_before = (deck.members[pos_key].entry.de_fp, deck.members[pos_key].entry.en_fp)
+        migrate_ledger_key(deck, "s0", "s0-new")
+        new_key = pos_key.replace("pos:s0/", "pos:s0-new/", 1)
+        assert (deck.members[new_key].entry.de_fp, deck.members[new_key].entry.en_fp) == fp_before


### PR DESCRIPTION
## Summary

PR 1 of 2 for #572. Adds **`clm slides rename-id DECK OLD NEW`**, which renames a `slide_id` across both halves of a split deck **and** the committed sync ledger, atomically — so a deliberate rename never resets the deck to *cold*.

### The bug

On a split DE/EN deck, renaming a `slide_id` by hand silently drops the member's v3 ledger baseline to cold: the engine keys trust by `id:<slide_id>` and the only key migration it recovers is `pos: → id:` (id-less → id'd), so a hand `id: → id:` rename reads as a cold add (and a `record_remove` on the old id). A cell that is renamed **and** edited in one go then reports `verify_cold` — whose only answer, `confirm`, banks the existing, now-**stale** twin — with no signal to the driving agent. `sync verify` and `clm validate` both pass afterward, so the failure ships silently.

### The fix

`rename-id` rewrites the `slide_id` (and every `for_slide` owner reference) on both halves and **migrates** the ledger baseline key — *migrates*, never re-fingerprints, so the recorded content hashes are carried under the new key. Consequences:

- A **pure rename** (no content change) reports **clean** afterward, not cold.
- A rename done **alongside an edit** reports **`translate_edit`** against the carried baseline on the next `sync report` — so the stale twin can never be banked unnoticed by a cold `confirm`. The end-to-end test drives the full loop (rename → edit → `translate_edit` → apply body → clean).

Handles the group-anchor cascade (an anchor's bare id tokens every `pos:` key of its group) via `doc_ledger.rename_group_scopes`, plus owner references and member-order handles. Refuses (exit 2) a rename that would create a duplicate id, a missing `OLD`, `OLD == NEW`, or an unusable `NEW`.

### Why this over an automated differ fix

The tempting alternative — teach the differ to auto-migrate `id → id` renames by content fingerprint — was rejected after a 3-way adversarial review: it fights v3's *total identity / monotone-id* invariant (the only sanctioned migration is `pos → id`, deliberately) and mis-migrates on the boilerplate/blank/short-cell fingerprint collisions that are the norm in decks, introducing a *new* silent-failure class. An explicit atomic command keeps identity total across a deliberate rename without any inference.

## Scope

PR 2 will add `body`/`keep_twin` recovery on already-cold two-sided `verify_cold` members (for decks that fell cold before this command existed), per the issue author's #1 suggestion.

## Testing

- New unit tests (`tests/slides/test_rename_id.py`): text rewrite (marker-preserving, byte-stable no-op, `for_slide` cascade) and ledger migration (member re-key + fingerprint carry, owner refs, member-order handles, anchor positional cascade).
- New CLI/e2e tests (`tests/cli/test_rename_id_cli.py`): the money test (rename + edit → `translate_edit`, full apply loop to clean), anchor rename stays clean, all guard rejections, dry-run writes nothing, rename without a ledger still rewrites files.
- Full `tests/slides` + `tests/cli` green (3435 passed); ruff + mypy clean.

Docs: `clm info commands` and `clm info sync-agents` updated; changelog fragment added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MHWeqbb4VaqRToiscAaS5