### PR TITLE
feat(sync): inline body+side recovery on cold verify_cold cells (#572)

### DIFF
--- a/changelog.d/572-cold-body-recovery.added.md
+++ b/changelog.d/572-cold-body-recovery.added.md
@@ -1,0 +1,11 @@
+- **Inline stale-twin recovery on cold cells.** A two-sided `verify_cold` item
+  on an **id-keyed** member now accepts a `body` answer in the sync decisions
+  document, alongside a new `side` (`"de"`/`"en"`) field naming the twin to
+  overwrite: `{"key": "id:x", "body": "…", "side": "de"}`. Previously the only
+  answer was `confirm`, which banks **both sides as-is** — so a cell that fell
+  cold with a *stale* twin (e.g. its source was edited while the ledger was
+  cold) could only be fixed by hand-editing the file and then confirming.
+  Supplying the corrected twin inline makes cold recovery a one-pass operation,
+  consistent with `translate_edit`. Positional cold members (no addressable id)
+  still take only `confirm` — mint a `slide_id` first if their twin is stale.
+  See `clm info sync-agents` / `clm info commands`. (#572)

--- a/docs/claude/handovers/issue-572-cold-ledger-handover.md
+++ b/docs/claude/handovers/issue-572-cold-ledger-handover.md
@@ -1,8 +1,8 @@
 # Issue #572 — cold-ledger stale-twin — handover
 
-**Status:** plan approved; implementing as two PRs. PR 1 = Phase A
-(`clm slides rename-id`). PR 2 = Phase B (`body`/`keep_twin` on id-keyed
-two-sided `verify_cold`) + Phase C-3a (reworded cold detail).
+**Status:** BOTH PRs shipped. PR 1 = Phase A (`clm slides rename-id`, PR #573,
+merged). PR 2 = Phase B (`body` + `side` on id-keyed two-sided `verify_cold`) +
+Phase C-3a (reworded cold detail) — implemented; see "PR 2 as built" below.
 
 **Issue:** On a split DE/EN deck whose per-topic ledger is cold for the current
 `slide_id`s, an id-keyed cell whose EN source was **edited** is framed
@@ -77,6 +77,37 @@ check cannot exist on a cold cell anyway (no baseline by construction).
 - `changelog.d/572-*.added.md` / `.changed.md`.
 - Info Topics Maintenance Rule: `rename-id` is a new CLI command → update
   `commands.md`.
+
+## PR 2 as built (what actually shipped vs the plan)
+
+- **Answer = `body` + `side`, NOT `keep_twin`.** `verify_cold` vocabulary is
+  now `("confirm", "body")`. `keep_twin` was *dropped* from scope: on a cold
+  member it is exactly `confirm` in ledger effect (both bank as-is), so adding
+  it would be a confusing synonym. `--strict-cold` also dropped (as planned).
+- **`Decision.side`** (`"de"`/`"en"`) added + parsed + validated in
+  `parse_decisions` (must accompany a `body`; must be de/en). Threaded into
+  `_apply_body_decision(..., side=...)`. Rejected on any non-`verify_cold` body
+  answer (translate_edit etc. derive their own target) — checked in
+  `_execute_decision`.
+- **Scoped to id-keyed** at the executor: the `verify_cold` branch of
+  `_apply_body_decision` refuses a `pos:` key with a mint-a-slide_id hint.
+- **Report honesty:** new `doc_apply.item_answers(item)` is key-aware — drops
+  `body` from a *positional* `verify_cold`'s advertised answers. `doc_report`
+  uses it instead of `decision_vocabulary`.
+- **Blocker 1 (pool-coherence) resolved by construction, not by widening the
+  guard.** Because a `body` is rejected on any `pos:` member, it can never land
+  a wholesale `rerecord_pool`; an id-keyed body has no pool. Widening
+  `_incoherent_pool_confirms` to count body/keep_twin would have *reintroduced*
+  the silent-bless bug (it would mark a pool coherent while the body is rejected
+  downstream). A comment on that function documents "do not widen."
+- **Blocker 3 (`side` wire schema)** handled as above.
+- Tests: `tests/slides/test_doc_apply.py::TestColdBodyRecovery` +
+  `TestDecisionParsing`; `tests/cli/test_sync_v3_cli.py::…test_cold_body_recovery_fixes_a_stale_twin`.
+  Existing `["confirm"]`-only assertions updated (test_sync_v3_cli, mcp/test_tools)
+  to the key-aware expectation.
+- Docs: `sync-agents.md` (framed actions, `side` field, cold-members section),
+  `commands.md` (apply decisions doc + rename-id cross-ref), changelog fragment
+  `572-cold-body-recovery.added.md`.
 
 Full plan: this repo did not commit the working plan; the reasoning is captured
 above and in the PR descriptions.

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1663,9 +1663,12 @@ Rename a `slide_id` from `OLD` to `NEW` across **both** halves of a split deck
 footgun: the v3 sync engine keys trust by `id:<slide_id>` and only recovers a
 `pos: → id:` (id-less → id'd) migration, so a hand `id: → id:` rename drops the
 member's ledger baseline to **cold**. A later edit of the renamed cell then reports
-`verify_cold` (whose only answer, `confirm`, banks the *existing* — possibly stale —
-twin), instead of a `translate_edit` that would re-translate it. This command does
-the rename the safe way so the deck never resets to cold (issue #572).
+`verify_cold` rather than a `translate_edit` against a live baseline — and a bare
+`confirm` on it banks the *existing*, now-stale twin. (A cold `verify_cold` does
+accept an inline `body`/`side` recovery — see `apply` below — but that puts the
+freshness judgment back on you; the rename kept the baseline warm so the engine
+frames the edit for you.) This command does the rename the safe way so the deck
+never resets to cold (issue #572).
 
 ```bash
 clm slides rename-id PATH OLD NEW [EN_PATH]
@@ -1911,8 +1914,12 @@ clm slides sync apply DECK [--decisions FILE|-] [--member KEY]... [--dry-run] [-
 Writes, **per item**: every mechanical row executes deterministically; framed
 rows execute only with a valid decision from the `--decisions` JSON document
 (`{"decisions": [{"key": "id:…", "choice": "confirm"} | {"key": "id:…",
-"body": "…"}]}`, `-` reads stdin). Each answer is validated individually — a
-body smuggling a cell delimiter, a wrong choice, or a stale handle is rejected
+"body": "…"}]}`, `-` reads stdin). A row may add `"side": "de"|"en"` **only**
+alongside a `body` on a two-sided `verify_cold` item — it names the stale twin
+to overwrite, turning cold recovery into one pass instead of hand-editing the
+file then `confirm`-ing (issue #572); `side` is rejected on any other action.
+Each answer is validated individually — a body smuggling a cell delimiter, a
+wrong choice, a `side` where it is meaningless, or a stale handle is rejected
 with a reason while the valid answers still land. The mutated bundle is
 re-parsed before anything touches disk and written atomically (≤4 files);
 every landed item is recorded into the ledger, **gated on the structural

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -68,7 +68,9 @@ the target-language body — or answer `translate_edit` with `keep_twin` when
 your edit did not change what the twin should say), `verify_translation` (both
 sides moved — confirm or supply a body), `conflict_shared` / `remove_vs_edit`
 / `unify_choose_body` / `order_decision` / `conflict_preamble` (choose a side),
-`verify_cold` (confirm the member is genuinely in sync), `ambiguous_alignment`
+`verify_cold` (confirm the member is in sync — or, on an **id-keyed** member,
+supply a `body` + `side` to overwrite a stale twin in the same pass),
+`ambiguous_alignment`
 (mint ids / choose), and the normalize-refusal deck item (run
 `clm slides normalize`, then re-report).
 
@@ -109,6 +111,11 @@ One JSON document answers any subset of framed items:
   `keep_twin`). For a `translate_edit` whose edit left the twin a faithful
   rendering, `{"key": …, "choice": "keep_twin"}` records the new baseline and
   keeps the existing twin verbatim — no need to re-supply an unchanged body.
+- `side` — `"de"` or `"en"`, **only** alongside a `body` on a two-sided
+  `verify_cold` item: it names the stale twin to overwrite. `{"key":
+  "id:intro", "body": "# frische Übersetzung", "side": "de"}` replaces the DE
+  cell and records the fixed pair — cold recovery in one pass. Every other
+  action derives its target side itself, so a `side` there is rejected.
 
 Feed it to `apply` (`-` reads stdin):
 
@@ -131,9 +138,16 @@ present) as `verify_cold` — the engine will not silently trust a pair it has
 never recorded. Two ways to converge:
 
 - **Per item**: answer `{"key": …, "choice": "confirm"}` in a decision
-  document after you have checked the pair is genuinely in sync. Pool-scoped
-  coherence applies to `pos:` handles: confirm the whole `(group, kind)`
-  pool's cold items in one document (a lone positional confirm is rejected).
+  document after you have checked the pair is genuinely in sync. `confirm`
+  banks **both sides as-is** — it makes no freshness guarantee, so read both
+  bodies first. If the twin is **stale** (e.g. the source was edited while the
+  ledger was cold), do not `confirm`: on an **id-keyed** member, answer with a
+  `body` + `side` naming the stale twin (`{"key": "id:x", "body": "…", "side":
+  "de"}`) to overwrite it in the same pass. A *positional* cold member has no
+  addressable id and takes only `confirm` (mint a `slide_id` first if its twin
+  is stale). Pool-scoped coherence applies to `pos:` handles: confirm the whole
+  `(group, kind)` pool's cold items in one document (a lone positional confirm
+  is rejected).
 - **Wholesale**: `clm slides sync record DECK|DIR` after a verified pass —
   bless/accept collapsed into one verb, gated on the structural verify, with
   `--provenance agent` (or `semantic:<model>` when a model attested the

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -79,6 +79,7 @@ __all__ = [
     "ItemResult",
     "apply_deck",
     "decision_vocabulary",
+    "item_answers",
     "parse_decisions",
 ]
 
@@ -98,11 +99,18 @@ def _other(lang: Lang) -> Lang:
 
 @frozen
 class Decision:
-    """One agent answer to a framed item, keyed by the member handle."""
+    """One agent answer to a framed item, keyed by the member handle.
+
+    ``side`` (``"de"`` / ``"en"``) is only meaningful alongside a ``body`` on a
+    two-sided ``verify_cold`` item: it names the stale twin to overwrite with
+    the supplied text. Every other framed action derives its target side from
+    the item itself, so ``side`` there is rejected as a mistake.
+    """
 
     key: str
     choice: str | None = None
     body: str | None = None
+    side: str | None = None
 
 
 #: Framed actions this executor can resolve from a decision, with the answer
@@ -112,7 +120,7 @@ _DECISION_VOCABULARY: dict[str, tuple[str, ...]] = {
     "translate_edit": ("body", "keep_twin"),
     "translate_new": ("body",),
     "verify_translation": ("confirm",),
-    "verify_cold": ("confirm",),
+    "verify_cold": ("confirm", "body"),
     "conflict_shared": ("de", "en", "body"),
     "pending_divergence": ("de", "en"),
     "remove_vs_edit": ("remove", "keep"),
@@ -127,6 +135,22 @@ _DECISION_VOCABULARY: dict[str, tuple[str, ...]] = {
 def decision_vocabulary(action: str) -> tuple[str, ...]:
     """The answer shapes ``apply --decisions`` accepts for a framed action."""
     return _DECISION_VOCABULARY.get(action, ())
+
+
+def item_answers(item: DiffItem) -> tuple[str, ...]:
+    """The key-aware answer vocabulary the report advertises for one item.
+
+    Identical to :func:`decision_vocabulary` except for ``verify_cold``: a
+    ``body`` recovery targets a named ``side`` and can only be placed on an
+    **id-keyed** two-sided member. A *positional* cold member has no stable
+    id to address and its ordinal aliases a neighboring slot, so it accepts
+    only ``confirm`` (or: mint a ``slide_id`` and re-report). Advertising
+    ``body`` there would be a lie the executor then rejects.
+    """
+    answers = decision_vocabulary(item.action)
+    if item.action == "verify_cold" and not item.key.startswith("id:"):
+        return tuple(a for a in answers if a != "body")
+    return answers
 
 
 def parse_decisions(payload: object) -> tuple[dict[str, Decision], list[str]]:
@@ -146,6 +170,7 @@ def parse_decisions(payload: object) -> tuple[dict[str, Decision], list[str]]:
             continue
         choice = row.get("choice")
         body = row.get("body")
+        side = row.get("side")
         if choice is not None and not isinstance(choice, str):
             errors.append(f"decision #{i} ({row['key']}): 'choice' must be a string")
             continue
@@ -155,10 +180,16 @@ def parse_decisions(payload: object) -> tuple[dict[str, Decision], list[str]]:
         if (choice is None) == (body is None):
             errors.append(f"decision #{i} ({row['key']}): give exactly one of 'choice' or 'body'")
             continue
+        if side is not None and side not in ("de", "en"):
+            errors.append(f"decision #{i} ({row['key']}): 'side' must be 'de' or 'en'")
+            continue
+        if side is not None and body is None:
+            errors.append(f"decision #{i} ({row['key']}): 'side' only accompanies a 'body' answer")
+            continue
         if row["key"] in decisions:
             errors.append(f"decision #{i} ({row['key']}): duplicate key")
             continue
-        decisions[row["key"]] = Decision(key=row["key"], choice=choice, body=body)
+        decisions[row["key"]] = Decision(key=row["key"], choice=choice, body=body, side=side)
     return decisions, errors
 
 
@@ -900,10 +931,15 @@ def _execute_decision(
             raise _ItemError(
                 f"'{item.action}' does not accept a body answer (allowed: {', '.join(allowed)})"
             )
+        if decision.side is not None and item.action != "verify_cold":
+            raise _ItemError(
+                f"'side' is only meaningful on a two-sided verify_cold body answer, "
+                f"not on '{item.action}' (which derives its target side itself)"
+            )
         error = _validate_body(decision.body, comment_token)
         if error:
             raise _ItemError(error)
-        _apply_body_decision(ex, item, decision.body)
+        _apply_body_decision(ex, item, decision.body, side=decision.side)
         return
     choice = decision.choice or ""
     if choice not in allowed:
@@ -913,8 +949,42 @@ def _execute_decision(
     _apply_choice_decision(ex, item, choice)
 
 
-def _apply_body_decision(ex: _Executor, item: DiffItem, body: str) -> None:
+def _apply_body_decision(
+    ex: _Executor, item: DiffItem, body: str, *, side: str | None = None
+) -> None:
     member = item.member
+    if item.action == "verify_cold":
+        # Cold recovery (issue #572): the agent read both bodies, judged the
+        # named twin stale, and supplies the corrected text — a one-pass fix
+        # instead of hand-editing the file then `confirm`-ing the stale twin.
+        # Scoped to id-keyed two-sided members: a positional cold member has
+        # no addressable id and its ordinal aliases a neighboring slot, so it
+        # cannot take a body (mint a slide_id and re-report). Because the target
+        # is always id-keyed, it is never in a `pos:` pool — the pool-coherence
+        # guard (which blesses pool siblings wholesale) is untouched here.
+        if not item.key.startswith("id:"):
+            raise _ItemError(
+                "a positional cold member cannot take a body — confirm the pool "
+                "(after checking the pair is in sync), or mint a slide_id and "
+                "re-report so the twin can be framed"
+            )
+        if member is None or member.is_one_sided:
+            raise _ItemError(
+                "cold body recovery needs a two-sided member — supply the missing "
+                "twin with translate_new instead"
+            )
+        if side is None:
+            raise _ItemError(
+                "a verify_cold body answer must name the 'side' to overwrite "
+                "(the stale twin: 'de' or 'en')"
+            )
+        target: Lang = side  # type: ignore[assignment]
+        holder = ex._holder(item, target)
+        cell = holder.side(target) if holder is not None else None
+        if holder is None or cell is None:
+            raise _ItemError(f"the {target} side of {item.key} is missing")
+        ex.set_side(holder, target, evolve(cell, lines=_replace_body(cell, body)))
+        return
     if item.action == "translate_edit":
         target = _decision_target_side(item)
         twin_member, twin_cell = ex._locate_twin(item, target)
@@ -1273,7 +1343,15 @@ def apply_deck(
 def _incoherent_pool_confirms(
     diff: DeckDiff, decisions: dict[str, Decision]
 ) -> set[tuple[str, str]]:
-    """Pools where only *some* cold members received a confirm decision."""
+    """Pools where only *some* cold members received a confirm decision.
+
+    Keyed strictly on ``choice == "confirm"`` — the only answer a *positional*
+    cold member accepts. A ``body`` (issue #572) is rejected on a positional
+    member (:func:`_apply_body_decision`), so it never lands a wholesale
+    ``rerecord_pool``; counting it as a resolving answer here would bless the
+    pool while the body itself is rejected downstream — the exact silent-bless
+    bug this guard exists to prevent. Do not widen it to body/keep_twin.
+    """
     cold_by_pool: dict[tuple[str, str], set[str]] = {}
     for item in diff.items:
         if item.action not in ("verify_cold", "verify_translation"):

--- a/src/clm/slides/doc_report.py
+++ b/src/clm/slides/doc_report.py
@@ -65,7 +65,7 @@ def item_payloads(diff: DeckDiff) -> list[dict]:
     items = []
     for item in diff.items:
         payload = item.payload()
-        answers = doc_apply.decision_vocabulary(item.action)
+        answers = doc_apply.item_answers(item)
         if answers:
             payload["answers"] = list(answers)
         items.append(payload)

--- a/tests/cli/test_sync_v3_cli.py
+++ b/tests/cli/test_sync_v3_cli.py
@@ -67,7 +67,11 @@ class TestSyncLoop:
         assert payload["is_clean"] is False
         assert payload["needs_agent"] is True
         assert {i["action"] for i in payload["items"]} == {"verify_cold"}
-        assert all(i["answers"] == ["confirm"] for i in payload["items"])
+        # id-keyed cold members also advertise `body` (inline stale-twin recovery,
+        # issue #572); positional ones stay confirm-only (no addressable id).
+        for i in payload["items"]:
+            expected = ["confirm", "body"] if i["key"].startswith("id:") else ["confirm"]
+            assert i["answers"] == expected, i
 
         # record blesses the current state (verify-gated).
         record = cli_runner.invoke(slides_sync_group, ["record", str(de), "--json"])
@@ -104,6 +108,45 @@ class TestSyncLoop:
         )
         assert result.exit_code == 0, result.output
         assert "# EN new" in en.read_text(encoding="utf-8")
+
+    def test_cold_body_recovery_fixes_a_stale_twin(self, cli_runner: CliRunner, tmp_path: Path):
+        # Issue #572: on a cold deck an id-keyed member whose EN was rewritten
+        # (DE twin now stale) is framed verify_cold — which now also offers a
+        # `body` answer. Supplying it with `side` overwrites the stale twin in
+        # one pass instead of `confirm` banking the stale German.
+        de, en = _write_pair(tmp_path)
+        # The DE twin of s0-m is a stale placeholder relative to the EN body.
+        de.write_text(
+            de.read_text(encoding="utf-8").replace("# DE Text", "# *(placeholder)*"), "utf-8"
+        )
+
+        report = _json_payload(
+            cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"]).output
+        )
+        s0m = next(i for i in report["items"] if i["key"] == "id:s0-m")
+        assert s0m["action"] == "verify_cold"
+        assert s0m["answers"] == ["confirm", "body"]
+
+        # Fix the stale DE twin inline; confirm the rest of the cold pairs.
+        rows = []
+        for item in report["items"]:
+            if item["key"] == "id:s0-m":
+                rows.append({"key": item["key"], "body": "# DE frisch übersetzt", "side": "de"})
+            else:
+                rows.append({"key": item["key"], "choice": "confirm"})
+        applied = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--decisions", "-", "--json"],
+            input=json.dumps({"decisions": rows}),
+        )
+        assert applied.exit_code == 0, applied.output
+        de_text = de.read_text(encoding="utf-8")
+        assert "# DE frisch übersetzt" in de_text
+        assert "placeholder" not in de_text
+
+        clean = cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"])
+        assert clean.exit_code == 0, clean.output
+        assert _json_payload(clean.output)["is_clean"] is True
 
     def test_apply_residue_exits_one(self, cli_runner: CliRunner, tmp_path: Path):
         de, en = _write_pair(tmp_path)

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -898,7 +898,11 @@ class TestSyncReport:
         assert data["is_clean"] is False
         assert data["needs_agent"] is True
         assert {i["action"] for i in data["items"]} == {"verify_cold"}
-        assert all(i["answers"] == ["confirm"] for i in data["items"])
+        # id-keyed cold members also advertise `body` (inline stale-twin recovery,
+        # issue #572); positional ones stay confirm-only (no addressable id).
+        for i in data["items"]:
+            expected = ["confirm", "body"] if i["key"].startswith("id:") else ["confirm"]
+            assert i["answers"] == expected, i
 
     async def test_localized_edit_needs_model(self, tmp_path):
         de_path, en_path = self._pair(tmp_path)

--- a/tests/slides/test_doc_apply.py
+++ b/tests/slides/test_doc_apply.py
@@ -468,8 +468,14 @@ class TestPerItem:
 # ---------------------------------------------------------------------------
 
 
-def _decision(key: str, *, choice: str | None = None, body: str | None = None):
-    return {key: doc_apply.Decision(key=key, choice=choice, body=body)}
+def _decision(
+    key: str,
+    *,
+    choice: str | None = None,
+    body: str | None = None,
+    side: str | None = None,
+):
+    return {key: doc_apply.Decision(key=key, choice=choice, body=body, side=side)}
 
 
 class TestDecisions:
@@ -605,6 +611,125 @@ class TestDecisions:
         assert outcome.all_applied, outcome.to_payload()
         assert "y = 99" not in deck.de_path.read_text(encoding="utf-8")
         deck.assert_converged()
+
+
+class TestColdBodyRecovery:
+    """Issue #572: a `body` answer fixes a stale twin on a two-sided
+    `verify_cold` member in one pass, instead of `confirm` banking it stale."""
+
+    def _cold_member_with_stale_de(self, tmp_path: Path) -> _Deck:
+        # Record the base, then add a NEW id member whose DE twin is a stale
+        # placeholder while EN carries the real content — the shape the issue
+        # describes (a renamed/edited cell that fell cold with a stale twin).
+        deck = _deck(tmp_path)
+        deck.write_de(*DE_PARTS, _localized("s0-new", "de", "*(placeholder)*"))
+        deck.write_en(*EN_PARTS, _localized("s0-new", "en", "Real EN content"))
+        _, diff = deck.diff()
+        assert [(i.key, i.action) for i in diff.items] == [("id:s0-new", "verify_cold")]
+        return deck
+
+    def test_body_overwrites_the_named_stale_twin(self, tmp_path: Path):
+        deck = self._cold_member_with_stale_de(tmp_path)
+        outcome = deck.apply(_decision("id:s0-new", body="# Echte DE-Übersetzung", side="de"))
+        assert outcome.all_applied, outcome.to_payload()
+        assert outcome.wrote
+        de_text = deck.de_path.read_text(encoding="utf-8")
+        assert "# Echte DE-Übersetzung" in de_text
+        assert "*(placeholder)*" not in de_text
+        # The other half is untouched, and the fixed pair records clean.
+        assert "Real EN content" in deck.en_path.read_text(encoding="utf-8")
+        deck.assert_converged()
+
+    def test_body_answer_advertised_only_for_id_keyed_cold(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.write_de(*DE_PARTS, _localized("s0-new", "de", "Neu"))
+        deck.write_en(*EN_PARTS, _localized("s0-new", "en", "New"))
+        _, diff = deck.diff()
+        (item,) = diff.items
+        assert doc_apply.item_answers(item) == ("confirm", "body")
+
+    def test_body_without_side_is_rejected(self, tmp_path: Path):
+        deck = self._cold_member_with_stale_de(tmp_path)
+        before = deck.de_path.read_text(encoding="utf-8")
+        outcome = deck.apply(_decision("id:s0-new", body="# irgendwas"))
+        result = next(r for r in outcome.results if r.key == "id:s0-new")
+        assert result.status == "rejected"
+        assert "side" in result.reason
+        assert deck.de_path.read_text(encoding="utf-8") == before
+
+    def test_confirm_still_records_the_pair_as_is(self, tmp_path: Path):
+        # `confirm` remains valid — it banks both sides verbatim (the caller
+        # judged them in sync). This is the pre-#572 behavior, still available.
+        deck = self._cold_member_with_stale_de(tmp_path)
+        outcome = deck.apply(_decision("id:s0-new", choice="confirm"))
+        assert outcome.all_applied, outcome.to_payload()
+        assert not outcome.wrote
+        deck.assert_converged()
+
+    def test_body_on_a_positional_cold_member_is_rejected(self, tmp_path: Path):
+        # A new un-id'd shared code cell inserted among existing cells falls
+        # cold positionally (its ordinal aliases a neighbor); it has no
+        # addressable id, so a body is refused (mint a slide_id instead).
+        deck = _deck(tmp_path)
+        new = _shared_code("z", 9)  # new, between x and y — added on BOTH sides
+        deck.write_de(
+            HEADER_DE,
+            _slide("s0", "de", "Titel"),
+            _shared_code("x"),
+            new,
+            _shared_code("y", 2),
+            _localized("s0-m", "de", "DE Text"),
+        )
+        deck.write_en(
+            HEADER_EN,
+            _slide("s0", "en", "Title"),
+            _shared_code("x"),
+            new,
+            _shared_code("y", 2),
+            _localized("s0-m", "en", "EN text"),
+        )
+        _, diff = deck.diff()
+        cold = [i for i in diff.items if i.action == "verify_cold" and i.key.startswith("pos:")]
+        assert cold, [(i.key, i.action) for i in diff.items]
+        item = cold[0]
+        assert doc_apply.item_answers(item) == ("confirm",)
+        outcome = deck.apply(_decision(item.key, body="z = 9", side="de"))
+        result = next(r for r in outcome.results if r.key == item.key)
+        assert result.status == "rejected"
+        assert "positional" in result.reason
+
+    def test_side_on_a_translate_edit_body_is_rejected(self, tmp_path: Path):
+        deck = _deck(tmp_path)
+        deck.edit_de("DE Text", "DE Text NEU")
+        _, diff = deck.diff()
+        assert [(i.key, i.action) for i in diff.items] == [("id:s0-m", "translate_edit")]
+        outcome = deck.apply(_decision("id:s0-m", body="# EN new", side="en"))
+        result = next(r for r in outcome.results if r.key == "id:s0-m")
+        assert result.status == "rejected"
+        assert "side" in result.reason
+
+
+class TestDecisionParsing:
+    def test_side_must_be_de_or_en(self):
+        decisions, errors = doc_apply.parse_decisions(
+            {"decisions": [{"key": "id:x", "body": "b", "side": "left"}]}
+        )
+        assert not decisions
+        assert any("'side' must be 'de' or 'en'" in e for e in errors)
+
+    def test_side_requires_a_body(self):
+        decisions, errors = doc_apply.parse_decisions(
+            {"decisions": [{"key": "id:x", "choice": "confirm", "side": "de"}]}
+        )
+        assert not decisions
+        assert any("only accompanies a 'body'" in e for e in errors)
+
+    def test_valid_side_body_parses(self):
+        decisions, errors = doc_apply.parse_decisions(
+            {"decisions": [{"key": "id:x", "body": "b", "side": "de"}]}
+        )
+        assert not errors
+        assert decisions["id:x"].side == "de"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR 2 of 2 for #572. Closes the second half of the cold-ledger stale-twin
footgun: recovery for decks that are **already cold**. (PR 1, #573, shipped
`clm slides rename-id` so a deliberate rename keeps the ledger warm.)

A two-sided `verify_cold` item on an **id-keyed** member now accepts a `body`
answer in the sync decisions document, with a new `side` (`"de"`/`"en"`) field
naming the stale twin to overwrite:

```json
{"key": "id:intro", "body": "# frische Übersetzung", "side": "de"}
```

Before, the only answer was `confirm`, which banks **both sides as-is** — so a
cell that fell cold with a *stale* twin (its source edited while the ledger was
cold, exactly the issue's repro) could only be fixed by hand-editing the `.de`
file and *then* confirming. Supplying the corrected twin inline makes cold
recovery a one-pass operation, consistent with how `translate_edit` already
works. This is the issue's suggestion #1 (the biggest ergonomic win) plus its
suggestion #4 tail (document that `confirm` banks the twin as-is).

## Scope & safety

- **id-keyed only.** A positional cold member has no addressable id and its
  ordinal aliases a neighboring slot, so it still takes only `confirm` (mint a
  `slide_id` first if its twin is stale). A new key-aware
  `doc_apply.item_answers` drops `body` from a positional `verify_cold`'s
  advertised `answers`; the executor refuses a body on a `pos:` key with a
  mint-a-slide_id hint.
- **The pool-coherence guard is deliberately NOT widened.** Because a body can
  only land on an id-keyed member (never in a `pos:` pool), it never triggers a
  wholesale `rerecord_pool`. Counting `body`/`keep_twin` as resolving answers —
  the tempting "fix" — would mark a pool coherent while the body is rejected
  downstream, reintroducing the exact silent-bless bug the guard exists to
  prevent. A comment on `_incoherent_pool_confirms` documents "do not widen."
- **`Decision.side`** is validated in `parse_decisions` (must accompany a
  `body`; must be `de`/`en`) and rejected on any non-`verify_cold` body answer
  (every other action derives its own target side).
- `keep_twin` for cold and `--strict-cold` were **not** shipped: on a cold
  member `keep_twin ≡ confirm` in ledger effect, so both would be redundant.

## Tests

- `tests/slides/test_doc_apply.py::TestColdBodyRecovery` — body overwrites the
  named stale twin then records clean; `confirm` still banks as-is; body
  without `side`, body on a positional member, and `side` on a `translate_edit`
  are each rejected byte-unchanged.
- `TestDecisionParsing` — `side` must be de/en and must accompany a body.
- `tests/cli/test_sync_v3_cli.py::…test_cold_body_recovery_fixes_a_stale_twin`
  — the full issue repro through the CLI (cold deck → `report` advertises
  `["confirm","body"]` → `apply` a `body`+`side` decision over stdin → clean).
- Updated the two existing `["confirm"]`-only report assertions to the
  key-aware expectation.

Full slides + cli + mcp suite: 3536 passed. ruff + mypy clean.

Docs: `clm info sync-agents` (framed actions, `side` field, cold-members
section), `clm info commands` (apply decisions doc + rename-id cross-ref),
changelog fragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018MHWeqbb4VaqRToiscAaS5
