### PR TITLE
fix(slides): skip the DE/EN interleaving pass on language-split halves (#611)

### DIFF
--- a/changelog.d/611-normalize-split-halves.fixed.md
+++ b/changelog.d/611-normalize-split-halves.fixed.md
@@ -1,0 +1,6 @@
+- `clm slides normalize`: the `interleaving` operation (within-file DE/EN
+  adjacency reorder + `count_mismatch`/`similarity_failure` reviews) is now
+  skipped on language-split halves (`*.de.py` / `*.en.py`), matching the
+  validator's split-file exemption. Every split half used to produce a
+  guaranteed-noise `count_mismatch` review and exit 2, making
+  `normalize --dry-run` unusable as a drift gate on split decks (#611).

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1422,6 +1422,15 @@ workshop tag insertion, DE/EN interleaving, slide ID auto-generation, **cell spa
 (`cell_spacing`), **preamble-code wrapping** (`preamble_code`), and — since CLM
 {version} — **placeholder-start demotion** (`placeholder_start`).
 
+Since CLM {version} the `interleaving` operation (within-file DE/EN adjacency
+reorder plus the `count_mismatch`/`similarity_failure` review items) is
+**skipped on language-split halves** (`*.de.py` / `*.en.py`) — a
+single-language file can never satisfy a within-file DE/EN correspondence
+check, so every half produced a guaranteed `count_mismatch` review and exit 2
+(issue #611). The other operations still run; cross-half DE/EN parity is
+owned by `clm slides sync verify`. This makes `normalize --dry-run` usable as
+a scripted drift gate on split decks (exit 0 when clean).
+
 The `placeholder_start` operation (since CLM {version}) fixes a recurring
 workshop mis-tag (issue #233): a code cell tagged `start` whose entire body is
 a solution placeholder (`# Your solution here`, `pass`, `...`) followed by a

--- a/src/clm/slides/normalizer.py
+++ b/src/clm/slides/normalizer.py
@@ -34,6 +34,7 @@ from clm.core.topic_resolver import (
     find_slide_files_recursive,
     matches_for_binding,
 )
+from clm.infrastructure.utils.path_utils import split_lang_suffix
 from clm.notebooks.slide_parser import comment_token_for_path, parse_cell_header
 from clm.slides.pairing import build_slide_groups
 from clm.slides.raw_cells import RawCell as _RawCell
@@ -1025,7 +1026,13 @@ def normalize_file(
         all_changes.extend(_apply_workshop_tags(cells, file_str))
         all_changes.extend(_apply_workshop_symmetry(cells, file_str))
 
-    if "interleaving" in op_set:
+    # The interleaving pass judges within-file DE/EN correspondence (adjacency
+    # reorder + count/similarity review items). A language-split half
+    # (``*.de.py`` / ``*.en.py``) carries one language only, so every review it
+    # could emit is structural noise (a guaranteed ``count_mismatch`` per half,
+    # exit 2) — skipped on the same signal the validator's bilingual pairing
+    # checks use; cross-half parity is owned by ``clm slides sync`` (#611).
+    if "interleaving" in op_set and split_lang_suffix(path) is None:
         cells, interleave_changes, interleave_reviews = _apply_interleaving(
             cells,
             file_str,

--- a/tests/slides/test_normalizer.py
+++ b/tests/slides/test_normalizer.py
@@ -608,6 +608,35 @@ class TestInterleaving:
         assert result.review_items[0].issue == "count_mismatch"
         assert result.review_items[0].details["category"] == "markdown"
 
+    def test_split_half_emits_no_within_file_review(self, tmp_path):
+        # Issue #611: a language-split half carries one language only, so the
+        # within-file DE/EN interleaving reviews are structural noise (every
+        # half is a guaranteed count_mismatch). Skipped on the same signal
+        # the validator uses; cross-half parity is owned by sync verify.
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "# # Folie 1\n"
+            "\n"
+            '# %% [markdown] lang="de" tags=["subslide"]\n'
+            "# ## Details\n"
+        )
+        for name in ("slides_test.de.py", "slides_test.en.py"):
+            path = _write_slide(
+                tmp_path / name, text.replace('"de"', '"en"') if name.endswith(".en.py") else text
+            )
+            result = normalize_file(path, operations=["interleaving"], dry_run=True)
+            assert result.review_items == [], (name, result.review_items)
+            assert result.status == "clean"
+
+    def test_split_half_still_runs_other_operations(self, tmp_path):
+        # Only the DE/EN interleaving pass is exempt on split halves — the
+        # mechanical single-file passes must still run.
+        text = '# %% [markdown] lang="de" tags=["notes"]\n# Hinweis\n'
+        path = _write_slide(tmp_path / "slides_test.de.py", text)
+        result = normalize_file(path)
+        assert result.review_items == []
+        assert any(c.operation == "cell_spacing" for c in result.changes), result.changes
+
     def test_similarity_failure_produces_review_item(self, tmp_path):
         """Tag mismatch between paired cells produces a review item."""
         text = (


### PR DESCRIPTION
## Summary

Fixes #611: `clm slides normalize --dry-run` on a language-split deck emitted a within-file DE/EN `count_mismatch` review per half (comparing the file's own language against the naturally-absent other language) and exited 2. On a fully split course the check is 100% noise — it can never pass, drowns out real review items, and makes `normalize --dry-run` unusable as a scripted "no mechanical drift" gate.

## Fix

The `interleaving` operation (within-file DE/EN adjacency reorder plus the `count_mismatch`/`similarity_failure` review items) is now skipped when the file is a split half, detected via `split_lang_suffix` — the same signal the validator's bilingual pairing checks already use. All other operations (`cell_spacing`, `tag_migration`, `preamble_code`, …) still run on split halves. Cross-half DE/EN parity remains owned by `clm slides sync verify`, per the issue's "simply skipping is the cleaner contract" note.

Exit code is now 0 for a clean split topic.

## Testing

- New tests: a `.de.py`/`.en.py` half emits zero review items (`status == "clean"`) with `--dry-run`; other operations still fire on split halves.
- `tests/slides/test_normalizer.py`: 104 passed; ruff + mypy clean; fast suite green on the pre-push hook.

## Docs

- `clm info commands` documents the split-half exemption under `clm slides normalize`
- `changelog.d/611-normalize-split-halves.fixed.md`

Closes #611

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AoWVyA6ddJH8d9VG4FP1Yg
