### PR TITLE
feat(harvest): share the voiceover artifact cache across decks (#568)

### DIFF
--- a/changelog.d/568-shared-voiceover-cache.changed.md
+++ b/changelog.d/568-shared-voiceover-cache.changed.md
@@ -1,0 +1,10 @@
+- The `clm harvest` voiceover artifact cache is now **shared and
+  deck-independent** (#568). It moved from the per-deck
+  `<deck dir>/.clm/voiceover-cache/` to `<shared-cache-dir>/voiceover/`,
+  where the shared cache dir resolves like the LLM cache (`$CLM_CACHE_DIR` →
+  `tool.clm.cache_dir` → `<project-root>/.clm-cache/`). Video-keyed entries
+  (ASR transcripts, transition detection) are computed once per recording and
+  reused by every deck in the repository, so forked/moved decks no longer
+  re-transcribe identical videos. Existing per-deck caches are probed on a
+  miss and promoted into the shared root automatically; `--cache-root` still
+  overrides everything.

--- a/docs/claude/handovers/issue-triage-2026-07-handover.md
+++ b/docs/claude/handovers/issue-triage-2026-07-handover.md
@@ -1,9 +1,10 @@
 # Open-Issue Triage & Execution Plan (2026-07-10) — Handover
 
-**Status**: Triage COMPLETE; execution IN PROGRESS — Phases 1–3 DONE
-(#600, #539, #524/#382/#362), next up Phase 4 (#568). This document is the
-source of truth for working through the open-issue backlog in priority
-order. Update phase statuses here as issues land.
+**Status**: Triage COMPLETE; execution IN PROGRESS — Phases 1–4 DONE
+(#600, #539, #524/#382/#362, #568), next up Phase 5 (#559, needs a
+quiet-repo window). This document is the source of truth for working through
+the open-issue backlog in priority order. Update phase statuses here as
+issues land.
 
 ## 1. Feature Overview
 
@@ -221,7 +222,25 @@ at `output_spec.py:413-423`); `clm slides normalize` symmetrization and
 `src/clm/slides/workshop_scope.py` may also key on cell type — check before
 changing.
 
-### Phase 4 [TODO] — #568: shared ASR transcript cache (before next harvest round)
+### Phase 4 [DONE] — #568: shared ASR transcript cache (before next harvest round)
+
+**Resolution (2026-07-11)**: implemented as the handover's second option,
+generalized — the **whole** voiceover cache root (all four stages, not just
+transcripts) moved from `<deck dir>/.clm/voiceover-cache/` to a shared
+`<shared-cache-dir>/voiceover/`, where the shared cache dir resolves exactly
+like the LLM cache (`$CLM_CACHE_DIR` → `tool.clm.cache_dir` →
+`<project-root>/.clm-cache/`). Safe because timeline/alignment keys already
+include the slides hash; transitions sharing (part of fix 2's benefit) falls
+out for free. Root discovery walks up from the **deck directory** via a new
+`start=` anchor on `describe_cache_dir` (keeps worktree re-anchoring active,
+unlike an explicit `repo_root`). Legacy per-deck entries are probed
+read-only on a shared-root miss and **promoted** into the shared root
+(automates the issue's manual-copy workaround; existing GPU transcripts
+survive the move; `--refresh-cache` skips the probe). `.clm-cache` added to
+`SKIP_DIRS_FOR_COURSE` per the gotcha below. Docs: commands/harvest-agents/
+migration/spec-files info topics, harvest.md + configuration.md user guides,
+changelog fragment. Fixes 2–4 remain deferred. Shipped from worktree
+`starry-nibbling-swing`.
 
 **Problem**: harvest caches ASR transcripts under
 `<deck dir>/.clm/voiceover-cache/transcripts/<video-fingerprint>.json` —
@@ -297,18 +316,23 @@ OpenAI-compatible client, zero new deps) or close as status-quo.
   PR #604, #524 via PR #607, #382 closed as pre-shipped (1.15.0), #362 via
   PR #608 (maintainer picked Option A). Resolution details live in each
   phase's block in §3.
+- **Phase 4 DONE** (2026-07-11): #568 fix 1 — shared deck-independent
+  voiceover cache with legacy promotion (see the Phase 4 resolution block).
+  Fixes 2–4 of the issue stay open as deferred follow-ups.
 - **#605** (bilingual dir-group `<name>` silently dropped — filed out of
   Phase 2) was fixed in parallel by another session via PR #606.
-- No blockers, no pending decisions. Remaining: Phase 4 (#568), Phase 5
-  (#559, needs a quiet-repo window), Phase 6 design tier (#383+#381 —
-  start with a verify-then-close pass, see the Phase 3 resolution note —
-  plus #484, #167).
+- No blockers, no pending decisions. Remaining: Phase 5 (#559, needs a
+  quiet-repo window), Phase 6 design tier (#383+#381 — start with a
+  verify-then-close pass, see the Phase 3 resolution note — plus #484,
+  #167).
 
 ## 5. Next Steps
 
-**Phases 1 (#600), 2 (#539), and 3 (#524/#382/#362) are DONE — start
-Phase 4 (#568 shared ASR transcript cache, fix 1 only; read the
-`project_video_narration_harvest` memory topic first).** The plan below
+**Phases 1–4 are DONE — next is Phase 5 (#559 CI matrix split), which
+needs a quiet-repo window (no PRs in flight) because the "Require CI green"
+ruleset must be updated atomically with the workflow's job renames.** After
+that, Phase 6a (#383+#381) should START with a verify-then-close pass
+against commit 90518611 (see the Phase 3 resolution note). The plan below
 documents how Phase 1 was executed (kept for reference):
 
 1. Read memory topics `project_sync_one_sided_cold` and
@@ -330,7 +354,7 @@ documents how Phase 1 was executed (kept for reference):
 
 ## 6. Key Files & Architecture
 
-Files identified during triage (issue → key sites); Phases 1–3 touched
+Files identified during triage (issue → key sites); Phases 1–4 touched
 their listed sites — see each phase's resolution block for what changed:
 
 - `#600` → sync v3 engine under `src/clm/` (search `ambiguous_alignment`);
@@ -348,10 +372,13 @@ their listed sites — see each phase's resolution block for what changed:
   `src/clm/workers/notebook/output_spec.py:39-64` (`find_workshop_ranges`),
   `src/clm/slides/workshop_scope.py`, `src/clm/slides/validator.py`,
   `src/clm/slides/normalizer.py`
-- `#568` → voiceover cache layout under `<deck>/.clm/voiceover-cache/`
-  (subdirs `transcripts/`, `transitions/`, `timelines/`, `alignments/`);
-  harvest code under `src/clm/voiceover/` / `src/clm/cli/commands/`
-  (`clm harvest`); LLM cache's `cache_dir` config as the pattern to copy
+- `#568` → `src/clm/voiceover/cache.py` (`resolve_cache_root` shared
+  resolution, `legacy_cache_root`, `_legacy_cache` promotion),
+  `src/clm/infrastructure/llm/cache.py` (`describe_cache_dir` `start=`
+  anchor), `src/clm/infrastructure/utils/path_utils.py` (`.clm-cache` in
+  `SKIP_DIRS_FOR_COURSE`); legacy per-deck layout was
+  `<deck>/.clm/voiceover-cache/` (subdirs `transcripts/`, `transitions/`,
+  `timelines/`, `alignments/` — still probed read-only)
 - `#559` → `.github/workflows/ci.yml` + the GitHub "Require CI green"
   ruleset (repo settings, must change atomically)
 - `#484` → `src/clm/infrastructure/backends/sqlite_backend.py`
@@ -381,7 +408,12 @@ sync-engine changes get a §13 amendments-log row.
   script-level (exact-match check test); #362 needs `find_workshop_ranges`
   tests for the chosen semantics; #559's "test" is CI itself — watch the
   first PR after the ruleset swap carefully.
-- Nothing implemented yet, so no test state to report.
+- Phase 4 (#568) shipped with resolution-tier tests (env / pyproject /
+  walk-up), legacy-promotion tests for all four artifact kinds, and a
+  fork-scenario test (`TestForkedDecksShareCache`) in
+  `tests/voiceover/test_cache.py`, plus a `start=` anchor test in
+  `tests/infrastructure/llm/test_cache_dir_resolution.py`; fast suite green
+  (8436 passed).
 
 ## 8. Session Notes
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -160,6 +160,7 @@ default is):
 | `CLM_CACHE_DB_PATH` | Cache database path (persistent — processed-file results) | `clm_cache.db` |
 | `CLM_JOBS_DB_PATH` | Job-queue database path (jobs, workers, events). Ephemeral: only needs to survive a single `clm` run, so it can live on a RAM disk (e.g. `Z:\clm_jobs.db`) to spare the SSD. `clm status` / `clm monitor` honor it too, so they inspect the same DB a redirected build wrote. **Direct worker mode only** — a host RAM-disk path is not visible inside Docker workers. | `clm_jobs.db` |
 | `CLM_TELEMETRY_DB_PATH` | Execution-telemetry database (per-deck kernel crash/flake history). Kept separate from the cache DB so clearing the cache never erases the history. | `clm_telemetry.db` next to the cache DB |
+| `CLM_CACHE_DIR` | Shared cache directory holding the LLM cache (translations, title suggestions, coverage verdicts) and, since #568, the voiceover artifact cache (`voiceover/` subdir: ASR transcripts, transitions, timelines, alignments). Resolution: `--cache-dir`/`--cache-root` flag → this variable → `tool.clm.cache_dir` in `pyproject.toml` → `<project-root>/.clm-cache/`. | `<project-root>/.clm-cache/` |
 
 > The database paths are **not** part of the `[…]` config-file model. They are
 > resolved from the global CLI options / the `CLM_*_DB_PATH` env vars above. (The

--- a/docs/user-guide/harvest.md
+++ b/docs/user-guide/harvest.md
@@ -138,7 +138,7 @@ offsets; part ordering is authoritative.
 | `-o`, `--output` | *(in-place)* | Write to a different output file |
 | `--keep-audio` | off | Keep the extracted WAV file |
 | `--transcript` | *(none)* | Skip ASR and load a precomputed transcript JSON (from `clm harvest transcribe -o ...`). Single-part only; combine with a single video argument |
-| `--alignment` | *(none)* | Skip ASR, detection, and matching; load a precomputed alignment JSON from a prior run (cached under `.clm/voiceover-cache/alignments/`) |
+| `--alignment` | *(none)* | Skip ASR, detection, and matching; load a precomputed alignment JSON from a prior run (cached under the shared cache root's `alignments/`) |
 | `--companion` / `--no-companion` | *(auto)* | Force companion-file merge on/off. Default: auto-detect whether a `voiceover_*.py` companion exists next to SLIDES |
 | `--propagate-to` | *(none)* | After merging `--lang`, translate the changes into the given target language (`de` or `en`) and update its voiceover cells. Must differ from `--lang`; cannot combine with `--overwrite` |
 | `--layout` | *(auto)* | Where to create a NEW companion: `subdir` (`voiceover/` folder) or `sibling` (next to SLIDES). Default: auto-detect an existing `voiceover/` folder, else sibling. Ignored when a companion already exists |
@@ -206,7 +206,15 @@ clm harvest identify video.mp4 slides.py --lang de
 ### Cache and traces
 
 Every expensive intermediate (transcripts, transitions, timelines,
-alignments) is cached under `.clm/voiceover-cache/`; manage it with
+alignments) is cached in a **shared, deck-independent** root:
+`<shared-cache-dir>/voiceover/`, where the shared cache dir resolves like
+the LLM cache (`$CLM_CACHE_DIR` → `tool.clm.cache_dir` in the project's
+`pyproject.toml` → `<project-root>/.clm-cache/`). Entries keyed by the video
+alone (transcripts, transitions) are computed once per recording and reused
+by every deck in the repository — forking or moving a deck does not re-run
+ASR (issue #568). Entries in the older per-deck
+`<deck dir>/.clm/voiceover-cache/` location are found on a miss and promoted
+into the shared root automatically. Manage the cache with
 `clm harvest cache list/prune/clear`. LLM merge calls are trace-logged under
 `.clm/voiceover-traces/`; inspect a log with `clm harvest trace show PATH`.
 The group-level flags `--cache-root`, `--no-cache`, and `--refresh-cache`

--- a/src/clm/cli/commands/harvest.py
+++ b/src/clm/cli/commands/harvest.py
@@ -62,7 +62,8 @@ class _DefaultVerbGroup(LazyGroup):
     "--cache-root",
     type=click.Path(path_type=Path),
     default=None,
-    help="Override the cache location (default: <deck dir>/.clm/voiceover-cache).",
+    help="Override the cache location (default: the shared cache dir's voiceover/ "
+    "subdir — CLM_CACHE_DIR, [tool.clm] cache_dir, or <project-root>/.clm-cache/).",
 )
 @click.option(
     "--no-cache",

--- a/src/clm/cli/commands/voiceover.py
+++ b/src/clm/cli/commands/voiceover.py
@@ -165,7 +165,7 @@ def voiceover_group():
     help=(
         "Skip ASR, detection, and matching; load a precomputed alignment "
         "from PATH. The alignment JSON is produced by a prior sync run "
-        "(cached under .clm/voiceover-cache/alignments/)."
+        "(cached under the shared cache dir's voiceover/alignments/)."
     ),
 )
 @click.option(
@@ -2851,7 +2851,7 @@ def _load_alignment_override(path: Path):
     """Load a precomputed :class:`AlignmentResult` from JSON.
 
     Expects the shape written by :func:`clm.voiceover.cache._encode_alignment`
-    (as stored under ``.clm/voiceover-cache/alignments/``). Accepts either
+    (as stored under the cache root's ``alignments/``). Accepts either
     the inner artifact object or the full cache payload (with ``artifact``
     wrapper).
     """
@@ -2947,11 +2947,13 @@ def cache_group():
     """Inspect and manage the voiceover artifact cache.
 
     The cache speeds up repeat runs of ``transcribe``/``detect``/
-    ``identify``/``sync`` by persisting their intermediate outputs under
-    ``.clm/voiceover-cache/``. Entries are keyed by cheap fingerprints of
-    the video (path+mtime+size) and slide file (content hash), and stale
-    entries are harmless — they become misses automatically when the
-    corresponding inputs change.
+    ``identify``/``autopilot`` by persisting their intermediate outputs in
+    the shared, deck-independent cache root (the shared cache dir's
+    ``voiceover/`` subdir — see ``--cache-root`` on the group). Entries are
+    keyed by cheap fingerprints of the video (path+mtime+size) and slide
+    file (content hash), so forked/moved decks share the video-keyed
+    entries; stale entries are harmless — they become misses automatically
+    when the corresponding inputs change.
     """
 
 

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -3394,13 +3394,18 @@ harvest report → (task → judge → accept [--record])* → verify
 
 | Option | Description |
 |--------|-------------|
-| `--cache-root PATH` | Override the cache location (default: `<deck dir>/.clm/voiceover-cache`) |
+| `--cache-root PATH` | Override the cache location (default: `<shared-cache-dir>/voiceover/`, where the shared cache dir resolves like the LLM cache: `$CLM_CACHE_DIR` → `tool.clm.cache_dir` in `pyproject.toml` → `<project-root>/.clm-cache/`) |
 | `--no-cache` | Disable the artifact cache for this invocation |
 | `--refresh-cache` | Force recomputation and overwrite existing cache entries |
 
 The cache stores intermediate pipeline artifacts (transcripts, transitions,
 timelines, alignments) keyed by video and slide-file fingerprints, so repeat
 invocations skip the expensive ASR/detection steps when inputs are unchanged.
+The cache root is **shared and deck-independent**: video-keyed entries
+(transcripts, transitions) are computed once per recording and reused by
+every deck in the project — including forked/moved decks. On a miss, the
+older per-deck `<deck dir>/.clm/voiceover-cache/` location is probed and a
+hit is promoted into the shared root, so existing caches keep working.
 Manage the cache with `clm harvest cache list/prune/clear`.
 
 Since the CLM {version} harvest cutover, the video-side verbs live **only**

--- a/src/clm/cli/info_topics/harvest-agents.md
+++ b/src/clm/cli/info_topics/harvest-agents.md
@@ -105,9 +105,16 @@ That is the audit trail replacing the old embedded-model
 
 ## Caching and fingerprints
 
-All deterministic stages cache under `<deck dir>/.clm/voiceover-cache/`
-(group flags `--no-cache` / `--refresh-cache` / `--cache-root`). Re-running
-`report`/`task` after the first pass is cheap. Multi-part recordings
+All deterministic stages cache in a **shared, deck-independent** root:
+`<shared-cache-dir>/voiceover/`, where the shared cache dir resolves like
+the LLM cache (`$CLM_CACHE_DIR` → `tool.clm.cache_dir` → `<project-root>/
+.clm-cache/`; group flags `--no-cache` / `--refresh-cache` / `--cache-root`).
+Video-keyed entries (transcripts, transitions) are therefore computed once
+per recording and shared by every deck — forking or moving a deck does NOT
+re-run ASR. Entries under the older per-deck
+`<deck dir>/.clm/voiceover-cache/` are found on a miss and promoted into the
+shared root automatically. Re-running `report`/`task` after the first pass
+is cheap. Multi-part recordings
 (`VIDEO…` in order, or a quoted glob) share one composite fingerprint —
 the same value that keys the cache and the ledger provenance. For tests
 and replays, `--alignment FILE` injects a precomputed alignment (works for

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -2,6 +2,28 @@
 
 This guide covers breaking changes across major CLM versions.
 
+## The voiceover artifact cache moved to a shared, deck-independent root (#568, {version})
+
+**Behavior change, no action required.** `clm harvest` used to cache its
+deterministic stages (ASR transcripts, transition detection, timelines,
+alignments) under `<deck dir>/.clm/voiceover-cache/` — per deck directory, so
+forking or moving a deck re-transcribed identical videos from scratch. The
+cache now lives in one **shared root**: `<shared-cache-dir>/voiceover/`,
+where the shared cache dir resolves exactly like the LLM cache
+(`$CLM_CACHE_DIR` → `tool.clm.cache_dir` in the project's `pyproject.toml` →
+`<project-root>/.clm-cache/`, anchored at the project root discovered by
+walking up from the deck directory). Video-keyed entries are computed once
+per recording and reused by every deck in the repository.
+
+Existing per-deck caches keep working: on a shared-root miss, the old
+`<deck dir>/.clm/voiceover-cache/` location is probed read-only and a hit is
+promoted (copied) into the shared root. Once a course repo's harvests run
+clean, the leftover per-deck `voiceover-cache/` directories can be deleted.
+An explicit `--cache-root PATH` still overrides everything, and
+`clm harvest cache list/prune/clear` now operates on the shared root. If the
+repo's `.gitignore` does not already ignore `.clm-cache/` (the LLM cache's
+default home since 1.16), add it.
+
 ## The sync v2 engine was removed — the document-model engine is the only engine (#520 Phase 4, {version})
 
 **Breaking.** `clm slides sync` now always runs the document-model engine
@@ -78,8 +100,8 @@ name and options.
 `clm voiceover` **remains**, holding only the written-narration text layer:
 `extract`, `inline`, and `inline-notes`. The group also lost its
 `--cache-root` / `--no-cache` / `--refresh-cache` flags — the artifact cache
-belongs to `clm harvest` now (same on-disk location,
-`.clm/voiceover-cache/`).
+belongs to `clm harvest` now (since #568 in a shared root; see the cache
+relocation section above).
 
 The MCP tools were renamed in lockstep, likewise with no aliases:
 `voiceover_transcribe` → `harvest_transcribe`, `voiceover_identify_rev` →

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -1110,7 +1110,7 @@ layouts). Within it, CLM distinguishes three kinds of file:
 | **Core source** | `slides_*.<ext>` (incl. split `slides_*.de.<ext>` / `slides_*.en.<ext>`) | processed into notebooks/HTML |
 | **Output companions** | `img/`, `drawio/`, loose data files | **yes**, verbatim |
 | **Authoring sidecars** | `voiceover_*.<ext>`, `*.http-cassette.yaml` | **no** |
-| **Build-internal tree** | `.clm/` — committed: `cassettes/` (replay input), `sync-ledger.json`; ignored scratch: `voiceover-cache/`, `voiceover-backfill/`, `voiceover-traces/`, `config.toml` | **no** — `.clm/cassettes/` is a build *input* (read at runtime) but never copied to output; the rest is fully ignored everywhere |
+| **Build-internal tree** | `.clm/` — committed: `cassettes/` (replay input), `sync-ledger.json`; ignored scratch: legacy `voiceover-cache/`, `voiceover-backfill/`, `voiceover-traces/`, `config.toml`. Likewise `.clm-cache/` (the shared LLM + voiceover cache root, usually at the project root) is fully ignored wherever it appears | **no** — `.clm/cassettes/` is a build *input* (read at runtime) but never copied to output; the rest is fully ignored everywhere |
 
 The authoring sidecars may live either next to the slides or collected into
 per-type subdirectories so the topic directory stays focused on the editable

--- a/src/clm/infrastructure/llm/cache.py
+++ b/src/clm/infrastructure/llm/cache.py
@@ -379,6 +379,7 @@ def describe_cache_dir(
     *,
     cli_override: Path | None = None,
     repo_root: Path | None = None,
+    start: Path | None = None,
 ) -> CacheDirResolution:
     """Resolve the LLM cache directory and report its provenance (pure).
 
@@ -391,13 +392,17 @@ def describe_cache_dir(
 
     ``repo_root`` defaults to the **discovered project root** —
     :func:`clm.infrastructure.utils.path_utils.find_project_root` walks up from
-    the current working directory to the nearest ``pyproject.toml`` /
-    ``.clm/config.toml`` / ``.git`` (like ``git`` / ``uv`` / ``ruff``), so the
-    cache resolves to the same place no matter which subdirectory the command
-    was invoked from (issue #477). Without the walk-up, running from a topic
-    subdir treated the subdir as the root: it missed ``[tool.clm] cache_dir``
-    and created a stray ``<subdir>/.clm-cache``. This function has **no side
-    effects** — it does not create the directory.
+    ``start`` (default: the current working directory) to the nearest
+    ``pyproject.toml`` / ``.clm/config.toml`` / ``.git`` (like ``git`` / ``uv`` /
+    ``ruff``), so the cache resolves to the same place no matter which
+    subdirectory the command was invoked from (issue #477). Without the
+    walk-up, running from a topic subdir treated the subdir as the root: it
+    missed ``[tool.clm] cache_dir`` and created a stray ``<subdir>/.clm-cache``.
+    Pass ``start`` when the anchor is a *path argument* rather than cwd (the
+    voiceover cache walks up from the deck directory, issue #568); unlike an
+    explicit ``repo_root``, a ``start`` anchor keeps the git-worktree
+    re-anchoring below active. This function has **no side effects** — it does
+    not create the directory.
 
     Git-worktree anchoring: a *relative* ``[tool.clm] cache_dir`` (e.g.
     ``../shared-cache``) is normally joined to ``repo_root``. But in a git
@@ -425,7 +430,7 @@ def describe_cache_dir(
     # ``repo_root`` opts out and anchors to that root verbatim (library callers /
     # tests). The worktree re-anchoring of a relative value below then runs with
     # the correct root (the worktree checkout root, not a subdir).
-    root = repo_root or find_project_root()
+    root = repo_root or find_project_root(start)
     pyproject = root / "pyproject.toml"
     if pyproject.is_file():
         configured = _read_pyproject_cache_dir(pyproject)

--- a/src/clm/infrastructure/utils/path_utils.py
+++ b/src/clm/infrastructure/utils/path_utils.py
@@ -41,6 +41,12 @@ SKIP_DIRS_FOR_COURSE = frozenset(
         # the ``.http-cassette.yaml`` pattern). Also makes ``is_private_dir_name``'s
         # dot-prefix rule consistent — ``.clm`` already matches that shape.
         ".clm",
+        # The shared cache root (LLM cache + the deck-independent voiceover
+        # artifact cache, issue #568). Its default home is the project root —
+        # outside any topic walk — but ``[tool.clm] cache_dir`` may place it
+        # anywhere, so exclude it by name like ``.clm`` (no carve-outs: nothing
+        # under it is ever a build input).
+        ".clm-cache",
         ".git",
         ".idea",
         ".idea",

--- a/src/clm/mcp/server.py
+++ b/src/clm/mcp/server.py
@@ -429,7 +429,7 @@ def create_server(data_dir: Path) -> FastMCP:
     ) -> str:
         """Transcribe a video via the artifact cache and return a summary.
 
-        Reads the cache at ``.clm/voiceover-cache/transcripts/`` first;
+        Reads the shared voiceover cache's ``transcripts/`` first;
         computes + caches on miss.  Returns a JSON summary (segment
         count, duration, first/last segment) — not the full transcript,
         to keep MCP round-trips small.  For the full transcript, call
@@ -443,7 +443,7 @@ def create_server(data_dir: Path) -> FastMCP:
             device: "auto" | "cpu" | "cuda".
             no_cache: Disable cache reads (writes still happen).
             refresh_cache: Force recompute + overwrite cache.
-            cache_root: Override ``.clm/voiceover-cache`` location.
+            cache_root: Override the shared voiceover cache root.
         """
         return await handle_harvest_transcribe(
             video,
@@ -586,7 +586,7 @@ def create_server(data_dir: Path) -> FastMCP:
         """List entries in the voiceover artifact cache.
 
         Args:
-            cache_root: Override the default ``.clm/voiceover-cache``
+            cache_root: Override the default shared voiceover cache root
                 location.  Omit to use the project default.
         """
         return await handle_harvest_cache_list(data_dir, cache_root=cache_root)

--- a/src/clm/mcp/tools.py
+++ b/src/clm/mcp/tools.py
@@ -967,7 +967,7 @@ async def handle_harvest_transcribe(
         device: ``"auto" | "cpu" | "cuda"``.
         no_cache: Disable cache reads (writes still happen).
         refresh_cache: Force recompute + overwrite cache entry.
-        cache_root: Override ``.clm/voiceover-cache`` location.
+        cache_root: Override the shared voiceover cache root.
 
     Returns:
         JSON string with ``{cache_hit, language, duration_sec, segments,
@@ -1226,7 +1226,7 @@ async def handle_harvest_cache_list(
 
     Args:
         data_dir: Root data directory.
-        cache_root: Override the default ``.clm/voiceover-cache``.
+        cache_root: Override the default shared voiceover cache root.
 
     Returns:
         JSON string with ``{root, total_bytes, entries: [...]}``.

--- a/src/clm/voiceover/cache.py
+++ b/src/clm/voiceover/cache.py
@@ -7,10 +7,21 @@ Re-running the pipeline with the same inputs is expensive (especially ASR on
 multi-GB videos) but should produce identical results, which makes these
 artifacts good cache candidates.
 
-This module provides a local filesystem cache layered under the working
-directory's ``.clm/voiceover-cache/`` tree. Keys are derived from cheap
-fingerprints (path + mtime + size for videos; normalized source hash for
-slide files) so cache writes/reads stay fast even on large inputs.
+This module provides a local filesystem cache in a **shared, deck-independent
+root** (issue #568): ``<cache-dir>/voiceover/``, where ``<cache-dir>`` follows
+the LLM cache's resolution (``CLM_CACHE_DIR`` → ``[tool.clm] cache_dir`` →
+``<project-root>/.clm-cache/``), anchored at the project root discovered by
+walking up from the deck directory. Keys are derived from cheap fingerprints
+(path + mtime + size for videos; normalized source hash for slide files) so
+cache writes/reads stay fast even on large inputs — and, because a video's
+fingerprint is independent of any deck, forked/moved decks harvesting the
+same recording share every video-keyed entry instead of re-running ASR.
+
+Entries written by pre-#568 versions live in the per-deck
+``<deck dir>/.clm/voiceover-cache/`` tree; on a miss in the shared root the
+helpers below probe that legacy location and promote a hit into the shared
+root, so existing transcripts survive the layout change without manual
+copying.
 
 The cache is consulted at four points:
 
@@ -25,7 +36,7 @@ error — callers may cache alternate configurations side by side.
 
 Usage::
 
-    cache_root = resolve_cache_root()                   # .clm/voiceover-cache/
+    cache_root = resolve_cache_root()                   # <cache-dir>/voiceover/
     video_key = VideoKey.from_path(video_path)
     slides_key = SlidesKey.from_path(slide_path)
     tx_cfg = TranscribeConfig(backend="faster-whisper", model="large-v3",
@@ -54,7 +65,10 @@ from typing import Any, Generic, TypeVar
 
 logger = logging.getLogger(__name__)
 
+#: Pre-#568 per-deck cache location, still probed (read-only) as a fallback.
 CACHE_DIRNAME = ".clm/voiceover-cache"
+#: Subdirectory of the shared cache dir holding the voiceover artifact cache.
+SHARED_CACHE_SUBDIR = "voiceover"
 CACHE_SUBDIRS = ("transcripts", "transitions", "timelines", "alignments")
 
 
@@ -190,7 +204,25 @@ class DetectConfig:
 
 
 def resolve_cache_root(base_dir: str | Path | None = None) -> Path:
-    """Resolve the default cache root under ``base_dir`` (or cwd)."""
+    """Resolve the default **shared** cache root (issue #568).
+
+    Deck-independent: mirrors the LLM cache's directory treatment
+    (``CLM_CACHE_DIR`` env var → ``[tool.clm] cache_dir`` in the project's
+    ``pyproject.toml`` → ``<project-root>/.clm-cache/``) with a
+    ``voiceover/`` subdirectory. The project root is discovered by walking
+    up from ``base_dir`` (the deck directory in pipeline calls) or cwd, so
+    every deck in a course repository — including forks/moves — resolves to
+    the one shared cache and video-keyed entries (transcripts, transitions)
+    are computed once per recording.
+    """
+    from clm.infrastructure.llm.cache import describe_cache_dir
+
+    start = Path(base_dir) if base_dir is not None else None
+    return describe_cache_dir(start=start).path / SHARED_CACHE_SUBDIR
+
+
+def legacy_cache_root(base_dir: str | Path | None = None) -> Path:
+    """The pre-#568 per-deck cache root under ``base_dir`` (or cwd)."""
     base = Path(base_dir) if base_dir is not None else Path.cwd()
     return base / CACHE_DIRNAME
 
@@ -644,7 +676,8 @@ class CachePolicy:
 
     - ``enabled=False`` bypasses the cache entirely (no reads, no writes).
     - ``refresh=True`` forces a miss on read but still writes the new result.
-    - ``cache_root`` overrides the default ``.clm/voiceover-cache/`` location.
+    - ``cache_root`` overrides the default shared location (see
+      :func:`resolve_cache_root`).
     """
 
     enabled: bool = True
@@ -659,6 +692,25 @@ class CachePolicy:
         if self.cache_root is not None:
             return self.cache_root
         return resolve_cache_root(base_dir)
+
+
+def _legacy_cache(cache_cls, primary_root: Path, base_dir: str | Path | None):
+    """The pre-#568 per-deck cache to probe after a shared-root miss, or None.
+
+    Only probes when a deck anchor is known, the legacy tree actually has
+    entries of this kind, and the legacy root isn't the primary root itself
+    (an explicit ``--cache-root`` pointed at the old location). A hit is
+    promoted into the shared root by the caller, so the probe pays off once
+    per entry.
+    """
+    if base_dir is None:
+        return None
+    root = legacy_cache_root(base_dir)
+    if not (root / cache_cls.subdir).is_dir():
+        return None
+    if root.resolve() == primary_root.resolve():
+        return None
+    return cache_cls(root)
 
 
 def cached_transcribe(
@@ -689,13 +741,25 @@ def cached_transcribe(
         return transcribe_fn(), False
 
     video_key = VideoKey.from_path(video_path)
-    cache = TranscriptsCache(policy.resolve_root(base_dir))
+    root = policy.resolve_root(base_dir)
+    cache = TranscriptsCache(root)
 
     if not policy.refresh:
         hit = cache.get(video_key, cfg)
         if hit is not None:
             logger.info("Transcript cache hit for %s", Path(video_path).name)
             return hit, True
+        legacy = _legacy_cache(TranscriptsCache, root, base_dir)
+        if legacy is not None:
+            hit = legacy.get(video_key, cfg)
+            if hit is not None:
+                cache.put(video_key, cfg, hit)
+                logger.info(
+                    "Transcript cache hit for %s (promoted from per-deck cache %s)",
+                    Path(video_path).name,
+                    legacy.directory,
+                )
+                return hit, True
 
     transcript = transcribe_fn()
     cache.put(video_key, cfg, transcript)
@@ -729,13 +793,25 @@ def cached_detect(
         return detect_fn(), False
 
     video_key = VideoKey.from_path(video_path)
-    cache = TransitionsCache(policy.resolve_root(base_dir))
+    root = policy.resolve_root(base_dir)
+    cache = TransitionsCache(root)
 
     if not policy.refresh:
         hit = cache.get(video_key, cfg)
         if hit is not None:
             logger.info("Transitions cache hit for %s", Path(video_path).name)
             return hit, True
+        legacy = _legacy_cache(TransitionsCache, root, base_dir)
+        if legacy is not None:
+            hit = legacy.get(video_key, cfg)
+            if hit is not None:
+                cache.put(video_key, cfg, hit)
+                logger.info(
+                    "Transitions cache hit for %s (promoted from per-deck cache %s)",
+                    Path(video_path).name,
+                    legacy.directory,
+                )
+                return hit, True
 
     events = detect_fn()
     cache.put(video_key, cfg, events)
@@ -761,13 +837,25 @@ def cached_timeline(
 
     video_key = video_key_for(video_path)
     slides_key = SlidesKey.from_path(slide_path)
-    cache = TimelinesCache(policy.resolve_root(base_dir))
+    root = policy.resolve_root(base_dir)
+    cache = TimelinesCache(root)
 
     if not policy.refresh:
         hit = cache.get(video_key, slides_key, cfg)
         if hit is not None:
             logger.info("Timeline cache hit (%s)", video_key.hash)
             return hit, True
+        legacy = _legacy_cache(TimelinesCache, root, base_dir)
+        if legacy is not None:
+            hit = legacy.get(video_key, slides_key, cfg)
+            if hit is not None:
+                cache.put(video_key, slides_key, cfg, hit)
+                logger.info(
+                    "Timeline cache hit (%s, promoted from per-deck cache %s)",
+                    video_key.hash,
+                    legacy.directory,
+                )
+                return hit, True
 
     timeline = timeline_fn()
     cache.put(video_key, slides_key, cfg, timeline)
@@ -789,13 +877,25 @@ def cached_alignment(
 
     video_key = video_key_for(video_path)
     slides_key = SlidesKey.from_path(slide_path)
-    cache = AlignmentsCache(policy.resolve_root(base_dir))
+    root = policy.resolve_root(base_dir)
+    cache = AlignmentsCache(root)
 
     if not policy.refresh:
         hit = cache.get(video_key, slides_key, cfg)
         if hit is not None:
             logger.info("Alignment cache hit (%s)", video_key.hash)
             return hit, True
+        legacy = _legacy_cache(AlignmentsCache, root, base_dir)
+        if legacy is not None:
+            hit = legacy.get(video_key, slides_key, cfg)
+            if hit is not None:
+                cache.put(video_key, slides_key, cfg, hit)
+                logger.info(
+                    "Alignment cache hit (%s, promoted from per-deck cache %s)",
+                    video_key.hash,
+                    legacy.directory,
+                )
+                return hit, True
 
     alignment = alignment_fn()
     cache.put(video_key, slides_key, cfg, alignment)

--- a/tests/infrastructure/llm/test_cache_dir_resolution.py
+++ b/tests/infrastructure/llm/test_cache_dir_resolution.py
@@ -105,6 +105,19 @@ class TestSubdirWalkUp:
         # Anchored to the discovered root (repo), NOT the subdir → repo's sibling.
         assert res.path.resolve() == (tmp_path / "shared-cache").resolve()
 
+    def test_start_anchor_walks_up_without_chdir(self, tmp_path: Path, monkeypatch, git_available):
+        # start= anchors the walk-up at a path argument instead of cwd (the
+        # voiceover cache passes the deck directory, issue #568), while
+        # keeping repo_root=None so worktree detection stays active.
+        monkeypatch.delenv("CLM_CACHE_DIR", raising=False)
+        repo = tmp_path / "repo"
+        _init_repo(repo, cache_dir_value="../shared-cache")
+        sub = repo / "slides" / "module_410" / "topic_031"
+        sub.mkdir(parents=True)
+        res = describe_cache_dir(start=sub)
+        assert res.source == "pyproject"
+        assert res.path.resolve() == (tmp_path / "shared-cache").resolve()
+
     def test_default_anchors_to_root_from_subdir(self, tmp_path: Path, monkeypatch, git_available):
         # No [tool.clm] cache_dir → the default <root>/.clm-cache must anchor to
         # the discovered root, never creating a stray <subdir>/.clm-cache (#477).

--- a/tests/voiceover/test_cache.py
+++ b/tests/voiceover/test_cache.py
@@ -152,15 +152,52 @@ class TestTranscribeConfig:
         assert TranscribeConfig.normalize_device("auto") == "auto"
 
 
-class TestResolveCacheRoot:
-    def test_default_uses_cwd(self, tmp_path, monkeypatch):
-        monkeypatch.chdir(tmp_path)
-        root = resolve_cache_root()
-        assert root == tmp_path / CACHE_DIRNAME
+def _mark_project_root(path: Path) -> None:
+    """Give *path* a project-root marker so the walk-up stops there."""
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "pyproject.toml").write_text("[tool.other]\n", encoding="utf-8")
 
-    def test_explicit_base_dir(self, tmp_path):
-        root = resolve_cache_root(tmp_path)
-        assert root == tmp_path / CACHE_DIRNAME
+
+class TestResolveCacheRoot:
+    """The default root is shared and deck-independent (issue #568)."""
+
+    def test_default_uses_cwd_project_root(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CLM_CACHE_DIR", raising=False)
+        _mark_project_root(tmp_path)
+        monkeypatch.chdir(tmp_path)
+        assert resolve_cache_root() == tmp_path / ".clm-cache" / "voiceover"
+
+    def test_base_dir_walks_up_to_project_root(self, tmp_path, monkeypatch):
+        # The deck dir anchors the walk-up; the root's shared cache wins, so
+        # every deck in the project resolves to the SAME location.
+        monkeypatch.delenv("CLM_CACHE_DIR", raising=False)
+        _mark_project_root(tmp_path)
+        deck_a = tmp_path / "slides" / "module_410" / "topic_010"
+        deck_b = tmp_path / "slides" / "module_550" / "topic_010_azav"
+        deck_a.mkdir(parents=True)
+        deck_b.mkdir(parents=True)
+        shared = tmp_path / ".clm-cache" / "voiceover"
+        assert resolve_cache_root(deck_a) == shared
+        assert resolve_cache_root(deck_b) == shared
+
+    def test_env_override(self, tmp_path, monkeypatch):
+        target = tmp_path / "from-env"
+        monkeypatch.setenv("CLM_CACHE_DIR", str(target))
+        assert resolve_cache_root(tmp_path) == target / "voiceover"
+
+    def test_pyproject_cache_dir(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CLM_CACHE_DIR", raising=False)
+        (tmp_path / "pyproject.toml").write_text(
+            '[tool.clm]\ncache_dir = "custom-cache"\n', encoding="utf-8"
+        )
+        deck = tmp_path / "slides" / "topic_010"
+        deck.mkdir(parents=True)
+        assert resolve_cache_root(deck) == tmp_path / "custom-cache" / "voiceover"
+
+    def test_legacy_cache_root_is_per_deck(self, tmp_path):
+        from clm.voiceover.cache import legacy_cache_root
+
+        assert legacy_cache_root(tmp_path) == tmp_path / CACHE_DIRNAME
 
 
 class TestTranscriptsCache:
@@ -440,9 +477,13 @@ class TestCachePolicy:
         policy = CachePolicy(cache_root=override)
         assert policy.resolve_root(Path("/some/other/base")) == override
 
-    def test_resolve_root_falls_back_to_base_dir(self, tmp_path):
+    def test_resolve_root_defaults_to_shared_root(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CLM_CACHE_DIR", raising=False)
+        _mark_project_root(tmp_path)
+        deck = tmp_path / "slides" / "topic_010"
+        deck.mkdir(parents=True)
         policy = CachePolicy()
-        assert policy.resolve_root(tmp_path) == tmp_path / CACHE_DIRNAME
+        assert policy.resolve_root(deck) == tmp_path / ".clm-cache" / "voiceover"
 
 
 class TestCachedTranscribe:
@@ -621,6 +662,203 @@ class TestCachedTimelineAndAlignment:
         _, hit = cached_alignment(video, slides, policy=policy, alignment_fn=fake_align, cfg=cfg)
         assert hit is True
         assert calls["n"] == 1
+
+
+class TestLegacyPromotion:
+    """Pre-#568 per-deck entries are found on a miss and promoted."""
+
+    @staticmethod
+    def _transcript():
+        from clm.voiceover.transcribe import Transcript, TranscriptSegment
+
+        return Transcript(
+            segments=[TranscriptSegment(start=0.0, end=1.0, text="hi")],
+            language="de",
+            duration=1.0,
+        )
+
+    @staticmethod
+    def _seed_legacy_transcript(deck_dir: Path, video: Path, transcript) -> None:
+        from clm.voiceover.cache import legacy_cache_root
+
+        cfg = TranscribeConfig(
+            backend="faster-whisper", model="large-v3", language="de", device_class="cpu"
+        )
+        TranscriptsCache(legacy_cache_root(deck_dir)).put(
+            VideoKey.from_path(video), cfg, transcript
+        )
+
+    def test_transcript_promoted_from_per_deck_cache(self, tmp_path):
+        video = _touch_video(tmp_path)
+        deck = tmp_path / "topic_010"
+        deck.mkdir()
+        self._seed_legacy_transcript(deck, video, self._transcript())
+        shared = tmp_path / "shared-cache"
+        policy = CachePolicy(cache_root=shared)
+
+        def must_not_run():
+            raise AssertionError("legacy hit must not re-transcribe")
+
+        kwargs = {
+            "policy": policy,
+            "base_dir": deck,
+            "transcribe_fn": must_not_run,
+            "backend_name": "faster-whisper",
+            "model_size": "large-v3",
+            "language": "de",
+            "device": "cpu",
+        }
+        transcript, hit = cached_transcribe(video, **kwargs)
+        assert hit is True
+        assert transcript.segments[0].text == "hi"
+        # Promoted: the shared root now holds the entry itself.
+        key = VideoKey.from_path(video)
+        assert (shared / "transcripts" / f"{key.hash}.json").is_file()
+        _, hit2 = cached_transcribe(video, **kwargs)
+        assert hit2 is True
+
+    def test_refresh_skips_legacy_probe(self, tmp_path):
+        video = _touch_video(tmp_path)
+        deck = tmp_path / "topic_010"
+        deck.mkdir()
+        self._seed_legacy_transcript(deck, video, self._transcript())
+        calls = {"n": 0}
+
+        def fresh():
+            calls["n"] += 1
+            return self._transcript()
+
+        cached_transcribe(
+            video,
+            policy=CachePolicy(cache_root=tmp_path / "shared-cache", refresh=True),
+            base_dir=deck,
+            transcribe_fn=fresh,
+            backend_name="faster-whisper",
+            model_size="large-v3",
+            language="de",
+            device="cpu",
+        )
+        assert calls["n"] == 1
+
+    def test_no_probe_when_legacy_is_primary(self, tmp_path):
+        from clm.voiceover.cache import legacy_cache_root
+
+        # --cache-root pointing AT the old per-deck location: no self-probe,
+        # plain read works.
+        video = _touch_video(tmp_path)
+        deck = tmp_path / "topic_010"
+        deck.mkdir()
+        self._seed_legacy_transcript(deck, video, self._transcript())
+        _, hit = cached_transcribe(
+            video,
+            policy=CachePolicy(cache_root=legacy_cache_root(deck)),
+            base_dir=deck,
+            transcribe_fn=lambda: (_ for _ in ()).throw(AssertionError("must hit")),
+            backend_name="faster-whisper",
+            model_size="large-v3",
+            language="de",
+            device="cpu",
+        )
+        assert hit is True
+
+    def test_detect_promoted_from_per_deck_cache(self, tmp_path):
+        from clm.voiceover.cache import legacy_cache_root
+        from clm.voiceover.keyframes import TransitionEvent
+
+        video = _touch_video(tmp_path)
+        deck = tmp_path / "topic_010"
+        deck.mkdir()
+        cfg = DetectConfig(sample_fps=2.0, threshold_factor=3.0, percentile=95.0, merge_window=3.0)
+        events = [TransitionEvent(timestamp=5.0, peak_diff=0.4, confidence=2.0, num_frames=2)]
+        TransitionsCache(legacy_cache_root(deck)).put(VideoKey.from_path(video), cfg, events)
+
+        loaded, hit = cached_detect(
+            video,
+            policy=CachePolicy(cache_root=tmp_path / "shared-cache"),
+            base_dir=deck,
+            detect_fn=lambda: (_ for _ in ()).throw(AssertionError("must hit legacy")),
+        )
+        assert hit is True
+        assert loaded[0].timestamp == 5.0
+
+    def test_timeline_and_alignment_promoted(self, tmp_path):
+        from clm.voiceover.aligner import AlignmentResult, SlideNotes
+        from clm.voiceover.cache import legacy_cache_root
+        from clm.voiceover.matcher import TimelineEntry
+
+        video = _touch_video(tmp_path)
+        deck = tmp_path / "topic_010"
+        deck.mkdir()
+        slides = deck / "slides.py"
+        slides.write_text("x = 1\n", encoding="utf-8")
+        video_key = VideoKey.from_path(video)
+        slides_key = SlidesKey.from_path(slides)
+        legacy = legacy_cache_root(deck)
+        tl_cfg = {"lang": "de"}
+        al_cfg = {"bias": 0.4}
+        TimelinesCache(legacy).put(
+            video_key,
+            slides_key,
+            tl_cfg,
+            [TimelineEntry(slide_index=1, start_time=0.0, end_time=5.0, match_score=90.0)],
+        )
+        AlignmentsCache(legacy).put(
+            video_key,
+            slides_key,
+            al_cfg,
+            AlignmentResult(
+                slide_notes={1: SlideNotes(slide_index=1, segments=["hi"])},
+                unassigned_segments=[],
+            ),
+        )
+
+        policy = CachePolicy(cache_root=tmp_path / "shared-cache")
+
+        def boom():
+            raise AssertionError("must hit legacy")
+
+        timeline, tl_hit = cached_timeline(
+            video, slides, policy=policy, base_dir=deck, timeline_fn=boom, cfg=tl_cfg
+        )
+        alignment, al_hit = cached_alignment(
+            video, slides, policy=policy, base_dir=deck, alignment_fn=boom, cfg=al_cfg
+        )
+        assert (tl_hit, al_hit) == (True, True)
+        assert timeline[0].slide_index == 1
+        assert alignment.slide_notes[1].segments == ["hi"]
+
+
+class TestForkedDecksShareCache:
+    def test_second_deck_hits_first_decks_transcript(self, tmp_path, monkeypatch):
+        """The issue #568 scenario: a forked deck reuses the original's ASR."""
+        from clm.voiceover.transcribe import Transcript
+
+        monkeypatch.delenv("CLM_CACHE_DIR", raising=False)
+        _mark_project_root(tmp_path)
+        deck_a = tmp_path / "slides" / "module_410" / "topic_010"
+        deck_b = tmp_path / "slides" / "module_550" / "topic_010_azav"
+        deck_a.mkdir(parents=True)
+        deck_b.mkdir(parents=True)
+        video = _touch_video(tmp_path, name="recording.mp4")
+        calls = {"n": 0}
+
+        def fake_transcribe():
+            calls["n"] += 1
+            return Transcript(segments=[], language="de", duration=1.0)
+
+        kwargs = {
+            "policy": CachePolicy(),
+            "transcribe_fn": fake_transcribe,
+            "backend_name": "faster-whisper",
+            "model_size": "large-v3",
+            "language": "de",
+            "device": "cpu",
+        }
+        _, hit_a = cached_transcribe(video, base_dir=deck_a, **kwargs)
+        _, hit_b = cached_transcribe(video, base_dir=deck_b, **kwargs)
+        assert (hit_a, hit_b) == (False, True)
+        assert calls["n"] == 1
+        assert (tmp_path / ".clm-cache" / "voiceover" / "transcripts").is_dir()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Fix 1 of #568: the `clm harvest` artifact cache is now **shared and deck-independent**. The root moves from the per-deck `<deck dir>/.clm/voiceover-cache/` to `<shared-cache-dir>/voiceover/`, where the shared cache dir resolves exactly like the LLM cache (`$CLM_CACHE_DIR` → `[tool.clm] cache_dir` → `<project-root>/.clm-cache/`), anchored at the project root discovered by walking up from the deck directory. Video-keyed entries (ASR transcripts, transition detection) are computed once per recording and reused by every deck — forking/moving a deck (the `module_410_ai_dev` → `module_550_ml_azav` case, ~3.5 h measured avoidable GPU time) no longer re-transcribes.

## Details

- `describe_cache_dir` gains a `start=` anchor: walk up from a path argument instead of cwd while keeping the git-worktree re-anchoring of a relative `cache_dir` active (an explicit `repo_root` still opts out).
- **Legacy promotion**: on a shared-root miss, the old per-deck location is probed read-only and a hit is promoted into the shared root — the issue's confirmed manual-copy workaround, automated; existing GPU transcripts survive the layout change. `--refresh-cache` skips the probe; `--cache-root` pointed at the old location doesn't self-probe.
- All four stages share the root (timeline/alignment keys already include the slides hash, so sharing is inherently safe); transitions sharing — part of fix 2's benefit — falls out for free.
- `.clm-cache` is walk-excluded like `.clm/` (never a build input).
- Docs: `commands` / `harvest-agents` / `migration` / `spec-files` info topics, `harvest.md` + `configuration.md` user guides, changelog fragment; triage handover Phase 4 marked DONE.

Fixes 2–4 of the issue (detect/match split, batch warmup, frame stride) stay deferred; follow-up issue to come.

## Testing

- New: resolution-tier tests (env / pyproject / walk-up), legacy-promotion tests for all four artifact kinds, refresh/self-probe guards, and the fork scenario (second deck hits the first deck's transcript, exactly one transcription call); `start=` anchor test in the LLM cache-dir suite.
- Fast suite: 8436 passed, 7 skipped, 1 xfailed. Ruff + mypy clean.
- Manual smoke: `clm harvest cache list` from a topic subdir resolves to `<project-root>\.clm-cache\voiceover`.

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEj1XR9vYjEf5XCMD4EMJ6
