### PR TITLE
fix(build): make --only-sections repeatable, accumulating all occurrences

### DIFF
--- a/changelog.d/616-only-sections-repeatable.fixed.md
+++ b/changelog.d/616-only-sections-repeatable.fixed.md
@@ -1,0 +1,5 @@
+- `clm build --only-sections` is now repeatable: passing the flag multiple
+  times accumulates all selector tokens instead of silently keeping only the
+  last occurrence (which made a "build sections X, Y, Z" verification pass on
+  a build that had only built Z). The single-flag comma-separated form keeps
+  working, and an empty value in any occurrence is still rejected (#616).

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -1717,12 +1717,15 @@ async def main_build(
 
     selected_targets = [t.strip() for t in targets.split(",") if t.strip()] if targets else None
 
-    # Parse --only-sections tokens. An empty value after stripping is an
-    # error, not a silent fallthrough to full build. Resolution happens in
+    # Parse --only-sections tokens. The option is repeatable (issue #616:
+    # repeated flags used to silently keep only the last occurrence), so
+    # `only_sections` is a tuple of raw values whose comma-separated tokens
+    # all accumulate. An empty value after stripping is an error, not a
+    # silent fallthrough to full build. Resolution happens in
     # initialize_paths_and_course once the spec has been loaded.
     selected_sections: list[str] | None = None
-    if only_sections is not None:
-        tokens = [t.strip() for t in only_sections.split(",")]
+    if only_sections:
+        tokens = [t.strip() for value in only_sections for t in value.split(",")]
         if not any(tokens) or not all(tokens):
             raise click.UsageError(
                 "--only-sections received an empty or whitespace-only value. "
@@ -2202,10 +2205,11 @@ async def main_build(
 @click.option(
     "--only-sections",
     type=str,
-    default=None,
+    multiple=True,
     help=(
         "Comma-separated selector tokens; rebuilds only those sections "
         "and leaves unselected section output directories untouched. "
+        "May be given multiple times; all occurrences accumulate. "
         "Bare tokens try id → 1-based index → case-insensitive substring "
         "match on either the German or English name. Use 'id:', 'idx:', "
         "or 'name:' prefixes to force a specific strategy. "

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -55,7 +55,7 @@ Key options:
 | `--clean` | Wipe each output root and regenerate from scratch (legacy flow; preserves nested `.git/`). Use for emergency recovery from a corrupted output tree. The default no longer wipes — see "Git-friendly output writes" below. |
 | `--no-sweep` | Disable the post-build stray-file sweep. Useful when iterating on a single section and you don't want orphans from other sections deleted. |
 | `--incremental` | Keep directories, only write newly processed files (skip cached ones). Implies `--no-sweep`. |
-| `--only-sections TEXT` | Comma-separated selector tokens; rebuild only those sections and leave unselected section output untouched. Dir-group processing is skipped in this mode. See "Iterating on a single section" below. |
+| `--only-sections TEXT` | Comma-separated selector tokens; rebuild only those sections and leave unselected section output untouched. May be given multiple times; all occurrences accumulate. Dir-group processing is skipped in this mode. See "Iterating on a single section" below. |
 | `--workers [direct\|docker]` | Worker execution mode |
 | `--notebook-workers N` | Number of notebook workers |
 | `--plantuml-workers N` | Number of PlantUML workers |
@@ -141,6 +141,10 @@ Selector syntax (comma-separated tokens):
 - Section indices are 1-based and count **all** sections in declared
   order, including disabled ones — toggling `enabled="false"` does not
   renumber the sections that follow.
+- The flag is **repeatable**: `--only-sections w03 --only-sections w04`
+  selects both sections, exactly like `--only-sections w03,w04`
+  (CLM {version}+; earlier versions silently kept only the last
+  occurrence).
 
 Selector errors:
 

--- a/tests/cli/test_build_only_sections.py
+++ b/tests/cli/test_build_only_sections.py
@@ -132,6 +132,89 @@ class TestBuildOnlySectionsCli:
         assert result.exit_code != 0
 
 
+class TestOnlySectionsRepeatedFlags:
+    """Regression tests for issue #616.
+
+    ``--only-sections`` was a plain single-value option, so repeated
+    flags were accepted but silently kept only the *last* occurrence —
+    a green build that never built the earlier sections. The option is
+    now ``multiple=True`` and all occurrences accumulate.
+
+    These tests capture the token list that actually reaches the build
+    config by stubbing ``initialize_paths_and_course`` (the first
+    consumer of the parsed config) — exactly the boundary where the
+    earlier occurrences used to vanish.
+    """
+
+    def _invoke_capturing_selection(self, tmp_path, monkeypatch, args):
+        spec_file = tmp_path / "spec.xml"
+        spec_file.write_text(THREE_SECTION_XML)
+        captured: dict[str, list[str] | None] = {}
+
+        def fake_initialize(config):
+            captured["selected_sections"] = config.selected_sections
+            raise SystemExit(0)
+
+        monkeypatch.setattr(
+            "clm.cli.commands.build.initialize_paths_and_course",
+            fake_initialize,
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["build", str(spec_file), *args])
+        return result, captured
+
+    def test_repeated_flags_accumulate(self, tmp_path, monkeypatch):
+        """Two occurrences → both token lists survive, in order."""
+        result, captured = self._invoke_capturing_selection(
+            tmp_path,
+            monkeypatch,
+            ["--only-sections", "w01", "--only-sections", "w03"],
+        )
+        assert result.exit_code == 0
+        assert captured["selected_sections"] == ["w01", "w03"]
+
+    def test_repeated_flags_mix_with_comma_form(self, tmp_path, monkeypatch):
+        """Comma-separated values inside each occurrence still split."""
+        result, captured = self._invoke_capturing_selection(
+            tmp_path,
+            monkeypatch,
+            ["--only-sections", "w01,w02", "--only-sections", "w03"],
+        )
+        assert result.exit_code == 0
+        assert captured["selected_sections"] == ["w01", "w02", "w03"]
+
+    def test_single_flag_comma_form_unchanged(self, tmp_path, monkeypatch):
+        """The documented single-flag comma form keeps working."""
+        result, captured = self._invoke_capturing_selection(
+            tmp_path,
+            monkeypatch,
+            ["--only-sections", "w01,w02"],
+        )
+        assert result.exit_code == 0
+        assert captured["selected_sections"] == ["w01", "w02"]
+
+    def test_no_flag_means_full_build(self, tmp_path, monkeypatch):
+        """Without the flag the config carries no section selection
+        (``multiple=True`` yields ``()``, which must not be mistaken
+        for an empty selection error)."""
+        result, captured = self._invoke_capturing_selection(tmp_path, monkeypatch, [])
+        assert result.exit_code == 0
+        assert captured["selected_sections"] is None
+
+    def test_repeated_flags_with_empty_occurrence_rejected(self, tmp_path, monkeypatch):
+        """An empty value in *any* occurrence is an error, not a silent
+        partial selection."""
+        result, captured = self._invoke_capturing_selection(
+            tmp_path,
+            monkeypatch,
+            ["--only-sections", "w01", "--only-sections", ""],
+        )
+        assert result.exit_code != 0
+        assert "selected_sections" not in captured
+        combined = result.output + (str(result.exception) if result.exception else "")
+        assert "empty or whitespace-only value" in combined
+
+
 # ---------------------------------------------------------------------------
 # Course.from_spec + section_selection — the filter cascade
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #616: `clm build --only-sections` was a plain single-value TEXT option, so repeating the flag was accepted without complaint but silently kept only the **last** occurrence. A build invoked as

```
clm build course.xml --only-sections "Week 12: …" --only-sections "Week 13: …" --only-sections "Week 14: …"
```

built only Week 14 and finished green, so section-scoped verification gates passed on sections that were never built (same silent-wrong-scope family as #516).

## Root cause

The Click option was declared without `multiple=True`; Click's default behavior for repeated single-value options is last-one-wins, with no warning.

## Fix (accumulate — option 1 from the issue)

- `--only-sections` is now `multiple=True`; `main_build` flattens the comma-separated tokens of **all** occurrences in order. `CourseSpec.resolve_section_selectors` already dedupes repeated matches, so overlapping selectors stay safe.
- The documented single-flag comma form is unchanged.
- An empty/whitespace-only value in **any** occurrence is still a `UsageError`, not a silent partial selection.
- Help text and the `clm info commands` topic document the repeatable form.

## Regression tests

`tests/cli/test_build_only_sections.py::TestOnlySectionsRepeatedFlags` captures the token list that reaches the build config (by stubbing `initialize_paths_and_course`, the exact boundary where earlier occurrences used to vanish) and asserts:

- repeated flags accumulate in order,
- repeated flags mix with the comma form,
- the single-flag comma form is unchanged,
- no flag still means full build (`()` from `multiple=True` is not mistaken for an empty selection),
- an empty occurrence among valid ones is rejected with the usual message.

Also verified live: `--only-sections bogus --only-sections w01` now exits 1 with the selector error for `bogus` (previously the `bogus` occurrence was discarded and the build proceeded with only `w01`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FVKEYi8DEMrqCN2CoMvsk
