### PR TITLE
docs(handovers): mark triage Phases 1-3 done, refresh status sections

### DIFF
--- a/docs/claude/design/validator-workshop-voiceover-suppression.md
+++ b/docs/claude/design/validator-workshop-voiceover-suppression.md
@@ -14,9 +14,10 @@ The `voiceover` review check in the slide validator currently expects every
 slide, subslide, and code cell in a file to be covered by a voiceover cell.
 That assumption is wrong for **workshops**.
 
-In CLM, a workshop is a stretch of cells bounded by markdown cells tagged
-`workshop` (inclusive, start) and `end-workshop` (exclusive, end) — see
-`src/clm/slides/workshop_scope.py`. Workshops are trainer-driven exercise
+In CLM, a workshop is a stretch of cells starting at a markdown cell tagged
+`workshop` (inclusive) and ending at the next cell tagged `end-workshop`
+(exclusive; any cell type since issue #362 — markdown-only when this doc was
+written) — see `src/clm/slides/workshop_scope.py`. Workshops are trainer-driven exercise
 blocks: the trainer narrates them live during the lecture, so the
 *authoring convention* is **not to attach voiceover to cells inside a
 workshop**. Only the workshop's opening heading carries a voiceover

--- a/docs/claude/handovers/issue-triage-2026-07-handover.md
+++ b/docs/claude/handovers/issue-triage-2026-07-handover.md
@@ -1,6 +1,7 @@
 # Open-Issue Triage & Execution Plan (2026-07-10) — Handover
 
-**Status**: Triage COMPLETE; execution NOT STARTED. This document is the
+**Status**: Triage COMPLETE; execution IN PROGRESS — Phases 1–3 DONE
+(#600, #539, #524/#382/#362), next up Phase 4 (#568). This document is the
 source of truth for working through the open-issue backlog in priority
 order. Update phase statuses here as issues land.
 
@@ -292,11 +293,16 @@ OpenAI-compatible client, zero new deps) or close as status-quo.
   PRs #357/#358).
 - **#501 CLOSED** with evidence comment (phases shipped via PRs
   #505/#510/#513/#515/#518).
-- **No implementation started** on any of the 11 remaining issues; no
-  merged commit on master references #568/#559/#539/#524 (verified via
-  `git log --grep`).
-- No blockers. One decision pending from the maintainer: #362 semantics
-  (Option A vs B in Phase 3c).
+- **Phases 1–3 DONE** (all 2026-07-10): #600 via PRs #602/#603, #539 via
+  PR #604, #524 via PR #607, #382 closed as pre-shipped (1.15.0), #362 via
+  PR #608 (maintainer picked Option A). Resolution details live in each
+  phase's block in §3.
+- **#605** (bilingual dir-group `<name>` silently dropped — filed out of
+  Phase 2) was fixed in parallel by another session via PR #606.
+- No blockers, no pending decisions. Remaining: Phase 4 (#568), Phase 5
+  (#559, needs a quiet-repo window), Phase 6 design tier (#383+#381 —
+  start with a verify-then-close pass, see the Phase 3 resolution note —
+  plus #484, #167).
 
 ## 5. Next Steps
 
@@ -322,12 +328,10 @@ documents how Phase 1 was executed (kept for reference):
    `changelog.d/`, add a §13 amendments-log row, ship via the standard
    worktree → PR flow (`/ship-a-pr` skill).
 
-Prerequisite for Phase 3c only: ask the maintainer to pick #362 Option A
-or B.
-
 ## 6. Key Files & Architecture
 
-No code modified yet. Files identified during triage (issue → key sites):
+Files identified during triage (issue → key sites); Phases 1–3 touched
+their listed sites — see each phase's resolution block for what changed:
 
 - `#600` → sync v3 engine under `src/clm/` (search `ambiguous_alignment`);
   decision-doc apply path in `src/clm/cli/commands/slides/sync.py`


### PR DESCRIPTION
## Summary

Post-phase documentation pass after the Phase 3 quick-win batch (#524 → PR #607, #382 → closed as pre-shipped in 1.15.0, #362 → PR #608):

- Triage handover: header **Status** line and §4 **Current Status** no longer claim "execution NOT STARTED" / "no implementation started"; they now record Phases 1–3 as DONE with PR references, note the parallel #605 fix (PR #606), and point remaining work at Phases 4–6. The resolved #362 Option A/B prerequisite is removed from §5, and §6's "No code modified yet" preamble is corrected.
- `docs/claude/design/validator-workshop-voiceover-suppression.md`: the workshop-boundary description still said `end-workshop` is markdown-only; updated to the any-cell-type semantics from #362 (with a note that markdown-only was accurate when the doc was written).

Docs-only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEj1XR9vYjEf5XCMD4EMJ6
