### PR TITLE
fix(deps): pin exclude-newer as uv's canonical timestamp (#524)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,15 +123,15 @@ jobs:
         # Install the EXACT versions from uv.lock so CI matches a developer's
         # local `uv sync` (issue #516 follow-up: the old fresh `uv pip install`
         # resolved a different Click than the lock, hiding environment drift).
-        # `--frozen` (not `--locked`): install the lock as-is without a freshness
-        # re-check — the `[tool.uv].exclude-newer` bare date normalizes to a
-        # slightly different timestamp across uv versions, which would make
-        # `--locked` spuriously reject an otherwise-valid lock. Same extra set as
-        # before via explicit `--extra` + `--no-default-groups` (the `dev` extra
-        # carries the pytest stack), so the only change is the version source.
+        # `--locked` fails fast when the lockfile is stale — safe now that
+        # pyproject pins exclude-newer as a full canonical timestamp, so uv's
+        # bare-date normalization can no longer drift across versions
+        # (issue #524). Same extra set as before via explicit `--extra` +
+        # `--no-default-groups` (the `dev` extra carries the pytest stack),
+        # so the only change is the version source.
         # `replay` keeps the HTTP-replay cassette tests running instead of
         # importorskip-skipping. ML/jupyterlite stay out by design.
-        uv sync --frozen --python ${{ matrix.python-version }} --no-default-groups \
+        uv sync --locked --python ${{ matrix.python-version }} --no-default-groups \
           --extra all-workers --extra summarize --extra recordings --extra slides \
           --extra mcp --extra replay --extra dev --extra tui --extra web
 
@@ -217,11 +217,11 @@ jobs:
     - name: Install dependencies
       if: needs.changes.outputs.code == 'true'
       run: |
-        # From the lockfile (see the test job; `--frozen` for the same reason),
+        # From the lockfile (see the test job; `--locked` for the same reason),
         # same extra set as before so lint/type-check sees the exact versions
         # developers do. The `dev` extra carries ruff + mypy; the worker extras
         # give mypy the imports to resolve.
-        uv sync --frozen --python 3.12 --no-default-groups \
+        uv sync --locked --python 3.12 --no-default-groups \
           --extra dev --extra tui --extra web --extra notebook --extra summarize \
           --extra recordings --extra slides --extra mcp
 
@@ -298,9 +298,9 @@ jobs:
 
     - name: Install dependencies
       run: |
-        # From the lockfile (see the test job; `--frozen` for the same reason),
+        # From the lockfile (see the test job; `--locked` for the same reason),
         # same extra set as before.
-        uv sync --frozen --python 3.12 --no-default-groups \
+        uv sync --locked --python 3.12 --no-default-groups \
           --extra all-workers --extra recordings --extra dev --extra tui --extra web
 
     - name: Run Docker integration tests

