### PR TITLE
feat(sync): point-of-use agent ergonomics for the sync verbs

### DIFF
--- a/changelog.d/591-sync-agent-ux.changed.md
+++ b/changelog.d/591-sync-agent-ux.changed.md
@@ -1,0 +1,15 @@
+- `clm slides sync` agent ergonomics, driven by a transcript audit of 11 real
+  agent sessions: the first decision-document error now teaches the full JSON
+  shape (with the body format) instead of one field per round-trip; `apply
+  --help`'s `--decisions` shows the schema inline; every report item now
+  carries `answers` (`[]` = mechanical) so drivers need no missing-key guard;
+  an all-cold report emits a `hint` pointing at `sync record` (text + JSON);
+  rejected decisions are echoed to stderr in both output modes with their
+  reasons; `duplicate_id` refusals name `clm slides rename-id` as the fix;
+  `report`/`apply`/`record --help` point at `clm info sync-agents`; and
+  `clm validate`'s shared-cell-drift suggestions now recommend `sync
+  report`/`apply` over the legacy `unify` + `split` round-trip. The
+  `sync-agents` info topic gains the apply-result JSON envelope, the
+  report field names, a confirm-all-vs-`record` rule, and a "working
+  patterns for agents" section (stdin decisions, script-generated decision
+  documents, answers-aware batching, parallel-sweep capture discipline).

--- a/src/clm/cli/commands/slides/sync.py
+++ b/src/clm/cli/commands/slides/sync.py
@@ -489,6 +489,10 @@ def sync_report_cmd(
     the committed per-topic ledger; a member with no ledger entry is **cold**
     (frame ``verify_cold``), never silently trusted. ``--since DATE|REF``
     switches to the forensic git-window view. Works over a directory.
+
+    \b
+    Exit 1 means "work pending", not failure. Agent loop + JSON reference:
+    `clm info sync-agents`.
     """
     from clm.cli.commands.slides.sync_v3 import run_report_v3
 
@@ -546,6 +550,11 @@ def sync_record_cmd(
     (a corrupt pair is refused, nothing written). A full record sweeps stale
     entries and performs the §7.3 pos→id key migration (logged); ``--member``
     upserts just the named handles. Works over a directory.
+
+    \b
+    This is the efficient answer to an all-cold report (a freshly authored or
+    never-recorded deck) — no per-item confirm document needed. Agent loop:
+    `clm info sync-agents`.
     """
     from clm.cli.commands.slides.sync_v3 import run_record_v3
 
@@ -571,8 +580,11 @@ def sync_record_cmd(
     metavar="FILE|-",
     help=(
         "A JSON decision document answering framed report items per member "
-        "handle ('-' reads stdin). Invalid answers are rejected per item; "
-        "valid ones land."
+        'handle (\'-\' reads stdin). Shape: {"decisions": [{"key": "id:intro", '
+        '"choice": "confirm"}, {"key": "id:x", "body": "..."}]}. A body is the '
+        "cell text WITHOUT its '# %%' delimiter line, WITH the '# ' comment "
+        "prefixes. Invalid answers are rejected per item; valid ones land. "
+        "Reference: `clm info sync-agents`."
     ),
 )
 @click.option(
@@ -610,6 +622,7 @@ def sync_apply_cmd(
     \b
     Needs no API key. Review writes with `git diff`; confirm soundness with
     `clm slides sync verify`. Exit 0 all-applied / 1 residue / 2 error.
+    Decision-document shape and body format: `clm info sync-agents`.
     """
     from clm.cli.commands.slides.sync_v3 import run_apply_v3
 

--- a/src/clm/cli/commands/slides/sync_v3.py
+++ b/src/clm/cli/commands/slides/sync_v3.py
@@ -27,7 +27,12 @@ import click
 
 from clm.slides import doc_apply, doc_ledger
 from clm.slides.doc_lenses import DocLensError, LoadedBundle, load_bundle
-from clm.slides.doc_report import diff_bundle, diff_bundle_at_ref, pair_payload
+from clm.slides.doc_report import (
+    cold_sweep_hint,
+    diff_bundle,
+    diff_bundle_at_ref,
+    pair_payload,
+)
 from clm.slides.pairing import (
     find_split_slide_files_recursive,
     iter_split_pairs,
@@ -77,11 +82,14 @@ def _render_pair(bundle: LoadedBundle, diff: DeckDiff) -> str:
     if diff.refusal is not None:
         lines.append("  " + diff.refusal.render().replace("\n", "\n  "))
     for item in diff.items:
-        answers = doc_apply.decision_vocabulary(item.action)
+        answers = doc_apply.item_answers(item)
         suffix = f"  [answers: {', '.join(answers)}]" if answers else ""
         lines.append(
             f"  {item.outcome}/{item.action} {item.key} ({item.direction}) {item.detail}{suffix}"
         )
+    hint = cold_sweep_hint(diff)
+    if hint is not None:
+        lines.append(f"  hint: {hint}")
     return "\n".join(lines)
 
 
@@ -264,6 +272,17 @@ def run_apply_v3(
                 "recorded into the ledger; fix the pair, then `sync record`",
                 err=True,
             )
+    rejected = [r for r in outcome.results if r.status == "rejected"]
+    if rejected:
+        # Stderr in both modes: agents parsing --json counts alone provably
+        # committed with rejections unnoticed. Keep it one line per item.
+        click.echo(
+            f"{len(rejected)} decision(s) rejected — each item's accepted answers "
+            "come from report --json (its `answers` list); see `clm info sync-agents`:",
+            err=True,
+        )
+        for result in rejected:
+            click.echo(f"  {result.key} ({result.action}): {result.reason}", err=True)
     if outcome.error is not None:
         return 2
     return 0 if outcome.all_applied and not verify_violations else 1

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1954,10 +1954,12 @@ already agree — ledger-only), the §7.3 transitions (`record_fork`,
 propagation. **Framed actions** (need a decision): `translate_edit`,
 `translate_new`, `verify_translation`, `conflict_shared`,
 `pending_divergence`, `remove_vs_edit`, `unify_choose_body`, `order_decision`,
-`ambiguous_alignment`, `verify_cold`, and friends. Each framed JSON item
-carries an `answers` list naming the decision shapes `apply --decisions`
-accepts for it, plus the full current cell bytes so an agent can answer
-without re-reading files.
+`ambiguous_alignment`, `verify_cold`, and friends. Every JSON item carries an
+`answers` list — the decision shapes `apply --decisions` accepts for it, `[]`
+on mechanical items (nothing to answer) — plus the full current cell bytes
+(`de` / `en`) so an agent can answer without re-reading files. A report whose
+items are all `verify_cold` (a never-recorded deck) carries a top-level
+`hint` pointing at `sync record`, the wholesale seeding verb.
 
 `--since DATE|REF` — the **forensic view**: diff against the bundle at a git
 ref instead of the ledger ("what changed in this window?"). A ref is used
@@ -1987,7 +1989,11 @@ verify** (a pair failing verify keeps its file writes — review with
 `git diff` — but records nothing). `--member KEY` limits the pass to the named
 handles; `--dry-run` executes and validates everything, writes nothing. Exit
 `0` all-applied / `1` residue / `2` error. Needs no API key; single deck only
-(run `report` over a directory to find work).
+(run `report` over a directory to find work). The `--json` result carries
+`counts` (`applied` / `recorded` / `pending` / `rejected` / `failed` /
+`skipped`), per-item `items[].status` + `reason`, `ledger_recorded`, and
+`verify_violations`; rejected decisions are additionally echoed to stderr in
+both output modes. Full envelope example: `clm info sync-agents`.
 
 #### `clm slides sync verify`
 

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -54,9 +54,14 @@ Branch on the stable booleans rather than scanning the lists:
 
 Each item row carries `key` (the member handle), `outcome`, `action`,
 `direction` (`de_to_en` / `en_to_de` / `both` / `none`), `detail`, the full
-current cell bytes for both sides (so you never re-read files to act), and —
-for framed items — an **`answers` list naming exactly the decision shapes
-`apply --decisions` accepts** for that item.
+current cell bytes for both sides under **`de` and `en`** (those exact key
+names — so you never re-read files to act), and an **`answers` list naming
+exactly the decision shapes `apply --decisions` accepts** for that item.
+`answers` is present on every item; `[]` means mechanical (nothing to
+answer — `apply` executes it). Note the `de`/`en` excerpts **include** the
+`# %%` header line; a `body` answer must **not** (see below). A report whose
+items are *all* `verify_cold` also carries a top-level `hint` — that is the
+seeding case; use `record`, not a confirm-all document (see "Cold members").
 
 **Mechanical actions** (no decision needed — `apply` executes them):
 `propagate_shared_edit`, `copy_new_shared`, `mirror_remove`, `mirror_tags`,
