### PR TITLE
fix(build): dedupe dir-group copies per destination directory (#539)

### DIFF
--- a/changelog.d/539-dirgroup-dest-collision.fixed.md
+++ b/changelog.d/539-dirgroup-dest-collision.fixed.md
@@ -1,0 +1,7 @@
+- Dir-group copy deduplication is now per destination directory instead of
+  per dir-group, so two `<dir-group>`s that overlap in a single `<subdir>` no
+  longer copy it twice concurrently (the racing `copytree` calls aborted
+  otherwise-complete Windows builds with WinError 32 at the final dir-group
+  stage). `clm validate` now warns (`duplicate_dir_group_destination`) when
+  several dir-groups resolve to the same output destination — both for
+  redundant duplicates and for conflicting sources (#539).

--- a/docs/claude/handovers/issue-triage-2026-07-handover.md
+++ b/docs/claude/handovers/issue-triage-2026-07-handover.md
@@ -102,7 +102,22 @@ cells on one side) resolves through `report` → decision doc → `apply
   slide_id parity into the other half, then `record_remove` +`confirm`) —
   the fix should not break that path.
 
-### Phase 2 [TODO] — #539: duplicate dir-group destination copytree race
+### Phase 2 [DONE] — #539: duplicate dir-group destination copytree race
+
+**Resolution (2026-07-10)**: the whole-group dedup had already landed on
+master (commit `318bfdd5`, the PR #556/#563 arc) but did NOT cover the
+issue's actual shape — two same-named dir-groups that merely *overlap* in
+one `<subdir>` produce different whole-group keys and still raced. Fixed by
+making the dedup per copied directory (`DirGroup._without_seen_copies`:
+one key per `(destination dir, source dir, recursive)` pair plus one per
+root-file batch; the operation gets an `attrs.evolve`d dir-group with only
+the not-yet-covered pairs). Different-source-same-destination pairs are
+deliberately NOT deduped (spec conflict — stays visible to the write
+registry), but `clm validate` now warns about both shapes as
+`duplicate_dir_group_destination` (`_validate_dir_group_destinations` in
+`src/clm/slides/spec_validator.py`). Note: dir-group `<name>` parsing is
+monolingual (`element_text` ignores `<de>/<en>` children), so per-language
+collisions are currently unreachable via real specs.
 
 **Problem**: Two `<dir-group>`s resolving to the same output destination →
 two concurrent `shutil.copytree(src, same_dest, dirs_exist_ok=True)` per
@@ -253,9 +268,9 @@ OpenAI-compatible client, zero new deps) or close as status-quo.
 
 ## 5. Next Steps
 
-**Phase 1 (#600) is DONE — start Phase 2 (#539: duplicate dir-group
-destination copytree race).** The plan below documents how Phase 1 was
-executed (kept for reference):
+**Phases 1 (#600) and 2 (#539) are DONE — start Phase 3 (quick-win batch:
+#524, #382, #362; note the pending #362 Option A/B decision).** The plan
+below documents how Phase 1 was executed (kept for reference):
 
 1. Read memory topics `project_sync_one_sided_cold` and
    `project_sync_v3_design_audit`, plus the sync v3 design note (find via

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -526,6 +526,16 @@ Copy additional directories (e.g., code examples) to output.
 </dir-group>
 ```
 
+#### Duplicate destinations
+
+Each destination directory is copied at most once per build: when the same
+source resolves to the same destination through several `<dir-group>`s
+(e.g. the same `<subdir>` listed under two same-named groups), the
+duplicate copies are skipped. Two dir-groups copying *different* sources
+to the same destination are a spec conflict — the surviving content would
+be nondeterministic. `clm validate` warns about both shapes
+(`duplicate_dir_group_destination`).
+
 ### `<include>`
 
 Splice a shared source directory or file from elsewhere in the course root

--- a/src/clm/core/dir_group.py
+++ b/src/clm/core/dir_group.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from attrs import frozen
+from attrs import evolve, frozen
 
 from clm.core.course_spec import DirGroupSpec
 from clm.core.utils.text_utils import Text
@@ -95,29 +95,60 @@ class DirGroup:
             for dir_ in self.relative_paths
         )
 
