### PR TITLE
fix(build): render a failure summary when stage processing raises

### DIFF
--- a/changelog.d/596-abort-failure-summary.fixed.md
+++ b/changelog.d/596-abort-failure-summary.fixed.md
@@ -1,0 +1,7 @@
+- A build whose stage processing raised (e.g. "No workers available") no
+  longer prints "✓ Build completed successfully" with a clean summary while
+  the exception propagates (#596). The summary now shows "✗ Build aborted"
+  (JSON output: `"status": "aborted"` plus an `aborted` flag), the failure is
+  counted as a fatal infrastructure error, and — because errors were
+  recorded — the stale-output sweep skips itself instead of running against
+  the aborted build's incomplete write registry.

--- a/src/clm/cli/build_data_classes.py
+++ b/src/clm/cli/build_data_classes.py
@@ -205,6 +205,11 @@ class BuildSummary:
     timed-out build must always exit non-zero, independent of the
     ``--fail-on-error`` policy, because pending jobs mean the output tree is
     incomplete."""
+    aborted: bool = False
+    """True when stage processing raised and the exception is propagating
+    past the summary (issue #596) — e.g. a job-submission failure such as
+    "No workers available". The build did not complete, so renderers must
+    show a failure headline instead of "Build completed successfully"."""
 
     @property
     def failed_files(self) -> int:
@@ -253,10 +258,14 @@ class BuildSummary:
 
     def __str__(self) -> str:
         """Human-readable summary representation."""
-        status = "✗" if self.has_errors() else "✓"
-        status_text = "with errors" if self.has_errors() else "successfully"
+        if self.aborted:
+            headline = f"✗ Build aborted after {self.duration:.1f}s"
+        elif self.has_errors():
+            headline = f"✗ Build completed with errors in {self.duration:.1f}s"
+        else:
+            headline = f"✓ Build completed successfully in {self.duration:.1f}s"
 
-        parts = [f"{status} Build completed {status_text} in {self.duration:.1f}s"]
+        parts = [headline]
         parts.append("")
         parts.append("Summary:")
         parts.append(f"  {self.total_files} files processed")

--- a/src/clm/cli/build_reporter.py
+++ b/src/clm/cli/build_reporter.py
@@ -69,6 +69,11 @@ class BuildReporter:
         # exit independent of the --fail-on-error policy.
         self._timed_out: bool = False
 
+        # Set when stage processing raised and the exception is propagating
+        # past the summary (issue #596). Carried into BuildSummary.aborted so
+        # renderers show a failure headline instead of "completed successfully".
+        self._aborted: bool = False
+
         # Output-write registry summary, populated by
         # :meth:`report_output_writes` shortly before ``finish_build``.
         self._output_dedup_count: int = 0
@@ -301,6 +306,45 @@ class BuildReporter:
         """
         self._timed_out = True
 
+    def mark_aborted(self, exc: BaseException) -> None:
+        """Flag the build as aborted by a propagating exception (issue #596).
+
+        Called from the stage-processing exception handler *before* the
+        exception is re-raised, so the summary rendered by the ``finally``
+        block reports a failure instead of "Build completed successfully".
+
+        Also records the exception as a fatal infrastructure error: it then
+        appears in the summary's error count (submission-time failures
+        previously never did, unlike execution failures) and — because the
+        stale-output sweep skips itself when errors were recorded — keeps an
+        aborted build's incomplete write registry from sweeping away valid
+        outputs of prior successful builds.
+        """
+        self._aborted = True
+        messages = [f"{type(exc).__name__}: {exc}"]
+        # ``BaseExceptionGroup`` is a builtin on the supported runtimes but
+        # ruff's py310 target flags the bare name (same workaround as
+        # ``_contains_jobs_pending_timeout`` in the build command).
+        import builtins
+
+        group_type = getattr(builtins, "BaseExceptionGroup", None)
+        if group_type is not None and isinstance(exc, group_type):
+            messages.extend(f"{type(sub).__name__}: {sub}" for sub in exc.exceptions[:5])
+        self.errors.append(
+            BuildError(
+                error_type="infrastructure",
+                category="build_aborted",
+                severity="fatal",
+                file_path="",
+                message="\n".join(messages),
+                actionable_guidance=(
+                    "The build was aborted before all stages completed; the "
+                    "output tree is incomplete. See the traceback below for "
+                    "the underlying failure."
+                ),
+            )
+        )
+
     def report_warning(self, warning: BuildWarning) -> None:
         """Report a warning (display if appropriate, always collect).
 
@@ -479,6 +523,7 @@ class BuildReporter:
             flaky_files=sorted(self._flaky_files.values(), key=lambda f: f.file_path),
             rebuild_reasons=dict(self._rebuild_reasons),
             timed_out=self._timed_out,
+            aborted=self._aborted,
         )
 
         # Display summary

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -1462,6 +1462,15 @@ async def process_course_with_backend(
                         "tree is incomplete; see the error summary."
                     )
                 else:
+                    # Issue #596: the finally block below still renders the
+                    # summary while this exception propagates. Without an
+                    # explicit abort mark it printed "✓ Build completed
+                    # successfully" (with 0 errors) for a failed build, and
+                    # the stale-output sweep ran against an incomplete write
+                    # registry. mark_aborted flips the summary to a failure
+                    # and records a fatal error, which also makes the sweep
+                    # skip itself.
+                    build_reporter.mark_aborted(exc)
                     raise
 
         finally:

--- a/src/clm/cli/output_formatter.py
+++ b/src/clm/cli/output_formatter.py
@@ -407,19 +407,24 @@ class DefaultOutputFormatter(OutputFormatter):
             self._is_started = False
 
         # Status symbol and message
-        if summary.has_errors():
-            status_symbol = "✗"
-            status_color = "red"
-            status_text = "with errors"
+        if summary.aborted:
+            self.console.print(
+                f"\n[bold red]✗ Build aborted[/bold red] after {summary.duration:.1f}s\n"
+            )
         else:
-            status_symbol = "✓"
-            status_color = "green"
-            status_text = "successfully"
+            if summary.has_errors():
+                status_symbol = "✗"
+                status_color = "red"
+                status_text = "with errors"
+            else:
+                status_symbol = "✓"
+                status_color = "green"
+                status_text = "successfully"
 
-        self.console.print(
-            f"\n[bold {status_color}]{status_symbol} Build completed {status_text}[/bold {status_color}] "
-            f"in {summary.duration:.1f}s\n"
-        )
+            self.console.print(
+                f"\n[bold {status_color}]{status_symbol} Build completed {status_text}[/bold {status_color}] "
+                f"in {summary.duration:.1f}s\n"
+            )
 
         # Summary statistics
         self.console.print("[bold]Summary:[/bold]")
@@ -709,19 +714,24 @@ class VerboseOutputFormatter(DefaultOutputFormatter):
             self._is_started = False
 
         # Status symbol and message
-        if summary.has_errors():
-            status_symbol = "✗"
-            status_color = "red"
-            status_text = "with errors"
+        if summary.aborted:
+            self.console.print(
+                f"\n[bold red]✗ Build aborted[/bold red] after {summary.duration:.1f}s\n"
+            )
         else:
-            status_symbol = "✓"
-            status_color = "green"
-            status_text = "successfully"
+            if summary.has_errors():
+                status_symbol = "✗"
+                status_color = "red"
+                status_text = "with errors"
+            else:
+                status_symbol = "✓"
+                status_color = "green"
+                status_text = "successfully"
 
-        self.console.print(
-            f"\n[bold {status_color}]{status_symbol} Build completed {status_text}[/bold {status_color}] "
-            f"in {summary.duration:.1f}s\n"
-        )
+            self.console.print(
+                f"\n[bold {status_color}]{status_symbol} Build completed {status_text}[/bold {status_color}] "
+                f"in {summary.duration:.1f}s\n"
+            )
 
         # Summary statistics
         self.console.print("[bold]Summary:[/bold]")
@@ -874,7 +884,15 @@ class QuietOutputFormatter(OutputFormatter):
 
     def show_summary(self, summary: BuildSummary) -> None:
         """Display minimal summary."""
-        if summary.has_errors():
+        if summary.aborted:
+            self.console.print(
+                f"\nBuild aborted after {summary.duration:.1f}s",
+                style="red bold",
+            )
+            from clm.infrastructure.logging.log_paths import get_log_dir
+
+            self.console.print(f"See logs: {get_log_dir()}", style="dim")
+        elif summary.has_errors():
             self.console.print(
                 f"\nBuild failed with {len(summary.errors)} errors in {summary.duration:.1f}s",
                 style="red bold",
@@ -961,12 +979,15 @@ class JSONOutputFormatter(OutputFormatter):
     def show_summary(self, summary: BuildSummary) -> None:
         """Output final JSON to stdout."""
         # Determine final status
-        if summary.has_fatal_errors():
+        if summary.aborted:
+            self.output_data["status"] = "aborted"
+        elif summary.has_fatal_errors():
             self.output_data["status"] = "fatal"
         elif summary.has_errors():
             self.output_data["status"] = "failed"
         else:
             self.output_data["status"] = "success"
+        self.output_data["aborted"] = summary.aborted
 
         # Add summary data
         self.output_data["duration_seconds"] = summary.duration

--- a/tests/cli/test_build_abort_summary.py
+++ b/tests/cli/test_build_abort_summary.py
@@ -1,0 +1,154 @@
+"""Failure summary when stage processing raises (issue #596).
+
+When ``course.process_stage()`` raises (e.g. the worker-availability
+``ExceptionGroup`` from issue #594), the ``finally`` block in ``_run_stages``
+still renders the summary while the exception propagates. Previously it
+printed "✓ Build completed successfully" with 0 errors for a failed build,
+and the stale-output sweep ran against an incomplete write registry.
+``BuildReporter.mark_aborted`` flips the summary to a failure and records a
+fatal error so the sweep skips itself.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from clm.cli.build_data_classes import BuildSummary
+from clm.cli.build_reporter import BuildReporter
+from clm.cli.output_formatter import (
+    DefaultOutputFormatter,
+    JSONOutputFormatter,
+    QuietOutputFormatter,
+    VerboseOutputFormatter,
+)
+
+
+def _reporter() -> BuildReporter:
+    return BuildReporter(MagicMock())
+
+
+class TestMarkAborted:
+    def test_summary_is_flagged_aborted_and_has_fatal_error(self):
+        reporter = _reporter()
+        reporter.mark_aborted(RuntimeError("No workers available"))
+
+        summary = reporter.finish_build()
+        assert summary.aborted is True
+        assert summary.has_errors()
+        assert summary.has_fatal_errors()
+        [error] = summary.errors
+        assert error.category == "build_aborted"
+        assert error.error_type == "infrastructure"
+        assert "No workers available" in error.message
+
+    def test_exception_group_sub_exceptions_appear_in_message(self):
+        # Reference the builtin via ``builtins`` — ruff's py310 target flags
+        # the bare name (same workaround as the production code).
+        import builtins
+
+        group_type = builtins.BaseExceptionGroup  # type: ignore[attr-defined]
+        exc = group_type(
+            "unhandled errors in a TaskGroup",
+            [
+                RuntimeError("No workers available to process 'notebook' jobs"),
+                RuntimeError("No workers available to process 'plantuml' jobs"),
+            ],
+        )
+        reporter = _reporter()
+        reporter.mark_aborted(exc)
+
+        [error] = reporter.finish_build().errors
+        assert "'notebook' jobs" in error.message
+        assert "'plantuml' jobs" in error.message
+
+    def test_untouched_reporter_is_not_aborted(self):
+        summary = _reporter().finish_build()
+        assert summary.aborted is False
+        assert not summary.has_errors()
+
+
+def _aborted_summary() -> BuildSummary:
+    return BuildSummary(duration=11.0, total_files=145, aborted=True)
+
+
+class TestFormatterHeadlines:
+    def test_default_formatter_reports_abort(self, capsys):
+        formatter = DefaultOutputFormatter(show_progress=False, use_color=False)
+        formatter.show_summary(_aborted_summary())
+        err = capsys.readouterr().err
+        assert "Build aborted" in err
+        assert "completed successfully" not in err
+
+    def test_verbose_formatter_reports_abort(self, capsys):
+        formatter = VerboseOutputFormatter(show_progress=False, use_color=False)
+        formatter.show_summary(_aborted_summary())
+        err = capsys.readouterr().err
+        assert "Build aborted" in err
+        assert "completed successfully" not in err
+
+    def test_quiet_formatter_reports_abort(self, capsys):
+        formatter = QuietOutputFormatter()
+        formatter.show_summary(_aborted_summary())
+        err = capsys.readouterr().err
+        assert "Build aborted" in err
+        assert "completed successfully" not in err
+
+    def test_json_formatter_reports_abort(self, capsys):
+        formatter = JSONOutputFormatter()
+        formatter.show_summary(_aborted_summary())
+        data = json.loads(capsys.readouterr().out)
+        assert data["status"] == "aborted"
+        assert data["aborted"] is True
+
+    def test_json_formatter_emits_aborted_false_on_success(self, capsys):
+        formatter = JSONOutputFormatter()
+        formatter.show_summary(BuildSummary(duration=1.0, total_files=0))
+        data = json.loads(capsys.readouterr().out)
+        assert data["status"] == "success"
+        assert data["aborted"] is False
+
+    def test_summary_str_reports_abort(self):
+        text = str(_aborted_summary())
+        assert "✗ Build aborted" in text
+        assert "completed successfully" not in text
+
+
+class TestSweepSkipsAfterAbort:
+    def test_stale_output_sweep_skips_when_build_aborted(self):
+        """The abort error keeps the sweep from deleting outputs that the
+        aborted build never got around to (re)writing."""
+        from clm.cli.commands.build import _maybe_run_sweep
+
+        reporter = _reporter()
+        reporter.mark_aborted(RuntimeError("No workers available"))
+
+        config = SimpleNamespace(sweep=True, clean=False, watch=False)
+        with patch("clm.cli.output_sweep.sweep_stray_files") as sweep:
+            sweep.return_value = MagicMock(skipped=True, skip_reason="errors")
+            _maybe_run_sweep(
+                config=config,
+                root_dirs=[],
+                backend=MagicMock(),
+                build_reporter=reporter,
+                only_sections_mode=False,
+            )
+        skip_reason = sweep.call_args.kwargs["skip_reason"]
+        assert skip_reason is not None and "error" in skip_reason
+
+
+class TestWiring:
+    def test_run_stages_marks_abort_before_reraise(self):
+        """Pin the ``mark_aborted`` call in the stage-processing exception
+        handler (same style as the orphan-cassette-sweep pin test)."""
+        import inspect
+
+        from clm.cli.commands.build import process_course_with_backend
+
+        source = inspect.getsource(process_course_with_backend)
+        assert "mark_aborted" in source, (
+            "process_course_with_backend must call build_reporter."
+            "mark_aborted(exc) in its stage-processing exception handler "
+            "before re-raising (issue #596). Without it the finally block "
+            "renders 'Build completed successfully' for a failed build and "
+            "runs the stale-output sweep on an incomplete write registry."
+        )


### PR DESCRIPTION
Closes #596

## Problem

When `course.process_stage()` raises (e.g. the worker-availability `ExceptionGroup` from #594), the `finally` block in `_run_stages` still runs `build_reporter.finish_build()`, the stale-output sweep, and cleanup while the exception propagates. The user saw:

```
✓ Build completed successfully in 11.0s
Summary:
  145 files processed
  0 errors
```

followed by the traceback — a failed build claiming success, with the exit code saved only by the exception reaching the top level. Two further consequences:

- Submission-time failures never appeared in the summary's error counts, unlike execution failures.
- The stale-output sweep ran against the aborted build's **incomplete** write registry. Its errors guard (`build_reporter.errors`) saw an empty list, so the sweep could delete valid outputs of prior successful builds that this build never got around to (re)writing.

## Fix

`BuildReporter.mark_aborted(exc)` — called from the existing `except BaseException` handler in `_run_stages` before re-raising (the same spot the issue-#143 `mark_timed_out` fix lives):

- sets `BuildSummary.aborted`, so every renderer shows a failure headline — "**✗ Build aborted** after 11.0s" in default/verbose/quiet modes, `"status": "aborted"` plus an always-present `"aborted"` key in JSON mode;
- records the exception (including the first sub-exceptions of a `BaseExceptionGroup`) as a fatal infrastructure `BuildError` with category `build_aborted`, so the failure appears in the error counts **and** the sweep's existing errors guard skips the sweep.

`KeyboardInterrupt` flows through the same handler, so Ctrl-C now also renders "Build aborted" and skips the sweep instead of claiming success.

## Testing

New `tests/cli/test_build_abort_summary.py`: `mark_aborted` semantics (flag, fatal error, `ExceptionGroup` flattening), abort headlines in all four formatters + `BuildSummary.__str__`, sweep skip after abort, and a source-pin test for the handler wiring. Related CLI suites (281 tests) and the fast suite (pre-push hook) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEj1XR9vYjEf5XCMD4EMJ6
