### PR TITLE
fix(spec): honor bilingual <dir-group> names instead of silently dropping them

### DIFF
--- a/changelog.d/605-dirgroup-bilingual-name.fixed.md
+++ b/changelog.d/605-dirgroup-bilingual-name.fixed.md
@@ -1,0 +1,8 @@
+- Bilingual `<dir-group>` names (`<name><de>…</de><en>…</en></name>`) are now
+  honored instead of silently parsing as empty — previously such a group's
+  content was copied to the root of every output target (#605). All bilingual
+  spec elements (course/section names, `<description>`, `<certificate>`,
+  `<organization>`, dir-group names) now share one bilingual-or-simple parser:
+  plain text applies to both languages, a single `<de>`/`<en>` child falls
+  back to the other language, and unknown child elements or text mixed with
+  `<de>`/`<en>` children raise a spec error instead of being dropped.

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -39,6 +39,13 @@ They use XML format and are typically named `course.xml`.
 
 ## Required Elements
 
+Bilingual elements (`<name>`, `<description>`, `<certificate>`,
+`<organization>`, section names, dir-group names) all follow the same
+**bilingual-or-simple** convention: either `<de>`/`<en>` children or
+plain text used for both languages. When only one of `<de>`/`<en>` is
+given, the other language falls back to it; any other child element (or
+text mixed with `<de>`/`<en>` children) is a spec error.
+
 ### `<name>`
 
 Bilingual course name with `<de>` and `<en>` children.
@@ -503,6 +510,18 @@ Copy additional directories (e.g., code examples) to output.
 | `<subdirs>` | No | Specific subdirectories to copy (omit to copy all) |
 | `include-root-files` | No | Also copy files from base path (default: `false`) |
 | `recursive` | No | Recurse into subdirectories (default: `true`) |
+
+`<name>` accepts both shapes of the bilingual-or-simple convention:
+
+```xml
+<name>Examples</name>                            <!-- same name for both languages -->
+<name><de>Beispiele</de><en>Examples</en></name> <!-- per-language names -->
+```
+
+If only one of `<de>`/`<en>` is given, the other language falls back to
+it. Any other child element, or text mixed with `<de>`/`<en>` children,
+is a spec error (before CLM {version}, such names were silently read as
+empty, dumping the group at the output root).
 
 #### Selective subdirectories with root files
 

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -450,6 +450,49 @@ def element_text(element: ETree.Element, tag: str) -> str:
     return ""
 
 
+_MULTILANG_TAGS = frozenset({"de", "en"})
+
+
+def parse_multilang_element(element: ETree.Element | None, *, context: str) -> Text:
+    """Parse an element holding either a bilingual or a simple text value.
+
+    Spec elements like ``<name>`` accept two shapes:
+
+    - bilingual: ``<name><de>Beispiele</de><en>Examples</en></name>``
+    - simple text: ``<name>Examples</name>`` (used for both languages)
+
+    When only one of ``<de>``/``<en>`` is given, the other language falls
+    back to it — mirroring the simple form, where a single value serves
+    both languages. Any other child element, or non-whitespace text mixed
+    with ``<de>``/``<en>`` children, is a :class:`CourseSpecError`:
+    silently dropping it would change output locations without warning
+    (issue #605). A missing element parses as an empty ``Text``.
+    """
+    if element is None:
+        return Text(de="", en="")
+    children = list(element)
+    if not children:
+        return Text.from_string((element.text or "").strip())
+    unknown = sorted({child.tag for child in children} - _MULTILANG_TAGS)
+    if unknown:
+        raise CourseSpecError(
+            f"{context}: unsupported child element(s) "
+            f"{', '.join(f'<{tag}>' for tag in unknown)}. "
+            f"Expected <de>/<en> children or plain text."
+        )
+    stray_text = (element.text or "") + "".join(child.tail or "" for child in children)
+    if stray_text.strip():
+        raise CourseSpecError(
+            f"{context}: cannot mix text ({stray_text.strip()!r}) with "
+            f"<de>/<en> child elements. Use either plain text or "
+            f"<de>/<en> children, not both."
+        )
+    values = {child.tag: (child.text or "") for child in children}
+    de = values.get("de", values.get("en", ""))
+    en = values.get("en", values.get("de", ""))
+    return Text(de=de, en=en)
+
+
 def _parse_bool_attr(value: str | None, *, attr_name: str) -> bool:
     if value is None:
         return False
@@ -860,7 +903,7 @@ class DirGroupSpec:
         topic_id: str | None = None,
     ):
         subdirs = find_subdirs(element)
