### PR TITLE
fix(sync): close two stamp_vs_new gaps found by adversarial review of #602

### DIFF
--- a/changelog.d/600-stamp-vs-new-review-followups.fixed.md
+++ b/changelog.d/600-stamp-vs-new-review-followups.fixed.md
@@ -1,0 +1,12 @@
+- **Sync**: two defects found by the adversarial review of the `stamp_vs_new`
+  action (#600, PR #602). The vanished-cell (`pos:…`) row is no longer emitted
+  when the surviving twin was also edited — its only advertised answer
+  (`treat_as_new` → mirrored removal) was deterministically rejected by the
+  off-base guard, an unbreakable report→answer→reject loop; the shape now
+  frames `remove_vs_edit` (whose `remove`/`keep` answers land) with the stamp
+  suspicion in the row's detail. And answering `treat_as_new` on only *some*
+  rows of a pool no longer erases the ledger evidence behind the pool's other
+  suspected-stamp rows: pools that still carry an unresolved
+  `stamp_vs_new`/`remove_vs_edit` item are frozen during apply's ledger
+  re-record, so the remaining suspicion keeps its framing on the next report
+  instead of silently downgrading to mechanical cell duplication.

--- a/docs/claude/design/sync-total-identity-document-model.md
+++ b/docs/claude/design/sync-total-identity-document-model.md
@@ -473,8 +473,12 @@ clm slides sync autopilot DECK|DIR [--model ...]            # a SCRIPT over repo
   `ambiguous_alignment` shape (a new id'd cell while a positional cell of the
   same pool is unaccounted on that side — both the id-view and the pos-view
   row) became its own framed action with a uniform `treat_as_new` answer
-  (grow the twin verbatim / mirror the removal; an edited survivor rejects),
-  instead of conditioning `ambiguous_alignment`'s answers by shape.
+  (grow the twin verbatim / mirror the removal), instead of conditioning
+  `ambiguous_alignment`'s answers by shape. The pos-view row is only emitted
+  while the survivor sits on base: an *edited* survivor would
+  deterministically reject the mirrored removal, so that shape frames
+  `remove_vs_edit` (whose answers land) with the suspicion in the detail —
+  the report never advertises an answer apply is guaranteed to refuse.
   `ambiguous_alignment` itself stays answerless — its remaining shapes
   (rival id stamps, both-sides-added pool collisions, multi-candidate
   pending twins) are genuinely manual.
@@ -647,3 +651,4 @@ row here (or an edit to the section it refines) has skipped the checklist.
 | #572 — `clm slides rename-id` = the second sanctioned key migration; fingerprint-inferred `id:→id:` migration **rejected** | §7.3 | design extension (explicit, never inferred) |
 | #572 — `body`+`side` recovery on cold id-keyed two-sided members; cold-`confirm` caveat documented | §6.2, §8, §9 | P8(c) extension + honest-residue entry |
 | #600 — `stamp_vs_new` framed action: the "new id'd cell while a positional pool cell is unaccounted" shapes (id-view + pos-view rows) split out of `ambiguous_alignment`, with a `treat_as_new` answer (grow the twin / mirror the removal) | §8 | new framed kind via the §8 watch-item's "redesign the action" route — `ambiguous_alignment` stays answerless |
+| #600 follow-up (adversarial review of #602) — pos-view `stamp_vs_new` only emitted while the survivor sits on base (edited survivor frames `remove_vs_edit` with the suspicion in the detail); pools carrying an unresolved `stamp_vs_new`/`remove_vs_edit` item are frozen during apply's ledger re-record so a partial answer cannot erase a sibling's removal evidence | §8 | defect fixes: "never advertise an answer apply must refuse" + one-sided evidence has no cold state to fall back to |

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -247,14 +247,19 @@ The answer vocabulary is `treat_as_new`:
   verbatim to the twin — the normal `copy_new_shared` path it would have taken
   without the suspicion.
 - On the vanished positional cell's row (`pos:…`), `{"choice": "treat_as_new"}`
-  mirrors the removal onto the surviving half. It is rejected if that survivor
-  was *also* edited (removal would lose the edit) — reconcile that shape by
-  editing the files.
+  mirrors the removal onto the surviving half. This row only appears while the
+  survivor is untouched; if it was *also* edited (removal would lose the
+  edit), the row frames `remove_vs_edit` instead — answer `remove` (delete the
+  edited survivor) or `keep` (re-add it on the other half), with the stamp
+  suspicion repeated in the row's detail.
 
 Answer all the affected rows in one document and the whole replacement lands in
-one `apply` pass. If the cell really was stamped-and-edited (the same cell, now
-carrying an id), do NOT answer `treat_as_new` — stamp the twin cell with the
-same `slide_id` by hand (the halves then pair id-keyed) and re-`report`.
+one `apply` pass. Partial answers are safe: while any row of a pool is still
+unanswered, the pool's ledger entries stay frozen, so the remaining rows keep
+their framing on the next `report` (already-landed slots re-frame as
+mechanical records). If the cell really was stamped-and-edited (the same cell,
+now carrying an id), do NOT answer `treat_as_new` — stamp the twin cell with
+the same `slide_id` by hand (the halves then pair id-keyed) and re-`report`.
 
 ## The forensic window — `report --since`
 

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -779,18 +779,45 @@ def _pool_scope(item: DiffItem) -> tuple[str, str] | None:
     return None
 
 
+#: Framed actions whose pos-view evidence is a two-sided base entry facing a
+#: one-sided survivor. While one is unresolved, its pool must NOT be
+#: re-recorded wholesale: the fresh snapshot only knows the one-sided present
+#: state, and :func:`_drop_unresolved_from_pools` then erases even that — the
+#: only record that the gone side ever existed would vanish, silently
+#: downgrading the pending conflict to mechanical duplication/resurrection on
+#: the next report. (For two-sided members the drop-to-cold fail-safe is
+#: sound; one-sided evidence has no cold state to fall back to.)
+_POOL_FREEZING_ACTIONS = frozenset({"stamp_vs_new", "remove_vs_edit"})
+
+
+def _frozen_pools(unresolved_items: list[DiffItem]) -> set[tuple[str, str]]:
+    """Pools whose ledger entries must stay untouched this pass (#600)."""
+    frozen: set[tuple[str, str]] = set()
+    for item in unresolved_items:
+        if item.action not in _POOL_FREEZING_ACTIONS:
+            continue
+        pool = _pool_scope(item)
+        if pool is not None:
+            frozen.add(pool)
+    return frozen
+
+
 def _record_item(
     target: DeckLedger,
     fresh: DeckLedger,
     item: DiffItem,
     *,
     provenance: str,
+    frozen_pools: set[tuple[str, str]],
 ) -> set[tuple[str, str]]:
     """Update the ledger for one landed item (surgical, never wholesale).
 
     Returns the ``(group, kind)`` pools that were re-recorded wholesale, so
     the caller can un-bless the pool siblings that still carry unresolved
-    items (:func:`_drop_unresolved_from_pools`).
+    items (:func:`_drop_unresolved_from_pools`). Pools in ``frozen_pools``
+    are never re-recorded (nor patched — renumbered ordinals make a per-entry
+    patch unsafe): the landed item simply stays unrecorded and re-frames
+    mechanically once the pool's pending conflicts are answered.
     """
     key = item.key
     action = item.action
@@ -817,6 +844,8 @@ def _record_item(
             body = key.split(":", 1)[1]
             group, tail, _ = body.rsplit("/", 2)
             kind = tail[len("pool.") :]
+            if (group, kind) in frozen_pools:
+                return set()
             rerecord_pool(target, fresh, group, kind)
             return {(group, kind)}
         if "/order." in key:
@@ -836,6 +865,8 @@ def _record_item(
     if action in ("record_remove", "mirror_remove", "remove_vs_edit", "remove_localized_side"):
         pool = _pool_scope(item)
         if pool is not None:
+            if pool in frozen_pools:
+                return set()
             rerecord_pool(target, fresh, *pool)
             return {pool}
         if key not in fresh.members:
@@ -846,6 +877,8 @@ def _record_item(
 
     pool = _pool_scope(item)
     if pool is not None:
+        if pool in frozen_pools:
+            return set()
         rerecord_pool(target, fresh, *pool)
         return {pool}
     _upsert(target, fresh, key, provenance)
@@ -1366,9 +1399,12 @@ def apply_deck(
     fresh = snapshot_deck(final_deck, provenance="apply", commit=commit)
     target = ledger.decks.setdefault(deck_key, DeckLedger())
     priority = {"record_group_rename": 0, "record_key_migration": 1}
+    frozen_pools = _frozen_pools(unresolved_items)
     rerecorded_pools: set[tuple[str, str]] = set()
     for item, provenance in sorted(landed, key=lambda e: priority.get(e[0].action, 2)):
-        rerecorded_pools |= _record_item(target, fresh, item, provenance=provenance)
+        rerecorded_pools |= _record_item(
+            target, fresh, item, provenance=provenance, frozen_pools=frozen_pools
+        )
     # Never bless the unresolved: a wholesale pool re-record must not trust
     # siblings whose framed items were left pending/rejected/failed.
     unresolved_members = [

--- a/src/clm/slides/sync_diff.py
+++ b/src/clm/slides/sync_diff.py
@@ -1880,13 +1880,19 @@ class _Differ:
         if "missing" in states:
             gone: Lang = "de" if de_state == "missing" else "en"
             other_state = en_state if gone == "de" else de_state
-            if self._stamped_candidate_exists(group, entry.kind, gone):
+            suspected_stamp = self._stamped_candidate_exists(group, entry.kind, gone)
+            if suspected_stamp and other_state == "same":
                 # An unmatched one-sided id'd cell exists on the "removed"
                 # side: the cell was plausibly stamped (and edited), not
                 # removed — a mechanical removal could delete real content.
                 # `treat_as_new` resolves it as a genuine removal (mirrors it,
                 # #600); a stamped-edit is reconciled manually. ``side`` names
-                # the gone side, the anchor a mirrored removal needs.
+                # the gone side, the anchor a mirrored removal needs. Only the
+                # untouched-survivor shape gets this framing: an edited
+                # survivor would deterministically reject the mirrored removal
+                # (mirror_remove's off-base guard), so advertising
+                # treat_as_new there would be an answer apply can never
+                # accept — that shape frames remove_vs_edit below instead.
                 self.emit(
                     handle,
                     "conflict",
@@ -1915,12 +1921,20 @@ class _Differ:
                     base=entry,
                 )
             else:
+                detail = f"removed on the {gone} side but edited on the twin"
+                if suspected_stamp:
+                    detail += (
+                        f"; the {gone} side also gained an unmatched id'd cell — "
+                        f"possibly this cell stamped and edited: if so, stamp the "
+                        f"surviving twin with the same slide_id by hand and "
+                        f"re-run report instead of answering"
+                    )
                 self.emit(
                     handle,
                     "conflict",
                     "remove_vs_edit",
                     "both",
-                    f"removed on the {gone} side but edited on the twin",
+                    detail,
                     group=group,
                     side=gone,
                     member=member,

--- a/tests/slides/test_doc_apply.py
+++ b/tests/slides/test_doc_apply.py
@@ -762,19 +762,84 @@ class TestStampVsNew:
         assert "y = 2" not in deck.de_path.read_text(encoding="utf-8")
         deck.assert_converged()
 
-    def test_treat_as_new_rejected_when_the_survivor_moved_off_base(self, tmp_path: Path):
-        # The surviving positional twin carries an edit: removing it would
-        # silently lose content, so the pos-view treat_as_new must fail the
-        # item instead (P8: never guess).
+    def test_edited_survivor_frames_remove_vs_edit_instead_of_a_dead_end(self, tmp_path: Path):
+        # #602 adversarial review: the surviving positional twin carries an
+        # edit, so a mirrored removal is deterministically rejected — the
+        # report must not advertise treat_as_new as the row's only answer.
+        # The shape frames remove_vs_edit instead (remove/keep both land),
+        # with the stamp suspicion spelled out in the detail.
         deck = self._replace_pos_cell_on_en(tmp_path)
         deck.edit_de("y = 2", "y = 99")
         _, diff = deck.diff()
         pos_item = next(i for i in diff.items if i.key == "pos:s0/code/1")
-        assert pos_item.action == "stamp_vs_new"
-        outcome = deck.apply(_decision(pos_item.key, choice="treat_as_new"))
-        result = next(r for r in outcome.results if r.key == pos_item.key)
-        assert result.status == "rejected"
-        assert "y = 99" in deck.de_path.read_text(encoding="utf-8")
+        assert pos_item.action == "remove_vs_edit", (pos_item.action, pos_item.detail)
+        assert "unmatched id'd cell" in pos_item.detail
+        assert doc_apply.item_answers(pos_item) == ("remove", "keep")
+        decisions = {
+            "id:y-assign": doc_apply.Decision(key="id:y-assign", choice="treat_as_new"),
+            "id:y-check": doc_apply.Decision(key="id:y-check", choice="treat_as_new"),
+            "pos:s0/code/1": doc_apply.Decision(key="pos:s0/code/1", choice="remove"),
+        }
+        outcome = deck.apply(decisions)
+        assert outcome.all_applied, outcome.to_payload()
+        de = deck.de_path.read_text(encoding="utf-8")
+        assert "y = 99" not in de  # the deliberate removal landed
+        assert '# %% tags=["keep"] slide_id="y-assign"\ny = 3\n' in de
+        deck.assert_converged()
+
+    def test_partial_pool_answer_keeps_the_sibling_suspicion(self, tmp_path: Path):
+        # #602 adversarial review: landing treat_as_new on ONE pool slot must
+        # not re-record the pool wholesale — that would erase the two-sided
+        # base entries evidencing the OTHER slot's suspicion, silently
+        # downgrading it to mechanical duplication on the next report.
+        deck = _deck(tmp_path)
+        deck.edit_en(
+            '# %% tags=["keep"]\nx = 1\n',
+            '# %% tags=["keep"] slide_id="x-new"\nx = 10\n',
+        )
+        deck.edit_en(
+            '# %% tags=["keep"]\ny = 2\n',
+            '# %% tags=["keep"] slide_id="y-new"\ny = 20\n',
+        )
+        _, diff = deck.diff()
+        assert {(i.key, i.action) for i in diff.items} == {
+            ("id:x-new", "stamp_vs_new"),
+            ("id:y-new", "stamp_vs_new"),
+            ("pos:s0/code/0", "stamp_vs_new"),
+            ("pos:s0/code/1", "stamp_vs_new"),
+        }, [(i.key, i.action, i.detail) for i in diff.items]
+        # Answer only the x rows; the y suspicion is left pending.
+        outcome = deck.apply(
+            {
+                key: doc_apply.Decision(key=key, choice="treat_as_new")
+                for key in ("id:x-new", "pos:s0/code/0")
+            }
+        )
+        statuses = _statuses(outcome)
+        assert statuses["id:x-new"] == "applied"
+        assert statuses["pos:s0/code/0"] == "applied"
+        assert statuses["pos:s0/code/1"] == "pending"
+        # The next report must still frame y as a suspected stamp (never as a
+        # mechanical copy plus a resurrected "new" cell).
+        _, diff = deck.diff()
+        actions = {i.key: i.action for i in diff.items}
+        assert actions["id:y-new"] == "stamp_vs_new"
+        assert actions["pos:s0/code/1"] == "stamp_vs_new"
+        # x's landed slot re-frames as a mechanical removal record (the frozen
+        # pool deferred its ledger update) and everything converges once the
+        # remaining suspicion is answered.
+        assert actions.get("pos:s0/code/0") == "record_remove"
+        outcome = deck.apply(
+            {
+                key: doc_apply.Decision(key=key, choice="treat_as_new")
+                for key in ("id:y-new", "pos:s0/code/1")
+            }
+        )
+        assert outcome.all_applied, outcome.to_payload()
+        de = deck.de_path.read_text(encoding="utf-8")
+        assert de.count("x = 10") == 1 and de.count("y = 20") == 1
+        assert "x = 1\n" not in de and "y = 2\n" not in de
+        deck.assert_converged()
 
 
 class TestDecisionParsing:

--- a/tests/slides/test_sync_diff.py
+++ b/tests/slides/test_sync_diff.py
@@ -985,6 +985,30 @@ class TestAdversarialReviewRegressions:
         assert by_key["pos:s0/code/1"].side == "en"
         assert by_key["id:y-assign"].side == "en"
 
+    def test_edited_survivor_with_stamp_suspicion_frames_remove_vs_edit(self):
+        """#602 adversarial review: an edited survivor deterministically
+        rejects a mirrored removal, so the pos-view row must not advertise
+        ``treat_as_new`` as its only answer (an unbreakable report→reject
+        loop). The shape frames ``remove_vs_edit`` — whose remove/keep answers
+        both land — with the stamp suspicion spelled out in the detail."""
+        base = _snapshot(DE0, EN0)
+        base.complete = False
+        en = EN0.replace(
+            '# %% tags=["keep"]\ny = 2\n',
+            '# %% tags=["keep"] slide_id="y-assign"\ny = 3\n\n# %% slide_id="y-check"\ny\n',
+        )
+        de = DE0.replace("y = 2", "y = 99")
+        diff = _diff(base, de, en)
+        by_key = {i.key: i for i in diff.items}
+        pos = by_key["pos:s0/code/1"]
+        assert pos.action == "remove_vs_edit", (pos.action, pos.detail)
+        assert pos.side == "en"
+        assert "unmatched id'd cell" in pos.detail
+        # The id-view rows keep the stamp_vs_new framing — copying them to
+        # the twin stays answerable regardless of the survivor's edit.
+        assert by_key["id:y-assign"].action == "stamp_vs_new"
+        assert by_key["id:y-check"].action == "stamp_vs_new"
+
     def test_conflicting_stamp_shape_stays_ambiguous_alignment(self):
         """The rival-id shapes must NOT gain ``stamp_vs_new``'s treat_as_new
         answer: copying a cell that already claimed a base entry under a


### PR DESCRIPTION
## Summary

An adversarial multi-agent review of PR #602 (`stamp_vs_new`, issue #600) confirmed two correctness defects; this PR fixes both.

### 1. Dead-end advertisement on an edited survivor (`sync_diff.py`)

The pos-view `stamp_vs_new` row was emitted before the `other_state` check, so when the surviving twin had **also been edited**, the report still advertised `treat_as_new` as the row's only answer — an answer `mirror_remove`'s off-base guard then *deterministically* rejected, and re-running `report` reproduced the same row. That is an unbreakable report → answer → reject loop, the exact class of dead end #600 set out to remove.

**Fix:** `stamp_vs_new` (pos view) is only emitted while the survivor sits on base. The edited-survivor shape frames `remove_vs_edit` — whose `remove`/`keep` answers actually land — with the stamp suspicion spelled out in the row's detail (manual stamp-by-hand remains the escape hatch for a genuine stamped edit).

### 2. Partial pool answers erased sibling suspicion evidence (`doc_apply.py`)

Landing `treat_as_new` on **one** slot of a pool re-recorded the whole `(group, kind)` pool wholesale, and `_drop_unresolved_from_pools` then dropped the still-pending sibling's entries to cold — destroying the two-sided base entry that was the *only record the sibling's gone side ever existed*. The next report framed the sibling mechanically (`copy_new_shared` + a "new" survivor) and apply duplicated the cell on both sides with no agent decision ever recorded.

**Fix:** pools that still carry an unresolved `stamp_vs_new`/`remove_vs_edit` item are frozen during apply's ledger re-record. The drop-to-cold fail-safe is only sound for two-sided members; one-sided removal evidence has no cold state to fall back to. Landed slots in a frozen pool stay unrecorded and re-frame as mechanical records once every suspicion in the pool is answered — restoring the pre-#602 "suspected-stamp pools stay untouched in the ledger" invariant explicitly, instead of by the accident that `ambiguous_alignment` could never land.

## Tests

- `test_edited_survivor_frames_remove_vs_edit_instead_of_a_dead_end` (replaces the old expects-rejection test): asserts the reframing, the suspicion note, and that `remove` + `treat_as_new` on the id rows converge.
- `test_partial_pool_answer_keeps_the_sibling_suspicion`: two suspect slots, answer one — asserts the sibling keeps its `stamp_vs_new` framing on the next report, the landed slot re-frames as `record_remove`, and full resolution converges with no duplicated cells.
- `test_edited_survivor_with_stamp_suspicion_frames_remove_vs_edit` (differ level).
- Full `tests/slides` suite: 1651 passed, 5 skipped.

## Docs

- `sync-agents` info topic: pos-view row condition + "partial answers are safe" paragraph.
- Design note: §8 wording corrected ("never advertise an answer apply must refuse") + §13 amendments row.
- Changelog fragment `changelog.d/600-stamp-vs-new-review-followups.fixed.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEj1XR9vYjEf5XCMD4EMJ6
