### PR TITLE
docs(claude): retire nine completed handover documents

### DIFF
--- a/docs/claude/handovers/issue-572-cold-ledger-handover-archive.md
+++ b/docs/claude/handovers/issue-572-cold-ledger-handover-archive.md
@@ -1,3 +1,17 @@
+<!-- HANDOVER-ARCHIVE — fully retired on 2026-07-11 -->
+
+# Handover Archive: Issue #572 — Cold-Ledger Fix
+
+> ⚠️ **FULLY RETIRED HANDOVER — NOT ACTIVE**
+>
+> This document archives a handover whose work is fully complete or has
+> been abandoned. **There is no active handover document.** It must
+> **not** be used with `/resume-feature`, `/implement-next-phase`, or
+> similar commands that expect an active work plan.
+>
+> If you need to resume related work, start a fresh handover.
+
+---
 # Issue #572 — cold-ledger stale-twin — handover
 
 **Status:** BOTH PRs shipped. PR 1 = Phase A (`clm slides rename-id`, PR #573,

--- a/docs/claude/handovers/video-narration-harvest-handover-archive.md
+++ b/docs/claude/handovers/video-narration-harvest-handover-archive.md
@@ -1,3 +1,17 @@
+<!-- HANDOVER-ARCHIVE — fully retired on 2026-07-11 -->
+
+# Handover Archive: Video Narration Harvest
+
+> ⚠️ **FULLY RETIRED HANDOVER — NOT ACTIVE**
+>
+> This document archives a handover whose work is fully complete or has
+> been abandoned. **There is no active handover document.** It must
+> **not** be used with `/resume-feature`, `/implement-next-phase`, or
+> similar commands that expect an active work plan.
+>
+> If you need to resume related work, start a fresh handover.
+
+---
 # Handover: Video Narration Harvest (agent-first rebuild)
 
 **Status**: ALL FOUR PHASES implemented (v3 extraction; `clm harvest

--- a/docs/claude/per-topic-solution-release-followups-handover.md
+++ b/docs/claude/per-topic-solution-release-followups-handover.md
@@ -2,7 +2,7 @@
 
 **Branch**: `worktree-logical-jingling-fiddle` ·
 **Issue**: [#208](https://github.com/hoelzl/clm/issues/208) ·
-**Parent handover** (the shipped 5-step feature): `docs/claude/per-topic-solution-release-handover.md`
+**Parent handover** (the shipped 5-step feature, retired 2026-07-11): `docs/claude/per-topic-solution-release-handover-archive.md`
 
 The 5-step #208 plan is **complete and pushed** (provenance manifest → release
 engine → spec channels + `clm git`/`clm release` push → multi-cohort tests →

--- a/docs/claude/per-topic-solution-release-handover-archive.md
+++ b/docs/claude/per-topic-solution-release-handover-archive.md
@@ -1,3 +1,17 @@
+<!-- HANDOVER-ARCHIVE — fully retired on 2026-07-11 -->
+
+# Handover Archive: Per-Topic Solution Release (issue #208)
+
+> ⚠️ **FULLY RETIRED HANDOVER — NOT ACTIVE**
+>
+> This document archives a handover whose work is fully complete or has
+> been abandoned. **There is no active handover document.** It must
+> **not** be used with `/resume-feature`, `/implement-next-phase`, or
+> similar commands that expect an active work plan.
+>
+> If you need to resume related work, start a fresh handover.
+
+---
 # Handover: Per-Topic Solution Release (issue #208)
 
 **Branch**: `worktree-logical-jingling-fiddle` ·

--- a/docs/claude/python-courses-revamp-handover-archive.md
+++ b/docs/claude/python-courses-revamp-handover-archive.md
@@ -1,3 +1,17 @@
+<!-- HANDOVER-ARCHIVE — fully retired on 2026-07-11 -->
+
+# Handover Archive: Python Courses Revamp
+
+> ⚠️ **FULLY RETIRED HANDOVER — NOT ACTIVE**
+>
+> This document archives a handover whose work is fully complete or has
+> been abandoned. **There is no active handover document.** It must
+> **not** be used with `/resume-feature`, `/implement-next-phase`, or
+> similar commands that expect an active work plan.
+>
+> If you need to resume related work, start a fresh handover.
+
+---
 # Handover: PythonCourses Revamp — Next Steps (CLM side)
 
 CLM-resident tracking doc for the work requested in

--- a/docs/claude/recordings-deck-selection-handover-archive.md
+++ b/docs/claude/recordings-deck-selection-handover-archive.md
@@ -1,3 +1,17 @@
+<!-- HANDOVER-ARCHIVE — fully retired on 2026-07-11 -->
+
+# Handover Archive: Recordings Deck Selection
+
+> ⚠️ **FULLY RETIRED HANDOVER — NOT ACTIVE**
+>
+> This document archives a handover whose work is fully complete or has
+> been abandoned. **There is no active handover document.** It must
+> **not** be used with `/resume-feature`, `/implement-next-phase`, or
+> similar commands that expect an active work plan.
+>
+> If you need to resume related work, start a fresh handover.
+
+---
 # Handover: Slide-Deck-Based Lecture Selection & Dashboard Improvements
 
 ## 1. Feature Overview

--- a/docs/claude/sync-corpus-mutation-443-investigation-handover-archive.md
+++ b/docs/claude/sync-corpus-mutation-443-investigation-handover-archive.md
@@ -1,3 +1,17 @@
+<!-- HANDOVER-ARCHIVE — fully retired on 2026-07-11 -->
+
+# Handover Archive: test_sync_corpus_mutation Failures (#443)
+
+> ⚠️ **FULLY RETIRED HANDOVER — NOT ACTIVE**
+>
+> This document archives a handover whose work is fully complete or has
+> been abandoned. **There is no active handover document.** It must
+> **not** be used with `/resume-feature`, `/implement-next-phase`, or
+> similar commands that expect an active work plan.
+>
+> If you need to resume related work, start a fresh handover.
+
+---
 # Handover — `test_sync_corpus_mutation` failures (#443) + the CI-coverage gap
 
 > ## ✅ RESOLVED (2026-06-24)

--- a/docs/claude/sync-plan-resolve-apply-handover-archive.md
+++ b/docs/claude/sync-plan-resolve-apply-handover-archive.md
@@ -1,3 +1,19 @@
+<!-- HANDOVER-ARCHIVE — fully retired on 2026-07-11 -->
+
+# Handover Archive: Sync Resolve-then-Apply Redesign (#216)
+
+> ⚠️ **FULLY RETIRED HANDOVER — NOT ACTIVE**
+>
+> This document archives a handover whose work is fully complete or has
+> been abandoned. **There is no active handover document.** It must
+> **not** be used with `/resume-feature`, `/implement-next-phase`, or
+> similar commands that expect an active work plan.
+>
+> If you need to resume related work, start a fresh handover.
+
+> **Retirement note (2026-07-11):** All three phases shipped on the v2 engine. The remaining Phase-2 deferred follow-ups (id-migration recoverer, `sync_code` structural translate) are **moot**: the entire v2 sync core (`sync_plan.py`, `sync_apply.py`, `sync_code`, …) was deleted by the Sync v3 core replacement (#520, cutover 2026-07-04). The resolve-then-apply *principles* live on in the v3 design; the code this handover describes no longer exists.
+
+---
 # Handover: Sync Resolve-then-Apply redesign (#216)
 
 **Branch:** `claude/sync-plan-resolve-apply-redesign` (off `master` @ `1a105f6`)

--- a/docs/claude/sync-v3-handover-archive.md
+++ b/docs/claude/sync-v3-handover-archive.md
@@ -1,3 +1,17 @@
+<!-- HANDOVER-ARCHIVE — fully retired on 2026-07-11 -->
+
+# Handover Archive: Sync v3 Core Replacement (#520)
+
+> ⚠️ **FULLY RETIRED HANDOVER — NOT ACTIVE**
+>
+> This document archives a handover whose work is fully complete or has
+> been abandoned. **There is no active handover document.** It must
+> **not** be used with `/resume-feature`, `/implement-next-phase`, or
+> similar commands that expect an active work plan.
+>
+> If you need to resume related work, start a fresh handover.
+
+---
 Sync v3 core replacement (#520) — **COMPLETE through Phase 4 (cutover)**.
 
 **State (2026-07-04)**: Phases 0–4 are done. The document-model engine is the

--- a/docs/claude/test-coverage-expansion-handover-archive.md
+++ b/docs/claude/test-coverage-expansion-handover-archive.md
@@ -1,3 +1,17 @@
+<!-- HANDOVER-ARCHIVE — fully retired on 2026-07-11 -->
+
+# Handover Archive: Test Coverage Expansion (Round 2)
+
+> ⚠️ **FULLY RETIRED HANDOVER — NOT ACTIVE**
+>
+> This document archives a handover whose work is fully complete or has
+> been abandoned. **There is no active handover document.** It must
+> **not** be used with `/resume-feature`, `/implement-next-phase`, or
+> similar commands that expect an active work plan.
+>
+> If you need to resume related work, start a fresh handover.
+
+---
 # Handover: Test Coverage Expansion (Round 2)
 
 **Created**: 2026-04-17


### PR DESCRIPTION
## Summary

Retires the nine handover documents whose work is fully complete, per the `/retire-handover` full-retirement flow: each active document is replaced by a companion `*-handover-archive.md` containing the full original content under a prominent **FULLY RETIRED — NOT ACTIVE** notice.

Retired handovers:

- `sync-v3-handover.md` — complete through Phase 4 (cutover, #520)
- `per-topic-solution-release-handover.md` — all 5 steps of #208 shipped
- `handovers/issue-572-cold-ledger-handover.md` — both PRs shipped
- `handovers/video-narration-harvest-handover.md` — all four phases implemented
- `recordings-deck-selection-handover.md` — all phases complete and merged
- `test-coverage-expansion-handover.md` — 85% coverage target achieved
- `sync-corpus-mutation-443-investigation-handover.md` — marked RESOLVED 2026-06-24
- `python-courses-revamp-handover.md` — all phases shipped/closed
- `sync-plan-resolve-apply-handover.md` (#216) — **retired as obsolete**: all three phases shipped on the v2 sync engine, and the only remaining items (Phase-2 deferred follow-ups) target `sync_plan.py`/`sync_apply.py`/`sync_code`, which the sync-v3 cutover (#520) deleted. The archive carries an explicit retirement note; the design principles survive in `docs/claude/design/sync-plan-resolve-apply.md`.

The still-active `per-topic-solution-release-followups-handover.md` now links to the parent's archive instead of the deleted original. References inside other archives and the frozen `sync-engine-assessment-2` analysis are historical citations and were left untouched.

Docs-only change (agent-internal docs) — no changelog fragment, no info-topic impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoWVyA6ddJH8d9VG4FP1Yg