### PR TITLE
fix(sync): resolve the suspected-stamp pool dead end with stamp_vs_new (#600)

### DIFF
--- a/changelog.d/600-stamp-vs-new-answer.fixed.md
+++ b/changelog.d/600-stamp-vs-new-answer.fixed.md
@@ -1,0 +1,12 @@
+- **Sync: replacing an un-id'd positional cell with new `slide_id`-keyed cells
+  no longer dead-ends the decision loop** (#600). The two "suspected stamp"
+  shapes — a new id'd cell appearing while a positional base cell of the same
+  pool is unaccounted for, and the vanished positional cell itself — are now
+  framed as a new `stamp_vs_new` action carrying a `treat_as_new` answer
+  (previously `ambiguous_alignment` with an empty `answers` vocabulary, which
+  no decision document could resolve). Answering `treat_as_new` grows the
+  twin for the new id'd cell and mirrors the vanished positional cell's
+  removal in one `apply --decisions` pass; the stamped-and-edited reading is
+  still reconciled manually, and the genuinely ambiguous
+  `ambiguous_alignment` shapes (rival id stamps, both-sides-added pools)
+  remain answerless by design.

--- a/docs/claude/design/sync-total-identity-document-model.md
+++ b/docs/claude/design/sync-total-identity-document-model.md
@@ -469,6 +469,15 @@ clm slides sync autopilot DECK|DIR [--model ...]            # a SCRIPT over repo
   one principle ("what can be addressed, and what can be trusted"); a
   proposal for a **fourth** shape-conditional answer set on any single action
   is the P8 alarm — redesign the action instead of conditioning it further.
+  `stamp_vs_new` (#600) is that rule applied: the one *resolvable*
+  `ambiguous_alignment` shape (a new id'd cell while a positional cell of the
+  same pool is unaccounted on that side — both the id-view and the pos-view
+  row) became its own framed action with a uniform `treat_as_new` answer
+  (grow the twin verbatim / mirror the removal; an edited survivor rejects),
+  instead of conditioning `ambiguous_alignment`'s answers by shape.
+  `ambiguous_alignment` itself stays answerless — its remaining shapes
+  (rival id stamps, both-sides-added pool collisions, multi-candidate
+  pending twins) are genuinely manual.
 - **One baseline rule everywhere.** Every verb trusts the ledger; `--since REF`
   is a forensic *view* on `report` (show me git-window changes annotated with
   trust state), not a trust change. `provider_available`, `--use-watermark`,
@@ -637,3 +646,4 @@ row here (or an edit to the section it refines) has skipped the checklist.
 | #570 — `DiffItem.side` means the *present/source* side on every `translate_new` emitter; executor derives the mint target from the member | none (implementation consistency; one field, one meaning — P6 spirit) | inconsistency removal |
 | #572 — `clm slides rename-id` = the second sanctioned key migration; fingerprint-inferred `id:→id:` migration **rejected** | §7.3 | design extension (explicit, never inferred) |
 | #572 — `body`+`side` recovery on cold id-keyed two-sided members; cold-`confirm` caveat documented | §6.2, §8, §9 | P8(c) extension + honest-residue entry |
+| #600 — `stamp_vs_new` framed action: the "new id'd cell while a positional pool cell is unaccounted" shapes (id-view + pos-view rows) split out of `ambiguous_alignment`, with a `treat_as_new` answer (grow the twin / mirror the removal) | §8 | new framed kind via the §8 watch-item's "redesign the action" route — `ambiguous_alignment` stays answerless |

--- a/docs/claude/handovers/issue-triage-2026-07-handover.md
+++ b/docs/claude/handovers/issue-triage-2026-07-handover.md
@@ -55,7 +55,20 @@ dogfooding work.
 Phases are execution waves, not strict dependencies — waves 2–5 can be
 reordered if priorities shift. Everything is currently [TODO].
 
-### Phase 1 [TODO] — #600: sync `ambiguous_alignment` dead end (ACTIVE PRIORITY)
+### Phase 1 [DONE] — #600: sync `ambiguous_alignment` dead end (ACTIVE PRIORITY)
+
+**Resolution (2026-07-10)**: implemented as a NEW framed action `stamp_vs_new`
+(not answers on `ambiguous_alignment` itself — the design note's §8 watch-item
+prescribes "redesign the action" over shape-conditional vocabularies, and the
+rival-id-stamp shape is structurally indistinguishable from the resolvable
+shape, so advertising `treat_as_new` on `ambiguous_alignment` would offer a
+content-duplicating answer there). Both the id-view and pos-view rows frame
+`stamp_vs_new` with answer `treat_as_new`: grows the twin verbatim (id row) /
+mirrors the removal (pos row, rejected if the survivor moved off base).
+`treat_as_stamped_edit` was NOT added — binding is ambiguous when several id'd
+cells claim one base (the issue's own 2-for-1 case); the manual stamp-by-hand
+path covers it. Partial answering converges (tested). §13 amendments row
+added. Shipped on branch `claude/issue-600-stamp-vs-new`.
 
 **Problem**: Replacing an un-id'd positional cell with new `slide_id`-keyed
 cells makes `clm slides sync report` frame each new cell AND the vanished
@@ -240,7 +253,9 @@ OpenAI-compatible client, zero new deps) or close as status-quo.
 
 ## 5. Next Steps
 
-**Start Phase 1 (#600).** Concretely:
+**Phase 1 (#600) is DONE — start Phase 2 (#539: duplicate dir-group
+destination copytree race).** The plan below documents how Phase 1 was
+executed (kept for reference):
 
 1. Read memory topics `project_sync_one_sided_cold` and
    `project_sync_v3_design_audit`, plus the sync v3 design note (find via

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1954,6 +1954,8 @@ already agree — ledger-only), the §7.3 transitions (`record_fork`,
 propagation. **Framed actions** (need a decision): `translate_edit`,
 `translate_new`, `verify_translation`, `conflict_shared`,
 `pending_divergence`, `remove_vs_edit`, `unify_choose_body`, `order_decision`,
+`stamp_vs_new` (a suspected id-stamp of a vanished positional cell — answer
+`treat_as_new` to grow the twin / mirror the removal),
 `ambiguous_alignment`, `verify_cold`, and friends. Every JSON item carries an
 `answers` list — the decision shapes `apply --decisions` accepts for it, `[]`
 on mechanical items (nothing to answer) — plus the full current cell bytes

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -75,8 +75,12 @@ sides moved — confirm or supply a body), `conflict_shared` / `remove_vs_edit`
 / `unify_choose_body` / `order_decision` / `conflict_preamble` (choose a side),
 `verify_cold` (confirm the member is in sync — or, on an **id-keyed** member,
 supply a `body` + `side` to overwrite a stale twin in the same pass),
-`ambiguous_alignment`
-(mint ids / choose), and the normalize-refusal deck item (run
+`stamp_vs_new` (a new id'd cell appeared while a positional cell of the same
+pool vanished on that side — answer `treat_as_new` when the id'd cell really
+is new; see "Replacing a positional cell" below), `ambiguous_alignment`
+(genuinely ambiguous residue — rival id stamps, both sides adding different
+content into one pool; carries **no** answers: reconcile by editing, minting
+ids, then re-report), and the normalize-refusal deck item (run
 `clm slides normalize`, then re-report).
 
 ## The decision document
@@ -228,6 +232,29 @@ among existing cells is instead reported `verify_cold`: its ordinal aliases a
 **Mint a `slide_id`** on the new cell (e.g. `clm slides assign-ids`, or add one
 by hand) and re-`report` — it then frames `translate_new` / `copy_new_shared`
 and the twin is created for you.
+
+## Replacing a positional cell with id-keyed cells — `stamp_vs_new`
+
+Replacing an un-id'd positional cell with one or more new `slide_id`-keyed
+cells on ONE half (e.g. a display-only `df.drop_duplicates()` cell replaced by
+an assign-back + check pair) frames every affected row `stamp_vs_new`: the
+engine cannot tell whether the positional cell was *removed* (and the id'd
+cells are genuinely new) or *stamped with an id and edited* — mechanically
+copying could duplicate it, mechanically removing could delete real content.
+The answer vocabulary is `treat_as_new`:
+
+- On the new id'd cell's row (`id:…`), `{"choice": "treat_as_new"}` copies it
+  verbatim to the twin — the normal `copy_new_shared` path it would have taken
+  without the suspicion.
+- On the vanished positional cell's row (`pos:…`), `{"choice": "treat_as_new"}`
+  mirrors the removal onto the surviving half. It is rejected if that survivor
+  was *also* edited (removal would lose the edit) — reconcile that shape by
+  editing the files.
+
+Answer all the affected rows in one document and the whole replacement lands in
+one `apply` pass. If the cell really was stamped-and-edited (the same cell, now
+carrying an id), do NOT answer `treat_as_new` — stamp the twin cell with the
+same `slide_id` by hand (the halves then pair id-keyed) and re-`report`.
 
 ## The forensic window — `report --since`
 

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -129,6 +129,7 @@ _DECISION_VOCABULARY: dict[str, tuple[str, ...]] = {
     "conflict_owner": ("de", "en"),
     "conflict_preamble": ("de", "en"),
     "order_decision": ("de", "en"),
+    "stamp_vs_new": ("treat_as_new",),
 }
 
 
@@ -364,6 +365,21 @@ _PHASES: dict[str, int] = {
     "propagate_preamble": 5,
     "conflict_preamble": 5,
 }
+
+
+def _item_phase(item: DiffItem) -> int:
+    """The execution phase of one item.
+
+    ``stamp_vs_new`` is the one action whose resolution spans two phases: the
+    id-view row inserts (a ``treat_as_new`` grows the twin — phase 1, with the
+    other inserts) while the pos-view row removes (phase 2, with the other
+    removes) — so the grown twin is placed before its superseded positional
+    neighbor disappears.
+    """
+    if item.action == "stamp_vs_new":
+        return 1 if item.key.startswith("id:") else 2
+    return _PHASES.get(item.action, 9)
+
 
 #: Mechanical rows that are pure ledger records (no file mutation).
 _RECORD_ONLY = frozenset(
@@ -1126,6 +1142,24 @@ def _apply_choice_decision(ex: _Executor, item: DiffItem, choice: str) -> None:
             )
         ex.copy_new(item, _other(item.side))
         return
+    if choice == "treat_as_new":
+        # stamp_vs_new (#600): the agent judged the suspected stamped-edit to
+        # be a genuine add/remove instead. The id-view row (the new id'd cell)
+        # grows the twin verbatim — the copy_new_shared path it would have
+        # taken without the pool deficit; the pos-view row (the vanished
+        # positional base cell) mirrors the removal. ``item.side`` names the
+        # source side (id view) / the gone side (pos view) at emission.
+        if item.side is None:
+            raise _ItemError(f"{item.key} names no side — reconcile manually (edit + record)")
+        if item.key.startswith("id:"):
+            if item.member is None or not item.member.is_one_sided:
+                raise _ItemError(
+                    f"the one-sided shape of {item.key} no longer holds — re-run report"
+                )
+            ex.copy_new(item, item.side)
+            return
+        ex.mirror_remove(item, item.side)
+        return
     if choice == "keep_twin":
         # translate_edit only: the edited side did not change what the twin
         # should say, so record the new (edited) baseline and keep the existing
@@ -1222,7 +1256,7 @@ def apply_deck(
     # to be confirmed in the same document.
     incoherent_pools = _incoherent_pool_confirms(diff, decisions)
 
-    ordered = sorted(enumerate(diff.items), key=lambda e: (_PHASES.get(e[1].action, 9), e[0]))
+    ordered = sorted(enumerate(diff.items), key=lambda e: (_item_phase(e[1]), e[0]))
     landed: list[tuple[DiffItem, str]] = []  # (item, provenance)
     unresolved_items: list[DiffItem] = []  # pending / rejected / failed
     seen_decisions: set[str] = set()

--- a/src/clm/slides/sync_diff.py
+++ b/src/clm/slides/sync_diff.py
@@ -164,6 +164,7 @@ FRAMED_ACTIONS = frozenset(
         "kind_mismatch",  # paired sides disagree about cell kind
         "order_decision",  # both sides reordered differently
         "ambiguous_alignment",  # §3.3 residue: dup-fp reorder + edit
+        "stamp_vs_new",  # suspected stamp: new id'd cell vs unaccounted pool cell (#600)
         "conflict_preamble",  # preambles moved differently on both sides
         "verify_cold",  # no baseline entry (ledger mode)
     }
@@ -714,15 +715,19 @@ class _Differ:
                 # A base cell of this pool is unaccounted for on this side:
                 # the "new" id'd cell is plausibly that cell, stamped AND
                 # edited. A mechanical copy could duplicate it on apply —
-                # frame instead (P8).
+                # frame instead (P8). `treat_as_new` resolves it as a genuine
+                # add (verbatim copy to the twin, #600); a stamped-edit is
+                # reconciled manually.
                 self.emit(
                     handle,
                     "conflict",
-                    "ambiguous_alignment",
+                    "stamp_vs_new",
                     "both",
                     f"new id'd cell on the {side} side while a positional base "
                     f"cell of this pool is unaccounted for — possibly the same "
-                    f"cell stamped and edited; reconcile before copying",
+                    f"cell stamped and edited; answer treat_as_new if it is a "
+                    f"genuinely new cell (copies it to the twin), or reconcile "
+                    f"the stamped edit manually",
                     group=group,
                     side=side,
                     member=member,
@@ -1879,15 +1884,21 @@ class _Differ:
                 # An unmatched one-sided id'd cell exists on the "removed"
                 # side: the cell was plausibly stamped (and edited), not
                 # removed — a mechanical removal could delete real content.
+                # `treat_as_new` resolves it as a genuine removal (mirrors it,
+                # #600); a stamped-edit is reconciled manually. ``side`` names
+                # the gone side, the anchor a mirrored removal needs.
                 self.emit(
                     handle,
                     "conflict",
-                    "ambiguous_alignment",
+                    "stamp_vs_new",
                     "both",
                     f"the {gone} side lost this positional cell while gaining an "
                     f"unmatched id'd cell — possibly the same cell stamped and "
-                    f"edited; reconcile before removing",
+                    f"edited; answer treat_as_new if the cell was genuinely "
+                    f"removed (mirrors the removal), or reconcile the stamped "
+                    f"edit manually",
                     group=group,
+                    side=gone,
                     member=member,
                     base=entry,
                 )

--- a/tests/slides/test_doc_apply.py
+++ b/tests/slides/test_doc_apply.py
@@ -709,6 +709,74 @@ class TestColdBodyRecovery:
         assert "side" in result.reason
 
 
+class TestStampVsNew:
+    """Issue #600: replacing an un-id'd positional cell with new id'd cells on
+    one side frames every affected row ``stamp_vs_new`` with a ``treat_as_new``
+    answer — the loop resolves through one decision document instead of
+    dead-ending on an empty vocabulary."""
+
+    def _replace_pos_cell_on_en(self, tmp_path: Path) -> _Deck:
+        deck = _deck(tmp_path)
+        deck.edit_en(
+            '# %% tags=["keep"]\ny = 2\n',
+            '# %% tags=["keep"] slide_id="y-assign"\ny = 3\n\n# %% slide_id="y-check"\ny\n',
+        )
+        return deck
+
+    def test_treat_as_new_grows_twins_and_mirrors_the_removal(self, tmp_path: Path):
+        deck = self._replace_pos_cell_on_en(tmp_path)
+        _, diff = deck.diff()
+        assert {(i.key, i.action) for i in diff.items} == {
+            ("id:y-assign", "stamp_vs_new"),
+            ("id:y-check", "stamp_vs_new"),
+            ("pos:s0/code/1", "stamp_vs_new"),
+        }, [(i.key, i.action, i.detail) for i in diff.items]
+        # The report advertises exactly what the executor accepts — never [].
+        assert all(doc_apply.item_answers(i) == ("treat_as_new",) for i in diff.items)
+        decisions = {
+            i.key: doc_apply.Decision(key=i.key, choice="treat_as_new") for i in diff.items
+        }
+        outcome = deck.apply(decisions)
+        assert outcome.all_applied, outcome.to_payload()
+        de = deck.de_path.read_text(encoding="utf-8")
+        assert '# %% tags=["keep"] slide_id="y-assign"\ny = 3\n' in de
+        assert '# %% slide_id="y-check"\ny\n' in de
+        assert "y = 2" not in de  # the superseded positional cell is gone
+        deck.assert_converged()
+
+    def test_partial_answering_still_converges(self, tmp_path: Path):
+        # Answering only the id-view rows grows the twins; the vanished
+        # positional cell then resolves mechanically on the next pass.
+        deck = self._replace_pos_cell_on_en(tmp_path)
+        outcome = deck.apply(
+            {
+                key: doc_apply.Decision(key=key, choice="treat_as_new")
+                for key in ("id:y-assign", "id:y-check")
+            }
+        )
+        assert _statuses(outcome)["pos:s0/code/1"] == "pending"
+        _, diff = deck.diff()
+        assert [(i.key, i.action) for i in diff.items] == [("pos:s0/code/1", "mirror_remove")]
+        outcome = deck.apply()
+        assert outcome.all_applied, outcome.to_payload()
+        assert "y = 2" not in deck.de_path.read_text(encoding="utf-8")
+        deck.assert_converged()
+
+    def test_treat_as_new_rejected_when_the_survivor_moved_off_base(self, tmp_path: Path):
+        # The surviving positional twin carries an edit: removing it would
+        # silently lose content, so the pos-view treat_as_new must fail the
+        # item instead (P8: never guess).
+        deck = self._replace_pos_cell_on_en(tmp_path)
+        deck.edit_de("y = 2", "y = 99")
+        _, diff = deck.diff()
+        pos_item = next(i for i in diff.items if i.key == "pos:s0/code/1")
+        assert pos_item.action == "stamp_vs_new"
+        outcome = deck.apply(_decision(pos_item.key, choice="treat_as_new"))
+        result = next(r for r in outcome.results if r.key == pos_item.key)
+        assert result.status == "rejected"
+        assert "y = 99" in deck.de_path.read_text(encoding="utf-8")
+
+
 class TestDecisionParsing:
     def test_wrong_top_level_shape_error_teaches_the_schema(self):
         # The first error an agent sees must show the whole document shape —

--- a/tests/slides/test_sync_diff.py
+++ b/tests/slides/test_sync_diff.py
@@ -962,6 +962,43 @@ class TestAdversarialReviewRegressions:
         item = _only_item(_diff(base, de, EN0))
         assert item.action == "verify_cold"
 
+    def test_replacing_positional_cell_with_idd_cells_frames_stamp_vs_new(self):
+        """issue #600: replacing an un-id'd positional cell with new id'd cells
+        on ONE side must frame every affected row ``stamp_vs_new`` (which
+        carries the ``treat_as_new`` answer) — not ``ambiguous_alignment``,
+        whose empty answer vocabulary dead-ends the decision-document loop."""
+        base = _snapshot(DE0, EN0)
+        base.complete = False
+        en = EN0.replace(
+            '# %% tags=["keep"]\ny = 2\n',
+            '# %% tags=["keep"] slide_id="y-assign"\ny = 3\n\n# %% slide_id="y-check"\ny\n',
+        )
+        diff = _diff(base, DE0, en)
+        assert {(i.key, i.outcome, i.action) for i in diff.items} == {
+            ("id:y-assign", "conflict", "stamp_vs_new"),
+            ("id:y-check", "conflict", "stamp_vs_new"),
+            ("pos:s0/code/1", "conflict", "stamp_vs_new"),
+        }, [(i.key, i.outcome, i.action) for i in diff.items]
+        by_key = {i.key: i for i in diff.items}
+        # The pos-view row names the gone side — the anchor a mirrored
+        # removal needs; the id-view rows name their present (source) side.
+        assert by_key["pos:s0/code/1"].side == "en"
+        assert by_key["id:y-assign"].side == "en"
+
+    def test_conflicting_stamp_shape_stays_ambiguous_alignment(self):
+        """The rival-id shapes must NOT gain ``stamp_vs_new``'s treat_as_new
+        answer: copying a cell that already claimed a base entry under a
+        different id would duplicate content (#600 scope guard)."""
+        shared = "# %% [markdown]\n# Shared text\n\n"
+        de = _build(HEADER_DE, _slide("s0", "de", "T"), shared)
+        en = _build(HEADER_EN, _slide("s0", "en", "T"), shared)
+        base = _snapshot(de, en)
+        de2 = de.replace("# %% [markdown]\n# Shared", '# %% [markdown] slide_id="ida"\n# Shared')
+        en2 = en.replace("# %% [markdown]\n# Shared", '# %% [markdown] slide_id="idb"\n# Shared')
+        diff = _diff(base, de2, en2)
+        assert diff.items
+        assert {i.action for i in diff.items} == {"ambiguous_alignment"}
+
     def test_slide_id_containing_slash_does_not_crash(self):
         """MAJOR: '/' is legal in slide ids; pos-key parsing must rsplit."""
         de = _build(


### PR DESCRIPTION
## Summary

Replacing an un-id'd positional cell with new `slide_id`-keyed cells on one half framed every affected row `conflict / ambiguous_alignment` with an **empty `answers` vocabulary** — no decision that `apply --decisions` would accept, dead-ending the agent sync loop (issue #600, hit while dogfooding on PythonCourses).

The two suspected-stamp shapes — the new id'd cell emitted under a pool deficit, and the vanished positional base cell with an unmatched id'd candidate — are now their own framed action **`stamp_vs_new`** carrying a **`treat_as_new`** answer:

- **id-view row** (`id:…`): grows the twin verbatim — the `copy_new_shared` path it would have taken without the suspicion (phase 1, with the other inserts).
- **pos-view row** (`pos:…`): mirrors the removal onto the surviving half (phase 2); **rejected** if that survivor moved off base, so an edit is never silently deleted (P8). The emission now carries `side` (the gone side) as the removal anchor.

Partial answering converges: whichever row lands first, the next `report` frames the remainder mechanically (`copy_new_shared` / `mirror_remove`).

## Why a new action instead of answers on `ambiguous_alignment`

The design note's §8 watch-item says a shape-conditional answer set on a single action is the P8 alarm — redesign the action. Concretely: the rival-id-stamp shape is *structurally indistinguishable* (one-sided, id-keyed, no base entry) from the resolvable pool-deficit shape, so advertising `treat_as_new` on `ambiguous_alignment` would offer a content-duplicating answer on the rival shape. `ambiguous_alignment` stays answerless for its genuinely manual shapes (rival stamps, both-sides-added pool collisions, multi-candidate pending twins) — pinned by a scope-guard test.

`treat_as_stamped_edit` was deliberately **not** added: the binding is ambiguous whenever several id'd cells claim one positional base (the issue's own 2-for-1 case). The manual stamp-by-hand path covers that reading; the docs say so explicitly.

## Acceptance (from the triage handover, Phase 1)

The issue's exact scenario (positional cell → two new id'd cells on one side) resolves through `report` → decision doc (`treat_as_new` ×3) → `apply --decisions` → converged, with clean ledger records; no empty `answers` arrays for this shape. Covered by engine-level framing tests plus full-loop apply tests (grow + mirror + converge, partial-answer convergence, edited-survivor rejection).

## Bookkeeping

- `clm info sync-agents` (new "Replacing a positional cell" section + framed-action list) and `clm info commands` updated (info-topic rule)
- Design note §8 amended + **§13 amendments-log row** added
- Changelog fragment `changelog.d/600-stamp-vs-new-answer.fixed.md`
- Triage handover Phase 1 marked DONE

Closes #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEj1XR9vYjEf5XCMD4EMJ6