-    def _copy_key(
+    def _without_seen_copies(
         self,
         is_speaker: bool,
         lang: str,
         output_root: Path | None,
         skip_toplevel: bool,
-    ) -> tuple:
-        """Identity of a copy operation's effect on disk.
+        seen_copy_keys: set,
+    ) -> "DirGroup | None":
+        """Drop the copy targets of this variant already covered by an earlier one.
 
-        Two operations with the same key copy the same sources to the same
-        destination, so all but one are redundant — and running them
-        concurrently makes ``shutil.copytree`` race against itself, which on
-        Windows raises WinError 32 (sharing violation). The key deliberately
-        includes the sources: operations writing *different* content to the
-        same destination are a spec conflict, not a duplicate, and must stay
-        visible to the output-write registry's conflict detection.
+        Deduplication is per copied directory (and per root-file batch), not
+        per dir-group: two dir-groups that merely *overlap* in one ``<subdir>``
+        resolving to the same destination must not both copy that subdir —
+        concurrent ``shutil.copytree`` calls on the same destination race,
+        which on Windows aborts the build with WinError 32 sharing violations
+        (issue #539). Each key deliberately includes the source: operations
+        writing *different* content to the same destination are a spec
+        conflict, not a duplicate, and must stay visible to the output-write
+        registry's conflict detection (``clm validate`` warns about them as
+        ``duplicate_dir_group_destination``).
+
+        Returns this dir-group with only the not-yet-covered copy targets
+        (``self`` when nothing was covered), or ``None`` when every target is
+        already covered and no operation is needed.
         """
-        return (
-            self.output_path(is_speaker, lang, output_root, skip_toplevel=skip_toplevel),
-            self.source_dirs,
-            self.relative_paths,
-            self.base_path,
-            self.recursive,
+        output_path = self.output_path(is_speaker, lang, output_root, skip_toplevel=skip_toplevel)
+
+        base_path = self.base_path
+        if base_path is not None:
+            root_key = ("root-files", output_path, base_path)
+            if root_key in seen_copy_keys:
+                base_path = None
+            else:
+                seen_copy_keys.add(root_key)
+
+        kept_sources: list[Path] = []
+        kept_relative: list[Path] = []
+        for source_dir, relative_path in zip(self.source_dirs, self.relative_paths, strict=True):
+            dir_key = ("dir", output_path / relative_path, source_dir, self.recursive)
+            if dir_key in seen_copy_keys:
+                continue
+            seen_copy_keys.add(dir_key)
+            kept_sources.append(source_dir)
+            kept_relative.append(relative_path)
+
+        if base_path is None and not kept_sources:
+            return None
+        if base_path == self.base_path and len(kept_sources) == len(self.source_dirs):
+            return self
+        return evolve(
+            self,
+            source_dirs=tuple(kept_sources),
+            relative_paths=tuple(kept_relative),
+            base_path=base_path,
         )
 
     async def get_processing_operation(
@@ -140,15 +171,17 @@ class DirGroup:
             skip_toplevel: If True, skip the "public"/"speaker" directory prefix.
                           Used for explicitly specified output targets.
             seen_copy_keys: Mutable set used to deduplicate copy operations
-                           that would write the same sources to the same
+                           that would write the same source to the same
                            destination. Pass one shared set across all
                            dir-groups of a build to also collapse duplicates
                            between dir-groups; if None, deduplication is
-                           limited to this call. Deduplication matters for
-                           explicit output targets, where the public/speaker
-                           split collapses to a single path and both
-                           is_speaker variants would otherwise copy the same
-                           tree concurrently.
+                           limited to this call. Deduplication is per copied
+                           directory, so it matters both for explicit output
+                           targets (the public/speaker split collapses to a
+                           single path and both is_speaker variants would
+                           otherwise copy the same tree concurrently) and for
+                           dir-groups that overlap in a single <subdir>
+                           (issue #539).
         """
         from clm.core.operations.copy_dir_group import CopyDirGroupOperation
         from clm.infrastructure.operation import Concurrently, NoOperation
@@ -165,16 +198,15 @@ class DirGroup:
         operations = []
         for lang in sorted(langs_to_copy):
             for is_speaker in speaker_options:
-                key = self._copy_key(is_speaker, lang, output_root, skip_toplevel)
-                if key in seen_copy_keys:
-                    logger.debug(
-                        f"Skipping duplicate dir-group copy of '{self.name[lang]}' to {key[0]}"
-                    )
+                remaining = self._without_seen_copies(
+                    is_speaker, lang, output_root, skip_toplevel, seen_copy_keys
+                )
+                if remaining is None:
+                    logger.debug(f"Skipping fully duplicate dir-group copy of '{self.name[lang]}'")
                     continue
-                seen_copy_keys.add(key)
                 operations.append(
                     CopyDirGroupOperation(
-                        dir_group=self,
+                        dir_group=remaining,
                         lang=lang,
                         is_speaker=is_speaker,
                         output_root=output_root,

--- a/src/clm/slides/spec_validator.py
+++ b/src/clm/slides/spec_validator.py
@@ -2,7 +2,8 @@
 
 Checks a course specification XML file for consistency against the
 filesystem (unresolved topics, ambiguous topics, duplicate references,
-missing dir-group paths) and returns structured findings.
+missing dir-group paths, dir-group destination collisions) and returns
+structured findings.
 """
 
 from __future__ import annotations
@@ -76,6 +77,7 @@ def validate_spec(
     - Ambiguous topics (same ID in multiple modules)
     - Duplicate topic references within the spec
     - Missing dir-group paths
+    - Dir-group destination collisions (issue #539)
     - Empty sections
     - ``<include>`` source missing / shadowed / inside a topic dir
     - ``<include>`` dependencies (info) and section-level inheritance (info)
@@ -287,6 +289,9 @@ def validate_spec(
                 )
             )
 
+    # Dir-group destination collisions (issue #539).
+    _validate_dir_group_destinations(spec=spec, findings=findings)
+
     # <include> checks (see docs/claude/design/shared-source-includes-and-output-dedup.md).
     _validate_includes(
         spec=spec,
@@ -364,6 +369,78 @@ def _validate_tasks(
                         message=f"Task '{task.name}', step {i}: {error}",
                     )
                 )
+
+
+def _validate_dir_group_destinations(
+    *,
+    spec: CourseSpec,
+    findings: list[SpecFinding],
+) -> None:
+    """Warn when several ``<dir-group>`` declarations write to one destination.
+
+    The build deduplicates *identical* copies (same source directory to the
+    same destination), so those are merely redundant declarations. Two
+    dir-groups copying *different* sources to the same destination, however,
+    merge their trees nondeterministically: files present in both sources
+    are written by concurrently racing copytrees (historically WinError 32
+    build aborts on Windows — issue #539) and the surviving content depends
+    on scheduling.
+
+    Destinations are compared per language (``<name>`` may be bilingual); a
+    collision that is identical for both languages is reported once.
+    """
+    # (dest, sorted sources) -> languages in which the collision occurs.
+    collisions: dict[tuple[str, tuple[str, ...]], set[str]] = {}
+
+    for lang in ("de", "en"):
+        dest_map: dict[str, list[str]] = {}
+        for dg in spec.dictionaries:
+            name = dg.name[lang]
+            if dg.subdirs:
+                for subdir in dg.subdirs:
+                    dest = f"{name}/{subdir}" if name else subdir
+                    dest_map.setdefault(dest, []).append(f"{dg.path}/{subdir}")
+            elif dg.recursive:
+                # Whole-directory copy: the destination is the group dir itself.
+                dest_map.setdefault(name or ".", []).append(dg.path)
+            # Non-recursive groups without subdirs copy no directories, only
+            # root files; whether those collide depends on the file names on
+            # disk, which is out of scope for a spec-level check.
+
+        for dest, sources in dest_map.items():
+            if len(sources) > 1:
+                collisions.setdefault((dest, tuple(sorted(sources))), set()).add(lang)
+
+    for (dest, colliding), langs in collisions.items():
+        lang_note = "" if langs == {"de", "en"} else f" (language: {next(iter(langs))})"
+        unique_sources = sorted(set(colliding))
+        if len(unique_sources) == 1:
+            message = (
+                f"Output destination '{dest}'{lang_note} is declared by "
+                f"{len(colliding)} <dir-group> entries copying the same source "
+                f"'{unique_sources[0]}'; the build copies it only once."
+            )
+            suggestion = "Remove the redundant <subdir> / <dir-group> declaration."
+        else:
+            message = (
+                f"Multiple <dir-group>s copy different sources "
+                f"({', '.join(unique_sources)}) to the same output destination "
+                f"'{dest}'{lang_note}; files present in more than one source "
+                f"are copied concurrently and the surviving content is "
+                f"nondeterministic."
+            )
+            suggestion = (
+                "Give the dir-groups distinct <name>s, or rename the "
+                "colliding <subdir>s so each destination has one source."
+            )
+        findings.append(
+            SpecFinding(
+                severity="warning",
+                type="duplicate_dir_group_destination",
+                message=message,
+                suggestion=suggestion,
+            )
+        )
 
 
 def _validate_subsections(

--- a/tests/core/course_test.py
+++ b/tests/core/course_test.py
@@ -314,6 +314,97 @@ async def test_dir_group_copy_deduped_across_calls_with_shared_keys(course_1_spe
     assert isinstance(second, NoOperation)
 
 
+async def test_dir_group_copy_dedup_is_per_destination_dir(course_1_spec, tmp_path):
+    """Two dir-groups overlapping in one <subdir> dedupe only the shared copy.
+
+    The issue #539 shape: the same example project is listed as a <subdir>
+    of two same-named dir-groups. The groups are not identical, so a
+    whole-group dedup key misses them, and the shared subdir used to be
+    copied twice concurrently — racing copytrees abort the build on
+    Windows with WinError 32.
+    """
+    from clm.core.dir_group import DirGroup
+
+    course = Course.from_spec(course_1_spec, DATA_DIR, tmp_path)
+    full = course.dir_groups[0]  # Code/Solutions: Example_1, Example_3
+    base = DirGroup(
+        name=full.name,
+        source_dirs=full.source_dirs[:1],
+        relative_paths=full.relative_paths[:1],
+        course=course,
+    )
+    seen: set = set()
+
+    first = await base.get_processing_operation(
+        output_root=tmp_path,
+        languages=frozenset({"de"}),
+        is_speaker_options=[False],
+        seen_copy_keys=seen,
+    )
+    # `full` shares Example_1 with `base` and adds Example_3.
+    second = await full.get_processing_operation(
+        output_root=tmp_path,
+        languages=frozenset({"de"}),
+        is_speaker_options=[False],
+        seen_copy_keys=seen,
+    )
+
+    # The first group is untouched; the second keeps only the subdir that
+    # is not already covered.
+    assert isinstance(first, Concurrently)
+    assert first.operations[0].dir_group is base
+    assert isinstance(second, Concurrently)
+    filtered = second.operations[0].dir_group
+    assert filtered.source_dirs == full.source_dirs[1:]
+    assert filtered.relative_paths == full.relative_paths[1:]
+
+    # Executing both operations still produces the complete merged tree.
+    async with PytestLocalOpsBackend() as backend:
+        async with TaskGroup() as tg:
+            tg.create_task(first.execute(backend))
+            tg.create_task(second.execute(backend))
+
+    out = tmp_path / "public" / "Mein Kurs-de" / "Code" / "Solutions"
+    assert (out / "Example_1" / "example-1.txt").is_file()
+    assert (out / "Example_3" / "example-3.txt").is_file()
+
+
+async def test_dir_group_copy_same_dest_different_source_not_deduped(course_1_spec, tmp_path):
+    """Different sources to the same destination are a conflict, not a duplicate.
+
+    They must stay visible to the output-write registry's conflict
+    detection, so the dedup key includes the source directory.
+    """
+    from clm.core.dir_group import DirGroup
+
+    course = Course.from_spec(course_1_spec, DATA_DIR, tmp_path)
+    base = course.dir_groups[0]
+    conflicting = DirGroup(
+        name=base.name,
+        source_dirs=(DATA_DIR / "code/other-solutions/Example_1",),
+        relative_paths=(base.relative_paths[0],),
+        course=course,
+    )
+    seen: set = set()
+
+    first = await base.get_processing_operation(
+        output_root=tmp_path,
+        languages=frozenset({"de"}),
+        is_speaker_options=[False],
+        seen_copy_keys=seen,
+    )
+    second = await conflicting.get_processing_operation(
+        output_root=tmp_path,
+        languages=frozenset({"de"}),
+        is_speaker_options=[False],
+        seen_copy_keys=seen,
+    )
+
+    assert isinstance(first, Concurrently)
+    assert isinstance(second, Concurrently)
+    assert second.operations[0].dir_group is conflicting
+
+
 async def test_count_stage_operations_returns_correct_counts(course_1_spec, tmp_path):
     """Test that count_stage_operations counts operations, not just files.
 

--- a/tests/slides/test_spec_validator.py
+++ b/tests/slides/test_spec_validator.py
@@ -267,6 +267,118 @@ class TestMissingDirGroup:
         assert result.findings == []
 
 
+class TestDuplicateDirGroupDestination:
+    """Two <dir-group>s resolving to the same output destination (issue #539)."""
+
+    SECTIONS = """\
+            <sections><section>
+              <name><de>S</de><en>S</en></name>
+              <topics><topic>intro</topic></topics>
+            </section></sections>"""
+
+    def _validate(self, tmp_path, dir_groups_xml: str, *, dirs: list[str]):
+        _make_topic(tmp_path, "module_100_basics", "topic_010_intro")
+        for d in dirs:
+            (tmp_path / d).mkdir(parents=True, exist_ok=True)
+        spec_file = _write_spec(tmp_path, self.SECTIONS, dir_groups_xml=dir_groups_xml)
+        return validate_spec(spec_file, tmp_path / "slides")
+
+    def test_same_subdir_in_two_same_named_groups_warns_redundant(self, tmp_path):
+        result = self._validate(
+            tmp_path,
+            """\
+            <dir-groups>
+              <dir-group>
+                <name>Code</name>
+                <path>examples</path>
+                <subdirs><subdir>Demo</subdir><subdir>Alpha</subdir></subdirs>
+              </dir-group>
+              <dir-group>
+                <name>Code</name>
+                <path>examples</path>
+                <subdirs><subdir>Demo</subdir><subdir>Beta</subdir></subdirs>
+              </dir-group>
+            </dir-groups>""",
+            dirs=["examples"],
+        )
+
+        dups = [f for f in result.findings if f.type == "duplicate_dir_group_destination"]
+        assert len(dups) == 1
+        f = dups[0]
+        assert f.severity == "warning"
+        assert "Code/Demo" in f.message
+        assert "copies it only once" in f.message
+
+    def test_same_dest_different_sources_warns_conflict(self, tmp_path):
+        result = self._validate(
+            tmp_path,
+            """\
+            <dir-groups>
+              <dir-group>
+                <name>Code</name>
+                <path>examples</path>
+                <subdirs><subdir>Demo</subdir></subdirs>
+              </dir-group>
+              <dir-group>
+                <name>Code</name>
+                <path>more-examples</path>
+                <subdirs><subdir>Demo</subdir></subdirs>
+              </dir-group>
+            </dir-groups>""",
+            dirs=["examples", "more-examples"],
+        )
+
+        dups = [f for f in result.findings if f.type == "duplicate_dir_group_destination"]
+        assert len(dups) == 1
+        f = dups[0]
+        assert f.severity == "warning"
+        assert "different sources" in f.message
+        assert "examples/Demo" in f.message
+        assert "more-examples/Demo" in f.message
+
+    def test_whole_dir_groups_with_same_name_warn(self, tmp_path):
+        result = self._validate(
+            tmp_path,
+            """\
+            <dir-groups>
+              <dir-group>
+                <name>Extras</name>
+                <path>div/extras</path>
+              </dir-group>
+              <dir-group>
+                <name>Extras</name>
+                <path>div/more-extras</path>
+              </dir-group>
+            </dir-groups>""",
+            dirs=["div/extras", "div/more-extras"],
+        )
+
+        dups = [f for f in result.findings if f.type == "duplicate_dir_group_destination"]
+        assert len(dups) == 1
+        assert "different sources" in dups[0].message
+
+    def test_distinct_destinations_are_clean(self, tmp_path):
+        result = self._validate(
+            tmp_path,
+            """\
+            <dir-groups>
+              <dir-group>
+                <name>Code</name>
+                <path>examples</path>
+                <subdirs><subdir>Demo</subdir></subdirs>
+              </dir-group>
+              <dir-group>
+                <name>Bonus</name>
+                <path>examples</path>
+                <subdirs><subdir>Demo</subdir></subdirs>
+              </dir-group>
+            </dir-groups>""",
+            dirs=["examples"],
+        )
+
+        assert result.findings == []
+
+
 class TestCombinedFindings:
     """Multiple issues in a single spec."""
 


### PR DESCRIPTION
## Summary

Fixes #539 — duplicate dir-group destinations raced concurrent `shutil.copytree` calls and aborted otherwise-complete Windows builds with WinError 32 at the final dir-group stage.

The whole-group dedup that landed earlier (`318bfdd5`) keyed on the entire dir-group's `(destination, sources)`, which misses the issue's actual shape: two same-named `<dir-group>`s that merely **overlap** in one `<subdir>` (e.g. `CopilotAdvancedDemo` listed under two `Code` groups) produce different keys, so the shared subdir was still copied twice concurrently per target.

## Changes

- **Per-directory dedup** (`DirGroup._without_seen_copies`): one dedup key per `(destination dir, source dir, recursive)` pair plus one per root-file batch, shared across all dir-groups and targets of a build. A partially covered operation runs with an `attrs.evolve`d dir-group holding only the uncovered pairs. Pairs writing *different* sources to the same destination are deliberately kept, so the output-write registry's conflict detection still sees them.
- **`clm validate` warning** (`duplicate_dir_group_destination`): warns when several `<dir-group>`s resolve to the same output destination — redundant duplicates ("the build copies it only once") and conflicting sources (nondeterministic surviving content) get distinct messages/suggestions.
- Info topic `spec-files.md` documents the dedup semantics and the new warning; changelog fragment in `changelog.d/`.

## Tests

- Engine: overlapping same-named groups dedupe only the shared pair, and executing the filtered operations still produces the complete merged tree; different-source-same-destination is not deduped.
- Validator: redundant duplicate, conflicting sources, whole-dir name collision, and clean-spec cases.
- Full fast suite green locally (8413 passed); ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEj1XR9vYjEf5XCMD4EMJ6