@@ -130,6 +135,36 @@ everything and writes nothing. Every landed item is recorded into the ledger,
 structurally corrupt stay on disk for review, but nothing is recorded as
 trusted.
 
+### Reading the apply result (`--json`)
+
+The envelope (keys verbatim — do not guess `applied`/`results`/`outcome`,
+they do not exist):
+
+```json
+{
+  "schema": 3, "engine": "v3",
+  "dry_run": false,
+  "error": null,
+  "wrote": true, "written": ["…/slides_x.en.py"],
+  "counts": {"applied": 4, "recorded": 2, "pending": 1,
+             "rejected": 1, "failed": 0, "skipped": 0},
+  "items": [
+    {"key": "id:intro", "action": "translate_edit",
+     "status": "applied", "reason": ""},
+    {"key": "id:setup", "action": "verify_cold",
+     "status": "rejected", "reason": "…why…"}
+  ],
+  "ledger_recorded": true,
+  "verify_violations": []
+}
+```
+
+**Always check `counts.rejected` (and each rejected item's `reason`) before
+moving on** — rejections are also echoed to stderr. `pending` = framed items
+you did not answer (exit 1, not an error). `ledger_recorded: false` with
+`verify_violations` means writes landed but nothing was trusted — fix the
+pair, then `record`.
+
 ## Cold members and `record`
 
 A brand-new checkout, a never-synced deck, or a deck whose ledger entries
@@ -152,6 +187,12 @@ never recorded. Two ways to converge:
   bless/accept collapsed into one verb, gated on the structural verify, with
   `--provenance agent` (or `semantic:<model>` when a model attested the
   translation quality).
+
+**Rule of thumb: when a report is *all* `verify_cold` (the report says so in
+a `hint`), use `record`, not a confirm-all decision document.** They assert
+the same trust; `record` is one command instead of a scripted
+report→build-JSON→apply pipeline. Reserve per-item `confirm` for the mixed
+case where cold items sit next to real work.
 
 `clm slides split` and `clm slides translate` record freshly-created pairs
 automatically, so a normal authoring flow starts warm.
@@ -228,6 +269,50 @@ sync handoff closes through the ordinary loop.
 `slides_sync_report` (MCP) returns the same schema-3 pair payload as
 `report --json`, including the `answers` vocabulary per framed item.
 Writing decisions currently requires the CLI `apply --decisions`.
+
+## Working patterns for agents
+
+Patterns proven in real sessions (the sessions that used them had zero
+rejected decisions; the sessions that improvised did not):
+
+- **Generate the decision document with a script, from the report JSON** —
+  never by hand-escaping JSON in a shell string. The report items carry
+  everything you need:
+
+  ```python
+  import json, subprocess
+  rep = json.loads(subprocess.run(
+      ["clm", "slides", "sync", "report", DECK, "--json"],
+      capture_output=True, text=True).stdout)
+  decisions = []
+  for it in rep["items"]:
+      if not it["answers"]:            # [] = mechanical, apply handles it
+          continue
+      # your judgment per item: a translated body, confirm, keep_twin, de/en …
+      decisions.append({"key": it["key"], "choice": "confirm"})
+  print(json.dumps({"decisions": decisions}))
+  ```
+
+- **Feed decisions via stdin** (`apply DECK --decisions - --json`) — it
+  sidesteps every temp-file/path/quoting problem (Windows `/tmp`, unset
+  env vars, MSYS path mangling all produced real failures).
+- **Answer by `answers`, never blanket-confirm**: a `translate_edit` offers
+  `body`/`keep_twin` — a `confirm` on it is rejected. Branch on each item's
+  `answers` list.
+- **Always `--dry-run` first** on a nontrivial decision document; it
+  validates every answer without writing.
+- **Many `translate_new` bodies at once** (e.g. a whole deck authored in one
+  language): answering each in JSON works but is heavy. The sanctioned bulk
+  alternative is `clm slides translate DECK.en.py` to bootstrap the missing
+  half wholesale (it records the ledger), then review and reconcile the
+  drifts through the normal loop (`keep_twin` for cells your review left
+  unchanged).
+- **Parallel sweeps**: `report --json` writes to stdout — in a fan-out,
+  capture each deck's output under a deck-derived filename (generic names
+  like `report1.json` collided and mixed decks up in real runs), and verify
+  `de_path` in the payload matches the deck you asked about.
+- **Exit codes are states, not failures**: `report` exits 1 whenever work is
+  pending — a read-only command doing its job. Treat only 2 as an error.
 
 ## Quick reference
 