--- a/changelog.d/524-exclude-newer-canonical.fixed.md
+++ b/changelog.d/524-exclude-newer-canonical.fixed.md
@@ -1,0 +1,9 @@
+- Pin `[tool.uv].exclude-newer` as uv's canonical `<date>T00:00:00Z` timestamp
+  instead of a bare date, so `uv lock --check` / `uv sync --locked` accept the
+  committed lockfile on a clean checkout ([#524](https://github.com/hoelzl/clm/issues/524)).
+  `scripts/update_exclude_newer.py` now canonicalizes a bare-date argument to
+  the next UTC midnight (and passes a full timestamp through unchanged),
+  `scripts/check_exclude_newer.py` requires exact equality between
+  pyproject.toml and uv.lock (the old date-prefix comparison let the drift
+  reach CI), and CI installs with `uv sync --locked` again, restoring
+  fail-fast lockfile-drift detection.

--- a/docs/claude/handovers/issue-triage-2026-07-handover.md
+++ b/docs/claude/handovers/issue-triage-2026-07-handover.md
@@ -139,7 +139,12 @@ destination for a target.
 **Acceptance**: a spec with the same `<subdir>` under two same-named
 dir-groups builds cleanly; stress-repeat passes on Windows; validate warns.
 
-### Phase 3 [TODO] — Quick-win batch (3 small PRs, one session)
+### Phase 3 [IN PROGRESS] — Quick-win batch (3 small PRs, one session)
+
+**#362 decision (2026-07-10, maintainer)**: Option A — honor `end-workshop`
+on any cell type with end-**exclusive** semantics (the tagged cell is NOT
+part of the workshop), plus allowlist + info-topic updates documenting that
+tagging the workshop's last code cell excludes it.
 
 **3a — #524: uv.lock exclude-newer timestamp mismatch.** Three
 representations are in play: pyproject bare date `2026-05-28`; uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -506,10 +506,13 @@ dev = [
 ]
 
 [tool.uv]
-# Only allow packages published before this date (supply-chain safety).
-# Update with: python scripts/update_exclude_newer.py
+# Only allow packages published before this instant (supply-chain safety).
+# Update with: python scripts/update_exclude_newer.py [DATE]
 # (also refreshes uv.lock; see scripts/check_exclude_newer.py for drift check)
-exclude-newer = "2026-05-28"
+# Must stay in uv's canonical `<date>T00:00:00Z` form and exactly equal
+# uv.lock's [options].exclude-newer, or `uv sync --locked` rejects the
+# lockfile on a clean checkout (issue #524).
+exclude-newer = "2026-05-29T00:00:00Z"
 
 # NOTE: there is deliberately no `[tool.uv] conflicts` block. It previously
 # forked the `jupyterlite` extra (whose `empack` caps `click<8.2`) away from

--- a/scripts/check_exclude_newer.py
+++ b/scripts/check_exclude_newer.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
 """Verify that pyproject.toml and uv.lock agree on exclude-newer.
 
-Exits 0 when ``[tool.uv].exclude-newer`` in pyproject.toml matches the
-date prefix of ``[options].exclude-newer`` in uv.lock; exits 1 with a
-clear remediation message when they drift apart.
+Exits 0 when ``[tool.uv].exclude-newer`` in pyproject.toml is **exactly
+equal** to ``[options].exclude-newer`` in uv.lock; exits 1 with a clear
+remediation message when they drift apart.
+
+Exact equality matters: uv compares the timestamps exactly, so a
+date-prefix match (the check's original behavior) passes locally while
+``uv lock --check`` / ``uv sync --locked`` still reject the lockfile as
+stale (issue #524). Both files must hold uv's canonical
+``<date>T00:00:00Z`` form, which ``scripts/update_exclude_newer.py``
+writes.
 
 Wired into ``.pre-commit-config.yaml`` so a commit that bumps the pin in
 pyproject.toml without refreshing uv.lock is rejected before it can
@@ -55,18 +62,21 @@ def check(pyproject_path: Path, lock_path: Path) -> tuple[bool, str]:
     pyproject_pin = _read_pyproject_pin(pyproject_path)
     lock_pin = _read_lock_pin(lock_path)
 
-    # pyproject stores e.g. "2026-04-20"; uv.lock stores e.g.
-    # "2026-04-20T22:00:00Z". Compare the date prefix.
-    if lock_pin.startswith(pyproject_pin):
+    # Exact comparison: uv itself compares the timestamps exactly, so
+    # anything short of equality (e.g. a bare date whose prefix matches)
+    # still fails `uv lock --check` / `uv sync --locked` (issue #524).
+    if lock_pin == pyproject_pin:
         return True, ""
 
     return False, (
         f"pyproject.toml [tool.uv].exclude-newer is {pyproject_pin!r} but "
         f"uv.lock [options].exclude-newer is {lock_pin!r}.\n"
-        "These must agree; otherwise 'uv run' will silently re-lock the "
-        "working tree on the next invocation.\n"
-        "Fix: run 'uv lock' (or 'python scripts/update_exclude_newer.py "
-        "<date>') and commit the resulting uv.lock alongside pyproject.toml."
+        "These must be exactly equal (uv's canonical '<date>T00:00:00Z' "
+        "form); otherwise 'uv run' will silently re-lock the working tree "
+        "on the next invocation and 'uv sync --locked' rejects the lock.\n"
+        "Fix: run 'python scripts/update_exclude_newer.py <date>' (writes "
+        "the canonical form and re-locks) and commit the resulting uv.lock "
+        "alongside pyproject.toml."
     )
 
 

--- a/scripts/update_exclude_newer.py
+++ b/scripts/update_exclude_newer.py
@@ -1,14 +1,23 @@
 #!/usr/bin/env python3
-"""Update the exclude-newer date in pyproject.toml and refresh uv.lock.
+"""Update the exclude-newer timestamp in pyproject.toml and refresh uv.lock.
 
 Usage:
-    python scripts/update_exclude_newer.py          # sets to 14 days ago
-    python scripts/update_exclude_newer.py 2026-04-01  # sets to specific date
+    python scripts/update_exclude_newer.py                       # 14 days ago
+    python scripts/update_exclude_newer.py 2026-04-01            # specific date
+    python scripts/update_exclude_newer.py 2026-04-02T00:00:00Z  # exact timestamp
+
+A bare date ``D`` means "allow packages published through the end of day
+``D`` (UTC)" and is canonicalized to ``<D+1>T00:00:00Z`` — the exact form
+uv itself normalizes a bare date to. Pinning the full timestamp in
+pyproject.toml keeps ``uv lock --check`` / ``uv sync --locked`` happy on a
+clean checkout: uv compares exclude-newer *timestamps* exactly, so any
+other representation (bare date, timezone-shifted local midnight) makes uv
+consider the lockfile stale (issue #524).
 
 After editing pyproject.toml, this script invokes ``uv lock`` so that
 ``uv.lock``'s ``[options].exclude-newer`` is realigned with the new pin.
-The two values must agree: when they don't, ``uv run`` silently re-locks
-the working tree on the next invocation, surfacing as a mystery
+The two values must agree exactly: when they don't, ``uv run`` silently
+re-locks the working tree on the next invocation, surfacing as a mystery
 ``uv.lock`` modification. See ``scripts/check_exclude_newer.py`` for the
 companion drift check.
 """
@@ -25,11 +34,34 @@ PATTERN = re.compile(r'(exclude-newer\s*=\s*)"[^"]*"')
 DEFAULT_DAYS = 14
 
 
+def canonical_timestamp(value: str) -> str:
+    """Return uv's canonical exclude-newer form for ``value``.
+
+    A bare ``YYYY-MM-DD`` date becomes ``<date+1>T00:00:00Z`` (uv's own
+    normalization: the whole day is included, so the cutoff is the next UTC
+    midnight). A full timestamp is passed through unchanged so callers can
+    pin an exact instant.
+    """
+    if "T" in value:
+        return value
+    day = date.fromisoformat(value)
+    return f"{(day + timedelta(days=1)).isoformat()}T00:00:00Z"
+
+
 def main() -> int:
     if len(sys.argv) > 1:
-        target = sys.argv[1]
+        raw_target = sys.argv[1]
     else:
-        target = (date.today() - timedelta(days=DEFAULT_DAYS)).isoformat()
+        raw_target = (date.today() - timedelta(days=DEFAULT_DAYS)).isoformat()
+
+    try:
+        target = canonical_timestamp(raw_target)
+    except ValueError:
+        print(
+            f"error: {raw_target!r} is neither a YYYY-MM-DD date nor a timestamp",
+            file=sys.stderr,
+        )
+        return 1
 
     text = PYPROJECT.read_text()
     new_text, count = PATTERN.subn(rf'\1"{target}"', text, count=1)

--- a/tests/test_check_exclude_newer.py
+++ b/tests/test_check_exclude_newer.py
@@ -36,48 +36,51 @@ def _write_lock(path: Path, pin: str | None) -> None:
 
 
 class TestCheck:
-    def test_dates_match_exactly(self, tmp_path):
+    def test_timestamps_match_exactly(self, tmp_path):
         pyproject = tmp_path / "pyproject.toml"
         lock = tmp_path / "uv.lock"
-        _write_pyproject(pyproject, "2026-04-20")
-        _write_lock(lock, "2026-04-20")
+        _write_pyproject(pyproject, "2026-04-21T00:00:00Z")
+        _write_lock(lock, "2026-04-21T00:00:00Z")
 
         ok, message = check_exclude_newer.check(pyproject, lock)
         assert ok is True
         assert message == ""
 
-    def test_lock_has_full_timestamp_with_matching_date(self, tmp_path):
-        # uv.lock typically stores the wall-clock end-of-day form;
-        # pyproject stores the date-only form. The check compares prefixes.
+    def test_date_prefix_match_is_drift(self, tmp_path):
+        # Regression for issue #524: uv compares the timestamps exactly, so
+        # a bare date in pyproject whose prefix matches the lock's timestamp
+        # still fails `uv lock --check`. The old prefix comparison passed
+        # here and let the drift reach CI.
         pyproject = tmp_path / "pyproject.toml"
         lock = tmp_path / "uv.lock"
         _write_pyproject(pyproject, "2026-04-20")
         _write_lock(lock, "2026-04-20T22:00:00Z")
 
-        ok, _ = check_exclude_newer.check(pyproject, lock)
-        assert ok is True
+        ok, message = check_exclude_newer.check(pyproject, lock)
+        assert ok is False
+        assert "exactly equal" in message
 
     def test_drift_is_reported(self, tmp_path):
         pyproject = tmp_path / "pyproject.toml"
         lock = tmp_path / "uv.lock"
-        _write_pyproject(pyproject, "2026-04-20")
-        _write_lock(lock, "2026-04-18T22:00:00Z")  # older than pyproject
+        _write_pyproject(pyproject, "2026-04-21T00:00:00Z")
+        _write_lock(lock, "2026-04-19T00:00:00Z")  # older than pyproject
 
         ok, message = check_exclude_newer.check(pyproject, lock)
         assert ok is False
-        assert "2026-04-20" in message
-        assert "2026-04-18" in message
+        assert "2026-04-21" in message
+        assert "2026-04-19" in message
         # Remediation guidance must be present so a developer can fix it
         # without consulting external docs.
-        assert "uv lock" in message
+        assert "update_exclude_newer.py" in message
 
     def test_lock_ahead_of_pyproject_is_also_drift(self, tmp_path):
         # The asymmetric case: someone hand-edited uv.lock or `uv lock`-d
         # against a different env var without bumping pyproject.
         pyproject = tmp_path / "pyproject.toml"
         lock = tmp_path / "uv.lock"
-        _write_pyproject(pyproject, "2026-04-20")
-        _write_lock(lock, "2026-04-22T22:00:00Z")
+        _write_pyproject(pyproject, "2026-04-21T00:00:00Z")
+        _write_lock(lock, "2026-04-23T00:00:00Z")
 
         ok, _ = check_exclude_newer.check(pyproject, lock)
         assert ok is False

--- a/tests/test_update_exclude_newer.py
+++ b/tests/test_update_exclude_newer.py
@@ -52,7 +52,10 @@ class _RecordingRun:
 
 
 class TestEditPhase:
-    def test_explicit_date_is_written(self, fake_pyproject, monkeypatch):
+    def test_explicit_date_is_canonicalized(self, fake_pyproject, monkeypatch):
+        # A bare date means "allow the whole day", so the pin becomes the
+        # next UTC midnight — the exact form uv normalizes a bare date to
+        # (issue #524).
         monkeypatch.setattr(sys, "argv", ["update_exclude_newer.py", "2026-04-20"])
         monkeypatch.setattr(update_exclude_newer.shutil, "which", lambda _: "/usr/bin/uv")
         monkeypatch.setattr(update_exclude_newer.subprocess, "run", _RecordingRun())
@@ -60,9 +63,44 @@ class TestEditPhase:
         rc = update_exclude_newer.main()
 
         assert rc == 0
-        assert 'exclude-newer = "2026-04-20"' in fake_pyproject.read_text()
+        assert 'exclude-newer = "2026-04-21T00:00:00Z"' in fake_pyproject.read_text()
 
-    def test_default_is_14_days_ago(self, fake_pyproject, monkeypatch):
+    def test_month_rollover_is_handled(self, fake_pyproject, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["update_exclude_newer.py", "2026-04-30"])
+        monkeypatch.setattr(update_exclude_newer.shutil, "which", lambda _: "/usr/bin/uv")
+        monkeypatch.setattr(update_exclude_newer.subprocess, "run", _RecordingRun())
+
+        rc = update_exclude_newer.main()
+
+        assert rc == 0
+        assert 'exclude-newer = "2026-05-01T00:00:00Z"' in fake_pyproject.read_text()
+
+    def test_full_timestamp_is_passed_through(self, fake_pyproject, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["update_exclude_newer.py", "2026-04-20T12:30:00Z"])
+        monkeypatch.setattr(update_exclude_newer.shutil, "which", lambda _: "/usr/bin/uv")
+        monkeypatch.setattr(update_exclude_newer.subprocess, "run", _RecordingRun())
+
+        rc = update_exclude_newer.main()
+
+        assert rc == 0
+        assert 'exclude-newer = "2026-04-20T12:30:00Z"' in fake_pyproject.read_text()
+
+    def test_invalid_argument_is_rejected(self, fake_pyproject, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "argv", ["update_exclude_newer.py", "not-a-date"])
+        monkeypatch.setattr(
+            update_exclude_newer.subprocess,
+            "run",
+            lambda *a, **kw: pytest.fail("uv lock must not run for an invalid argument"),
+        )
+
+        rc = update_exclude_newer.main()
+
+        assert rc == 1
+        assert "not-a-date" in capsys.readouterr().err
+        # pyproject must be untouched.
+        assert 'exclude-newer = "2025-12-01"' in fake_pyproject.read_text()
+
+    def test_default_is_14_days_ago_canonicalized(self, fake_pyproject, monkeypatch):
         from datetime import date, timedelta
 
         monkeypatch.setattr(sys, "argv", ["update_exclude_newer.py"])
@@ -72,8 +110,9 @@ class TestEditPhase:
         rc = update_exclude_newer.main()
 
         assert rc == 0
-        expected = (date.today() - timedelta(days=14)).isoformat()
-        assert f'exclude-newer = "{expected}"' in fake_pyproject.read_text()
+        # 14 days ago, canonicalized to the following UTC midnight.
+        expected = (date.today() - timedelta(days=13)).isoformat()
+        assert f'exclude-newer = "{expected}T00:00:00Z"' in fake_pyproject.read_text()
 
     def test_missing_pin_in_pyproject_returns_error(self, tmp_path, monkeypatch):
         pyproject = tmp_path / "pyproject.toml"
@@ -124,7 +163,7 @@ class TestUvLockPhase:
         assert rc == 2
         # pyproject was still updated — but the user must be told the lockfile
         # is now stale so they can recover.
-        assert 'exclude-newer = "2026-04-20"' in fake_pyproject.read_text()
+        assert 'exclude-newer = "2026-04-21T00:00:00Z"' in fake_pyproject.read_text()
         err = capsys.readouterr().err
         assert "uv.lock" in err
         assert "stale" in err.lower()

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-28T22:00:00Z"
+exclude-newer = "2026-05-29T00:00:00Z"
 
 [options.exclude-newer-package]
 torchvision = false


### PR DESCRIPTION
## Summary

Fixes #524 — `uv lock --check` / `uv sync --locked` rejected the committed lockfile on every clean checkout because three representations of the exclude-newer cutoff were in play (pyproject bare date `2026-05-28`, uv.lock's profile-written local midnight `2026-05-28T22:00:00Z`, uv's normalization `2026-05-29T00:00:00Z`).

This standardizes on uv's canonical form end to end (issue directions 2 + 3, plus the CI payoff):

- **pyproject.toml** pins the full `2026-05-29T00:00:00Z` timestamp — the exact normalization of the previous bare date, so the effective cutoff is unchanged — and **uv.lock** is re-locked to match (one-line diff, no package changes).
- **`scripts/update_exclude_newer.py`** canonicalizes a bare-date argument to `<date+1>T00:00:00Z` (uv's own normalization) and passes a full timestamp through unchanged.
- **`scripts/check_exclude_newer.py`** now requires **exact equality** between the two pins; the old date-prefix `startswith` comparison is precisely why the drift guard passed while uv's exact check failed.
- **CI** moves back from `uv sync --frozen` to `uv sync --locked` in all three jobs, restoring fail-fast lockfile-drift detection (the issue's stated goal, #516 follow-up).

The profile-side `Sync-UvExcludeNewer` half needs no change: the hook is parked (`disabled.ps1`, not loaded) and its current code already mirrors the pyproject value verbatim, so it composes correctly if ever re-enabled.

## Testing

- `tests/test_check_exclude_newer.py`: exact-match semantics, plus a regression test that the old prefix-match shape (`2026-04-20` vs `2026-04-20T22:00:00Z`) is now reported as drift; `TestRepoState` validates the real repo files agree exactly.
- `tests/test_update_exclude_newer.py`: bare-date canonicalization, month rollover, full-timestamp passthrough, invalid-argument rejection, canonicalized 14-day default.
- `uv lock --check` passes on the branch with no `UV_EXCLUDE_NEWER` in the environment (the clean-checkout scenario from the issue).
- Fast suite green via pre-push hook; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEj1XR9vYjEf5XCMD4EMJ6
