### PR TITLE
fix(workers): ownership for worker reuse — never borrow another build's auto-stopped workers

### DIFF
--- a/changelog.d/594-worker-reuse-ownership.fixed.md
+++ b/changelog.d/594-worker-reuse-ownership.fixed.md
@@ -1,0 +1,8 @@
+- Fixed intermittent `RuntimeError: No workers available to process 'notebook' jobs`
+  mid-build (issue #594). Worker reuse could count another build's auto-stopped
+  workers in a shared jobs DB as reusable; when that build exited, its workers were
+  deleted and the borrowing build was stranded with zero workers at its first
+  non-cached submission. Managed workers are now stamped with their owning session
+  (`workers.session_id`) and an ownership marker (`workers.managed_by`): a build
+  only reuses its own workers, deliberately persistent workers (`auto_stop=false`),
+  or unmarked externally started workers.

--- a/src/clm/infrastructure/workers/discovery.py
+++ b/src/clm/infrastructure/workers/discovery.py
@@ -10,6 +10,17 @@ from clm.infrastructure.workers.worker_executor import WorkerExecutor
 
 logger = logging.getLogger(__name__)
 
+# Ownership markers stored in workers.managed_by (issue #594). A build whose
+# lifecycle manager will auto-stop its workers tags them MANAGED_BY_BUILD:
+# they are torn down (rows DELETEd) the moment that build exits, so another
+# build must never count them as reusable — reusing them is a race that
+# strands the borrowing build with zero workers mid-build. Workers a build
+# deliberately leaves running (auto_stop=false) are tagged
+# MANAGED_BY_PERSISTENT and stay reusable, as do legacy self-registered rows
+# (managed_by IS NULL).
+MANAGED_BY_BUILD = "build"
+MANAGED_BY_PERSISTENT = "persistent"
+
 
 @dataclass
 class DiscoveredWorker:
@@ -25,6 +36,20 @@ class DiscoveredWorker:
     started_at: datetime
     is_docker: bool
     is_healthy: bool
+    session_id: str | None = None
+    managed_by: str | None = None
+
+    def is_reusable_by(self, session_id: str | None) -> bool:
+        """Whether a session may count this worker toward its own needs.
+
+        Another session's build-owned worker (managed_by = MANAGED_BY_BUILD)
+        vanishes when that build exits, so it is only reusable by the session
+        that owns it. Everything else — persistent workers and legacy rows
+        with no ownership marker — is fair game (issue #594).
+        """
+        if self.managed_by != MANAGED_BY_BUILD:
+            return True
+        return self.session_id is not None and self.session_id == session_id
 
 
 class WorkerDiscovery:
@@ -75,7 +100,8 @@ class WorkerDiscovery:
         query = """
             SELECT
                 id, worker_type, container_id, status,
-                last_heartbeat, jobs_processed, jobs_failed, started_at
+                last_heartbeat, jobs_processed, jobs_failed, started_at,
+                session_id, managed_by
             FROM workers
         """
 
@@ -120,6 +146,8 @@ class WorkerDiscovery:
                 started_at=started_at,
                 is_docker=is_docker,
                 is_healthy=False,  # Will be set by health check
+                session_id=row[8],
+                managed_by=row[9],
             )
 
             workers.append(worker)
@@ -180,7 +208,12 @@ class WorkerDiscovery:
 
         return True
 
