### PR TITLE
feat(course): clm course renumber — spec-order topic renumbering with cache migration

### DIFF
--- a/changelog.d/589-course-renumber.added.md
+++ b/changelog.d/589-course-renumber.added.md
@@ -1,0 +1,8 @@
+- `clm course renumber` — renumber `topic_NNN_` directories to match the course
+  spec's topic order **without losing cached build state**: directories move via
+  two-phase `git mv` and the `clm_cache.db` input-path columns are rewritten in
+  the same run, so the next build replays every cached result instead of
+  re-executing. Fails closed on non-canonical topic names (renumbering them
+  would change their topic id), orphan collisions, ambiguous topic resolution,
+  and active builds; `--report-only`/`--json` preview the full change set
+  including dry-run cache-row counts (#589).

--- a/docs/claude/design/course-restructure-move-rename.md
+++ b/docs/claude/design/course-restructure-move-rename.md
@@ -399,9 +399,17 @@ observable outcome, not just row counts. `results_cache.output_file`
 (`clm_jobs.db`) is the deliberately-separate analogue for output-moving ops and is
 **not** part of this unit (a topic renumber does not move outputs).
 
-**Still to wire (Phase 1 remainder):** the `clm course renumber` command that
-computes spec-order numbering, does the two-phase `git mv`, and calls this
-migrator; plus its `--report-only`/`--json` surface.
+**Phase 1 complete:** `clm course renumber` is wired
+(`src/clm/core/course_renumber.py` + `src/clm/cli/commands/course/renumber.py`):
+spec-order numbering via `iter_topic_bindings` (the same contract build/
+validate/normalize share), two-phase move (park on interim names, then land)
+through `git mv` with a plain-rename fallback, one batched
+`migrate_cache_paths` transaction, `--report-only`/`--json`, and all five
+§5.1 validation guards (canonical-name skip, orphan collision abort,
+ambiguity abort, jobs-DB active-build guard with `--force`, DB paths taken
+from the `clm` entry point's resolution — never guessed). Missing spec topics
+are reported, and the report names the ordering spec. Docs:
+`commands.md` info topic + `changelog.d/589-course-renumber.added.md`.
 
 ---
 

--- a/src/clm/cli/commands/course/__init__.py
+++ b/src/clm/cli/commands/course/__init__.py
@@ -19,6 +19,7 @@ def course_group() -> None:
 from clm.cli.commands.course.decks import spec_decks_cmd  # noqa: E402
 from clm.cli.commands.course.gate import course_gate_cmd  # noqa: E402
 from clm.cli.commands.course.orphans import spec_orphans_cmd  # noqa: E402
+from clm.cli.commands.course.renumber import renumber_cmd  # noqa: E402
 from clm.cli.commands.course.resolve_topic import resolve_topic_cmd  # noqa: E402
 from clm.cli.commands.course.sync_includes import sync_includes_cmd  # noqa: E402
 from clm.cli.commands.course.targets import list_targets  # noqa: E402
@@ -27,5 +28,6 @@ course_group.add_command(spec_decks_cmd, name="decks")
 course_group.add_command(spec_orphans_cmd, name="orphans")
 course_group.add_command(list_targets, name="targets")
 course_group.add_command(course_gate_cmd, name="gate")
+course_group.add_command(renumber_cmd, name="renumber")
 course_group.add_command(resolve_topic_cmd, name="resolve-topic")
 course_group.add_command(sync_includes_cmd, name="sync-includes")

--- a/src/clm/cli/commands/course/renumber.py
+++ b/src/clm/cli/commands/course/renumber.py
@@ -1,0 +1,263 @@
+"""``clm course renumber`` — renumber topic dirs to course-spec order.
+
+Phase 1 of the course-restructure design (issue #589;
+``docs/claude/design/course-restructure-move-rename.md`` §5.1): rename
+``topic_NNN_<suffix>`` directories so their ordinal prefixes ascend in the
+spec's topic order, then rewrite the input-path columns of ``clm_cache.db``
+so every cached result and executed notebook keeps hitting — **no kernel
+re-execution**. The ordinal is a sort key only; suffix (= topic id), spec
+references, cross-references, output paths, and sync ledgers are all
+untouched by construction.
+
+Exit codes: ``0`` renumbered (or would-renumber / nothing to do); ``2``
+validation or usage error (ambiguous topic, orphan collision, active build,
+unknown module, bad width).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import click
+
+from clm.core.course_renumber import (
+    RenumberError,
+    RenumberPlan,
+    apply_renumber,
+    plan_renumber,
+)
+
+
+@click.command("renumber")
+@click.argument("module", required=False)
+@click.option(
+    "--spec",
+    "spec_file",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Course spec whose topic order defines the numbering.",
+)
+@click.option(
+    "--data-dir",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    help="Course data directory (contains slides/). Default: inferred from --spec.",
+)
+@click.option("--start", default=10, show_default=True, help="First ordinal.")
+@click.option("--step", default=10, show_default=True, help="Ordinal increment.")
+@click.option(
+    "--width",
+    default=None,
+    type=int,
+    help="Zero-pad width for ordinals. Default: preserve the module's widest existing ordinal.",
+)
+@click.option(
+    "--report-only",
+    "--dry-run",
+    "report_only",
+    is_flag=True,
+    help="Report what would change (including cache-row counts) without touching anything.",
+)
+@click.option("--json", "as_json", is_flag=True, help="Emit a JSON report.")
+@click.option(
+    "--no-cache-migrate",
+    is_flag=True,
+    help="Skip the clm_cache.db rewrite (accept a one-time re-execution of the moved topics).",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Proceed even when the jobs database shows an active build.",
+)
+@click.pass_context
+def renumber_cmd(
+    ctx: click.Context,
+    module: str | None,
+    spec_file: Path,
+    data_dir: Path | None,
+    start: int,
+    step: int,
+    width: int | None,
+    report_only: bool,
+    as_json: bool,
+    no_cache_migrate: bool,
+    force: bool,
+) -> None:
+    """Renumber topic directories to match the spec's topic order.
+
+    \b
+    MODULE restricts the renumber to one module directory (e.g.
+    "module_550_ml_azav"); without it, every module the spec references is
+    renumbered. Only canonical ``topic_<digits>_<suffix>`` names are touched —
+    the suffix is the topic's identity and is preserved verbatim, so specs,
+    cross-references, output paths, and sync ledgers all stay valid. The
+    cache-database lookup paths are rewritten in the same run, so the next
+    build replays every cached result instead of re-executing.
+
+    \b
+    Examples:
+        clm course renumber module_550_ml_azav --spec course-specs/ml.xml --report-only
+        clm course renumber --spec course-specs/ml.xml --start 10 --step 10
+    """
+    from clm.core.course_paths import resolve_course_paths
+    from clm.core.course_spec import CourseSpec, CourseSpecError
+
+    course_root, _ = resolve_course_paths(spec_file.absolute(), data_dir)
+    slides_dir = course_root / "slides"
+
+    try:
+        spec = CourseSpec.from_file(spec_file.absolute())
+    except CourseSpecError as e:
+        _fail(f"Failed to parse course spec: {e}", as_json)
+
+    try:
+        plan = plan_renumber(
+            spec,
+            slides_dir,
+            spec_name=spec_file.name,
+            module=module,
+            start=start,
+            step=step,
+            width=width,
+        )
+    except RenumberError as e:
+        _fail(str(e), as_json)
+
+    # Issue #589 guard: the migrator (and the git mv, more so) must not race a
+    # build. The jobs DB is resolved exactly like the build resolves it.
+    if plan.renames and not report_only and not force:
+        active = _active_job_count(_db_path(ctx, "JOBS_DB_PATH"))
+        if active:
+            _fail(
+                f"{active} job(s) pending or processing in the jobs database — a build "
+                f"appears to be active. Wait for it to finish or pass --force.",
+                as_json,
+            )
+
+    used_git = False
+    if plan.renames and not report_only:
+        used_git = apply_renumber(plan)
+
+    cache_report = None
+    if plan.renames and not no_cache_migrate:
+        cache_report = _migrate_cache(_db_path(ctx, "CACHE_DB_PATH"), plan, dry_run=report_only)
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                _to_dict(plan, cache_report, report_only=report_only, used_git=used_git), indent=2
+            )
+        )
+    else:
+        _print_human(plan, cache_report, report_only=report_only, no_cache_migrate=no_cache_migrate)
+    sys.exit(0)
+
+
+def _db_path(ctx: click.Context, key: str) -> Path:
+    """The DB path resolved by the ``clm`` entry point (issue #589: never a
+    guessed project-root default — always the same DB the build opens)."""
+    obj = ctx.obj or {}
+    path = obj.get(key)
+    if path is None:
+        raise click.ClickException(
+            f"internal error: {key} not initialized — run this command via the `clm` entry point."
+        )
+    return Path(path)
+
+
+def _active_job_count(jobs_db: Path) -> int:
+    """Pending/processing jobs in the jobs DB; 0 when the DB or table is absent."""
+    if not jobs_db.exists():
+        return 0
+    try:
+        conn = sqlite3.connect(str(jobs_db))
+        try:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM jobs WHERE status IN ('pending', 'processing')"
+            ).fetchone()
+            return int(row[0])
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return 0
+
+
+def _migrate_cache(cache_db: Path, plan: RenumberPlan, *, dry_run: bool):
+    """Batch every rename's path mappings into ONE transactional rewrite."""
+    from clm.infrastructure.database.cache_path_migration import (
+        migrate_cache_paths,
+        plan_dir_rename,
+    )
+
+    mappings = [
+        m for op in plan.renames for m in plan_dir_rename(cache_db, op.old_path, op.new_path)
+    ]
+    return migrate_cache_paths(cache_db, mappings, dry_run=dry_run)
+
+
+def _to_dict(plan: RenumberPlan, cache_report, *, report_only: bool, used_git: bool) -> dict:
+    return {
+        "spec": plan.spec_name,
+        "slides_dir": str(plan.slides_dir),
+        "report_only": report_only,
+        "git_mv": used_git,
+        "modules": [
+            {
+                "module": m.module,
+                "renames": [
+                    {"topic_id": op.topic_id, "old": op.old_path.name, "new": op.new_path.name}
+                    for op in m.renames
+                ],
+                "unchanged": [p.name for p in m.unchanged],
+                "skipped": [
+                    {"topic_id": s.topic_id, "path": s.path.name, "reason": s.reason}
+                    for s in m.skipped
+                ],
+            }
+            for m in plan.modules
+        ],
+        "missing_topics": list(plan.missing),
+        "cache": None
+        if cache_report is None
+        else {
+            "db_path": cache_report.db_path,
+            "rows_rewritten": cache_report.rows_rewritten,
+            "collisions_dropped": cache_report.collisions_dropped,
+            "tables": {t.table: t.rows_rewritten for t in cache_report.tables},
+        },
+    }
+
+
+def _print_human(
+    plan: RenumberPlan, cache_report, *, report_only: bool, no_cache_migrate: bool
+) -> None:
+    verb = "would rename" if report_only else "renamed"
+    click.echo(f"order: {plan.spec_name}")
+    for m in plan.modules:
+        click.echo(
+            f"{m.module}: {len(m.renames) + len(m.unchanged)} topic(s) — "
+            f"{len(m.renames)} {verb}, {len(m.unchanged)} already in order"
+        )
+        for op in m.renames:
+            click.echo(f"  {op.old_path.name}  ->  {op.new_path.name}")
+        for s in m.skipped:
+            click.echo(f"  skipped {s.path.name}: {s.reason}")
+    if plan.missing:
+        click.echo(
+            f"missing from slides tree (spec-referenced, not found): {', '.join(plan.missing)}"
+        )
+    if not plan.renames:
+        click.echo("nothing to renumber — topic order already matches the spec.")
+    elif no_cache_migrate:
+        click.echo("cache: migration skipped (--no-cache-migrate); moved topics re-execute once.")
+    elif cache_report is not None:
+        click.echo(f"cache: {cache_report.summary()}")
+
+
+def _fail(message: str, as_json: bool) -> None:
+    if as_json:
+        click.echo(json.dumps({"error": message}, indent=2))
+        sys.exit(2)
+    raise click.UsageError(message)

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -955,6 +955,66 @@ clm course orphans course-specs/ --clean-checkpoints             # report + dele
 clm course orphans course-specs/ --slides-dir ../other/slides --json
 ```
 
+### `clm course renumber`
+
+*Added in CLM {version}.*
+
+Renumber `topic_NNN_<suffix>` directories so their ordinal prefixes ascend in
+the course spec's topic order — **without losing any cached build state**. The
+ordinal is a sort key only (topic identity is the suffix), so specs,
+cross-references (`clm:<id>`), output paths, and sync ledgers are all
+untouched by construction; the command rewrites the input-path lookup columns
+of `clm_cache.db` in the same run, so the next build replays every cached
+result and executed notebook instead of re-executing.
+
+```
+clm course renumber [OPTIONS] [MODULE]
+```
+
+`MODULE` restricts the renumber to one module directory (e.g.
+`module_550_ml_azav`); without it, every module the spec references is
+renumbered. Directory moves go through `git mv` when the tree is a git work
+tree (history-preserving; sidecars like `.clm/` ledgers and `cassettes/` ride
+along with the physical rename).
+
+| Option | Description |
+|--------|-------------|
+| `--spec FILE` | **Required.** Course spec whose topic order defines the numbering. |
+| `--data-dir DIR` | Course data directory (contains `slides/`). Default: inferred from `--spec`. |
+| `--start N` | First ordinal (default `10`). |
+| `--step K` | Ordinal increment (default `10` — leaves gaps for future inserts). |
+| `--width W` | Zero-pad width. Default: preserve the module's widest existing ordinal. |
+| `--report-only` / `--dry-run` | Print the full change set — renames, skips, and dry-run cache-row counts — without touching anything. |
+| `--json` | Emit a JSON report (`modules[].renames/unchanged/skipped`, `missing_topics`, `cache`). |
+| `--no-cache-migrate` | Skip the `clm_cache.db` rewrite (moved topics re-execute once on the next build). |
+| `--force` | Proceed even when the jobs database shows pending/processing jobs. |
+
+Safety guards (the command fails closed, exit `2`, without touching anything):
+
+- Only canonical `topic_<digits>_<suffix>` names are renamed. A non-canonical
+  name (e.g. `topic_extras_bonus`) would silently **change its topic id** if
+  renumbered — such topics are skipped and listed in the report.
+- Entries on disk that the spec does not reference (orphans) are never touched;
+  a planned name colliding with one aborts the run.
+- Ambiguous topic resolution (same id in several modules without a `module=`
+  binding) aborts — fix the ambiguity first.
+- A build that appears active (pending/processing jobs) aborts unless
+  `--force` is given.
+- Spec-referenced topics missing from the slides tree are reported (the
+  renumber never silently covers less than the spec).
+
+The report names the spec that defined the order; in repos where several specs
+reference the same module, pick the spec whose order should win (build outputs
+are unaffected either way — output ordering is per-spec, not per-directory).
+
+Examples:
+
+```bash
+clm course renumber module_550_ml_azav --spec course-specs/ml.xml --report-only
+clm course renumber module_550_ml_azav --spec course-specs/ml.xml
+clm course renumber --spec course-specs/ml.xml --start 10 --step 10 --json
+```
+
 ### `clm course gate`
 
 Run the mechanical conversion passes over a course and report **readiness** —

--- a/src/clm/core/course_renumber.py
+++ b/src/clm/core/course_renumber.py
@@ -1,0 +1,326 @@
+"""Plan and apply spec-order renumbering of ``topic_NNN_`` directories.
+
+``clm course renumber`` (issue #589; design:
+``docs/claude/design/course-restructure-move-rename.md`` §5.1) renames the
+topic directories of a module so their ordinal prefixes ascend in the course
+spec's topic order. The ``NNN`` prefix is a sort key only — topic identity is
+the suffix (``simplify_ordered_name``) — so a renumber changes no identity,
+no spec reference, no output path, and no sync-ledger key. The only derived
+state that must follow the rename is the input-path columns of
+``clm_cache.db``, handled by
+:mod:`clm.infrastructure.database.cache_path_migration`.
+
+This module is deliberately CLI-free: :func:`plan_renumber` is pure planning
+(fail-closed validation, no filesystem writes), :func:`apply_renumber`
+performs the two-phase move. The CLI wires them to the cache migrator and
+the active-build guard.
+
+Hard guards (issue #589):
+
+- Only canonical ``topic_<digits>_<suffix>`` names are renamed.
+  ``simplify_ordered_name`` blindly drops the first two ``_``-parts, so
+  renumbering a non-canonical name like ``topic_extras_bonus`` (id ``bonus``)
+  would silently *change its topic id*. Such topics are skipped and reported.
+- Orphan entries (on disk, not referenced by the spec) are never touched, and
+  a planned name that collides with one fails the whole plan.
+- Ambiguous topic resolution (same id in several modules without a
+  ``module=`` binding) fails the plan; renumbering a tree the build cannot
+  resolve deterministically would guess.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from attrs import frozen
+
+from clm.core.topic_resolver import build_topic_map, matches_for_binding
+
+if TYPE_CHECKING:
+    from clm.core.course_spec import CourseSpec
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ModulePlan",
+    "RenumberError",
+    "RenumberPlan",
+    "SkippedTopic",
+    "TopicRenameOp",
+    "apply_renumber",
+    "plan_renumber",
+]
+
+#: A rename only ever swaps the digits of this pattern; the suffix — the
+#: identity — is preserved verbatim (including any file extension).
+_CANONICAL_TOPIC_RE = re.compile(r"topic_(\d+)_(.+)", re.DOTALL)
+
+#: Interim names used by the two-phase move so a batch whose target names
+#: overlap its source names can never collide mid-move.
+_TMP_SUFFIX = ".clm-renumber-tmp-"
+
+
+class RenumberError(Exception):
+    """A fail-closed validation error: nothing has been touched."""
+
+
+@frozen
+class TopicRenameOp:
+    """One topic directory (or file topic) changing its ordinal prefix."""
+
+    topic_id: str
+    old_path: Path
+    new_path: Path
+
+
+@frozen
+class SkippedTopic:
+    """A spec-referenced topic the plan refuses to rename, with the reason."""
+
+    topic_id: str
+    path: Path
+    reason: str
+
+
+@frozen
+class ModulePlan:
+    """The renumber outcome for one module directory."""
+
+    module: str
+    renames: tuple[TopicRenameOp, ...]
+    unchanged: tuple[Path, ...]
+    skipped: tuple[SkippedTopic, ...]
+
+
+@frozen
+class RenumberPlan:
+    """A validated, ready-to-apply renumber across one or more modules."""
+
+    spec_name: str
+    slides_dir: Path
+    modules: tuple[ModulePlan, ...]
+    #: Spec-referenced topic ids that resolve to nothing on disk. Not an
+    #: error here — ``clm validate`` owns dangling-spec reporting — but the
+    #: report surfaces them so a renumber never *silently* covers less than
+    #: the spec.
+    missing: tuple[str, ...]
+
+    @property
+    def renames(self) -> tuple[TopicRenameOp, ...]:
+        return tuple(op for m in self.modules for op in m.renames)
+
+
+def plan_renumber(
+    spec: CourseSpec,
+    slides_dir: Path,
+    *,
+    spec_name: str,
+    module: str | None = None,
+    start: int = 10,
+    step: int = 10,
+    width: int | None = None,
+) -> RenumberPlan:
+    """Compute the spec-order renumbering of every (or one) module's topics.
+
+    Topics are numbered ``start, start+step, …`` in the order their bindings
+    appear in the spec (the same ``iter_topic_bindings`` order the build,
+    validate, and normalize share). ``width`` zero-pads the ordinal; when
+    ``None`` the widest existing ordinal of the module is preserved.
+
+    Raises :class:`RenumberError` (fail closed, nothing touched) on ambiguous
+    topic resolution, an unknown ``module`` filter, an ordinal that does not
+    fit ``width``, or a planned name colliding with an entry that is not
+    itself being renamed.
+    """
+    if step <= 0 or start < 0:
+        raise RenumberError(f"invalid numbering scheme: start={start}, step={step}")
+
+    ordered, missing = _spec_ordered_topics(spec, slides_dir)
+
+    if module is not None:
+        if module not in ordered:
+            known = ", ".join(sorted(ordered)) or "none found"
+            raise RenumberError(
+                f"module '{module}' has no spec-referenced topics (modules with topics: {known})"
+            )
+        ordered = {module: ordered[module]}
+
+    modules = tuple(
+        _plan_module(name, matches, start=start, step=step, width=width)
+        for name, matches in ordered.items()
+    )
+    _validate_collisions(modules)
+
+    return RenumberPlan(
+        spec_name=spec_name,
+        slides_dir=slides_dir,
+        modules=modules,
+        missing=tuple(missing),
+    )
+
+
+def _spec_ordered_topics(spec: CourseSpec, slides_dir: Path):
+    """Resolve the spec's topics against the tree, grouped by module in spec
+    order. Ambiguity is a hard error: a tree the build cannot resolve
+    deterministically must be fixed before it is renumbered."""
+    topic_map = build_topic_map(slides_dir)
+
+    ordered: dict[str, list] = {}
+    seen_paths: set[Path] = set()
+    missing: list[str] = []
+    for binding in spec.iter_topic_bindings():
+        matches = matches_for_binding(topic_map, binding.topic_id, binding.effective_module)
+        if not matches:
+            missing.append(binding.topic_id)
+            continue
+        if len(matches) > 1:
+            locations = ", ".join(str(m.path) for m in matches)
+            raise RenumberError(
+                f"topic '{binding.topic_id}' is ambiguous ({locations}); "
+                f"fix the duplicate or bind it with module= in the spec before renumbering"
+            )
+        match = matches[0]
+        if match.path in seen_paths:  # same topic referenced twice: first wins
+            continue
+        seen_paths.add(match.path)
+        ordered.setdefault(match.module, []).append(match)
+    return ordered, missing
+
+
+def _plan_module(
+    module: str,
+    matches: list,
+    *,
+    start: int,
+    step: int,
+    width: int | None,
+) -> ModulePlan:
+    canonical: list[tuple[str, Path, str, str]] = []  # (topic_id, path, digits, suffix)
+    skipped: list[SkippedTopic] = []
+    for match in matches:
+        m = _CANONICAL_TOPIC_RE.fullmatch(match.path.name)
+        if m is None:
+            skipped.append(
+                SkippedTopic(
+                    topic_id=match.topic_id,
+                    path=match.path,
+                    reason=(
+                        "non-canonical name (not topic_<digits>_<suffix>) — "
+                        "renumbering it would change its topic id"
+                    ),
+                )
+            )
+            continue
+        canonical.append((match.topic_id, match.path, m.group(1), m.group(2)))
+
+    pad = (
+        width
+        if width is not None
+        else max((len(digits) for _, _, digits, _ in canonical), default=3)
+    )
+
+    renames: list[TopicRenameOp] = []
+    unchanged: list[Path] = []
+    for index, (topic_id, path, _digits, suffix) in enumerate(canonical):
+        number = start + index * step
+        if len(str(number)) > pad:
+            raise RenumberError(
+                f"module '{module}': ordinal {number} does not fit width {pad} "
+                f"(pass --width {len(str(number))} or adjust --start/--step)"
+            )
+        new_name = f"topic_{number:0{pad}d}_{suffix}"
+        if new_name == path.name:
+            unchanged.append(path)
+        else:
+            renames.append(
+                TopicRenameOp(topic_id=topic_id, old_path=path, new_path=path.with_name(new_name))
+            )
+
+    return ModulePlan(
+        module=module,
+        renames=tuple(renames),
+        unchanged=tuple(unchanged),
+        skipped=tuple(skipped),
+    )
+
+
+def _validate_collisions(modules: tuple[ModulePlan, ...]) -> None:
+    """No planned name may collide — with another planned name, or with any
+    on-disk entry that is not itself renamed away (orphans, skipped topics)."""
+    for plan in modules:
+        vacated = {os.path.normcase(str(op.old_path)) for op in plan.renames}
+        targets: dict[str, TopicRenameOp] = {}
+        for op in plan.renames:
+            key = os.path.normcase(str(op.new_path))
+            if key in targets:
+                raise RenumberError(
+                    f"module '{plan.module}': '{op.new_path.name}' is the target of both "
+                    f"'{targets[key].old_path.name}' and '{op.old_path.name}'"
+                )
+            targets[key] = op
+            if op.new_path.exists() and key not in vacated:
+                raise RenumberError(
+                    f"module '{plan.module}': target '{op.new_path.name}' already exists and is "
+                    f"not being renamed away (orphan or skipped entry) — resolve it first"
+                )
+
+
+def apply_renumber(plan: RenumberPlan, *, use_git: bool | None = None) -> bool:
+    """Perform the planned moves; returns whether ``git mv`` was used.
+
+    Two-phase: every source first moves to a unique interim name, then to its
+    final name — so a batch whose targets overlap its sources (impossible for
+    a legal topic renumber, cheap insurance regardless) cannot collide
+    mid-move. Moves go through ``git mv`` when the slides tree is inside a
+    git work tree (history-preserving; the physical rename also carries
+    untracked sidecars like ``.clm/`` ledgers), else ``Path.rename``.
+    """
+    ops = plan.renames
+    if not ops:
+        return False
+    git = _in_git_work_tree(plan.slides_dir) if use_git is None else use_git
+
+    interim = [
+        op.old_path.with_name(f"{op.old_path.name}{_TMP_SUFFIX}{i}") for i, op in enumerate(ops)
+    ]
+    for op, tmp in zip(ops, interim, strict=True):
+        _move(op.old_path, tmp, git=git)
+    for op, tmp in zip(ops, interim, strict=True):
+        _move(tmp, op.new_path, git=git)
+    return git
+
+
+def _in_git_work_tree(path: Path) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--is-inside-work-tree"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return False
+    return result.returncode == 0 and result.stdout.strip() == "true"
+
+
+def _move(src: Path, dst: Path, *, git: bool) -> None:
+    if git:
+        result = subprocess.run(
+            ["git", "-C", str(src.parent), "mv", str(src), str(dst)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        # E.g. an untracked topic dir: fall back to a plain rename (the user
+        # sees a delete+add instead of a rename in git status — still correct).
+        logger.warning(
+            "git mv %s -> %s failed (%s); falling back to rename", src, dst, result.stderr.strip()
+        )
+    src.rename(dst)

--- a/tests/cli/test_course_renumber.py
+++ b/tests/cli/test_course_renumber.py
@@ -1,0 +1,195 @@
+"""End-to-end tests for ``clm course renumber`` (issue #589).
+
+The command is invoked directly with an explicit ``obj`` carrying the DB paths
+the ``clm`` entry point would resolve — mirroring the production contract that
+the command never guesses database locations.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands.course.renumber import renumber_cmd
+from clm.infrastructure.database.db_operations import DatabaseManager
+from clm.infrastructure.messaging.base_classes import Result
+
+_META = "completed:python:en:html"
+
+
+class _Res(Result):
+    data: str
+    metadata: str
+
+    def result_bytes(self) -> bytes:
+        return self.data.encode("utf-8")
+
+    def output_metadata(self):
+        return self.metadata
+
+
+def _seed_cache(db: Path, file_path: Path) -> None:
+    result = _Res(
+        output_file="o",
+        input_file="i",
+        content_hash="h",
+        data="payload",
+        metadata=_META,
+        correlation_id="c",
+    )
+    with DatabaseManager(db) as m:
+        m.store_latest_result(str(file_path), "h1", "corr", result, retain_count=3)
+
+
+@pytest.fixture
+def course(tmp_path: Path) -> dict:
+    """A scratch course: two topics whose ordinals disagree with spec order."""
+    module_dir = tmp_path / "slides" / "module_100_m"
+    for name in ("topic_310_a", "topic_050_b"):
+        topic = module_dir / name
+        topic.mkdir(parents=True)
+        (topic / "slides_010_x.py").write_text("# %%\n", encoding="utf-8")
+    spec_file = tmp_path / "course-specs" / "test.xml"
+    spec_file.parent.mkdir(parents=True)
+    spec_file.write_text(
+        dedent(
+            """\
+            <course>
+                <name><de>K</de><en>C</en></name>
+                <prog-lang>python</prog-lang>
+                <sections>
+                    <section>
+                        <name><de>S</de><en>S</en></name>
+                        <topics><topic>a</topic><topic>b</topic></topics>
+                    </section>
+                </sections>
+            </course>
+            """
+        ),
+        encoding="utf-8",
+    )
+    return {
+        "root": tmp_path,
+        "module_dir": module_dir,
+        "spec": spec_file,
+        "cache_db": tmp_path / "clm_cache.db",
+        "jobs_db": tmp_path / "clm_jobs.db",
+        "obj": {
+            "CACHE_DB_PATH": tmp_path / "clm_cache.db",
+            "JOBS_DB_PATH": tmp_path / "clm_jobs.db",
+        },
+    }
+
+
+def _invoke(course: dict, *args: str):
+    return CliRunner().invoke(
+        renumber_cmd,
+        ["--spec", str(course["spec"]), *args],
+        obj=course["obj"],
+        catch_exceptions=False,
+    )
+
+
+def test_renumber_moves_dirs_and_migrates_cache_to_live_hits(course):
+    old_a = course["module_dir"] / "topic_310_a" / "slides_010_x.py"
+    old_b = course["module_dir"] / "topic_050_b" / "slides_010_x.py"
+    _seed_cache(course["cache_db"], old_a)
+    _seed_cache(course["cache_db"], old_b)
+
+    result = _invoke(course, "--json")
+
+    assert result.exit_code == 0, result.output
+    report = json.loads(result.output)
+    assert report["report_only"] is False
+    (module,) = report["modules"]
+    assert [(r["old"], r["new"]) for r in module["renames"]] == [
+        ("topic_310_a", "topic_010_a"),
+        ("topic_050_b", "topic_020_b"),
+    ]
+    assert report["cache"]["rows_rewritten"] >= 2
+
+    # Directories moved...
+    assert (course["module_dir"] / "topic_010_a" / "slides_010_x.py").exists()
+    assert not (course["module_dir"] / "topic_310_a").exists()
+    # ...and the cache HITS at the new paths, MISSES at the old (the point).
+    new_a = course["module_dir"] / "topic_010_a" / "slides_010_x.py"
+    with DatabaseManager(course["cache_db"]) as m:
+        assert m.get_result(str(new_a), "h1", _META) is not None
+        assert m.get_result(str(old_a), "h1", _META) is None
+
+
+def test_report_only_touches_nothing_but_reports_cache_counts(course):
+    old_a = course["module_dir"] / "topic_310_a" / "slides_010_x.py"
+    _seed_cache(course["cache_db"], old_a)
+
+    result = _invoke(course, "--report-only", "--json")
+
+    assert result.exit_code == 0, result.output
+    report = json.loads(result.output)
+    assert report["report_only"] is True
+    assert report["cache"]["rows_rewritten"] >= 1  # dry-run counts
+    # Nothing moved on disk, nothing moved in the DB.
+    assert (course["module_dir"] / "topic_310_a").exists()
+    with DatabaseManager(course["cache_db"]) as m:
+        assert m.get_result(str(old_a), "h1", _META) is not None
+
+
+def test_no_cache_migrate_moves_dirs_but_leaves_db(course):
+    old_a = course["module_dir"] / "topic_310_a" / "slides_010_x.py"
+    _seed_cache(course["cache_db"], old_a)
+
+    result = _invoke(course, "--no-cache-migrate", "--json")
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["cache"] is None
+    assert (course["module_dir"] / "topic_010_a").exists()
+    with DatabaseManager(course["cache_db"]) as m:
+        assert m.get_result(str(old_a), "h1", _META) is not None  # stale by choice
+
+
+def test_active_build_refuses_without_force(course):
+    conn = sqlite3.connect(str(course["jobs_db"]))
+    conn.execute("CREATE TABLE jobs (id INTEGER PRIMARY KEY, status TEXT)")
+    conn.execute("INSERT INTO jobs (status) VALUES ('processing')")
+    conn.commit()
+    conn.close()
+
+    refused = _invoke(course, "--json")
+    assert refused.exit_code == 2
+    assert "active" in json.loads(refused.output)["error"]
+    assert (course["module_dir"] / "topic_310_a").exists()  # untouched
+
+    forced = _invoke(course, "--force", "--json")
+    assert forced.exit_code == 0, forced.output
+    assert (course["module_dir"] / "topic_010_a").exists()
+
+
+def test_validation_error_exits_2_with_json_error(course):
+    result = _invoke(course, "unknown_module", "--json")
+
+    assert result.exit_code == 2
+    assert "no spec-referenced topics" in json.loads(result.output)["error"]
+
+
+def test_noop_when_already_in_spec_order(course):
+    ok = _invoke(course, "--json")
+    assert ok.exit_code == 0
+
+    again = _invoke(course, "--json")
+    assert again.exit_code == 0, again.output
+    report = json.loads(again.output)
+    assert report["modules"][0]["renames"] == []
+    assert report["cache"] is None  # no renames -> no migration attempted
+
+
+def test_human_report_names_the_ordering_spec(course):
+    result = _invoke(course, "--report-only")
+
+    assert result.exit_code == 0, result.output
+    assert "order: test.xml" in result.output
+    assert "topic_310_a  ->  topic_010_a" in result.output

--- a/tests/core/test_course_renumber.py
+++ b/tests/core/test_course_renumber.py
@@ -1,0 +1,261 @@
+"""Tests for spec-order topic renumbering (planning + apply; issue #589)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from clm.core.course_renumber import (
+    RenumberError,
+    apply_renumber,
+    plan_renumber,
+)
+from clm.core.course_spec import CourseSpec
+
+
+def _spec(tmp_path: Path, topics_by_section: list[list[str]]) -> CourseSpec:
+    sections = "\n".join(
+        "<section><name><de>S</de><en>S</en></name><topics>"
+        + "".join(f"<topic>{t}</topic>" for t in topics)
+        + "</topics></section>"
+        for topics in topics_by_section
+    )
+    xml = dedent(
+        f"""\
+        <course>
+            <name><de>K</de><en>C</en></name>
+            <prog-lang>python</prog-lang>
+            <sections>{sections}</sections>
+        </course>
+        """
+    )
+    spec_file = tmp_path / "course-specs" / "test.xml"
+    spec_file.parent.mkdir(parents=True, exist_ok=True)
+    spec_file.write_text(xml, encoding="utf-8")
+    return CourseSpec.from_file(spec_file)
+
+
+def _make_topics(slides: Path, module: str, names: list[str]) -> Path:
+    module_dir = slides / module
+    for name in names:
+        topic = module_dir / name
+        topic.mkdir(parents=True)
+        (topic / "slides_010_x.py").write_text("# %%\n", encoding="utf-8")
+    return module_dir
+
+
+def _plan(tmp_path, spec, **kwargs):
+    return plan_renumber(spec, tmp_path / "slides", spec_name="test.xml", **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Planning
+# ---------------------------------------------------------------------------
+
+
+def test_plan_orders_topics_by_spec_not_by_directory(tmp_path):
+    _make_topics(tmp_path / "slides", "module_100_m", ["topic_050_b", "topic_310_a", "topic_120_c"])
+    spec = _spec(tmp_path, [["a", "b", "c"]])
+
+    plan = _plan(tmp_path, spec)
+
+    (module,) = plan.modules
+    assert [(op.old_path.name, op.new_path.name) for op in module.renames] == [
+        ("topic_310_a", "topic_010_a"),
+        ("topic_050_b", "topic_020_b"),
+        ("topic_120_c", "topic_030_c"),
+    ]
+
+
+def test_plan_preserves_existing_ordinal_width(tmp_path):
+    _make_topics(tmp_path / "slides", "module_100_m", ["topic_0300_a", "topic_020_b"])
+    spec = _spec(tmp_path, [["a", "b"]])
+
+    plan = _plan(tmp_path, spec)
+
+    names = {op.new_path.name for op in plan.modules[0].renames}
+    assert names == {"topic_0010_a", "topic_0020_b"}  # widest existing = 4 digits
+
+
+def test_plan_explicit_width_and_overflow_error(tmp_path):
+    _make_topics(tmp_path / "slides", "module_100_m", ["topic_10_a", "topic_20_b"])
+    spec = _spec(tmp_path, [["a", "b"]])
+
+    plan = _plan(tmp_path, spec, width=3)
+    assert plan.modules[0].renames[0].new_path.name == "topic_010_a"
+
+    with pytest.raises(RenumberError, match="does not fit width"):
+        _plan(tmp_path, spec, start=100, step=10, width=2)
+
+
+def test_plan_in_order_topics_are_unchanged(tmp_path):
+    _make_topics(tmp_path / "slides", "module_100_m", ["topic_010_a", "topic_020_b"])
+    spec = _spec(tmp_path, [["a", "b"]])
+
+    plan = _plan(tmp_path, spec)
+
+    assert plan.renames == ()
+    assert [p.name for p in plan.modules[0].unchanged] == ["topic_010_a", "topic_020_b"]
+
+
+def test_plan_skips_non_canonical_names_that_would_change_identity(tmp_path):
+    # "topic_extras_bonus" has topic id "bonus"; renumbering it would change
+    # the id to "extras_bonus". It must be skipped, never renamed.
+    _make_topics(tmp_path / "slides", "module_100_m", ["topic_310_a", "topic_extras_bonus"])
+    spec = _spec(tmp_path, [["a", "bonus"]])
+
+    plan = _plan(tmp_path, spec)
+
+    (module,) = plan.modules
+    assert [op.old_path.name for op in module.renames] == ["topic_310_a"]
+    (skipped,) = module.skipped
+    assert skipped.path.name == "topic_extras_bonus"
+    assert "topic id" in skipped.reason
+
+
+def test_plan_leaves_orphans_untouched(tmp_path):
+    # topic_020_b_old is on disk but NOT in the spec (orphan): it gets no
+    # rename op and no assigned ordinal, and stays exactly where it is.
+    _make_topics(
+        tmp_path / "slides", "module_100_m", ["topic_300_a", "topic_400_b", "topic_020_b_old"]
+    )
+    spec = _spec(tmp_path, [["a", "b"]])
+
+    plan = _plan(tmp_path, spec)
+
+    assert {op.new_path.name for op in plan.renames} == {"topic_010_a", "topic_020_b"}
+    apply_renumber(plan, use_git=False)
+    assert (tmp_path / "slides" / "module_100_m" / "topic_020_b_old").exists()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="case-insensitive path collision is Windows-only")
+def test_plan_fails_when_target_collides_with_orphan_case_insensitively(tmp_path):
+    # An orphan whose name differs from a planned target only by case has a
+    # DIFFERENT topic id (ids are case-sensitive), so ambiguity does not catch
+    # it — but the rename would collide on a case-insensitive filesystem.
+    _make_topics(tmp_path / "slides", "module_100_m", ["topic_400_b", "topic_010_B"])
+    spec = _spec(tmp_path, [["b"]])
+
+    with pytest.raises(RenumberError, match="already exists"):
+        _plan(tmp_path, spec, start=10, step=10, width=3)
+
+
+def test_plan_rejects_ambiguous_topics(tmp_path):
+    _make_topics(tmp_path / "slides", "module_100_m", ["topic_010_a"])
+    _make_topics(tmp_path / "slides", "module_200_n", ["topic_050_a"])
+    spec = _spec(tmp_path, [["a"]])
+
+    with pytest.raises(RenumberError, match="ambiguous"):
+        _plan(tmp_path, spec)
+
+
+def test_plan_module_filter_and_unknown_module(tmp_path):
+    _make_topics(tmp_path / "slides", "module_100_m", ["topic_050_a"])
+    _make_topics(tmp_path / "slides", "module_200_n", ["topic_050_b"])
+    spec = _spec(tmp_path, [["a", "b"]])
+
+    plan = _plan(tmp_path, spec, module="module_200_n")
+    assert [m.module for m in plan.modules] == ["module_200_n"]
+
+    with pytest.raises(RenumberError, match="no spec-referenced topics"):
+        _plan(tmp_path, spec, module="module_999_zzz")
+
+
+def test_plan_reports_missing_topics(tmp_path):
+    _make_topics(tmp_path / "slides", "module_100_m", ["topic_050_a"])
+    spec = _spec(tmp_path, [["a", "ghost_topic"]])
+
+    plan = _plan(tmp_path, spec)
+
+    assert plan.missing == ("ghost_topic",)
+
+
+def test_plan_numbers_follow_spec_order_across_sections(tmp_path):
+    _make_topics(tmp_path / "slides", "module_100_m", ["topic_900_a", "topic_100_b"])
+    spec = _spec(tmp_path, [["a"], ["b"]])  # a in section 1, b in section 2
+
+    plan = _plan(tmp_path, spec)
+
+    assert [(op.old_path.name, op.new_path.name) for op in plan.modules[0].renames] == [
+        ("topic_900_a", "topic_010_a"),
+        ("topic_100_b", "topic_020_b"),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+
+
+def test_apply_renames_dirs_and_carries_contents(tmp_path):
+    _make_topics(tmp_path / "slides", "module_100_m", ["topic_310_a", "topic_050_b"])
+    # Untracked sidecar content must ride along with the physical rename.
+    ledger = tmp_path / "slides" / "module_100_m" / "topic_310_a" / ".clm" / "sync-ledger.json"
+    ledger.parent.mkdir()
+    ledger.write_text("{}", encoding="utf-8")
+    spec = _spec(tmp_path, [["a", "b"]])
+
+    plan = _plan(tmp_path, spec)
+    apply_renumber(plan, use_git=False)
+
+    module_dir = tmp_path / "slides" / "module_100_m"
+    assert (module_dir / "topic_010_a" / "slides_010_x.py").exists()
+    assert (module_dir / "topic_010_a" / ".clm" / "sync-ledger.json").exists()
+    assert (module_dir / "topic_020_b" / "slides_010_x.py").exists()
+    assert not (module_dir / "topic_310_a").exists()
+    assert not any(module_dir.glob("*.clm-renumber-tmp-*"))
+
+
+def test_apply_handles_targets_overlapping_sources(tmp_path):
+    # b currently holds ordinal 010 while a must take 010 and b move to 020:
+    # phase-1 parking makes the overlap safe.
+    _make_topics(tmp_path / "slides", "module_100_m", ["topic_020_a", "topic_010_b"])
+    spec = _spec(tmp_path, [["a", "b"]])
+
+    plan = _plan(tmp_path, spec)
+    apply_renumber(plan, use_git=False)
+
+    module_dir = tmp_path / "slides" / "module_100_m"
+    assert (module_dir / "topic_010_a").is_dir()
+    assert (module_dir / "topic_020_b").is_dir()
+
+
+@pytest.mark.serial
+def test_apply_uses_git_mv_inside_a_repo(tmp_path):
+    _make_topics(tmp_path / "slides", "module_100_m", ["topic_310_a"])
+    spec = _spec(tmp_path, [["a"]])
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "seed"],
+        cwd=tmp_path,
+        check=True,
+    )
+
+    plan = _plan(tmp_path, spec)
+    used_git = apply_renumber(plan)
+
+    assert used_git is True
+    module_dir = tmp_path / "slides" / "module_100_m"
+    assert (module_dir / "topic_010_a" / "slides_010_x.py").exists()
+    status = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=tmp_path, check=True, capture_output=True, text=True
+    ).stdout
+    assert "topic_010_a" in status  # staged rename
+
+
+def test_apply_file_topic_preserves_extension(tmp_path):
+    module_dir = tmp_path / "slides" / "module_100_m"
+    module_dir.mkdir(parents=True)
+    (module_dir / "topic_310_a.py").write_text("# %%\n", encoding="utf-8")
+    spec = _spec(tmp_path, [["a"]])
+
+    plan = _plan(tmp_path, spec)
+    (op,) = plan.renames
+    assert op.new_path.name == "topic_010_a.py"
+    apply_renumber(plan, use_git=False)
+    assert (module_dir / "topic_010_a.py").exists()


### PR DESCRIPTION
Closes #589. The Phase-1 remainder of the course-restructure design (`docs/claude/design/course-restructure-move-rename.md` §5.1), building on the cache-path migrator from #586/#591.

## What it does

`clm course renumber [MODULE] --spec <course.xml>` renames `topic_NNN_<suffix>` directories so their ordinal prefixes ascend in the spec's topic order — **with no kernel re-execution**. The ordinal is a sort key only (topic identity is the suffix), so specs, `clm:` cross-references, output paths, and sync ledgers are all untouched by construction. The moved topics' `clm_cache.db` input-path lookup columns are rewritten in one batched transaction (the #591-hardened migrator), so the next build replays every cached result and executed notebook.

- Spec order comes from `iter_topic_bindings()` — the same contract build/validate/normalize share.
- Numbering: `--start 10 --step 10` gap numbering (the "ran out of numbers" origin), `--width` zero-pad defaulting to the module's widest existing ordinal, overflow fails closed with a hint.
- Moves are two-phase (park on interim names, then land) via `git mv` when inside a git work tree — history-preserving, and the physical rename carries untracked sidecars (`.clm/` ledgers, cassettes) — with a plain-rename fallback.
- `--report-only`/`--dry-run` + `--json` print the full change set including dry-run cache-row counts; `--no-cache-migrate` opts into a one-time re-execution instead.

## The five #589 guards (all fail closed, exit 2, nothing touched)

1. Only canonical `topic_<digits>_<suffix>` names are renamed — a non-canonical name (e.g. `topic_extras_bonus`, id `bonus`) would silently change its topic id if renumbered; such topics are skipped and reported.
2. Orphans (on disk, not in the spec) are never touched; a planned target colliding with one aborts — including the Windows case-insensitive collision that topic-id ambiguity cannot catch.
3. The report names the ordering spec (multi-spec repos: outputs are unaffected either way, ordering is per-spec).
4. Pending/processing jobs in the jobs DB abort the run unless `--force`.
5. DB paths are taken from the `clm` entry point's resolution (`--cache-db-path` / `CLM_CACHE_DB_PATH` / project-root anchoring) — never guessed.

Missing spec topics are listed so a renumber never silently covers less than the spec.

## Verification

- 22 new tests: planning (spec-vs-directory order, width preservation/overflow, non-canonical skip, orphans, ambiguity, module filter, cross-section ordering), apply (two-phase overlap, sidecar carry, real `git mv` with staged-rename assertion, file-topic extension preservation), CLI end-to-end (live cache **hit at new path / miss at old** through the real cache manager, report-only inertness, `--no-cache-migrate`, active-build refusal + `--force`, JSON error contract).
- Driven end-to-end through the real `clm` entry point on a scratch git course: `git status` shows staged renames, cache rows verified rewritten to the new paths, orphan dir untouched.
- Docs: `commands.md` info topic section, `changelog.d/589-course-renumber.added.md`, design doc §9 marked Phase-1 complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TM3Pre9YPM5aTm65mmf6kM