-        name = Text.from_string(element_text(element, "name"))
+        name = parse_multilang_element(element.find("name"), context="<dir-group>/<name>")
         include_root_files = element.get("include-root-files", "").lower() == "true"
         recursive = element.get("recursive", "").lower() != "false"
         return cls(
@@ -2572,10 +2615,10 @@ class CourseSpec:
         # Parse author (simple text element, defaults handled by attrs)
         author = element_text(root, "author") or "Dr. Matthias Hölzl"
 
-        # Parse organization (bilingual element)
+        # Parse organization (bilingual or simple text element)
         org_elem = root.find("organization")
         if org_elem is not None:
-            organization = Text(**{child.tag: (child.text or "") for child in org_elem})
+            organization = parse_multilang_element(org_elem, context="<organization>")
         else:
             organization = Text(de="Coding-Akademie München", en="Coding-Academy Munich")
 
@@ -2601,7 +2644,4 @@ class CourseSpec:
 
 
 def parse_multilang(root: ETree.Element, tag: str) -> Text:
-    element = root.find(tag)
-    if element is None:
-        return Text(de="", en="")
-    return Text(**{child.tag: (child.text or "") for child in element})
+    return parse_multilang_element(root.find(tag), context=f"<{tag}>")

--- a/src/clm/core/utils/text_utils.py
+++ b/src/clm/core/utils/text_utils.py
@@ -19,7 +19,7 @@ class Text:
         return cast(str, getattr(self, item))
 
     @classmethod
-    def from_string(cls, text):
+    def from_string(cls, text: str) -> "Text":
         return cls(de=text, en=text)
 
 

--- a/tests/core/course_spec_test.py
+++ b/tests/core/course_spec_test.py
@@ -7,6 +7,7 @@ from clm.core.course_spec import (
     DEFAULT_OUTPUT_TARGET_SPECS,
     CourseSpec,
     CourseSpecError,
+    DirGroupSpec,
     GitHubSpec,
     TopicSpec,
     parse_multilang,
@@ -942,6 +943,100 @@ def test_parse_dictionaries(course_1_xml):
     assert dir_groups[2].path == "root-files"
     assert dir_groups[2].subdirs == []
     assert dir_groups[2].include_root_files is False
+
+
+class TestDirGroupBilingualName:
+    """Regression tests for issue #605.
+
+    A bilingual ``<dir-group>`` ``<name>`` used to parse as
+    ``Text(de="", en="")`` because only the element's direct text was
+    read — and an empty name means "course output root", so the whole
+    group was silently copied to the root of every output target.
+    """
+
+    @staticmethod
+    def _parse(xml: str) -> DirGroupSpec:
+        from xml.etree import ElementTree as ETree
+
+        return DirGroupSpec.from_element(ETree.fromstring(xml))
+
+    def test_bilingual_name(self):
+        spec = self._parse(
+            """
+            <dir-group>
+                <name><de>Beispiele</de><en>Examples</en></name>
+                <path>examples</path>
+            </dir-group>
+            """
+        )
+        assert spec.name == Text(de="Beispiele", en="Examples")
+
+    def test_bilingual_name_with_formatting_whitespace(self):
+        spec = self._parse(
+            """
+            <dir-group>
+                <name>
+                    <de>Beispiele</de>
+                    <en>Examples</en>
+                </name>
+                <path>examples</path>
+            </dir-group>
+            """
+        )
+        assert spec.name == Text(de="Beispiele", en="Examples")
+
+    def test_single_language_falls_back_to_other(self):
+        spec = self._parse(
+            """
+            <dir-group>
+                <name><de>Beispiele</de></name>
+                <path>examples</path>
+            </dir-group>
+            """
+        )
+        assert spec.name == Text(de="Beispiele", en="Beispiele")
+
+    def test_simple_name_is_stripped(self):
+        spec = self._parse(
+            """
+            <dir-group>
+                <name> Examples </name>
+                <path>examples</path>
+            </dir-group>
+            """
+        )
+        assert spec.name == Text(de="Examples", en="Examples")
+
+    def test_unknown_child_element_is_an_error(self):
+        with pytest.raises(CourseSpecError, match=r"<fr>"):
+            self._parse(
+                """
+                <dir-group>
+                    <name><de>Beispiele</de><fr>Exemples</fr></name>
+                    <path>examples</path>
+                </dir-group>
+                """
+            )
+
+    def test_text_mixed_with_children_is_an_error(self):
+        with pytest.raises(CourseSpecError, match="cannot mix text"):
+            self._parse(
+                """
+                <dir-group>
+                    <name>Examples<de>Beispiele</de></name>
+                    <path>examples</path>
+                </dir-group>
+                """
+            )
+
+
+def test_parse_multilang_accepts_simple_text():
+    """The dual bilingual-or-simple convention applies to all multilang
+    elements, not just dir-group names (issue #605)."""
+    from xml.etree import ElementTree as ETree
+
+    root = ETree.fromstring("<course><name>My Course</name></course>")
+    assert parse_multilang(root, "name") == Text(de="My Course", en="My Course")
 
 
 class TestParseDirGroupsDisabledSections:


### PR DESCRIPTION
Fixes #605.

### Problem

A bilingual `<dir-group>` name:

```xml
<dir-group>
    <name><de>Beispiele</de><en>Examples</en></name>
    <path>examples</path>
</dir-group>
```

silently parsed as `Text(de="", en="")` — `DirGroupSpec.from_element` only read the element's **direct text**, dropping the `<de>`/`<en>` children. Since an empty name means "course output root", the whole group was copied to the root of every output target with no warning (`clm validate` saw the same empty name).

### Root cause

Neither existing helper covered both documented name shapes:

- `element_text()` drops child elements (dir-group names).
- `parse_multilang()` drops direct text — and crashed with a bare `TypeError` on the simple form (`<name>Code</name>`) or when only one of `<de>`/`<en>` was given (course/section names, `<organization>`).

### Fix

One shared **bilingual-or-simple** parser, `parse_multilang_element()`, now used by dir-group names, course/section names, `<description>`, `<certificate>`, and `<organization>`:

- `<de>`/`<en>` children are honored; a single one falls back to the other language (mirroring the simple form, where one value serves both languages).
- Plain text applies to both languages (stripped).
- Unknown child elements, or non-whitespace text mixed with `<de>`/`<en>` children, raise `CourseSpecError` instead of being silently dropped — no silent-empty-name path remains, and `clm validate` surfaces the error since it parses the spec.

Also:

- Documented the convention in the `spec-files` info topic (dir-group section + a shared note under Required Elements).
- Changelog fragment `changelog.d/605-dirgroup-bilingual-name.fixed.md`.
- Added a return-type annotation to `Text.from_string` (fixes a mypy `no-any-return` in the new helper).

### Tests

New `TestDirGroupBilingualName` covering: bilingual name, formatted (multi-line) bilingual name, single-language fallback, simple-text stripping, unknown-child error, mixed-content error; plus `test_parse_multilang_accepts_simple_text` for the course-level path. Fast suite passes (also ran on the pre-push hook); ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JgkhwF8eUUfThPBRozi44B
