### PR TITLE
fix(cache): overlap-safe path migrator + embedded issue-path migration

### DIFF
--- a/docs/claude/design/course-restructure-move-rename.md
+++ b/docs/claude/design/course-restructure-move-rename.md
@@ -179,6 +179,29 @@ Options:
 - `--report-only` / `--json` — dry-run, same contract as `rename-id`.
 - `--no-cache-migrate` — skip the DB rewrite (accept a one-time re-execution).
 
+**Validation requirements (issue #589)** — hard guards the command MUST
+implement, found in adversarial review after Phase-1 core landed:
+
+1. **Only rename canonical `topic_<digits>_<suffix>` dirs.**
+   `simplify_ordered_name` blindly drops the first two `_`-parts, so a
+   non-canonical dir like `topic_extras_bonus` has id `bonus`; renumbering it
+   to `topic_045_extras_bonus` silently *changes its id* to `extras_bonus`,
+   breaking spec refs, `clm:` links, and every id-keyed store. Match against
+   `topic_(\d+)_(.+)` and loudly skip (or refuse on) anything else.
+2. **Leave orphan topic dirs untouched** (on disk, not referenced by the
+   spec), and validate that no newly assigned name collides with one.
+3. **Say which spec defines the order.** Repos carry several specs that may
+   reference the same module in different orders (outputs are unaffected —
+   ordering is per-spec — but the report should name the ordering spec and
+   ideally warn when another spec disagrees).
+4. **Refuse (or `--force`) while a build is active** — the migrator's "run
+   while no build is active" contract is not self-enforcing, and the
+   filesystem `git mv` mid-build is the bigger hazard.
+5. **Resolve `clm_cache.db` exactly like the build does**
+   (`--cache-db-path` / `CLM_CACHE_DB_PATH` / config), never an assumed
+   project-root default — migrating the wrong DB is a silent no-op followed
+   by a full re-execution.
+
 ### 5.2 `clm course mv` — general single move/rename
 
 ```
@@ -361,6 +384,14 @@ core of every later phase) right in isolation.
   interchangeable payload); `dry_run` does the identical work then rolls back so
   its counts equal a real run's.
 - `migrate_dir_rename(...)` — the `plan` + `migrate` convenience.
+- **Hardened post-merge (issues #587/#588):** the rewrite is two-phase
+  (park on sentinels, then land), making it order-independent and safe for
+  *overlapping* mapping sets — chains (`a→b, b→c`) and swaps (`a→b, b→a`) —
+  which the later phases (`--slides`, `mv`, `restructure`) can legitimately
+  produce; and `processing_issues.issue_json`'s embedded `file_path` is
+  re-pointed along with the column, so cached errors/warnings stop naming
+  the pre-rename path on replay. (The pickled `Result.input_file` is
+  verified inert on the replay path and deliberately left alone.)
 
 The tests seed rows through the *real* cache managers and assert a live cache
 **hit at the new path / miss at the old** after migration — verifying the

--- a/src/clm/infrastructure/database/cache_path_migration.py
+++ b/src/clm/infrastructure/database/cache_path_migration.py
@@ -29,18 +29,36 @@ prefix changes). The ``results_cache.output_file`` rewrite in ``clm_jobs.db`` is
 the analogous, deliberately-separate operation for moves that change output
 locations; it is not implemented here.
 
-Collision handling
-==================
+Overlapping mappings and collision handling
+===========================================
+
+The rewrite is **two-phase and order-independent** (issue #587): every
+mapping's rows are first parked on a unique sentinel path, then landed on
+their destinations. A naive sequential ``UPDATE old → new`` would let a later
+mapping re-migrate an earlier mapping's result whenever the set overlaps
+(``new₁ == old₂`` — a chain, or two paths swapping names in a batch
+restructure), silently piling rows onto the wrong path and, worse, letting the
+UNIQUE-collision check delete rows that were themselves about to move away.
+Parking first means each row moves exactly once and collisions are judged
+against the *final* state.
 
 Only ``executed_notebooks`` carries a ``UNIQUE(input_file, content_hash,
-language, prog_lang)`` constraint. A rewrite ``old → new`` collides only when a
-row already exists at ``new`` with the **same** ``content_hash`` — i.e. an
-equivalent executed notebook (same content ⇒ same cached payload). Such a
-migrated duplicate is simply dropped (counted as ``collisions_dropped``); the
-surviving destination row serves the identical hit. ``processed_files`` /
-``processing_issues`` have no UNIQUE constraint, so their rewrite is a plain
-``UPDATE``; any transient duplicate versions are trimmed by the ordinary
-newest-N build-end prune.
+language, prog_lang)`` constraint. After parking, a landing collides only when
+a row that was **never mapped away** already sits at ``new`` with the same
+``content_hash`` — i.e. an equivalent executed notebook (same content ⇒ same
+cached payload). Such a migrated duplicate is dropped (counted as
+``collisions_dropped``); the surviving destination row serves the identical
+hit. ``processed_files`` / ``processing_issues`` have no UNIQUE constraint, so
+their landing is a plain ``UPDATE``; any transient duplicate versions are
+trimmed by the ordinary newest-N build-end prune.
+
+``processing_issues`` rows additionally get the ``file_path`` **embedded in
+their ``issue_json`` payload** re-pointed (issue #588) — the column alone is
+not enough, because cached errors/warnings are re-reported from that JSON and
+would otherwise name the old, no-longer-existing path. The pickled ``Result``
+in ``processed_files`` also embeds its original ``input_file``, but that copy
+is inert: the replay path consumes only the freshly computed payload paths
+plus ``result_bytes()``, so it is deliberately left untouched.
 
 The whole rewrite runs in one transaction (``BEGIN IMMEDIATE`` … ``COMMIT``);
 ``dry_run`` performs the identical work and ``ROLLBACK``s, so the reported
@@ -49,6 +67,7 @@ counts always match what a real run would do. Run it while no build is active.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import sqlite3
@@ -244,6 +263,58 @@ def plan_dir_rename(
 # ---------------------------------------------------------------------------
 
 
+#: Sentinel paths park rows between the two rewrite phases. NUL bytes cannot
+#: appear in a real filesystem path, so a sentinel can never alias stored data.
+_SENTINEL_PREFIX = "\x00clm-cache-path-migration:"
+
+
+def _sentinel(index: int) -> str:
+    return f"{_SENTINEL_PREFIX}{index}\x00"
+
+
+def _rewrite_issue_json(issue_json: str, old: str, new: str) -> str | None:
+    """Return ``issue_json`` with its embedded ``file_path`` re-pointed from
+    ``old`` to ``new``, or ``None`` if there is nothing to rewrite.
+
+    ``BuildError`` / ``BuildWarning`` are stored as ``json.dumps(asdict(...))``
+    with a top-level ``file_path`` (issue #588). Free-text ``message`` content
+    is left alone — rewriting paths inside prose is not reliably possible —
+    and malformed JSON is left untouched rather than destroyed.
+    """
+    try:
+        data = json.loads(issue_json)
+    except ValueError:
+        return None
+    field = data.get("file_path")
+    if not isinstance(field, str):
+        return None
+    rewritten = _rewrite_under(field, old, new)
+    if rewritten is None or rewritten == field:
+        return None
+    data["file_path"] = rewritten
+    return json.dumps(data)
+
+
+def _rewrite_parked_issue_payloads(
+    conn: sqlite3.Connection, sentinel: str, mapping: PathMapping
+) -> None:
+    """Re-point the ``file_path`` embedded in parked ``processing_issues``
+    rows' ``issue_json`` — the column rewrite alone would leave cached
+    errors/warnings reporting the old, no-longer-existing path on replay
+    (issue #588)."""
+    rows = conn.execute(
+        "SELECT id, issue_json FROM processing_issues WHERE file_path = ?",
+        (sentinel,),
+    ).fetchall()
+    for row_id, issue_json in rows:
+        updated = _rewrite_issue_json(issue_json, mapping.old, mapping.new)
+        if updated is not None:
+            conn.execute(
+                "UPDATE processing_issues SET issue_json = ? WHERE id = ?",
+                (updated, row_id),
+            )
+
+
 def _migrate_table(
     conn: sqlite3.Connection,
     table: str,
@@ -251,21 +322,40 @@ def _migrate_table(
     mappings: Sequence[PathMapping],
 ) -> TableMigration:
     dims = _UNIQUE_CONTENT_DIMS.get(table)
+    # Phase 1: park every mapping's rows on a unique sentinel so no later
+    # UPDATE can observe (and re-migrate) an earlier mapping's result. This
+    # makes the rewrite order-independent and correct for overlapping mapping
+    # sets — a chain (a→b, b→c) or a swap (a→b, b→a) moves every row exactly
+    # once (issue #587).
+    parked: list[tuple[str, PathMapping]] = []
+    for index, m in enumerate(mappings):
+        sentinel = _sentinel(index)
+        moved = conn.execute(
+            f"UPDATE {table} SET {column} = ? WHERE {column} = ?",  # noqa: S608
+            (sentinel, m.old),
+        ).rowcount
+        if moved:
+            parked.append((sentinel, m))
+    # Phase 2: land the parked rows. Rows now sitting at a destination path
+    # are exactly the rows that were never mapped away, so the UNIQUE-collision
+    # check judges against the final state instead of a mid-rewrite one.
     rewritten = 0
     collisions = 0
-    for m in mappings:
+    for sentinel, m in parked:
         if dims:
-            # Drop old-path rows that would violate UNIQUE against a row already
+            # Drop parked rows that would violate UNIQUE against a row already
             # sitting at the new path (same content_hash ⇒ equivalent payload).
             dim_match = " AND ".join(f"t2.{d} = {table}.{d}" for d in dims)
             del_sql = (
                 f"DELETE FROM {table} WHERE {column} = ? AND EXISTS ("  # noqa: S608
                 f"SELECT 1 FROM {table} AS t2 WHERE t2.{column} = ? AND {dim_match})"
             )
-            collisions += conn.execute(del_sql, (m.old, m.new)).rowcount
+            collisions += conn.execute(del_sql, (sentinel, m.new)).rowcount
+        if table == "processing_issues":
+            _rewrite_parked_issue_payloads(conn, sentinel, m)
         upd = conn.execute(
             f"UPDATE {table} SET {column} = ? WHERE {column} = ?",  # noqa: S608
-            (m.new, m.old),
+            (m.new, sentinel),
         )
         rewritten += upd.rowcount
     return TableMigration(table=table, rows_rewritten=rewritten, collisions_dropped=collisions)
@@ -279,10 +369,13 @@ def migrate_cache_paths(
 ) -> CacheMigrationReport:
     """Rewrite ``old → new`` input paths across the three ``clm_cache.db`` tables.
 
-    Self-mappings (``old == new``) are ignored. If the DB does not exist or there
-    is nothing to rewrite, returns an empty report without creating the file.
-    ``dry_run`` performs the identical work then rolls back, so its counts equal
-    a real run's. The whole rewrite is a single transaction.
+    Overlapping mapping sets (one mapping's ``new`` equal to another's ``old`` —
+    chains, swaps) are safe and order-independent: rows are parked on sentinel
+    paths first, so each row moves exactly once (issue #587). Self-mappings
+    (``old == new``) are ignored. If the DB does not exist or there is nothing
+    to rewrite, returns an empty report without creating the file. ``dry_run``
+    performs the identical work then rolls back, so its counts equal a real
+    run's. The whole rewrite is a single transaction.
     """
     cache_db_path = Path(cache_db_path)
     mapping_list = [m for m in mappings if m.old != m.new]

--- a/tests/infrastructure/database/test_cache_path_migration.py
+++ b/tests/infrastructure/database/test_cache_path_migration.py
@@ -290,6 +290,125 @@ def test_sibling_topic_rows_are_not_touched(cache_db, tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Overlapping mapping sets — chains and swaps (issue #587)
+# ---------------------------------------------------------------------------
+
+
+def test_chained_mappings_move_each_row_exactly_once(cache_db, tmp_path):
+    x = tmp_path / "topic_010_a" / "s.py"
+    y = tmp_path / "topic_020_b" / "s.py"
+    z = tmp_path / "topic_030_c" / "s.py"
+    _seed_processed(cache_db, x, content_hash="hX")
+    _seed_processed(cache_db, y, content_hash="hY")
+
+    # Chain: x→y while y→z. A sequential rewrite would drag x's row on to z.
+    migrate_cache_paths(cache_db, [PathMapping(str(x), str(y)), PathMapping(str(y), str(z))])
+
+    with DatabaseManager(cache_db) as m:
+        assert m.get_result(str(y), "hX", _META) is not None  # moved once, not twice
+        assert m.get_result(str(z), "hY", _META) is not None
+        assert m.get_result(str(x), "hX", _META) is None
+        assert m.get_result(str(z), "hX", _META) is None  # the double-migration symptom
+
+
+def test_chained_mappings_are_order_independent(cache_db, tmp_path):
+    x = tmp_path / "topic_010_a" / "s.py"
+    y = tmp_path / "topic_020_b" / "s.py"
+    z = tmp_path / "topic_030_c" / "s.py"
+    _seed_processed(cache_db, x, content_hash="hX")
+    _seed_processed(cache_db, y, content_hash="hY")
+
+    # Same chain as above, mappings supplied in the reverse order.
+    migrate_cache_paths(cache_db, [PathMapping(str(y), str(z)), PathMapping(str(x), str(y))])
+
+    with DatabaseManager(cache_db) as m:
+        assert m.get_result(str(y), "hX", _META) is not None
+        assert m.get_result(str(z), "hY", _META) is not None
+        assert m.get_result(str(z), "hX", _META) is None
+
+
+def test_swap_mappings_preserve_both_executed_rows(cache_db, tmp_path):
+    x = tmp_path / "topic_010_a" / "s.py"
+    y = tmp_path / "topic_020_b" / "s.py"
+    # Same (content_hash, language, prog_lang) at both paths: a mid-rewrite
+    # collision check would delete one row even though both are live.
+    _seed_executed(cache_db, x, content_hash="h")
+    _seed_executed(cache_db, y, content_hash="h")
+
+    report = migrate_cache_paths(
+        cache_db, [PathMapping(str(x), str(y)), PathMapping(str(y), str(x))]
+    )
+
+    exec_report = next(t for t in report.tables if t.table == "executed_notebooks")
+    assert exec_report.collisions_dropped == 0
+    assert exec_report.rows_rewritten == 2
+    with ExecutedNotebookCache(cache_db) as c:
+        assert c.get(str(x), "h", "en", "python") is not None
+        assert c.get(str(y), "h", "en", "python") is not None
+
+
+def test_chain_does_not_count_mapped_away_row_as_collision(cache_db, tmp_path):
+    x = tmp_path / "topic_010_a" / "s.py"
+    y = tmp_path / "topic_020_b" / "s.py"
+    z = tmp_path / "topic_030_c" / "s.py"
+    _seed_executed(cache_db, x, content_hash="h")
+    _seed_executed(cache_db, y, content_hash="h")
+
+    # y's row leaves for z, so x's row landing on y must NOT be dropped.
+    report = migrate_cache_paths(
+        cache_db, [PathMapping(str(x), str(y)), PathMapping(str(y), str(z))]
+    )
+
+    exec_report = next(t for t in report.tables if t.table == "executed_notebooks")
+    assert exec_report.collisions_dropped == 0
+    assert exec_report.rows_rewritten == 2
+    with ExecutedNotebookCache(cache_db) as c:
+        assert c.get(str(y), "h", "en", "python") is not None
+        assert c.get(str(z), "h", "en", "python") is not None
+        assert c.get(str(x), "h", "en", "python") is None
+
+
+# ---------------------------------------------------------------------------
+# Embedded issue_json paths (issue #588)
+# ---------------------------------------------------------------------------
+
+
+def test_issue_json_embedded_file_path_is_rewritten(cache_db, tmp_path):
+    old = tmp_path / "topic_100" / "s.py"
+    new = tmp_path / "topic_040" / "s.py"
+    _seed_issues(cache_db, old)
+
+    migrate_cache_paths(cache_db, [PathMapping(str(old), str(new))])
+
+    with DatabaseManager(cache_db) as m:
+        errs, warns = m.get_issues(str(new), "h1", _META)
+    assert errs[0].file_path == str(new)
+    assert warns[0].file_path == str(new)
+
+
+def test_issue_json_unrelated_file_path_is_untouched(cache_db, tmp_path):
+    old = tmp_path / "topic_100" / "s.py"
+    new = tmp_path / "topic_040" / "s.py"
+    other = tmp_path / "elsewhere" / "other.py"
+    _seed_issues(cache_db, old)
+    # Make the embedded path differ from the column value: it must survive
+    # unchanged when it does not match the mapping.
+    with sqlite3.connect(str(cache_db)) as conn:
+        conn.execute(
+            "UPDATE processing_issues SET issue_json = "
+            "json_set(issue_json, '$.file_path', ?) WHERE issue_type = 'warning'",
+            (str(other),),
+        )
+
+    migrate_cache_paths(cache_db, [PathMapping(str(old), str(new))])
+
+    with DatabaseManager(cache_db) as m:
+        errs, warns = m.get_issues(str(new), "h1", _META)
+    assert errs[0].file_path == str(new)
+    assert warns[0].file_path == str(other)
+
+
+# ---------------------------------------------------------------------------
 # Edge cases
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Root-cause fixes for the defects found in adversarial review of #586, plus the design-doc addendum recording the `clm course renumber` validation requirements.

## Fixes #587 — overlapping/chained mapping sets corrupted the cache

`migrate_cache_paths` applied mappings as sequential `UPDATE`s, so when the set overlapped (`new₁ == old₂` — chains, swaps), later mappings re-migrated earlier mappings' rows onto the wrong path, and the `executed_notebooks` UNIQUE-collision `DELETE` judged against **mid-rewrite** state, destroying live rows that were themselves scheduled to move (confirmed by experiment; details in the issue).

The rewrite is now **two-phase inside the same transaction**: every mapping's rows are parked on a unique NUL-sentinel path (impossible as a real path), then landed on their destinations. Each row moves exactly once, the outcome is order-independent, and collisions are reconciled against the *final* state. Disjoint mapping sets — all of Phase 1 — keep byte-identical behavior and counts, so dry-run parity is preserved.

## Fixes #588 — migrated `processing_issues` re-reported the stale embedded path

The `file_path` embedded in each row's `issue_json` payload (`BuildError`/`BuildWarning`) is now re-pointed along with the column, so cached errors/warnings replay with the post-rename path. Free-text `message` content is not rewritten; malformed JSON is left untouched. The pickled `Result.input_file` in `processed_files` was verified **inert** on the replay path (only freshly computed payload paths plus `result_bytes()` are consumed) and is deliberately left alone — now documented in the module docstring.

## Refs #589 — renumber-command validation requirements (stays open)

`docs/claude/design/course-restructure-move-rename.md` §5.1 now records the five hard guards `clm course renumber` must implement (canonical `topic_<digits>_<suffix>` names only, orphan dirs untouched, ordering spec named, active-build guard, config-resolved cache-DB path), and the delivered-so-far section documents this hardening. #589 closes when the command ships with those guards.

## Tests

6 new tests (20 total in the module): chain moves each row exactly once, chain is order-independent, swap preserves both `executed_notebooks` rows, mapped-away destination rows are not counted as collisions, embedded `issue_json` path is rewritten, and a non-matching embedded path survives untouched. No changelog fragment / info-topic update: internal module with no CLI surface, fixing unreleased code (same reasoning as #586).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TM3Pre9YPM5aTm65mmf6kM