-    def count_healthy_workers(self, worker_type: str, execution_mode: str | None = None) -> int:
+    def count_healthy_workers(
+        self,
+        worker_type: str,
+        execution_mode: str | None = None,
+        reusable_for_session: str | None = None,
+    ) -> int:
         """Count healthy workers of a specific type.
 
         Args:
@@ -190,6 +223,11 @@ class WorkerDiscovery:
                 workers must not treat another build's Direct workers as
                 satisfying its requirement — they lack the Docker image's
                 toolchain (e.g. the xeus-cpp kernel).
+            reusable_for_session: When given, count only workers this session
+                may reuse (see DiscoveredWorker.is_reusable_by): another
+                build's auto-stopped workers are excluded because they vanish
+                when that build exits (issue #594). None = no ownership
+                filtering.
 
         Returns:
             Number of healthy workers
@@ -203,6 +241,7 @@ class WorkerDiscovery:
             and (
                 execution_mode is None or ("docker" if w.is_docker else "direct") == execution_mode
             )
+            and (reusable_for_session is None or w.is_reusable_by(reusable_for_session))
         )
 
     def get_worker_summary(self) -> dict[str, dict[str, int]]:

--- a/src/clm/infrastructure/workers/lifecycle_manager.py
+++ b/src/clm/infrastructure/workers/lifecycle_manager.py
@@ -157,8 +157,14 @@ class WorkerLifecycleManager:
             # Only workers of the required execution mode count: a Docker-mode
             # build must not be satisfied by Direct workers another build
             # registered in a shared jobs DB (they lack the image's toolchain).
+            # And only workers this session may reuse count: another build's
+            # auto-stopped workers are DELETEd when that build exits, so
+            # counting them here strands this build with zero workers at its
+            # first non-cached submission (issue #594).
             healthy_count = self.discovery.count_healthy_workers(
-                worker_type, execution_mode=required_config.execution_mode
+                worker_type,
+                execution_mode=required_config.execution_mode,
+                reusable_for_session=self.session_id,
             )
 
             if healthy_count < required_count:
@@ -198,7 +204,10 @@ class WorkerLifecycleManager:
         # Log pool starting
         self.event_logger.log_pool_starting(worker_configs, total_workers)
 
-        # Create pool manager
+        # Create pool manager. Workers started with auto_stop are owned by
+        # this session (torn down when the build exits, never reusable by
+        # other builds); with auto_stop disabled they outlive the build and
+        # are marked shareable (issue #594).
         self.pool_manager = WorkerPoolManager(
             db_path=self.db_path,
             workspace_path=self.workspace_path,
@@ -208,6 +217,8 @@ class WorkerLifecycleManager:
             log_level=logging.getLevelName(logger.getEffectiveLevel()),
             cache_db_path=self.cache_db_path,
             notebook_kernel_python=self.notebook_kernel_python,
+            session_id=self.session_id,
+            workers_shareable=not self.config.auto_stop,
         )
 
         # Update discovery to use pool_manager's executors for accurate health checks
@@ -303,10 +314,12 @@ class WorkerLifecycleManager:
         adjusted = []
 
         for config in configs:
-            # Mode-aware: only same-mode workers can be reused (see
-            # should_start_workers).
+            # Mode-aware and ownership-aware: only same-mode workers this
+            # session may reuse count (see should_start_workers, issue #594).
             healthy_count = self.discovery.count_healthy_workers(
-                config.worker_type, execution_mode=config.execution_mode
+                config.worker_type,
+                execution_mode=config.execution_mode,
+                reusable_for_session=self.session_id,
             )
             needed_count = max(0, config.count - healthy_count)
 
@@ -386,11 +399,15 @@ class WorkerLifecycleManager:
 
             # Take up to config.count healthy workers of the REQUIRED
             # execution mode — mirroring should_start_workers, a Direct
-            # worker never counts as a reused Docker worker or vice versa.
+            # worker never counts as a reused Docker worker or vice versa,
+            # and another session's build-owned workers are off limits
+            # (issue #594).
             healthy_workers = [
                 w
                 for w in discovered
-                if w.is_healthy and ("docker" if w.is_docker else "direct") == config.execution_mode
+                if w.is_healthy
+                and ("docker" if w.is_docker else "direct") == config.execution_mode
+                and w.is_reusable_by(self.session_id)
             ][: config.count]
 
             for worker in healthy_workers:

--- a/src/clm/infrastructure/workers/pool_manager.py
+++ b/src/clm/infrastructure/workers/pool_manager.py
@@ -26,6 +26,10 @@ from clm.infrastructure.api.server import (
     start_worker_api_server,
 )
 from clm.infrastructure.database.job_queue import JobQueue
+from clm.infrastructure.workers.discovery import (
+    MANAGED_BY_BUILD,
+    MANAGED_BY_PERSISTENT,
+)
 from clm.infrastructure.workers.worker_executor import (
     DirectWorkerExecutor,
     DockerWorkerExecutor,
@@ -120,6 +124,8 @@ class WorkerPoolManager:
         cache_db_path: Path | None = None,
         data_dir: Path | None = None,
         notebook_kernel_python: str = "",
+        session_id: str | None = None,
+        workers_shareable: bool = False,
     ):
         """Initialize worker pool manager.
 
