### PR TITLE
fix(workers): scope activation-timeout dead-marking by mode and session ownership

### DIFF
--- a/changelog.d/597-deadmark-mode-ownership.fixed.md
+++ b/changelog.d/597-deadmark-mode-ownership.fixed.md
@@ -1,0 +1,9 @@
+- The activation-timeout dead-marking in the SQLite backend is now scoped by
+  execution mode and session ownership (#597). Previously, a Direct-mode
+  build timing out on its own workers could mark a concurrent Docker-mode
+  build's still-starting pre-registrations (`status='created'`, over 30s old
+  — plausible for a cold Docker image pull) as dead in a shared jobs DB,
+  making that build fail with "No workers available" through no fault of its
+  own. The UPDATE now applies the same mode discriminator as the surrounding
+  availability queries and only dead-marks workers the build's own lifecycle
+  session registered (unowned legacy rows keep the issue-#348 fail-fast).

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -1943,6 +1943,11 @@ async def main_build(
                 worker_execution_modes={
                     c.worker_type: c.execution_mode for c in worker_config.get_all_worker_configs()
                 },
+                # Scope the activation-timeout dead-marking to workers this
+                # build's lifecycle session owns (issue #597) — a timeout on
+                # our own workers must not condemn a concurrent build's
+                # still-starting pre-registrations in a shared jobs DB.
+                worker_session_id=lifecycle_manager.session_id,
             )
 
             async with backend:

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -90,6 +90,13 @@ class SqliteBackend(LocalOpsBackend):
     # spurious "No such kernel named xcpp20" failures). An empty dict leaves
     # jobs untagged (legacy behaviour, used by tests).
     worker_execution_modes: dict[str, str] = field(factory=dict)
+    # The owning WorkerLifecycleManager session (issue #597). Pre-registered
+    # worker rows are stamped with their session_id (issue #594), and the
+    # activation-timeout dead-marking must not condemn another session's
+    # still-starting workers — only rows this session owns (or unowned legacy
+    # rows) may be marked dead. None (tests, legacy callers) restricts the
+    # dead-marking to the execution-mode filter only.
+    worker_session_id: str | None = None
 
     # Background result-cache writer (lazy). Retiring a completed job by reading
     # its output back, pickling it, and committing the blob to the cache DB is
@@ -1306,14 +1313,29 @@ class SqliteBackend(LocalOpsBackend):
                 logger.warning(
                     f"Timeout waiting for {job_type} workers to activate after {timeout}s"
                 )
+                # Scope the dead-marking like the availability queries above
+                # (issue #597): without the mode filter, a Direct-mode build
+                # timing out on its own workers condemned a concurrent
+                # Docker-mode build's still-starting pre-registrations (>30s
+                # old is plausible for a cold Docker image pull). Ownership
+                # narrows it further — only this session's workers (or
+                # unowned legacy rows) are ours to declare startup casualties.
+                if self.worker_session_id is None:
+                    ownership_clause = ""
+                    ownership_params: tuple[str, ...] = ()
+                else:
+                    ownership_clause = "AND (session_id = ? OR session_id IS NULL)"
+                    ownership_params = (self.worker_session_id,)
                 cursor = conn.execute(
-                    """
+                    f"""
                     UPDATE workers SET status = 'dead'
                     WHERE worker_type = ?
                     AND status = 'created'
                     AND started_at < datetime('now', '-30 seconds')
+                    {mode_clause}
+                    {ownership_clause}
                     """,
-                    (job_type,),
+                    (job_type, *mode_params, *ownership_params),
                 )
                 if cursor.rowcount:
                     conn.commit()

--- a/tests/infrastructure/backends/test_sqlite_backend_resilience.py
+++ b/tests/infrastructure/backends/test_sqlite_backend_resilience.py
@@ -157,17 +157,23 @@ def _seed_activated_worker(db_path: Path, worker_type: str = "notebook") -> int:
         conn.close()
 
 
-def _seed_created_worker(db_path: Path, worker_type: str = "notebook") -> int:
+def _seed_created_worker(
+    db_path: Path,
+    worker_type: str = "notebook",
+    *,
+    container_id: str | None = None,
+    session_id: str | None = None,
+) -> int:
     _container_id_counter[0] += 1
-    cid = f"pending-{worker_type}-{_container_id_counter[0]}"
+    cid = container_id or f"pending-{worker_type}-{_container_id_counter[0]}"
     conn = sqlite3.connect(db_path)
     try:
         cur = conn.execute(
             """
-            INSERT INTO workers (worker_type, container_id, status)
-            VALUES (?, ?, 'created')
+            INSERT INTO workers (worker_type, container_id, status, session_id)
+            VALUES (?, ?, 'created', ?)
             """,
-            (worker_type, cid),
+            (worker_type, cid, session_id),
         )
         conn.commit()
         return cur.lastrowid  # type: ignore[return-value]
@@ -637,6 +643,90 @@ async def test_activation_timeout_spares_freshly_created_workers(temp_db, temp_w
         finally:
             conn.close()
         assert row[0] == "created"
+    finally:
+        await backend.shutdown()
+
+
+def _age_worker(db_path: Path, worker_id: int, seconds: int = 120) -> None:
+    """Backdate started_at so the worker qualifies for the stuck check (> 30s)."""
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "UPDATE workers SET started_at = datetime('now', ?) WHERE id = ?",
+            (f"-{seconds} seconds", worker_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _run_activation_wait_to_timeout(backend, job_type: str = "notebook") -> int:
+    """Drive the activation wait loop with a fake clock so it times out instantly."""
+    fake_now = [time.time()]
+
+    def fast_sleep(seconds):
+        fake_now[0] += seconds
+
+    with (
+        patch(
+            "clm.infrastructure.backends.sqlite_backend.time.sleep",
+            side_effect=fast_sleep,
+        ),
+        patch(
+            "clm.infrastructure.backends.sqlite_backend.time.time",
+            side_effect=lambda: fake_now[0],
+        ),
+    ):
+        return backend._get_available_workers(job_type)
+
+
+def _worker_status(db_path: Path, worker_id: int) -> str:
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute("SELECT status FROM workers WHERE id = ?", (worker_id,)).fetchone()
+        return row[0]
+    finally:
+        conn.close()
+
+
+@pytest.mark.asyncio
+async def test_activation_timeout_dead_marking_respects_execution_mode(temp_db, temp_workspace):
+    """Issue #597: a Direct-mode build timing out on its own workers must not
+    condemn a concurrent Docker-mode build's still-starting pre-registrations
+    ('created', >30s old — plausible for a cold Docker image pull)."""
+    direct_id = _seed_created_worker(temp_db, container_id="direct-notebook-own")
+    docker_id = _seed_created_worker(temp_db, container_id="docker-notebook-other")
+    _age_worker(temp_db, direct_id)
+    _age_worker(temp_db, docker_id)
+
+    backend = _backend(temp_db, temp_workspace, worker_execution_modes={"notebook": "direct"})
+    try:
+        assert _run_activation_wait_to_timeout(backend) == 0
+
+        assert _worker_status(temp_db, direct_id) == "dead"
+        assert _worker_status(temp_db, docker_id) == "created"
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_activation_timeout_dead_marking_respects_ownership(temp_db, temp_workspace):
+    """Issue #597: with a lifecycle session attached, the timeout only
+    dead-marks workers this session owns — plus unowned legacy rows, which
+    keep the issue-#348 fail-fast — never another session's workers."""
+    own_id = _seed_created_worker(temp_db, session_id="session-A")
+    other_id = _seed_created_worker(temp_db, session_id="session-B")
+    legacy_id = _seed_created_worker(temp_db, session_id=None)
+    for worker_id in (own_id, other_id, legacy_id):
+        _age_worker(temp_db, worker_id)
+
+    backend = _backend(temp_db, temp_workspace, worker_session_id="session-A")
+    try:
+        assert _run_activation_wait_to_timeout(backend) == 0
+
+        assert _worker_status(temp_db, own_id) == "dead"
+        assert _worker_status(temp_db, legacy_id) == "dead"
+        assert _worker_status(temp_db, other_id) == "created"
     finally:
         await backend.shutdown()
 


### PR DESCRIPTION
Closes #597

## Problem

When `SqliteBackend._get_available_workers()` times out waiting for pre-registered workers to activate, it marks stragglers (`status='created'`, >30s old) dead so subsequent submissions fail fast (issue #348). Unlike the availability queries directly above it, that UPDATE had **no execution-mode clause**: in a shared jobs DB, a Direct-mode build timing out on its own workers could mark a concurrent Docker-mode build's still-starting pre-registrations as dead (>30s in `created` is plausible for a cold Docker image pull), failing that build with "No workers available" through no fault of its own.

## Fix

The dead-marking UPDATE now gets:

- the same `CASE WHEN container_id LIKE 'direct-%' …` mode discriminator used by the surrounding availability queries, and
- a session-ownership clause on top of #595's ownership stamping: `build.py` passes the `WorkerLifecycleManager` session into the new `SqliteBackend.worker_session_id` field, and the timeout only dead-marks rows that session registered — plus unowned legacy rows (`session_id IS NULL`), which keep the #348 fail-fast for pre-#595 setups.

Backends constructed without a session (tests, legacy callers) keep mode-only filtering; without modes either, behavior is unchanged.

## Testing

Two new tests in `tests/infrastructure/backends/test_sqlite_backend_resilience.py`:

- a Direct-mode backend's timeout dead-marks its own stuck Direct worker but spares a concurrent Docker pre-registration;
- with a session attached, the timeout dead-marks the session's own worker and an unowned legacy row, but spares another session's worker.

The pre-existing #348 dead-marking tests (no mode, no session) pass unchanged, as does the fast suite on the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEj1XR9vYjEf5XCMD4EMJ6
