### PR TITLE
fix(backend): register job-cache-hit output so the sweep keeps cached HTML (#577)

### DIFF
--- a/changelog.d/577-jobcache-hit-sweep-deletes-cached-html.fixed.md
+++ b/changelog.d/577-jobcache-hit-sweep-deletes-cached-html.fixed.md
@@ -1,0 +1,8 @@
+- **Incremental rebuilds no longer delete cached recording/speaker HTML.** A
+  SQLite job-cache hit (`jobcache_hit`) served the output from disk without
+  recording it in the output-write registry, so the end-of-build stray-file
+  sweep treated the valid cached file as an orphan and removed it. This bit
+  recording/speaker HTML for unchanged topics on incremental Docker-backend
+  rebuilds (notebooks and `shared`/`trainer` HTML were unaffected). The
+  job-cache-hit path now registers its on-disk output, matching the
+  database-cache and executed-job paths. (#577)

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -367,6 +367,32 @@ class SqliteBackend(LocalOpsBackend):
                     job_type,
                     detail="output already on disk, no execution",
                 )
+            # Register the already-on-disk output so the end-of-build stray
+            # sweep keeps it. The sweep deletes any output not in
+            # output_write_registry; without this a job-cache hit leaves the
+            # valid cached file unregistered and the sweep removes it (issue
+            # #577 — recording/speaker HTML for unchanged topics vanished on
+            # incremental rebuilds). Mirrors the executed-job registration and
+            # the DB-cache path above: the "cache replay is observationally
+            # equivalent to execution" invariant (issue #321) must include the
+            # write registry, not just issue replay and hit reporting.
+            registry_output_path = Path(payload.output_file)
+            if not registry_output_path.is_absolute():
+                registry_output_path = self.workspace_path / registry_output_path
+            if registry_output_path.exists():
+                registry_source = Path(payload.input_file)
+                if is_image_path(registry_source):
+                    self.image_registry.record_output_write(registry_output_path)
+                try:
+                    self.output_write_registry.record_write(
+                        registry_output_path,
+                        content_source=registry_output_path,
+                        source=registry_source,
+                    )
+                except Exception as reg_exc:
+                    logger.debug(
+                        f"Could not register cached output {registry_output_path}: {reg_exc}"
+                    )
             return True
 
         # outcome == "submitted": the job is in the jobs DB. Register it for the

--- a/tests/infrastructure/backends/test_sqlite_backend.py
+++ b/tests/infrastructure/backends/test_sqlite_backend.py
@@ -1125,6 +1125,75 @@ async def test_recording_html_cache_replay_blocked_when_executed_notebooks_cold(
 
 
 @pytest.mark.asyncio
+async def test_recording_html_jobcache_hit_registers_output_for_sweep(
+    temp_db, temp_workspace, temp_cache_db
+):
+    """A SQLite job-cache hit must register its on-disk output (issue #577).
+
+    Recording HTML with a cold executed_notebooks cache is steered off the
+    registering DB-cache replay path and into job submission. When the job
+    cache reports the output is already on disk, ``_submit_job_blocking``
+    returns ``jobcache_hit`` and no worker runs — but the file must still be
+    recorded in ``output_write_registry``. Otherwise the end-of-build stray
+    sweep (which deletes any output not in the registry) removes the valid
+    cached file, as seen with speaker/recording HTML for unchanged topics
+    disappearing on incremental rebuilds.
+    """
+    from clm.infrastructure.messaging.base_classes import Result
+
+    class MockResult(Result):
+        data: bytes = b"<html>cached</html>"
+
+        def result_bytes(self) -> bytes:
+            return self.data
+
+        def output_metadata(self) -> str:
+            return "recording:python:en:html"
+
+    backend = SqliteBackend(
+        db_path=temp_db,
+        workspace_path=temp_workspace,
+        ignore_db=False,
+        skip_worker_check=True,
+    )
+
+    try:
+        mock_result = MockResult(
+            correlation_id="test",
+            output_file="output/test.html",
+            input_file="test.py",
+            content_hash="abc123",
+        )
+        backend.db_manager = _make_mock_db_manager(temp_cache_db, mock_result)
+
+        operation = MockOperation(service_name_value="notebook-processor")
+        payload = _make_recording_html_payload()
+
+        # The cached output already exists on disk from a prior build.
+        output_path = temp_workspace / payload.output_file
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(b"<html>cached</html>")
+
+        # Force the SQLite job cache to report a hit so _submit_job_blocking
+        # short-circuits to jobcache_hit instead of enqueuing a worker job.
+        assert backend.job_queue is not None
+        backend.job_queue.check_cache = Mock(return_value={"hit": True})
+
+        await backend.execute_operation(operation, payload)
+
+        # jobcache_hit path: no worker job submitted, cached file preserved.
+        assert len(backend.active_jobs) == 0
+        assert output_path.exists()
+
+        # Regression: the on-disk output is now in the write registry, so the
+        # stray-file sweep treats it as live and keeps it.
+        assert output_path in backend.output_write_registry.entries
+    finally:
+        backend.active_jobs.clear()
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_recording_html_cache_replay_proceeds_when_executed_notebooks_warm(
     temp_db, temp_workspace, temp_cache_db
 ):


### PR DESCRIPTION
Closes #577.

## Problem

On an incremental Docker-backend rebuild, the end-of-build stray-file sweep **deleted valid, cached recording/speaker HTML** for unchanged topics. The sweep removes any output not present in `output_write_registry` (`output_sweep.py:160,265,270`), and the SQLite **job-cache-hit** path never registered its output.

When `_submit_job_blocking` finds a stored result already on disk it returns `("jobcache_hit", None)` (`sqlite_backend.py:429`); the caller's `jobcache_hit` branch replayed issues and reported the hit, then `return True` **without** `record_write` — unlike the DB-cache path (`:256`) and the executed-job path (`:767`). So the file was absent from the registry and the sweep removed it.

**Why only recording/speaker HTML:** `_can_replay_from_cache` (`:503`) returns `True` for everything except recording/speaker HTML, so notebooks and shared/trainer HTML take the registering DB-cache path and survive. Recording/speaker HTML with a cold `executed_notebooks` cache is steered into job submission, where the on-disk output yields a `jobcache_hit` — the one path that did not register.

## Fix

Register the already-on-disk output in the `jobcache_hit` branch before returning, mirroring the executed-job registration (guarded by `output_path.exists()`, with the same image-registry handling and defensive `try/except`). This extends the "a cache replay must be observationally equivalent to execution" invariant (#321) — already applied to issue replay and hit reporting — to the write registry.

## Test

Adds `test_recording_html_jobcache_hit_registers_output_for_sweep`, which drives a recording-HTML payload with a cold execution cache and a primed job-cache hit, then asserts the output path is in `output_write_registry.entries`. Verified it **fails against the pre-fix code** (empty registry) and passes with the fix. No existing test covered this path — the closest only exercised the "job submitted" outcome and asserted the output did *not* exist.

## Validation

- `pytest tests/infrastructure/backends/test_sqlite_backend.py -m "not docker"` → 37 passed
- ruff lint + format clean; mypy clean on the changed file
- pre-commit and pre-push (fast suite) hooks passed
- Changelog fragment added: `changelog.d/577-jobcache-hit-sweep-deletes-cached-html.fixed.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)