@@ -137,6 +143,13 @@ class WorkerPoolManager:
             notebook_kernel_python: Resolved interpreter for the Direct notebook
                 kernel (Wave 2b); "" = clm's own env. Forwarded to the direct
                 executor; Docker mode ignores it.
+            session_id: Owning lifecycle session; stamped on each worker row
+                so other builds sharing the jobs DB can tell whose workers
+                they are (issue #594).
+            workers_shareable: True when the workers will be left running
+                after the owning build exits (auto_stop=false) and may be
+                reused by other builds; False (default) marks them
+                build-owned, never reusable by another session.
         """
         self.db_path = db_path
         self.workspace_path = workspace_path
@@ -146,6 +159,8 @@ class WorkerPoolManager:
         self.log_level = log_level
         self.cache_db_path = cache_db_path
         self.notebook_kernel_python = notebook_kernel_python
+        self.session_id = session_id
+        self.workers_shareable = workers_shareable
 
         # Determine max startup concurrency
         if max_startup_concurrency is None:
@@ -616,13 +631,21 @@ class WorkerPoolManager:
         # Get parent process ID for orphan detection
         parent_pid = os.getpid()
 
+        # Ownership marker (issue #594): build-owned workers are DELETEd when
+        # the owning build exits, so other builds sharing the jobs DB must
+        # never count them as reusable. Activation only flips status
+        # created -> idle, so the marker written here survives for the
+        # worker's whole life.
+        managed_by = MANAGED_BY_PERSISTENT if self.workers_shareable else MANAGED_BY_BUILD
+
         conn = self.job_queue._get_conn()
         cursor = conn.execute(
             """
-            INSERT INTO workers (worker_type, container_id, status, parent_pid)
-            VALUES (?, ?, 'created', ?)
+            INSERT INTO workers (worker_type, container_id, status, parent_pid,
+                                 session_id, managed_by)
+            VALUES (?, ?, 'created', ?, ?, ?)
             """,
-            (worker_type, container_id, parent_pid),
+            (worker_type, container_id, parent_pid, self.session_id, managed_by),
         )
         db_worker_id = cursor.lastrowid
         assert db_worker_id is not None, "INSERT should always return a valid lastrowid"
@@ -630,7 +653,8 @@ class WorkerPoolManager:
 
         logger.debug(
             f"Pre-registered {worker_type} worker {db_worker_id} "
-            f"(container_id: {container_id}, parent_pid: {parent_pid})"
+            f"(container_id: {container_id}, parent_pid: {parent_pid}, "
+            f"session_id: {self.session_id}, managed_by: {managed_by})"
         )
 
         return db_worker_id, container_id

--- a/tests/infrastructure/workers/test_discovery.py
+++ b/tests/infrastructure/workers/test_discovery.py
@@ -15,6 +15,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from clm.infrastructure.workers.discovery import (
+    MANAGED_BY_BUILD,
+    MANAGED_BY_PERSISTENT,
     DiscoveredWorker,
     WorkerDiscovery,
 )
@@ -49,6 +51,8 @@ def make_db_row():
         jobs_processed=0,
         jobs_failed=0,
         started_at=None,
+        session_id=None,
+        managed_by=None,
     ):
         if last_heartbeat is None:
             last_heartbeat = datetime.now(timezone.utc).isoformat()
@@ -75,6 +79,8 @@ def make_db_row():
             jobs_processed,
             jobs_failed,
             started_at_str,
+            session_id,
+            managed_by,
         )
 
     return _make_row
@@ -477,6 +483,101 @@ class TestCountHealthyWorkers:
         assert worker_discovery.count_healthy_workers("notebook", execution_mode="direct") == 2
         # No mode → legacy count-everything behaviour
         assert worker_discovery.count_healthy_workers("notebook") == 3
+
+
+class TestWorkerOwnership:
+    """Worker reuse ownership (issue #594).
+
+    Another build's auto-stopped workers are DELETEd from the jobs DB the
+    moment that build exits; a build that counted them as reusable is
+    stranded with zero workers at its first non-cached submission. Only
+    unowned, persistent, or same-session workers may be reused.
+    """
+
+    def test_is_reusable_by_semantics(self):
+        now = datetime.now(timezone.utc)
+
+        def make_worker(session_id, managed_by):
+            return DiscoveredWorker(
+                db_id=1,
+                worker_type="notebook",
+                executor_id="direct-1",
+                status="idle",
+                last_heartbeat=now,
+                jobs_processed=0,
+                jobs_failed=0,
+                started_at=now,
+                is_docker=False,
+                is_healthy=True,
+                session_id=session_id,
+                managed_by=managed_by,
+            )
+
+        # Another session's build-owned worker: never reusable
+        other = make_worker("session-other", MANAGED_BY_BUILD)
+        assert other.is_reusable_by("session-mine") is False
+
+        # My own build-owned worker: reusable by me
+        mine = make_worker("session-mine", MANAGED_BY_BUILD)
+        assert mine.is_reusable_by("session-mine") is True
+
+        # Deliberately persistent worker (auto_stop=false): reusable by anyone
+        persistent = make_worker("session-other", MANAGED_BY_PERSISTENT)
+        assert persistent.is_reusable_by("session-mine") is True
+
+        # Legacy self-registered worker (no ownership marker): reusable
+        legacy = make_worker(None, None)
+        assert legacy.is_reusable_by("session-mine") is True
+
+        # Build-owned worker with no session recorded: not reusable (a
+        # marker without an owner cannot be proven to be ours)
+        orphan_marker = make_worker(None, MANAGED_BY_BUILD)
+        assert orphan_marker.is_reusable_by("session-mine") is False
+
+    def test_count_excludes_other_sessions_build_workers(
+        self, worker_discovery, mock_job_queue, make_db_row
+    ):
+        """count_healthy_workers(reusable_for_session=...) must not count
+        another build's auto-stopped workers."""
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        now = datetime.now(timezone.utc)
+        mock_cursor.fetchall.return_value = [
+            make_db_row(
+                db_id=1,
+                status="idle",
+                last_heartbeat=now,
+                session_id="session-other",
+                managed_by=MANAGED_BY_BUILD,
+            ),
+            make_db_row(
+                db_id=2,
+                status="idle",
+                last_heartbeat=now,
+                session_id="session-mine",
+                managed_by=MANAGED_BY_BUILD,
+            ),
+            make_db_row(
+                db_id=3,
+                status="idle",
+                last_heartbeat=now,
+                session_id="session-other",
+                managed_by=MANAGED_BY_PERSISTENT,
+            ),
+            # Legacy row without ownership marker
+            make_db_row(db_id=4, status="idle", last_heartbeat=now),
+        ]
+        mock_conn.execute.return_value = mock_cursor
+        mock_job_queue._get_conn.return_value = mock_conn
+
+        # Own worker + persistent worker + legacy worker are reusable;
+        # the other session's build-owned worker is not.
+        assert (
+            worker_discovery.count_healthy_workers("notebook", reusable_for_session="session-mine")
+            == 3
+        )
+        # Without the ownership filter the legacy behaviour is unchanged.
+        assert worker_discovery.count_healthy_workers("notebook") == 4
 
 
 class TestDatetimeCompatibility:

--- a/tests/infrastructure/workers/test_lifecycle_manager.py
+++ b/tests/infrastructure/workers/test_lifecycle_manager.py
@@ -264,6 +264,33 @@ class TestShouldStartWorkers:
 
         assert manager.should_start_workers() is False
 
+    def test_reuse_counts_only_workers_reusable_by_this_session(
+        self, db_path, workspace_path, mock_config
+    ):
+        """Reuse must ignore other builds' auto-stopped workers (issue #594).
+
+        should_start_workers must pass its own session id to
+        count_healthy_workers so another build's build-owned workers — which
+        vanish when that build exits — never satisfy this build's needs.
+        """
+        mock_config.auto_start = True
+        mock_config.reuse_workers = True
+
+        with patch("clm.infrastructure.workers.lifecycle_manager.DirectWorkerExecutor"):
+            manager = WorkerLifecycleManager(
+                config=mock_config,
+                db_path=db_path,
+                workspace_path=workspace_path,
+            )
+            counter = MagicMock(return_value=1)
+            manager.discovery.count_healthy_workers = counter
+
+        manager.should_start_workers()
+
+        assert counter.call_count > 0
+        for call in counter.call_args_list:
+            assert call.kwargs["reusable_for_session"] == manager.session_id
+
 
 class TestStartManagedWorkers:
     """Test start_managed_workers method."""
@@ -286,6 +313,35 @@ class TestStartManagedWorkers:
                 manager.start_managed_workers()
 
                 mock_pool.assert_called_once()
+
+    def test_start_managed_workers_marks_ownership(self, db_path, workspace_path, mock_config):
+        """Pool manager must receive this session's id and the ownership mode.
+
+        auto_stop=True → workers are build-owned (not shareable); their rows
+        are DELETEd when this build exits, so no other build may reuse them.
+        auto_stop=False → workers outlive the build and are shareable
+        (issue #594).
+        """
+        for auto_stop, expected_shareable in [(True, False), (False, True)]:
+            mock_config.auto_stop = auto_stop
+            with patch("clm.infrastructure.workers.lifecycle_manager.DirectWorkerExecutor"):
+                with patch(
+                    "clm.infrastructure.workers.lifecycle_manager.WorkerPoolManager"
+                ) as mock_pool:
+                    mock_pool_instance = MagicMock()
+                    mock_pool_instance.workers = {}
+                    mock_pool.return_value = mock_pool_instance
+
+                    manager = WorkerLifecycleManager(
+                        config=mock_config,
+                        db_path=db_path,
+                        workspace_path=workspace_path,
+                    )
+                    manager.start_managed_workers()
+
+                    kwargs = mock_pool.call_args.kwargs
+                    assert kwargs["session_id"] == manager.session_id
+                    assert kwargs["workers_shareable"] is expected_shareable
 
     def test_start_managed_workers_starts_pools(self, db_path, workspace_path, mock_config):
         """Should call start_pools on pool manager."""

--- a/tests/infrastructure/workers/test_pool_manager.py
+++ b/tests/infrastructure/workers/test_pool_manager.py
@@ -1112,6 +1112,48 @@ class TestWorkerPreRegistration:
 
             manager.close()
 
+    def test_pre_register_worker_stamps_ownership(self, db_path, workspace_path):
+        """Pre-registration must stamp session_id and managed_by (issue #594).
+
+        Build-owned workers (the default) are marked 'build' so other builds
+        sharing the jobs DB never count them as reusable; shareable workers
+        (auto_stop=false) are marked 'persistent'.
+        """
+        from clm.infrastructure.workers.discovery import (
+            MANAGED_BY_BUILD,
+            MANAGED_BY_PERSISTENT,
+        )
+
+        with patch("docker.from_env"):
+            owned = WorkerPoolManager(
+                db_path=db_path,
+                workspace_path=workspace_path,
+                worker_configs=[],
+                session_id="session-owner",
+            )
+            worker_id, _ = owned._pre_register_worker("notebook", "direct")
+            conn = owned.job_queue._get_conn()
+            row = conn.execute(
+                "SELECT session_id, managed_by FROM workers WHERE id = ?", (worker_id,)
+            ).fetchone()
+            assert tuple(row) == ("session-owner", MANAGED_BY_BUILD)
+            owned.close()
+
+            shareable = WorkerPoolManager(
+                db_path=db_path,
+                workspace_path=workspace_path,
+                worker_configs=[],
+                session_id="session-sharer",
+                workers_shareable=True,
+            )
+            worker_id, _ = shareable._pre_register_worker("notebook", "direct")
+            conn = shareable.job_queue._get_conn()
+            row = conn.execute(
+                "SELECT session_id, managed_by FROM workers WHERE id = ?", (worker_id,)
+            ).fetchone()
+            assert tuple(row) == ("session-sharer", MANAGED_BY_PERSISTENT)
+            shareable.close()
+
     def test_pre_register_worker_includes_parent_pid(self, db_path, workspace_path):
         """Test _pre_register_worker stores parent_pid for orphan detection."""
         import os


### PR DESCRIPTION
Closes #594

## Problem

Worker reuse (`reuse_workers`, on by default) counted **any** healthy same-mode worker in the jobs DB as satisfying this build's needs — including workers started and owned by a different build sharing the DB (e.g. via a shared `CLM_JOBS_DB_PATH`). Nothing marks borrowed workers: when the owning build finishes, `stop_pools()` DELETEs their rows and stops the containers. The borrowing build — which started zero workers of its own — then hits its first non-cached submission with an empty workers table and dies with an `ExceptionGroup` of `RuntimeError: No workers available to process 'notebook' jobs`. Full diagnosis in #594.

## Fix

Stamp ownership at pre-registration using the existing (previously unused) `workers.session_id` and `workers.managed_by` columns — **no schema migration needed**. Activation only flips `status created→idle`, so the stamp survives the worker's whole life.

| `managed_by` | Written when | Reusable by |
|---|---|---|
| `'build'` | `auto_stop=true` (default) | owning session only |
| `'persistent'` | `auto_stop=false` | anyone |
| `NULL` | self-registered / legacy | anyone (status quo) |

`should_start_workers`, `_adjust_configs_for_reuse` and `_collect_reused_worker_info` filter through the new `DiscoveredWorker.is_reusable_by(session_id)`; `count_healthy_workers` gains an optional `reusable_for_session` parameter (None = legacy behaviour, used by `clm workers` display paths).

Net effect: a default-config build always starts and owns its own workers and can never be stranded by another build's teardown. Deliberate cross-build sharing (`auto_stop=false`, exercised by `test_e2e_managed_workers_reuse_across_builds`) and same-session reuse keep working.

## Testing

- New unit tests: `is_reusable_by` semantics, ownership filtering in `count_healthy_workers`, session plumbing in `should_start_workers` / `start_managed_workers`, ownership stamping in `_pre_register_worker`.
- `tests/infrastructure/workers/` — 385 passed; lifecycle integration tests (real worker reuse) — 7 passed; fast suite green on the pre-push hook.

## Not addressed here (noted in #594)

- Misleading `✓ Build completed successfully` printed from `_run_stages`'s `finally` while the exception propagates.
- The activation-timeout dead-marking UPDATE lacking an execution-mode clause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEj1XR9vYjEf5XCMD4EMJ6