--- a/src/clm/slides/bilingual_doc.py
+++ b/src/clm/slides/bilingual_doc.py
@@ -235,6 +235,19 @@ class RefusalReason:
     member: MemberKey | None = None
 
 
+#: Remediation hints per refusal code, appended to the rendered refusal.
+#: The header line's remedy (`normalize --stamp-ids`) covers the id-less
+#: codes; codes it cannot fix name their own fix here, so a refusal is never
+#: a dead end for the driving agent.
+REFUSAL_HINTS: dict[str, str] = {
+    "duplicate_id": (
+        "rename colliding slide_ids with `clm slides rename-id DECK OLD NEW` "
+        "(rewrites both halves and migrates the sync-ledger key; `normalize` "
+        "cannot fix duplicates)"
+    ),
+}
+
+
 @define
 class NormalizeRefusal:
     """A framed "run normalize first" refusal for a whole deck (design §3.2).
@@ -248,6 +261,10 @@ class NormalizeRefusal:
     def render(self) -> str:
         lines = ["deck is not normalized — run `clm slides normalize --stamp-ids` first:"]
         lines += [f"  - [{r.code}] {r.detail}" for r in self.reasons]
+        for code in dict.fromkeys(r.code for r in self.reasons):
+            hint = REFUSAL_HINTS.get(code)
+            if hint:
+                lines.append(f"  hint: {hint}")
         return "\n".join(lines)
 
 

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -162,7 +162,16 @@ def parse_decisions(payload: object) -> tuple[dict[str, Decision], list[str]]:
     errors: list[str] = []
     rows = payload.get("decisions") if isinstance(payload, dict) else payload
     if not isinstance(rows, list):
-        return {}, ["decision document must be a list or {'decisions': [...]}"]
+        # The first schema error an agent ever sees — teach the whole shape at
+        # once instead of one field name per round-trip.
+        return {}, [
+            "decision document must be a list or {'decisions': [...]} — e.g. "
+            '{"decisions": [{"key": "id:intro", "choice": "confirm"}, '
+            '{"key": "id:motivation", "body": "# the translated cell body"}]}; '
+            "each item's accepted answers are in report --json (`answers`), "
+            "and a body is the cell text WITHOUT its '# %%' delimiter line — "
+            "see `clm info sync-agents`"
+        ]
     decisions: dict[str, Decision] = {}
     for i, row in enumerate(rows):
         if not isinstance(row, dict) or not isinstance(row.get("key"), str):

--- a/src/clm/slides/doc_report.py
+++ b/src/clm/slides/doc_report.py
@@ -13,7 +13,13 @@ from clm.slides import doc_apply, doc_ledger
 from clm.slides.doc_lenses import LoadedBundle
 from clm.slides.sync_diff import DeckDiff, diff_outcome
 
-__all__ = ["diff_bundle", "diff_bundle_at_ref", "item_payloads", "pair_payload"]
+__all__ = [
+    "cold_sweep_hint",
+    "diff_bundle",
+    "diff_bundle_at_ref",
+    "item_payloads",
+    "pair_payload",
+]
 
 
 def diff_bundle(bundle: LoadedBundle) -> DeckDiff:
@@ -61,15 +67,35 @@ def diff_bundle_at_ref(bundle: LoadedBundle, ref: str) -> tuple[DeckDiff, list[s
 
 
 def item_payloads(diff: DeckDiff) -> list[dict]:
-    """The §6.4 item rows, each framed item carrying its answer vocabulary."""
+    """The §6.4 item rows, each item carrying its answer vocabulary.
+
+    ``answers`` is present on **every** item — ``[]`` on mechanical rows
+    (nothing to answer; ``apply`` executes them) — so consumers can filter
+    with ``item["answers"]`` without guarding a missing key. Agent drivers
+    provably crashed on the key's absence before this was guaranteed.
+    """
     items = []
     for item in diff.items:
         payload = item.payload()
-        answers = doc_apply.item_answers(item)
-        if answers:
-            payload["answers"] = list(answers)
+        payload["answers"] = list(doc_apply.item_answers(item))
         items.append(payload)
     return items
+
+
+def cold_sweep_hint(diff: DeckDiff) -> str | None:
+    """A next-step hint when the whole report is cold (never-recorded deck).
+
+    An all-``verify_cold`` report is the seeding case, and the efficient
+    answer is the ``record`` verb, not a hand-built confirm-all decision
+    document — agents reliably scripted the latter when nothing said so.
+    """
+    if diff.items and all(item.action == "verify_cold" for item in diff.items):
+        return (
+            "every member is cold (no ledger entry) — for a freshly authored or "
+            "never-recorded deck, review the pair and bank it wholesale with "
+            "`clm slides sync record DECK` instead of confirming per item"
+        )
+    return None
 
 
 def pair_payload(bundle: LoadedBundle, diff: DeckDiff) -> dict:
@@ -78,4 +104,7 @@ def pair_payload(bundle: LoadedBundle, diff: DeckDiff) -> dict:
     payload["items"] = item_payloads(diff)
     payload["de_path"] = str(bundle.de_path)
     payload["en_path"] = str(bundle.en_path)
+    hint = cold_sweep_hint(diff)
+    if hint is not None:
+        payload["hint"] = hint
     return payload

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -1328,9 +1328,10 @@ def _check_shared_cell_parity(de_path: Path, en_path: Path) -> list[Finding]:
                 ),
                 suggestion=(
                     "Shared (no-lang) cells must appear in the same order "
-                    "in both '.de.py' and '.en.py'. Re-run "
-                    "`clm slides unify` followed by `clm slides split` to "
-                    "regenerate consistent split companions."
+                    "in both '.de.py' and '.en.py'. Run `clm slides sync "
+                    "report` to see the divergence per member and `sync "
+                    "apply` to reconcile; regenerate via `clm slides unify` "
+                    "+ `clm slides split` only if the pair no longer aligns."
                 ),
             )
         )
@@ -1353,8 +1354,11 @@ def _check_shared_cell_parity(de_path: Path, en_path: Path) -> list[Finding]:
                 ),
                 suggestion=(
                     "Shared cells must be byte-identical between the DE "
-                    "and EN companions. Reconcile the edit manually or "
-                    "regenerate via `clm slides unify` + `clm slides split`."
+                    "and EN companions. Propagate the edit with "
+                    "`clm slides sync report` + `sync apply` (mechanical "
+                    "for shared cells, no model); fall back to "
+                    "`clm slides unify` + `clm slides split` only if the "
+                    "pair no longer aligns at all."
                 ),
             )
         )

--- a/tests/cli/test_sync_v3_cli.py
+++ b/tests/cli/test_sync_v3_cli.py
@@ -51,8 +51,11 @@ def _write_pair(tmp_path: Path) -> tuple[Path, Path]:
 
 
 def _json_payload(output: str) -> dict:
+    # raw_decode: the runner may append stderr lines (e.g. apply's rejected
+    # summary) after the JSON document — parse the object, ignore the rest.
     start = output.index("{")
-    return json.loads(output[start:])
+    payload, _end = json.JSONDecoder().raw_decode(output[start:])
+    return payload
 
 
 class TestSyncLoop:
@@ -72,6 +75,8 @@ class TestSyncLoop:
         for i in payload["items"]:
             expected = ["confirm", "body"] if i["key"].startswith("id:") else ["confirm"]
             assert i["answers"] == expected, i
+        # An all-cold report is the seeding case — it says so.
+        assert "sync record" in payload["hint"]
 
         # record blesses the current state (verify-gated).
         record = cli_runner.invoke(slides_sync_group, ["record", str(de), "--json"])
@@ -86,8 +91,14 @@ class TestSyncLoop:
         de.write_text(de.read_text(encoding="utf-8").replace("x = 1", "x = 42"), "utf-8")
         flagged = cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"])
         assert flagged.exit_code == 1
-        items = _json_payload(flagged.output)["items"]
+        payload = _json_payload(flagged.output)
+        items = payload["items"]
         assert [i["action"] for i in items] == ["propagate_shared_edit"]
+        # Mechanical items carry answers == [] (present, never missing) so
+        # agent drivers can filter on item["answers"] without a key guard.
+        assert items[0]["answers"] == []
+        # A mixed/mechanical report carries no cold-seeding hint.
+        assert "hint" not in payload
 
         applied = cli_runner.invoke(slides_sync_group, ["apply", str(de), "--json"])
         assert applied.exit_code == 0, applied.output
@@ -147,6 +158,24 @@ class TestSyncLoop:
         clean = cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"])
         assert clean.exit_code == 0, clean.output
         assert _json_payload(clean.output)["is_clean"] is True
+
+    def test_rejected_decision_is_summarized_on_stderr(self, cli_runner: CliRunner, tmp_path: Path):
+        # Blanket-confirming a translate_edit is the classic wrong answer —
+        # the rejection must be loud (stderr, with the reason), not just a
+        # counts entry an agent's JSON filter can skip past.
+        de, en = _write_pair(tmp_path)
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0
+        de.write_text(de.read_text(encoding="utf-8").replace("DE Text", "DE neu"), "utf-8")
+        result = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--decisions", "-", "--json"],
+            input=json.dumps({"decisions": [{"key": "id:s0-m", "choice": "confirm"}]}),
+        )
+        assert result.exit_code == 1, result.output
+        assert _json_payload(result.output)["counts"]["rejected"] == 1
+        stderr = getattr(result, "stderr", "") or result.output
+        assert "decision(s) rejected" in stderr
+        assert "id:s0-m" in stderr
 
     def test_apply_residue_exits_one(self, cli_runner: CliRunner, tmp_path: Path):
         de, en = _write_pair(tmp_path)

--- a/tests/slides/test_bilingual_doc.py
+++ b/tests/slides/test_bilingual_doc.py
@@ -111,3 +111,20 @@ class TestNormalizeRefusal:
         assert "normalize" in text
         assert "duplicate_id" in text
         assert "idless_localized" in text
+
+    def test_render_appends_remediation_hint_once_per_code(self):
+        # duplicate_id names its fix (rename-id) — normalize cannot fix it —
+        # and the hint appears once even for multiple reasons with the code.
+        refusal = NormalizeRefusal(
+            reasons=[
+                RefusalReason(code="duplicate_id", detail="id x twice"),
+                RefusalReason(code="duplicate_id", detail="id y twice"),
+            ]
+        )
+        assert refusal.render().count("clm slides rename-id") == 1
+
+    def test_render_no_hint_for_codes_normalize_fixes(self):
+        refusal = NormalizeRefusal(
+            reasons=[RefusalReason(code="idless_localized", detail="line 7")]
+        )
+        assert "hint:" not in refusal.render()

--- a/tests/slides/test_doc_apply.py
+++ b/tests/slides/test_doc_apply.py
@@ -710,6 +710,16 @@ class TestColdBodyRecovery:
 
 
 class TestDecisionParsing:
+    def test_wrong_top_level_shape_error_teaches_the_schema(self):
+        # The first error an agent sees must show the whole document shape —
+        # agents provably guessed field names one rejection at a time.
+        decisions, errors = doc_apply.parse_decisions({"id:x": "confirm"})
+        assert not decisions
+        assert len(errors) == 1
+        assert '{"key": "id:intro", "choice": "confirm"}' in errors[0]
+        assert "clm info sync-agents" in errors[0]
+        assert "'# %%'" in errors[0]  # the body-format trap, stated up front
+
     def test_side_must_be_de_or_en(self):
         decisions, errors = doc_apply.parse_decisions(
             {"decisions": [{"key": "id:x", "body": "b", "side": "left"}]}


### PR DESCRIPTION
## Summary

A transcript audit of **11 real agent sessions** driving sync v3 in CppCourses and PythonCourses (2026-07-04..10) measured **20–45% of sync-related tool calls spent probing**: guessing the decision-document schema one error message at a time, reverse-engineering the `body` format via `--dry-run`, crashing on the missing `answers` key, scripting confirm-all pipelines instead of using `record`, committing past silent rejections, and hand-reimplementing `rename-id` because nothing pointed at it. The strongest predictor of a friction-free session was reading `clm info sync-agents` **before** the first `apply` — so this PR makes the CLI teach at the point of use.

## Changes

**CLI text/behavior**
- The first decision-document error now shows the full JSON shape, the body-format rule ("no `# %%` line"), and points at `clm info sync-agents`.
- `apply --help`'s `--decisions` shows the schema inline; `report`/`apply`/`record --help` point at the info topic; `report --help` states exit 1 = work pending, not failure.
- Every report item carries `answers` (`[]` = mechanical) — agent drivers provably crashed on the key's absence. Text renderer now uses the key-aware `item_answers` (positional cold members no longer advertise `body` in text mode — a latent text/JSON inconsistency).
- An all-`verify_cold` report emits a hint (text + JSON `hint` field) pointing at `sync record`, the seeding verb agents scripted around.
- Rejected decisions are echoed to **stderr with reasons in both output modes** — agents parsing `--json` counts alone committed past `rejected: 2`.
- `duplicate_id` refusals name `clm slides rename-id` as the fix (an agent on 1.21.0 hand-rolled a regex rename script + ledger migration because the refusal didn't).
- `clm validate`'s shared-cell-drift suggestions recommend `sync report`/`apply` over the legacy `unify` + `split` round-trip.

**Info topics**
- `sync-agents`: the apply-result JSON envelope (verbatim keys — `counts`/`items[].status`/`ledger_recorded`), the report field names (`de`/`en`/`answers` + the header-line trap), a confirm-all-vs-`record` rule, and a "Working patterns for agents" section (script-generated decision docs, stdin decisions, answers-aware batching, dry-run first, the bulk-translate path, parallel-sweep capture discipline, exit-code semantics).
- `commands.md` updated to match.

## Tests

New/extended: refusal hint rendering (once per code, none for normalize-fixable codes), schema-teaching top-level decision error, `answers == []` on mechanical items, all-cold `hint` presence/absence, rejected-decision stderr summary. Full fast suite green on the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GHzB6J1E1TWTgUevyuzajg
