### PR TITLE
fix(sync): frame cross-side tag divergences instead of silently banking them (#615)

### DIFF
--- a/changelog.d/615-sync-tag-parity.fixed.md
+++ b/changelog.d/615-sync-tag-parity.fixed.md
@@ -1,0 +1,17 @@
+- **Sync: a one-sided tag edit can no longer be silently banked by resolving
+  the body row it coincides with** (#615). Previously a tag change folded into
+  a `verify_translation` / `translate_edit` resolution (or a `verify_cold`
+  confirm) left the twins' tag sets diverged, with `sync report` silent while
+  `clm validate` kept warning. Tag parity is now a first-class diff aspect:
+  a one-sided tag move co-frames a mechanical `mirror_tags` row next to the
+  body row; a divergence with no attributable direction — both sides' tags
+  moved apart, or a divergence already banked in a ledger — frames a new
+  `conflict_tags` action (answer `de`/`en`; mirrors only the chosen side's
+  tag set onto the twin, bodies untouched); `confirm` on `verify_translation`
+  and `verify_cold` is rejected while the tag sets diverge; `apply` no longer
+  records a member that still carries an unresolved sibling item — deferred
+  record-only rows report the new `deferred` status (in the `--json` counts),
+  deferred file-mutating rows keep `applied` with a
+  "recording deferred" reason suffix; and
+  `clm slides sync verify` now surfaces cross-side tag-parity mismatches as a
+  warning (never failing the structural gate).

--- a/docs/claude/design/sync-tag-parity-conflicts.md
+++ b/docs/claude/design/sync-tag-parity-conflicts.md
@@ -153,6 +153,30 @@ Cases that keep their current behavior:
 - tags cross-side **equal** (even if off-base) → no tag row; whichever
   content/record row resolves the member records them.
 
+**Fork-time tag check.** `record_fork` is the one mechanical row that
+upgrades a member from one shared fingerprint to per-language fingerprints,
+so it is the one row that can *legitimize* cross-side divergent bytes —
+including a tag divergence — as a trusted baseline. (Its counterpart is
+safe: `record_unify` requires byte-equal content fingerprints, and tags are
+inside the fingerprint, so divergent tags land on `unify_choose_body`
+instead. The shared-path rows all enforce byte identity or copy whole
+cells.) Leaving this to the baseline-carried branch would work but has a
+conditional guarantee — "caught one report later" assumes a report pass
+happens, while the committed ledger advertises the divergence as verified in
+the meantime — and it destroys direction information the differ still has at
+fork time (the base entry holds the *shared* tag set, so a one-sided move is
+still attributable). Therefore `_check_tags` also runs on the fork-complete
+branch of `_classify_fork`, comparing each half's tags against the base
+shared tag set:
+
+- exactly one half's tags moved → co-emit mechanical `mirror_tags` alongside
+  `record_fork`. Two *mechanical* rows on one key have no decision-keying
+  collision (that problem only exists for two framed rows); both land in the
+  same pass and a tag-consistent state is banked immediately.
+- both halves moved differently → co-emit framed `conflict_tags`; F2's
+  unresolved-key guard then defers `record_fork`'s `_upsert` automatically,
+  so the divergent state is never banked and the member re-frames next pass.
+
 ### F2 — apply/recording: never bless a member with unresolved rows
 
 1. **Unresolved-key guard** (fixes S3, required for F1's co-emission): in
@@ -235,11 +259,14 @@ Attacks run against the design, and their resolutions:
   `item.member`/`item.twin`, so a guard in `_apply_choice_decision` observes
   the same-pass tag mirror. One-pass resolution works when the agent confirms
   alongside the mechanical mirror.
-- **"`record_fork` banks divergent tags."** True: a completed fork whose
-  halves carry different tags records as-is. *Mitigated, not prevented*: the
-  next report's baseline-carried branch frames it as `conflict_tags` — caught
-  one pass later, never silent-forever. Tightening `record_fork` itself is
-  possible follow-up, not required for the invariant.
+- **"`record_fork` banks divergent tags."** Initially accepted as residue
+  ("the baseline-carried branch catches it one report later"), then
+  *promoted into F1 scope* on a second look: the one-pass-later guarantee is
+  conditional on a report pass actually happening while the committed ledger
+  advertises the divergence as verified, the banking destroys the direction
+  attribution the differ still has at fork time, and closing the hole rides
+  entirely on machinery F1/F2 already build (see F1's fork-time tag check —
+  a few lines in `_classify_fork` plus two tests). *Closed.*
 - **"The verify_cold guard breaks legacy onboarding."** Confirming a cold
   member with committed tag asymmetry now rejects, and in a positional pool
   the pool-coherence rule leaves the whole pool unrecorded. *Intended*:
@@ -292,5 +319,12 @@ Attacks run against the design, and their resolutions:
    unchanged (old baseline), next report frames a clean `verify_translation`.
 7. **Verify**: tag-parity warning surfaces on a mismatched pair; exit code
    unchanged; `structural_gate` (error subset) unaffected.
-8. **Matrix/property tests**: extend the §7.4 walk with the tag axis; adjust
-   the per-mutation item ceiling.
+8. **Fork, one-sided tag move**: complete fork where one half changed its
+   tags off the shared base → `mirror_tags` + `record_fork` co-emit; one
+   apply pass lands both; the banked entry has matching per-side tags.
+9. **Fork, divergent tag moves**: complete fork where both halves changed
+   tags differently → `conflict_tags` (framed) + `record_fork`; with the
+   conflict unanswered, the ledger entry is unchanged (nothing banked); after
+   answering `de`/`en`, the next pass records a tag-consistent fork.
+10. **Matrix/property tests**: extend the §7.4 walk with the tag axis; adjust
+    the per-mutation item ceiling.

--- a/docs/claude/design/sync-tag-parity-conflicts.md
+++ b/docs/claude/design/sync-tag-parity-conflicts.md
@@ -1,0 +1,296 @@
+# Sync v3: Tag Parity as a First-Class Diff Aspect (Issue #615)
+
+**Status**: designed, not yet implemented.
+**Issue**: [#615](https://github.com/hoelzl/clm/issues/615) — `confirm` on a
+`verify_translation` item banks a one-sided tag edit; `report` goes silent
+while `validate` flags the pair.
+
+## 1. The bug, restated in engine terms
+
+A localized member whose DE **and** EN bodies drifted off the ledger baseline
+is framed as one `conflict/verify_translation` item. When the DE side *also*
+carries a one-sided tag edit (`notes` → `voiceover`), that tag delta is folded
+into the same item. `confirm` is "a pure ledger record; nothing mutates"
+(`doc_apply._apply_choice_decision`), so the apply pass re-records the member
+from a fresh snapshot of the **current** deck — including the cross-side tag
+divergence (`de_tags=["voiceover"]`, `en_tags=["notes"]`). From then on:
+
+- `sync report` is empty: `_classify_localized` compares each side only
+  against **its own** recorded fingerprint; both are at base → `in_sync`.
+- `sync verify` passes: its check set is unify + slide_id set symmetry +
+  `(slide_id, role)` uniqueness (`sync_verify.structural_violations`); tag
+  parity is not in it, and localized cells are exempt from unify's
+  byte-identity oracle by design.
+- `clm validate` warns via `_check_split_tag_parity` (positional pairing of
+  all non-j2 cells) — and its suggestion ("run `clm slides sync`") loops,
+  because sync no longer frames anything.
+
+## 2. Root cause
+
+**Cross-side tag parity is a *pair* invariant, but the v3 differ evaluates
+localized members side-against-own-baseline only.** The invariant "tags are
+language-independent and mirror across the twins" (§3.1; enforced by
+`validator._check_split_tag_parity`) is checked by the differ only
+*incidentally*, in the narrow states where the tag delta happens to be
+isolated:
+
+- `_classify_shared` emits `mirror_tags` only when the cross-side **bodies are
+  byte-equal** (`sync_diff.py:1047`);
+- `_classify_localized` reaches `_tags_only_change` only when **both bodies
+  are at their per-side baselines** (`sync_diff.py:1367-1369`).
+
+The moment a tag delta coincides with body drift, four independent gaps line
+up (defense-in-depth failure):
+
+1. **Classification gap** — the tag aspect is silently subsumed by the
+   body-centric row (`verify_translation` / `translate_edit`). No row
+   addresses it; no vocabulary can answer it. Note the design already treats
+   *layout* and *owner* as orthogonal aspects emitted as separate rows for the
+   same handle (`_check_layout` / `_check_owner`); tags never got that
+   treatment.
+2. **Recording gap** — resolving the body row (`confirm`, a `body` answer,
+   `keep_twin`) records the member's **entire** fresh snapshot as trusted
+   (`_record_item` → `_upsert` → `snapshot_deck`), tag divergence included.
+   `confirm` has no invariant gate.
+3. **Differ invariant-blindness** — a baseline that *itself* carries a
+   cross-side tag divergence classifies as `in_sync`. Contrast: for **shared**
+   members a base-carried *body* divergence gets a standing
+   `pending_divergence` row; localized members have no analogous row for the
+   one cross-side invariant they do have (tags).
+4. **Verify gap** — `sync verify` / `structural_gate` never check tag parity,
+   so the deterministic safety net that is supposed to catch what apply gets
+   wrong is blind to exactly this corruption class.
+
+The reproduction's "contrast" case (tag edit with bodies at base →
+`mirror_tags`, mirrors cleanly) confirms the doctrine is right and only the
+coverage is partial.
+
+## 3. Latent sibling bugs found during analysis
+
+These share the root cause and should be fixed by the same change (or at
+minimum tracked):
+
+- **S1 — `translate_edit` banks the same divergence.** DE body **and** tags
+  edited, EN untouched → single `translate_edit` row. The `body` answer writes
+  only the twin's body (`_apply_body_decision`, `_replace_body` keeps the
+  twin's header); recording then banks `de_tags≠en_tags`. Same silent end
+  state as #615 via a different path. Ditto `keep_twin`.
+- **S2 — tag conflict on a localized member is answered by whole-cell
+  propagate.** `_tags_only_change` emits `conflict_shared` when both tag sets
+  moved differently (`sync_diff.py:1388-1396`). The `de`/`en` answer for
+  `conflict_shared` executes `ex.propagate` — a **verbatim whole-cell copy** —
+  which would overwrite the twin's *translated body* with the other language.
+  (The `body` answer is equally wrong: it writes one shared body onto both
+  sides of a localized pair.)
+- **S3 — landing a mechanical aspect row blesses unverified siblings.** A
+  landed `mirror_layout` / `mirror_owner` / (post-fix) `mirror_tags` on a
+  member whose framed body row is still pending records the member's fresh
+  snapshot wholesale — including the unverified drifted bodies. The "never
+  bless the unresolved" doctrine exists only for positional pools
+  (`_drop_unresolved_from_pools`); id-keyed members have no equivalent.
+- **S4 — `verify_cold` confirm banks divergent tags.** A cold two-sided member
+  with mismatched tags can be confirmed, producing the same
+  report-silent/validate-flagged end state (with no baseline to attribute a
+  direction, so nothing ever re-frames it — until fix F1's baseline-carried
+  row, which needs recorded tags and therefore does not cover entries whose
+  tag fields predate recording).
+
+## 4. Design
+
+Four fixes, one per gap. F1 is the core; F2–F4 are the safety nets whose
+absence let F1's gap escalate to silent corruption.
+
+### F1 — differ: split the tag aspect out as an orthogonal row
+
+Add a `_check_tags(member, group, entry, handle)` aspect check in
+`_classify_matched`, following the `_check_layout`/`_check_owner` pattern, for
+matched **two-sided** members on the localized path (base-localized members
+and headers; shared members are already covered — any cross-side byte
+difference, tags included, keeps them in `pending_divergence` /
+`conflict_shared`, and every shared resolution copies whole cells). Per-side
+"tags moved" means `base tags is None or current ≠ base` (a `None` base —
+e.g. the just-landed variant of the `verify_translation` "landed" branch —
+counts as moved, never as trusted).
+
+Decision table, evaluated only when the **current cross-side tag sets
+differ**:
+
+| state | row | rationale |
+|---|---|---|
+| exactly one side's tags moved off base | `mirror_tags` (mechanical, existing action + executor) | doctrine: tags mirror; direction is attributable; executor works regardless of body drift |
+| both sides' tags moved, differently | **new framed action `conflict_tags`**, choices `("de", "en")` | no safe source side — P8 |
+| neither side moved (the baseline itself carries the divergence) | `conflict_tags` | the post-#615-damage state and any historical banked divergence; no direction inferable |
+
+`conflict_tags` execution: `ex.mirror_tags(item_with_side(item, choice),
+choice)` — mirrors **only the tag set** from the chosen side. This replaces
+`_tags_only_change`'s `conflict_shared` emission for localized members,
+fixing S2 (`conflict_shared`'s propagate/body answers are body-destroying for
+localized pairs).
+
+The body rows become tag-agnostic; `verify_translation`'s `confirm` keeps its
+meaning ("the bodies are a faithful pair").
+
+**Co-emission rule.** A mechanical `mirror_tags` may co-emit with a framed
+body row under the same key (mechanical rows never consult the decision
+document — no keying conflict; this is exactly how layout/owner rows coexist
+today). But decision documents are keyed by member handle alone, so **two
+framed rows on one key cannot both be answered** (a pre-existing wart —
+`conflict_owner` + `verify_translation` already collide). Therefore: when
+`_check_tags` produces a *framed* `conflict_tags` and the content
+classification would also produce a framed row, emit **only `conflict_tags`
+this pass** and suppress the body row. The report stays non-silent
+(`needs_agent`, non-empty counts), and the body row re-frames on the next
+report once tags are reconciled. Sequencing over parallelism; converges in
+two passes. (Follow-up option, out of scope: an optional `action` field on
+decision rows to disambiguate same-key framed items, which would remove the
+sequencing.)
+
+Cases that keep their current behavior:
+
+- bodies at base, one-sided tag move → `mirror_tags` (the issue's "contrast"
+  case);
+- bodies at base, both moved identically → `record_tags`;
+- tags cross-side **equal** (even if off-base) → no tag row; whichever
+  content/record row resolves the member records them.
+
+### F2 — apply/recording: never bless a member with unresolved rows
+
+1. **Unresolved-key guard** (fixes S3, required for F1's co-emission): in
+   `apply_deck`, compute `unresolved_keys = {i.key for i in unresolved_items}`
+   and skip the `_upsert` for any landed item whose key is in it. The file
+   mutation still lands; the ledger entry stays at its old baseline and the
+   member re-frames next report (e.g. post-`mirror_tags`: the mirrored twin's
+   fingerprint is off base → a clean `verify_translation`, tags now in
+   parity). Report such items with an honest status/reason ("applied
+   (recording deferred: unresolved sibling item)") rather than "recorded".
+   This extends the pool doctrine ("never bless the unresolved",
+   `_drop_unresolved_from_pools`) to id-keyed members.
+2. **`conflict_tags` records nothing** in `_record_item` (like frozen pools):
+   its resolution mutates a header line; the member re-frames and records on
+   the next pass. This avoids blessing bodies that were suppressed by the
+   co-emission rule (they are not in `unresolved_items`, so guard 1 cannot see
+   them).
+3. **Confirm guard** (belt-and-braces; fixes S4 and any future classification
+   gap): `confirm` — on `verify_translation` *and* `verify_cold` — refuses
+   when the member's current DE/EN tag sets differ, with a reason ("tag sets
+   diverge cross-side (de: [...], en: [...]) — tags are language-independent;
+   answer the tag item / align the tag lines, then re-report"). Safe in-pass:
+   `set_side` mutates `Member` in place, so a same-pass `mirror_tags`
+   (emitted before the body row, executed earlier in the ordered loop) is
+   visible to the guard, and a `confirm` answered in the same document still
+   lands in one pass.
+
+### F3 — verify: add a `tag-parity` check
+
+Add a tag-parity violation kind to `sync_verify.structural_violations`
+(pairing by `(slide_id, role)` for id'd cells, positionally for the id-less
+remainder — mirroring the validator's approach), at **warning** severity:
+
+- `validate`'s finding is itself a warning; verify then *agrees* with validate
+  (the issue's third expectation) instead of passing silently.
+- Error severity would (a) hard-fail CI for pre-existing committed
+  asymmetries, and (b) flow into `structural_gate`'s error subset, making the
+  per-slide/whole-deck **write gate** refuse to record a pair the apply pass
+  is in the middle of reconciling (chicken-and-egg with F1's own tag rows).
+  Verify's contract is "structural safety"; a tag mismatch does not corrupt
+  pairing or unification. Warning severity surfaces it without repurposing
+  the gate.
+
+### F4 — docs
+
+- `src/clm/cli/info_topics/sync-agents.md`: the new `conflict_tags` action and
+  vocabulary, the confirm tag guard, the two-pass sequencing behavior.
+- `src/clm/cli/info_topics/commands.md`: verify's new warning kind.
+- Changelog fragment `changelog.d/615-sync-tag-parity.fixed.md`.
+
+### Migration
+
+None needed. Decks already carrying a banked divergence (the #615 end state)
+re-frame automatically: baseline-carried divergence → `conflict_tags` on the
+next report. Ledger entries whose recorded tag fields are `None` (older
+`hash_version` states) classify per the `None`-means-moved rule and land on
+`conflict_tags` rather than a silently-mechanical mirror.
+
+## 5. Adversarial analysis
+
+Attacks run against the design, and their resolutions:
+
+- **"Sequencing hides the body conflict."** When `conflict_tags` suppresses a
+  framed body row, one agent pass cannot resolve everything. *Held, but
+  bounded*: the report is never silent, `needs_agent` is set, convergence is
+  exactly two passes, and the alternative (same-key decision disambiguation)
+  is a bigger schema change noted as follow-up. Correctness over latency.
+- **"The unresolved-key guard causes re-frame loops."** E.g. `mirror_layout`
+  landed + `translate_edit` pending → the layout re-records as
+  `record_relayout` every pass until the body is answered. *Accepted*:
+  record-only rows are idempotent, no file churn, and the loop ends with the
+  framed answer. The alternative — blessing drifted bodies (status quo, S3) —
+  is strictly worse.
+- **"Is auto-executing `mirror_tags` safe mid-body-drift?"** Yes: the twin's
+  tag set is at base (one-sided case), so no information is lost; the moved
+  side's tag set is doctrine-correct on both sides. Both-moved is framed. The
+  executor (`ex.mirror_tags`) touches only the header tag attribute.
+- **"Same-pass confirm reads stale state."** Checked: `DeckEmitter.set_side`
+  mutates the (non-frozen) `Member` in place and `_holder` resolves through
+  `item.member`/`item.twin`, so a guard in `_apply_choice_decision` observes
+  the same-pass tag mirror. One-pass resolution works when the agent confirms
+  alongside the mechanical mirror.
+- **"`record_fork` banks divergent tags."** True: a completed fork whose
+  halves carry different tags records as-is. *Mitigated, not prevented*: the
+  next report's baseline-carried branch frames it as `conflict_tags` — caught
+  one pass later, never silent-forever. Tightening `record_fork` itself is
+  possible follow-up, not required for the invariant.
+- **"The verify_cold guard breaks legacy onboarding."** Confirming a cold
+  member with committed tag asymmetry now rejects, and in a positional pool
+  the pool-coherence rule leaves the whole pool unrecorded. *Intended*:
+  validate flags those pairs anyway; blessing them would recreate #615's
+  silent state with no baseline to ever re-frame it. The rejection reason
+  tells the agent the one-line fix. Must be documented in `sync-agents.md`.
+- **"Warning-severity verify still 'passes'."** Exit code unchanged, yes — but
+  the mismatch is *surfaced* in verify output, validate remains the policy
+  authority, and F1/F2 ensure sync itself never again manufactures or
+  strands the state. Error severity was rejected for the gate/CI reasons in
+  F3.
+- **"Fix confirm only (make it mirror tags) instead of the differ?"**
+  Rejected: it leaves S1 (`translate_edit`/`keep_twin` bank the divergence),
+  leaves banked divergences invisible to report (still needs the differ row),
+  and breaks the load-bearing "confirm is a pure ledger record" simplicity.
+  The differ is where the engine's contract ("anything that fits no row must
+  become a framed decision carrying the member's full state — never a silent
+  default", P8) says this belongs.
+- **"Closed-registry costs."** `conflict_tags` must be added to
+  `FRAMED_ACTIONS`, `_DECISION_VOCABULARY`, the §7.4 matrix expectations, and
+  info topics. The hypothesis noise-floor property ("any single one-sided
+  mutation … hard per-mutation item ceiling") may need its ceiling revisited:
+  a one-sided tag+body edit now yields two rows where it yielded one. Known,
+  budgeted.
+- **"Scope holes."** One-sided members: no cross-side pair to check — their
+  add/remove/transition rows already force resolution to a two-sided state,
+  which is then checked. Shared members: covered by byte-identity rows.
+  J2/preamble scopes: carry no tags. Validator remains the backstop for
+  anything the member model cannot pair.
+
+## 6. Test plan
+
+1. **#615 end-to-end repro**: localized member, both bodies off base, DE tags
+   `notes→voiceover` → report frames `mirror_tags` + `verify_translation`;
+   `apply --decisions '[{key, confirm}]'` mirrors EN tags, banks bodies;
+   fresh report clean; `validate` clean.
+2. **Confirm guard**: divergent tags + confirm with no tag row landed →
+   `rejected` with the alignment reason (both `verify_translation` and
+   `verify_cold`).
+3. **Baseline-carried divergence** (the damaged-deck state): ledger with
+   `de_tags≠en_tags`, everything else at base → `conflict_tags`; answer
+   `de` → EN tag line mirrored, nothing recorded; next report → mechanical
+   record → clean.
+4. **Both-moved-differently tags** on a localized member → `conflict_tags`
+   (not `conflict_shared`); answering `de`/`en` must not touch bodies (S2
+   regression test).
+5. **S1**: DE body+tags edited → `mirror_tags` + `translate_edit`; body
+   answer lands on a twin whose header already carries the mirrored tags.
+6. **S3 guard**: `mirror_tags` landed, body row pending → ledger entry
+   unchanged (old baseline), next report frames a clean `verify_translation`.
+7. **Verify**: tag-parity warning surfaces on a mismatched pair; exit code
+   unchanged; `structural_gate` (error subset) unaffected.
+8. **Matrix/property tests**: extend the §7.4 walk with the tag axis; adjust
+   the per-mutation item ceiling.

--- a/docs/claude/design/sync-tag-parity-conflicts.md
+++ b/docs/claude/design/sync-tag-parity-conflicts.md
@@ -1,6 +1,8 @@
 # Sync v3: Tag Parity as a First-Class Diff Aspect (Issue #615)
 
-**Status**: designed, not yet implemented.
+**Status**: implemented (branch `claude/issue-615-tag-parity-design`). A
+post-implementation adversarial multi-agent review confirmed 11 findings, all
+closed — see "Post-implementation review" in §5.
 **Issue**: [#615](https://github.com/hoelzl/clm/issues/615) — `confirm` on a
 `verify_translation` item banks a one-sided tag edit; `report` goes silent
 while `validate` flags the pair.
@@ -110,7 +112,14 @@ difference, tags included, keeps them in `pending_divergence` /
 `conflict_shared`, and every shared resolution copies whole cells). Per-side
 "tags moved" means `base tags is None or current ≠ base` (a `None` base —
 e.g. the just-landed variant of the `verify_translation` "landed" branch —
-counts as moved, never as trusted).
+counts as moved, never as trusted). A `None` base counts as *moved* but is
+**never a mechanical mirror source**: when either side's recorded tag base is
+`None` and the cross-side sets differ, the "unmoved" side's only evidence
+would be the missing field itself, so the row frames `conflict_tags`
+(direction `none`, detail "cross-side tag divergence with an incomplete
+recorded tag baseline …") rather than mirroring — a never-recorded side must
+not silently wipe the recorded side's audience-routing tags
+(`notes`/`voiceover`).
 
 Decision table, evaluated only when the **current cross-side tag sets
 differ**:
@@ -176,6 +185,11 @@ shared tag set:
 - both halves moved differently → co-emit framed `conflict_tags`; F2's
   unresolved-key guard then defers `record_fork`'s `_upsert` automatically,
   so the divergent state is never banked and the member re-frames next pass.
+  This holds even when the `conflict_tags` is **answered in the same pass**:
+  an answered `conflict_tags` records nothing and marks its key unresolved
+  for recording purposes (F2), so the co-landed `record_fork` reports
+  `deferred` and the tag-consistent fork is banked on the **next** pass, not
+  the same one.
 
 ### F2 — apply/recording: never bless a member with unresolved rows
 
@@ -206,9 +220,16 @@ shared tag set:
 
 ### F3 — verify: add a `tag-parity` check
 
-Add a tag-parity violation kind to `sync_verify.structural_violations`
-(pairing by `(slide_id, role)` for id'd cells, positionally for the id-less
-remainder — mirroring the validator's approach), at **warning** severity:
+Add a tag-parity violation kind to `sync_verify.structural_violations`, with
+a **three-tier** pairing scheme (as shipped in
+`sync_verify.tag_parity_violations`): (1) id'd cells pair by
+`(slide_id, role)`, the engine's keying unit; (2) role-key orphans fall back
+to **per-`slide_id` positional** pairing — load-bearing, because the
+`notes`→`voiceover` edit *changes the derived role*, so a two-tier scheme
+would pair neither side and miss exactly the flagship #615 case; (3) the
+id-less remainder pairs positionally across the halves. A tier whose
+positional stream lengths differ is skipped silently (that is a structural
+asymmetry, not tag parity). Severity is **warning**:
 
 - `validate`'s finding is itself a warning; verify then *agrees* with validate
   (the issue's third expectation) instead of passing silently.
@@ -297,6 +318,48 @@ Attacks run against the design, and their resolutions:
   J2/preamble scopes: carry no tags. Validator remains the backstop for
   anything the member model cannot pair.
 
+### Post-implementation review
+
+An adversarial multi-agent review of the shipped implementation confirmed 11
+findings (5 code defects, the rest documentation); all are closed. The code
+findings, and how they resolved:
+
+1. **`None` baseline as mirror source** (`_check_tags`): a `None` recorded
+   tag base counted as MOVED, which made the *other* side look like a trusted
+   mirror source — mirroring from a never-recorded side would wipe recorded
+   audience-routing tags. Now, when either side's base tags are `None` and
+   the cross-side sets differ, the row frames `conflict_tags` (direction
+   `none`, "incomplete recorded tag baseline — no trusted mirror source").
+2. **Framed `conflict_tags` vs layout/owner rows** (`_classify_matched`):
+   the suppression rule originally spared the layout/owner aspect checks —
+   but a framed `conflict_owner` shares `conflict_tags`' exact `de`/`en`
+   vocabulary on the same handle, so one decision would silently execute
+   *both* mirrors. `_check_tags` now runs first, and a framed
+   `conflict_tags` suppresses the layout/owner checks too; they re-frame
+   next pass.
+3. **Pool residue mis-framing** (`_classify_pool_slot_localized`): the pass
+   after a `conflict_tags` answer leaves a pool slot with cross-side sets
+   EQUAL but a tag tuple off its recorded base — bodies at base. Without the
+   pool twin of `_tags_only_change`, that state mis-framed as
+   `translate_edit` and could never converge mechanically. A new
+   bodies-at-base residue branch emits `mirror_tags` (one mover) or
+   `record_tags` (identical both-sided move).
+4. **Answered `conflict_tags` did not defer same-key recordings**
+   (`apply_deck`): a co-landed same-key row (`conflict_owner`,
+   `record_fork`) would `_upsert` the fresh snapshot and bank the body drift
+   the suppression rule had hidden. An ANSWERED `conflict_tags` key now joins
+   `unresolved_keys` for the recording loop; its member/twin also feed
+   `_drop_unresolved_from_pools`, and `_sweep_migrated_pos` skips deferred
+   keys (a landed `stamp_twin_id` with a pending framed sibling keeps its
+   `pos:` baseline). Consequence: a divergent-tags fork banks on the next
+   pass (`record_fork` reports `deferred`), not the same pass.
+5. **Honest deferral statuses** (`ItemResult`/`ApplyOutcome`): a deferred
+   record-only row now reports a new status `deferred` (in the `--json`
+   counts enumeration) instead of a false `recorded`; a file-mutating
+   deferred row keeps `applied` with the reason suffix
+   "(recording deferred: unresolved sibling item on this member)". A landed
+   `conflict_tags` row itself gets no suffix — it records nothing by design.
+
 ## 6. Test plan
 
 1. **#615 end-to-end repro**: localized member, both bodies off base, DE tags
@@ -324,7 +387,9 @@ Attacks run against the design, and their resolutions:
    apply pass lands both; the banked entry has matching per-side tags.
 9. **Fork, divergent tag moves**: complete fork where both halves changed
    tags differently → `conflict_tags` (framed) + `record_fork`; with the
-   conflict unanswered, the ledger entry is unchanged (nothing banked); after
-   answering `de`/`en`, the next pass records a tag-consistent fork.
+   conflict unanswered, the ledger entry is unchanged (nothing banked);
+   answering `de`/`en` mirrors the tag line but still defers the co-landed
+   `record_fork` (status `deferred`, nothing banked that pass) — the **next**
+   pass records a tag-consistent fork.
 10. **Matrix/property tests**: extend the §7.4 walk with the tag axis; adjust
     the per-mutation item ceiling.

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1955,7 +1955,11 @@ propagation. **Framed actions** (need a decision): `translate_edit`,
 `translate_new`, `verify_translation`, `conflict_shared`,
 `pending_divergence`, `remove_vs_edit`, `unify_choose_body`, `order_decision`,
 `stamp_vs_new` (a suspected id-stamp of a vanished positional cell — answer
-`treat_as_new` to grow the twin / mirror the removal),
+`treat_as_new` to grow the twin / mirror the removal), `conflict_tags` (the
+twins' tag sets diverged with no attributable direction — answer `de`/`en` to
+mirror **only that side's tag set** onto the twin, bodies untouched; while it
+is framed it suppresses the member's other rows — body, layout, and owner —
+which re-frame on the next report once the tags are reconciled),
 `ambiguous_alignment`, `verify_cold`, and friends. Every JSON item carries an
 `answers` list — the decision shapes `apply --decisions` accepts for it, `[]`
 on mechanical items (nothing to answer) — plus the full current cell bytes
@@ -1986,14 +1990,22 @@ Each answer is validated individually — a body smuggling a cell delimiter, a
 wrong choice, a `side` where it is meaningless, or a stale handle is rejected
 with a reason while the valid answers still land. The mutated bundle is
 re-parsed before anything touches disk and written atomically (≤4 files);
-every landed item is recorded into the ledger, **gated on the structural
-verify** (a pair failing verify keeps its file writes — review with
-`git diff` — but records nothing). `--member KEY` limits the pass to the named
+landed items are recorded into the ledger **on fully resolved members only**,
+**gated on the structural verify** (a pair failing verify keeps its file
+writes — review with `git diff` — but records nothing). A landed row on a
+member that still carries an unresolved sibling item — or an answered
+`conflict_tags`, which records nothing and defers the same-key recordings so
+suppressed body drift is never banked (a divergent-tags fork therefore banks
+on the *next* pass) — keeps its file mutation but defers its ledger write:
+record-only rows report status `deferred`, file-mutating rows stay `applied`
+with the reason suffix `(recording deferred: unresolved sibling item on this
+member)`. `--member KEY` limits the pass to the named
 handles; `--dry-run` executes and validates everything, writes nothing. Exit
 `0` all-applied / `1` residue / `2` error. Needs no API key; single deck only
 (run `report` over a directory to find work). The `--json` result carries
-`counts` (`applied` / `recorded` / `pending` / `rejected` / `failed` /
-`skipped`), per-item `items[].status` + `reason`, `ledger_recorded`, and
+`counts` (`applied` / `recorded` / `deferred` / `pending` / `rejected` /
+`failed` / `skipped`), per-item `items[].status` + `reason`,
+`ledger_recorded`, and
 `verify_violations`; rejected decisions are additionally echoed to stderr in
 both output modes. Full envelope example: `clm info sync-agents`.
 
@@ -2008,7 +2020,9 @@ nothing**. Confirms the pair is a valid split: it unifies back into one
 bilingual source (byte-identical shared cells, matching header, clean
 alignment), the `de_id == en_id` symmetry holds, and no `(slide_id, role)`
 key is duplicated within a half; warns (never fails) on an id'd cell dropped
-vs git `HEAD`. Exit `0` = structurally sound, `2` = corrupt. Answers *"did
+vs git `HEAD` and on a cross-side tag-parity mismatch (twin cells whose tag
+sets differ — tags are language-independent, and `report` frames the fix as a
+tag row). Exit `0` = structurally sound, `2` = corrupt. Answers *"did
 this edit corrupt the pair?"*, not *"is it in sync?"* — run it in CI freely.
 The same checks gate every ledger write (`record`, and `apply`'s ledger
 updates), so a corrupt pair can never be recorded as trusted.

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -73,6 +73,9 @@ the target-language body — or answer `translate_edit` with `keep_twin` when
 your edit did not change what the twin should say), `verify_translation` (both
 sides moved — confirm or supply a body), `conflict_shared` / `remove_vs_edit`
 / `unify_choose_body` / `order_decision` / `conflict_preamble` (choose a side),
+`conflict_tags` (the twins' tag sets diverged with no attributable direction —
+answer `de` or `en`; mirrors **only the chosen side's tag set** onto the twin,
+bodies untouched — see "Tag parity" below),
 `verify_cold` (confirm the member is in sync — or, on an **id-keyed** member,
 supply a `body` + `side` to overwrite a stale twin in the same pass),
 `stamp_vs_new` (a new id'd cell appeared while a positional cell of the same
@@ -82,6 +85,49 @@ is new; see "Replacing a positional cell" below), `ambiguous_alignment`
 content into one pool; carries **no** answers: reconcile by editing, minting
 ids, then re-report), and the normalize-refusal deck item (run
 `clm slides normalize`, then re-report).
+
+## Tag parity (tags are language-independent)
+
+Cell tags mirror across the twins — a tag set is never per-language. The
+differ checks this as its own aspect, orthogonal to the body rows (the same
+way layout and owner changes get their own rows):
+
+- **One side's tags moved off base** → mechanical `mirror_tags`, even when
+  the bodies drifted too: a one-sided tag edit that coincides with body drift
+  co-frames a `mirror_tags` row *next to* the framed body row on the same
+  key. `apply` mirrors the tag set; you answer the body row as usual.
+- **Both sides' tags moved apart, or the ledger itself carries a cross-side
+  tag divergence** (e.g. banked by a pre-fix confirm) → framed
+  `conflict_tags`. Answer `de` or `en`; the chosen side's **tag set only** is
+  mirrored onto the twin — bodies are untouched.
+- **Sequencing**: a framed `conflict_tags` suppresses **every other row** on
+  that member for the pass — the framed body row *and* the layout/owner rows
+  alike (two framed rows on one key cannot both be answered, and a framed
+  `conflict_owner` shares `conflict_tags`' exact `de`/`en` vocabulary — one
+  decision would silently execute both mirrors). The report shows the tag
+  conflict first. Answer it, then **re-run `report`** — the suppressed rows
+  re-frame once the tags are reconciled. Convergence is two passes, and the
+  report is never silent in between.
+- **Recording deferral**: a landed `conflict_tags` records **nothing** by
+  design (its resolution mutates one tag line; the member re-frames and
+  records on the next pass) — and it also defers the ledger recording of
+  every *other* row that landed on the same key in that pass, so the
+  suppressed body drift is never banked alongside it. A deferred
+  **record-only** row reports status `deferred` (nothing was banked; it
+  re-frames next report); a deferred **file-mutating** row keeps status
+  `applied` with the reason suffix
+  `(recording deferred: unresolved sibling item on this member)` — the file
+  write stays, the ledger baseline does not move. Consequence: answering a
+  divergent-tags *fork*'s `conflict_tags` lands the tag mirror immediately,
+  but the co-emitted `record_fork` reports `deferred` and the fork banks on
+  the **next** pass.
+- **Confirm guard**: `confirm` — on `verify_translation` *and* `verify_cold`
+  — and `keep_twin` on `translate_edit` are **rejected while the member's
+  current DE/EN tag sets differ**; the rejection reason names both tag sets.
+  Answer the tag item (or align the tag lines by hand), then re-report. A
+  `confirm`/`keep_twin` answered in the same document as a co-framed
+  mechanical `mirror_tags` still lands in one pass — the mirror executes
+  first and the guard sees the reconciled state.
 
 ## The decision document
 
@@ -120,6 +166,8 @@ One JSON document answers any subset of framed items:
   `keep_twin`). For a `translate_edit` whose edit left the twin a faithful
   rendering, `{"key": …, "choice": "keep_twin"}` records the new baseline and
   keeps the existing twin verbatim — no need to re-supply an unchanged body.
+  On a `conflict_tags` item, `de`/`en` names the side whose **tag set** wins —
+  only the tag line is mirrored; bodies stay untouched.
 - `side` — `"de"` or `"en"`, **only** alongside a `body` on a two-sided
   `verify_cold` item: it names the stale twin to overwrite. `{"key":
   "id:intro", "body": "# frische Übersetzung", "side": "de"}` replaces the DE
@@ -134,10 +182,15 @@ clm slides sync apply DECK --decisions - --json < decisions.json
 ```
 
 `--member KEY` restricts a pass to named handles; `--dry-run` validates
-everything and writes nothing. Every landed item is recorded into the ledger,
-**gated on the structural verify** — file writes from a pass that ends
-structurally corrupt stay on disk for review, but nothing is recorded as
-trusted.
+everything and writes nothing. Landed items are recorded into the ledger
+**on fully resolved members only**, and the recording is **gated on the
+structural verify** — file writes from a pass that ends structurally corrupt
+stay on disk for review, but nothing is recorded as trusted. A landed row on
+a member that still carries an unresolved sibling item (pending, rejected,
+failed — or an answered `conflict_tags`, which re-frames by design) keeps its
+file mutation, but its ledger recording is **deferred**: the entry stays at
+its old baseline and the member re-frames on the next report (see "Tag
+parity" for the statuses this produces).
 
 ### Reading the apply result (`--json`)
 
@@ -150,7 +203,7 @@ they do not exist):
   "dry_run": false,
   "error": null,
   "wrote": true, "written": ["…/slides_x.en.py"],
-  "counts": {"applied": 4, "recorded": 2, "pending": 1,
+  "counts": {"applied": 4, "recorded": 2, "deferred": 0, "pending": 1,
              "rejected": 1, "failed": 0, "skipped": 0},
   "items": [
     {"key": "id:intro", "action": "translate_edit",
@@ -165,9 +218,13 @@ they do not exist):
 
 **Always check `counts.rejected` (and each rejected item's `reason`) before
 moving on** — rejections are also echoed to stderr. `pending` = framed items
-you did not answer (exit 1, not an error). `ledger_recorded: false` with
-`verify_violations` means writes landed but nothing was trusted — fix the
-pair, then `record`.
+you did not answer (exit 1, not an error). `deferred` = a record-only row
+whose ledger write was deferred because the member still carries an
+unresolved sibling item — nothing was banked; it re-frames on the next
+report. (A *file-mutating* row in the same situation stays `applied`, with
+the reason suffix `(recording deferred: unresolved sibling item on this
+member)`.) `ledger_recorded: false` with `verify_violations` means writes
+landed but nothing was trusted — fix the pair, then `record`.
 
 ## Cold members and `record`
 
@@ -179,10 +236,13 @@ never recorded. Two ways to converge:
 - **Per item**: answer `{"key": …, "choice": "confirm"}` in a decision
   document after you have checked the pair is genuinely in sync. `confirm`
   banks **both sides as-is** — it makes no freshness guarantee, so read both
-  bodies first. If the twin is **stale** (e.g. the source was edited while the
-  ledger was cold), do not `confirm`: on an **id-keyed** member, answer with a
-  `body` + `side` naming the stale twin (`{"key": "id:x", "body": "…", "side":
-  "de"}`) to overwrite it in the same pass. A *positional* cold member has no
+  bodies first — and it is **rejected while the twins' tag sets diverge**
+  (tags are language-independent): align the tag lines, or answer the framed
+  tag item, then re-report. If the twin is **stale** (e.g. the source was
+  edited while the ledger was cold), do not `confirm`: on an **id-keyed**
+  member, answer with a `body` + `side` naming the stale twin
+  (`{"key": "id:x", "body": "…", "side": "de"}`) to overwrite it in the same
+  pass. A *positional* cold member has no
   addressable id and takes only `confirm` (mint a `slide_id` first if its twin
   is stale). Pool-scoped coherence applies to `pos:` handles: confirm the whole
   `(group, kind)` pool's cold items in one document (a lone positional confirm
@@ -273,10 +333,11 @@ to scope a review; use the normal loop to reconcile.
 
 The deterministic structural gate (no model, no ledger): the pair unifies
 back into one bilingual source, `de_id == en_id` symmetry holds, no
-`(slide_id, role)` key is duplicated; warns on an id'd cell dropped vs git
-`HEAD`. Run it after every write batch and freely in CI. A green verify means
-the edit did not *corrupt* the deck — translation quality stays your
-judgment.
+`(slide_id, role)` key is duplicated; warns (never fails) on an id'd cell
+dropped vs git `HEAD` and on a cross-side **tag-parity** mismatch (twin cells
+whose tag sets differ — the state `report` frames as a tag row). Run it after
+every write batch and freely in CI. A green verify means the edit did not
+*corrupt* the deck — translation quality stays your judgment.
 
 ## Asymmetric voiceover/notes companions are alerted, not guessed
 

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -127,6 +127,7 @@ _DECISION_VOCABULARY: dict[str, tuple[str, ...]] = {
     "remove_localized_side": ("remove", "body"),
     "unify_choose_body": ("de", "en", "body"),
     "conflict_owner": ("de", "en"),
+    "conflict_tags": ("de", "en"),
     "conflict_preamble": ("de", "en"),
     "order_decision": ("de", "en"),
     "stamp_vs_new": ("treat_as_new",),
@@ -238,6 +239,9 @@ class ItemResult:
     action: str
     #: applied  — a file mutation landed (and was recorded)
     #: recorded — a ledger-only record landed
+    #: deferred — a record-only row whose ledger write was deferred because
+    #:            the member still carries an unresolved sibling item (#615);
+    #:            nothing happened — the row re-frames on the next report
     #: pending  — framed item without a decision (untouched residue)
     #: rejected — a supplied decision failed validation (nothing changed)
     #: failed   — a mechanical row the executor could not resolve safely
@@ -287,7 +291,15 @@ class ApplyOutcome:
             "written": [str(p) for p in self.written_paths],
             "counts": {
                 status: self.count(status)
-                for status in ("applied", "recorded", "pending", "rejected", "failed", "skipped")
+                for status in (
+                    "applied",
+                    "recorded",
+                    "deferred",
+                    "pending",
+                    "rejected",
+                    "failed",
+                    "skipped",
+                )
             },
             "items": [r.payload() for r in self.results],
         }
@@ -352,6 +364,7 @@ _PHASES: dict[str, int] = {
     "pending_divergence": 0,
     "unify_choose_body": 0,
     "conflict_owner": 0,
+    "conflict_tags": 0,
     "verify_translation": 0,
     "verify_cold": 0,
     "copy_new_shared": 1,
@@ -822,6 +835,13 @@ def _record_item(
     key = item.key
     action = item.action
 
+    if action == "conflict_tags":
+        # A conflict_tags resolution records NOTHING (#615 F2): it mutates
+        # one header line; the member re-frames and records on the next
+        # pass. Recording here would bless bodies the framed row's
+        # co-emission rule suppressed — those never reach unresolved_items,
+        # so the unresolved-key guard in apply_deck cannot see them.
+        return set()
     if action in ("record_key_migration",):
         if item.base is not None:
             target.members.pop(item.base.key, None)
@@ -1102,6 +1122,22 @@ def _apply_body_decision(
     raise _ItemError(f"'{item.action}' does not accept a body answer")
 
 
+def _reject_divergent_tags(de_cell: SideCell, en_cell: SideCell) -> None:
+    """The confirm tag guard (#615 F2, belt-and-braces for S4 and any
+    future classification gap): a pure ledger record must never bank a
+    cross-side tag divergence. Safe in-pass: ``set_side`` mutates the
+    member in place, so a same-pass ``mirror_tags`` (phase 0, emitted
+    before the body row) is visible here and a co-answered ``confirm``
+    still lands in one pass."""
+    if set(de_cell.tags) != set(en_cell.tags):
+        raise _ItemError(
+            f"tag sets diverge cross-side (de: {list(de_cell.tags)}, "
+            f"en: {list(en_cell.tags)}) — tags are language-independent — "
+            f"answer the tag item (or align the tag lines manually), then "
+            f"re-run report"
+        )
+
+
 def _apply_choice_decision(ex: _Executor, item: DiffItem, choice: str) -> None:
     action = item.action
     if choice == "confirm":
@@ -1120,9 +1156,15 @@ def _apply_choice_decision(ex: _Executor, item: DiffItem, choice: str) -> None:
                 "cannot confirm a member mid-transition (the sides disagree about "
                 "lang attributes) — complete or revert the transition first"
             )
+        _reject_divergent_tags(de_cell, en_cell)
         return  # confirmation is a pure ledger record; nothing mutates
     if choice in ("de", "en"):
         side: Lang = choice  # type: ignore[assignment]
+        if action == "conflict_tags":
+            # Mirror ONLY the tag set from the chosen side (#615) — never a
+            # whole-cell propagate, which would overwrite a translated body.
+            ex.mirror_tags(item_with_side(item, side), side)
+            return
         if action in ("conflict_shared", "pending_divergence"):
             ex.propagate(item_with_side(item, side), side)
             return
@@ -1205,6 +1247,7 @@ def _apply_choice_decision(ex: _Executor, item: DiffItem, choice: str) -> None:
         en_cell = en_holder.side("en") if en_holder is not None else None
         if de_cell is None or en_cell is None:
             raise _ItemError("keep_twin needs both sides present — supply the twin body instead")
+        _reject_divergent_tags(de_cell, en_cell)
         return
     raise _ItemError(f"unsupported choice {choice!r}")
 
@@ -1401,20 +1444,69 @@ def apply_deck(
     priority = {"record_group_rename": 0, "record_key_migration": 1}
     frozen_pools = _frozen_pools(unresolved_items)
     rerecorded_pools: set[tuple[str, str]] = set()
+    # Never bless a member with unresolved rows (#615 F2, fixes S3): a
+    # landed row on a member whose framed sibling row is still pending /
+    # rejected / failed must not record the member's fresh snapshot — that
+    # would bank the unverified drifted state wholesale. The file mutation
+    # stays; the ledger entry keeps its old baseline and the member
+    # re-frames on the next report.
+    unresolved_keys = {i.key for i in unresolved_items}
+    # An ANSWERED conflict_tags is unresolved for recording purposes too
+    # (adversarial review of #615): its resolution mutates one header line
+    # and the member re-frames next pass — but the framed body row it
+    # suppressed at the differ was never emitted, so it is in no
+    # unresolved list. Without this, a co-landed same-key row (e.g. a
+    # conflict_owner answered by the very same handle-keyed decision)
+    # would _upsert the fresh snapshot and bank the suppressed body drift.
+    unresolved_keys |= {item.key for item, _ in landed if item.action == "conflict_tags"}
     for item, provenance in sorted(landed, key=lambda e: priority.get(e[0].action, 2)):
+        if item.key in unresolved_keys:
+            if item.action == "conflict_tags":
+                continue  # records nothing BY DESIGN — no deferral suffix
+            deferral = " (recording deferred: unresolved sibling item on this member)"
+            for i, result in enumerate(outcome.results):
+                if (
+                    result.key == item.key
+                    and result.action == item.action
+                    and result.status in ("applied", "recorded")
+                    and not result.reason.endswith(deferral)
+                ):
+                    # ItemResult is frozen — replace by index; (key, action)
+                    # matching because keys repeat across a member's rows.
+                    # A record-only row that landed nothing at all must not
+                    # read "recorded" — downstream agents key on the status
+                    # (design F2.1: honest status, not just an amended
+                    # reason).
+                    status = "deferred" if result.status == "recorded" else result.status
+                    outcome.results[i] = ItemResult(
+                        result.key, result.action, status, result.reason + deferral
+                    )
+                    break
+            continue
         rerecorded_pools |= _record_item(
             target, fresh, item, provenance=provenance, frozen_pools=frozen_pools
         )
     # Never bless the unresolved: a wholesale pool re-record must not trust
-    # siblings whose framed items were left pending/rejected/failed.
+    # siblings whose framed items were left pending/rejected/failed — nor
+    # the slot of an answered conflict_tags (which re-frames next pass).
     unresolved_members = [
         holder
         for item in unresolved_items
         for holder in (item.member, item.twin)
         if holder is not None
+    ] + [
+        holder
+        for item, _ in landed
+        if item.action == "conflict_tags"
+        for holder in (item.member, item.twin)
+        if holder is not None
     ]
     _drop_unresolved_from_pools(target, rerecorded_pools, unresolved_members)
-    _sweep_migrated_pos(target, landed)
+    # The stale-pos: sweep must not touch members whose recording was
+    # deferred above — the "stale" entry IS their surviving old baseline
+    # (adversarial review of #615: a landed stamp_twin_id with a pending
+    # framed sibling would otherwise lose the divergence's only record).
+    _sweep_migrated_pos(target, [e for e in landed if e[0].key not in unresolved_keys])
     outcome.ledger_changed = True
     return outcome
 

--- a/src/clm/slides/sync_diff.py
+++ b/src/clm/slides/sync_diff.py
@@ -160,6 +160,7 @@ FRAMED_ACTIONS = frozenset(
         "fork_pending_twin",  # §7.2 fork in progress (one side marked)
         "unify_pending_twin",  # §7.2 unify in progress (one attr removed)
         "conflict_owner",  # owner references disagree
+        "conflict_tags",  # cross-side tag divergence — mirror from the chosen side (#615)
         "broken_owner",  # owner matches no anchor
         "kind_mismatch",  # paired sides disagree about cell kind
         "order_decision",  # both sides reordered differently
@@ -772,6 +773,29 @@ class _Differ:
         handle = entry.key if entry.key.startswith("id:") else member.key.render()
         migrated = self.key_migrations.get(entry.key)
 
+        # Cross-side tag parity (#615) — an orthogonal aspect row like the
+        # layout/owner checks below, but only on the localized path: shared
+        # members keep their byte-identity rows (``cross_divergent`` below
+        # already forces a tag delta past the shortcut into
+        # :meth:`_classify_shared`). Checked BEFORE the owner-only shortcut —
+        # a baseline-carried localized tag divergence classifies in_sync
+        # through that shortcut (and through the not-moved branches below).
+        tags_verdict: str | None = None
+        if member.role == "header" or entry.role == "header" or entry.langness == "localized":
+            tags_verdict = self._check_tags(member, group, entry, handle)
+        if tags_verdict == "framed":
+            # Decision documents are keyed by member handle alone — two
+            # framed rows on one key cannot both be answered, and a framed
+            # ``conflict_owner`` even shares ``conflict_tags``' exact de/en
+            # vocabulary (one decision would silently execute BOTH mirrors —
+            # adversarial review of #615). So a framed ``conflict_tags``
+            # suppresses every other row for this member this pass — the
+            # layout/owner checks and the content classification alike; they
+            # re-frame on the next report once the tags are reconciled
+            # (sequencing over parallelism; converges in two passes).
+            # Mechanical rows never consult the decision document, so a
+            # mechanical ``mirror_tags`` co-emits freely below.
+            return
         # Layout transitions (§7.3 relayout) — orthogonal to content rows.
         self._check_layout(member, group, entry, handle)
         self._check_owner(member, group, entry, handle)
@@ -833,14 +857,15 @@ class _Differ:
         base_class = entry.langness
         observed = self._observed_langness(member)
 
+        tags_mirrored = tags_verdict == "mechanical"
         if member.role == "header" or entry.role == "header":
             # Headers (and the title anchor) are per-language BY DESIGN —
             # their langness never transitions, whatever the lang attrs say.
-            self._classify_localized(member, group, entry, handle)
+            self._classify_localized(member, group, entry, handle, tags_mirrored=tags_mirrored)
         elif base_class == "shared" and observed == "shared":
             self._classify_shared(member, group, entry, handle)
         elif base_class == "localized" and observed == "localized":
-            self._classify_localized(member, group, entry, handle)
+            self._classify_localized(member, group, entry, handle, tags_mirrored=tags_mirrored)
         elif base_class == "shared":
             self._classify_fork(member, group, entry, handle)
         else:
@@ -974,6 +999,104 @@ class _Differ:
                     member=member,
                     base=entry,
                 )
+
+    def _check_tags(
+        self,
+        member: Member,
+        group: str,
+        entry: MemberBaseline,
+        handle: str,
+        *,
+        de_cell: SideCell | None = None,
+        en_cell: SideCell | None = None,
+        twin: Member | None = None,
+    ) -> str | None:
+        """Cross-side tag parity as an orthogonal aspect row (issue #615).
+
+        Tags are language-independent and mirror across the twins (§3.1),
+        but the localized path compares each side only against its own
+        recorded fingerprint — a tag delta coinciding with body drift (or
+        carried at the baseline) used to be silently subsumed by the body
+        row. Modeled on :meth:`_check_layout`/:meth:`_check_owner`; parity
+        is judged on tag *sets* (the validator's policy — a tuple-order-only
+        difference stays with the bodies-at-base normalization path).
+
+        Per-side "moved" is ``base tags is None or current != base``: a
+        ``None`` recorded tag baseline counts as *moved*, never as trusted
+        (the just-landed variant and pre-tag-recording ledger states).
+        Returns ``"mechanical"`` / ``"framed"`` when a row was emitted,
+        ``None`` otherwise. ``de_cell``/``en_cell``/``twin`` let the pool
+        path pass a slot whose two sides live on different parsed members.
+        """
+        de = de_cell if de_cell is not None else member.de
+        en = en_cell if en_cell is not None else member.en
+        if de is None or en is None:
+            return None  # one-sided: no cross-side pair to check
+        if set(de.tags) == set(en.tags):
+            return None
+        de_moved = entry.de_tags is None or de.tags != entry.de_tags
+        en_moved = entry.en_tags is None or en.tags != entry.en_tags
+        attributable = entry.de_tags is not None and entry.en_tags is not None
+        if not attributable:
+            # A None recorded tag baseline counts as MOVED but never as a
+            # mechanical mirror SOURCE (adversarial review of #615): the
+            # "unmoved" side's evidence would be the missing field itself,
+            # and mirroring from a never-recorded side silently wipes the
+            # recorded side's tags (notes/voiceover route audiences). No
+            # trusted source — framed.
+            direction: Direction = "none"
+            detail = (
+                f"cross-side tag divergence with an incomplete recorded tag "
+                f"baseline (de: {list(de.tags)}, en: {list(en.tags)}) — no "
+                f"trusted mirror source; answer de or en to mirror that "
+                f"side's tag set"
+            )
+        elif de_moved != en_moved:
+            moved_side: Lang = "de" if de_moved else "en"
+            moved_cell = de if de_moved else en
+            twin_cell = en if de_moved else de
+            self.emit(
+                handle,
+                "mechanical",
+                "mirror_tags",
+                "de_to_en" if de_moved else "en_to_de",
+                f"tag set changed on the {moved_side} side "
+                f"({list(twin_cell.tags)} → {list(moved_cell.tags)})",
+                group=group,
+                side=moved_side,
+                member=member,
+                base=entry,
+                twin=twin,
+            )
+            return "mechanical"
+        elif de_moved:  # both moved, differently — no safe source side (P8)
+            direction = "both"
+            detail = (
+                f"tag sets moved differently on both sides "
+                f"(de: {list(de.tags)}, en: {list(en.tags)}) — tags are "
+                f"language-independent; answer de or en to mirror that "
+                f"side's tag set"
+            )
+        else:  # neither moved: the recorded baseline carries the divergence
+            direction = "none"
+            detail = (
+                f"the recorded baseline itself carries this cross-side tag "
+                f"divergence (de: {list(de.tags)}, en: {list(en.tags)}) — no "
+                f"direction is inferable; answer de or en to mirror that "
+                f"side's tag set"
+            )
+        self.emit(
+            handle,
+            "conflict",
+            "conflict_tags",
+            direction,
+            detail,
+            group=group,
+            member=member,
+            base=entry,
+            twin=twin,
+        )
+        return "framed"
 
     # -- §7.2 base class shared -------------------------------------------------
 
@@ -1273,7 +1396,13 @@ class _Differ:
     # -- base class localized ---------------------------------------------------
 
     def _classify_localized(
-        self, member: Member, group: str, entry: MemberBaseline, handle: str
+        self,
+        member: Member,
+        group: str,
+        entry: MemberBaseline,
+        handle: str,
+        *,
+        tags_mirrored: bool = False,
     ) -> None:
         de_fp, en_fp = self._member_fps(member)
         moved_de = member.de is not None and de_fp != entry.de_fp
@@ -1329,8 +1458,12 @@ class _Differ:
             self.in_sync += 1
             return
         # A tags-only change is mechanical even on localized members: tag
-        # sets mirror across languages (§3.1), bodies do not.
-        if self._tags_only_change(member, entry, moved_de, moved_en):
+        # sets mirror across languages (§3.1), bodies do not. Cross-side
+        # tag divergence is :meth:`_check_tags`' aspect row (#615);
+        # ``tags_mirrored`` short-circuits the body row when that row
+        # already covers the whole move (tags sit inside the content
+        # fingerprint, so a tags-only move still reads as "moved" here).
+        if self._tags_only_change(member, entry, handle, group, tags_mirrored=tags_mirrored):
             return
         if moved_de and moved_en:
             self.emit(
@@ -1359,8 +1492,24 @@ class _Differ:
         )
 
     def _tags_only_change(
-        self, member: Member, entry: MemberBaseline, moved_de: bool, moved_en: bool
+        self,
+        member: Member,
+        entry: MemberBaseline,
+        handle: str,
+        group: str,
+        *,
+        tags_mirrored: bool = False,
     ) -> bool:
+        """The bodies-at-base residue of a tag move (cross-side sets EQUAL).
+
+        Every cross-side-divergent tag state is :meth:`_check_tags`' aspect
+        row (#615 — its old ``conflict_shared`` answer executed a whole-cell
+        propagate, body-destroying on a localized pair). What remains here:
+        an identical move on both sides (``record_tags``), a tuple-order-only
+        one-sided move (``mirror_tags`` normalization), and the short-circuit
+        for a move :meth:`_check_tags` already mirrored — all with the bodies
+        at their per-side baselines, so no body row is owed.
+        """
         de, en = member.de, member.en
         if de is None or en is None:
             return False
@@ -1368,11 +1517,16 @@ class _Differ:
         en_body_same = entry.en_body_fp is not None and _body_fp(en) == entry.en_body_fp
         if not (de_body_same and en_body_same):
             return False
+        if tags_mirrored:
+            # The mechanical mirror_tags already covers the whole move: the
+            # content fingerprints moved through the tag line alone.
+            return True
         de_tags_moved = entry.de_tags is not None and de.tags != entry.de_tags
         en_tags_moved = entry.en_tags is not None and en.tags != entry.en_tags
         if not (de_tags_moved or en_tags_moved):
             return False
-        handle = entry.key
+        if set(de.tags) != set(en.tags):
+            return False  # _check_tags' territory (framed rows suppress us)
         if de_tags_moved and en_tags_moved:
             if de.tags == en.tags:
                 self.emit(
@@ -1381,20 +1535,12 @@ class _Differ:
                     "record_tags",
                     "both",
                     f"tag set changed identically on both sides → {list(de.tags)}",
+                    group=group,
                     member=member,
                     base=entry,
                 )
                 return True
-            self.emit(
-                handle,
-                "conflict",
-                "conflict_shared",
-                "both",
-                f"tag sets moved differently (de: {list(de.tags)}, en: {list(en.tags)})",
-                member=member,
-                base=entry,
-            )
-            return True
+            return False  # sets equal, tuples ordered differently — framed below
         moved_side: Lang = "de" if de_tags_moved else "en"
         moved_cell = de if de_tags_moved else en
         self.emit(
@@ -1403,6 +1549,7 @@ class _Differ:
             "mirror_tags",
             "de_to_en" if de_tags_moved else "en_to_de",
             f"tag set changed on the {moved_side} side → {list(moved_cell.tags)}",
+            group=group,
             side=moved_side,
             member=member,
             base=entry,
@@ -1527,6 +1674,52 @@ class _Differ:
                 base=entry,
             )
             return
+        # Fork-time tag parity (#615): record_fork is the one mechanical row
+        # that upgrades a member to per-language fingerprints and can thereby
+        # legitimize cross-side divergent bytes — tags included — as a
+        # trusted baseline. Check the halves' tags against the base SHARED
+        # tag set first, while a one-sided move is still attributable. A
+        # framed conflict_tags co-emitting with record_fork is safe: the
+        # apply-side unresolved-key guard defers record_fork's upsert.
+        de, en = member.de, member.en
+        if de is not None and en is not None and set(de.tags) != set(en.tags):
+            base_tags = (
+                entry.de_tags
+                if entry.de_tags is not None and entry.de_tags == entry.en_tags
+                else None
+            )
+            de_moved = base_tags is None or de.tags != base_tags
+            en_moved = base_tags is None or en.tags != base_tags
+            if de_moved != en_moved:
+                moved_side: Lang = "de" if de_moved else "en"
+                moved_cell = de if de_moved else en
+                twin_cell = en if de_moved else de
+                self.emit(
+                    handle,
+                    "mechanical",
+                    "mirror_tags",
+                    "de_to_en" if de_moved else "en_to_de",
+                    f"tag set changed on the {moved_side} side "
+                    f"({list(twin_cell.tags)} → {list(moved_cell.tags)})",
+                    group=group,
+                    side=moved_side,
+                    member=member,
+                    base=entry,
+                )
+            else:  # both moved differently, or no attributable shared base
+                self.emit(
+                    handle,
+                    "conflict",
+                    "conflict_tags",
+                    "both",
+                    f"the forking halves carry divergent tag sets "
+                    f"(de: {list(de.tags)}, en: {list(en.tags)}) — tags are "
+                    f"language-independent; answer de or en to mirror that "
+                    f"side's tag set",
+                    group=group,
+                    member=member,
+                    base=entry,
+                )
         self.emit(
             handle,
             "transition",
@@ -1839,6 +2032,14 @@ class _Differ:
             )
             return
         if de_state == "same" and en_state == "same":
+            if entry.langness == "localized":
+                # Neither side moved, but the recorded baseline may itself
+                # carry a cross-side tag divergence (#615) — the localized
+                # analogue of the shared pending_divergence row below.
+                self._classify_pool_slot_localized(
+                    group, entry, de_state, en_state, de_member, en_member
+                )
+                return
             if (
                 entry.langness == "shared"
                 and entry.de_fp is not None
@@ -2157,7 +2358,88 @@ class _Differ:
                 base=entry,
             )
             return
+        # Cross-side tag parity (#615): the same decision table as
+        # :meth:`_check_tags`, over the slot's cells (which may live on
+        # different parsed members — the emits carry ``twin`` per the pool
+        # side convention so the executor acts on the right cells).
+        de_cell = de_member.de if de_member is not None else None
+        en_cell = en_member.en if en_member is not None else None
+        tags_verdict: str | None = None
+        if de_cell is not None and en_cell is not None:
+            assert member is not None  # both cells present ⇒ a carrier exists
+            tags_verdict = self._check_tags(
+                member,
+                group,
+                entry,
+                handle,
+                de_cell=de_cell,
+                en_cell=en_cell,
+                twin=pair_twin,
+            )
         moved = [lang for lang, state in (("de", de_state), ("en", en_state)) if state == "changed"]
+        if tags_verdict == "framed":
+            # Same-key framed rows cannot both be answered: the framed
+            # conflict_tags suppresses the slot's framed body rows this
+            # pass; they re-frame once the tags are reconciled (#615).
+            return
+        if not moved:
+            # Reached via the same/same dispatch: nothing but (possibly)
+            # the baseline-carried tag divergence handled above.
+            if tags_verdict is None:
+                self.in_sync += 1
+            return
+        de_body_same = (
+            entry.de_body_fp is not None
+            and de_cell is not None
+            and _body_fp(de_cell) == entry.de_body_fp
+        )
+        en_body_same = (
+            entry.en_body_fp is not None
+            and en_cell is not None
+            and _body_fp(en_cell) == entry.en_body_fp
+        )
+        if tags_verdict == "mechanical" and de_body_same and en_body_same:
+            return  # a tags-only move — the mirror covers the whole delta
+        if tags_verdict is None and de_body_same and en_body_same:
+            # The pool twin of :meth:`_tags_only_change` (adversarial review
+            # of #615): cross-side sets EQUAL but a tag tuple moved off its
+            # recorded base — e.g. the pass after a ``conflict_tags`` answer
+            # mirrored a slot's tag line. Without this, the slot's tags-only
+            # movement mis-frames as ``translate_edit`` (a model rewrite of
+            # an untouched header body) and the slot can never mechanically
+            # converge.
+            assert de_cell is not None and en_cell is not None
+            de_tags_moved = entry.de_tags is not None and de_cell.tags != entry.de_tags
+            en_tags_moved = entry.en_tags is not None and en_cell.tags != entry.en_tags
+            if de_tags_moved and en_tags_moved and de_cell.tags == en_cell.tags:
+                self.emit(
+                    handle,
+                    "mechanical",
+                    "record_tags",
+                    "both",
+                    f"tag set changed identically on both sides → {list(de_cell.tags)}",
+                    group=group,
+                    member=member,
+                    base=entry,
+                    twin=pair_twin,
+                )
+                return
+            if de_tags_moved != en_tags_moved:
+                moved_side: Lang = "de" if de_tags_moved else "en"
+                moved_cell = de_cell if de_tags_moved else en_cell
+                self.emit(
+                    handle,
+                    "mechanical",
+                    "mirror_tags",
+                    "de_to_en" if de_tags_moved else "en_to_de",
+                    f"tag set changed on the {moved_side} side → {list(moved_cell.tags)}",
+                    group=group,
+                    side=moved_side,
+                    member=member,
+                    base=entry,
+                    twin=pair_twin,
+                )
+                return
         if len(moved) == 2:
             self.emit(
                 handle,

--- a/src/clm/slides/sync_verify.py
+++ b/src/clm/slides/sync_verify.py
@@ -37,6 +37,18 @@ different roles by design (that is the standard pattern, not a collision). An
 asymmetric id, or a duplicated ``(slide_id, role)`` key, is a corruption unify
 cannot see.
 
+**Tag-parity check — warning (Issue #615).** Tags are language-independent, so a
+cell and its cross-language twin must carry the same tag *set* (order-insensitive
+— serialization order is not doctrine). A one-sided tag edit that coincides with
+body drift is invisible to unify (localized twins are *allowed* to differ) and can
+be banked by the sync engine's baseline-only view; verify surfaces it here, in
+agreement with ``clm validate``'s ``_check_split_tag_parity``. It is a **warning**
+by design: validate's own finding is a warning, error severity would hard-fail CI
+on pre-existing committed asymmetries, and — because :func:`structural_gate` is
+the *error* subset — an error would make the write gate refuse to record a pair
+the apply pass is in the middle of reconciling. A tag mismatch does not corrupt
+pairing or unification, so it does not belong in the gate.
+
 **Secondary check — no accidental drop vs the git pre-edit version.** A
 ``slide_id`` present in the committed (HEAD) half but gone from the working tree
 is a candidate *accidental* drop. Because a deliberate slide removal is
@@ -55,7 +67,7 @@ from pathlib import Path
 
 from clm.notebooks.slide_parser import comment_token_for_path
 from clm.slides.git_text import git_ref_text
-from clm.slides.raw_cells import split_cells
+from clm.slides.raw_cells import RawCell, split_cells
 from clm.slides.split import UnifyError, unify_texts
 from clm.slides.sync_companion import project_pair
 from clm.slides.sync_writeback import role_of
@@ -67,15 +79,19 @@ class VerifyViolation:
 
     ``error`` — a corruption the pair cannot be trusted with (a ``UnifyError``);
     fails the gate (exit 2). ``warning`` — flagged but not fatal (a candidate
-    accidental drop); informational, the exit code is unaffected.
+    accidental drop, or a cross-side tag-set mismatch); informational, the exit
+    code is unaffected.
     """
 
     severity: str  # "error" | "warning"
-    kind: str  # "unify" | "dropped-id"
+    # error kinds: "unify" | "id-asymmetry" | "duplicate-id"
+    # warning kinds: "tag-parity" | "dropped-id"
+    kind: str
     message: str
     slide_id: str | None = None
     # The cell role this finding is keyed to, when the check is per-(slide_id, role)
-    # (only ``duplicate-id`` today). ``None`` means role-agnostic — a slide-level
+    # (``duplicate-id``, and ``tag-parity`` when the twins matched on the role key).
+    # ``None`` means role-agnostic — a slide-level
     # finding (``id-asymmetry``) or a whole-deck one (``unify``). Used by
     # :func:`structural_gate` to scope a per-slide write gate; it is *not* part of
     # the CLI ``verify`` output (the JSON/human serializers enumerate fields
@@ -111,13 +127,15 @@ class VerifyResult:
 def structural_violations(de_text: str, en_text: str, comment_token: str) -> list[VerifyViolation]:
     """All structural-corruption findings for a pair (every check, enumerated).
 
-    Combines three deterministic checks: (1) :func:`unify_texts` as the
+    Combines four deterministic checks: (1) :func:`unify_texts` as the
     byte-identity / header / alignment oracle (its first ``UnifyError`` is surfaced
     verbatim — the message names the offending DE/EN line); (2) slide_id **set
     symmetry** between the halves (the ``de_id == en_id`` invariant unify does not
-    enforce); (3) **no duplicate** slide_id within a half. Unlike unify (which stops
-    at the first mismatch), the id checks enumerate every offender so the caller can
-    fix them in one pass.
+    enforce); (3) **no duplicate** slide_id within a half; (4) cross-side **tag
+    parity** between paired cells — a *warning* (Issue #615), so it surfaces in
+    verify output but never enters :func:`structural_gate`'s error subset. Unlike
+    unify (which stops at the first mismatch), the id and tag checks enumerate
+    every offender so the caller can fix them in one pass.
     """
     violations: list[VerifyViolation] = []
     try:
@@ -132,7 +150,136 @@ def structural_violations(de_text: str, en_text: str, comment_token: str) -> lis
     )
     violations.extend(_duplicate_id_violations(de_keys, "DE"))
     violations.extend(_duplicate_id_violations(en_keys, "EN"))
+    violations.extend(tag_parity_violations(de_text, en_text, comment_token))
     return violations
+
+
+def tag_parity_violations(de_text: str, en_text: str, comment_token: str) -> list[VerifyViolation]:
+    """Warn on every cross-side tag-set mismatch between paired cells (Issue #615).
+
+    Tags are language-independent: a cell and its cross-language twin must carry
+    the same tag **set** (order-insensitive — serialization order is not doctrine).
+    Pairing is two-tier for id'd cells and positional for the rest:
+
+    1. **Role-keyed** — id'd cells pair by ``(slide_id, role)``, the engine's
+       keying unit (:func:`role_of`). Duplicated keys within a half pair by first
+       occurrence (the duplication itself is ``duplicate-id``'s concern).
+    2. **Per-slide positional fallback** — the role is *derived from the tags*,
+       so the flagship #615 edit (``notes`` → ``voiceover`` on one half) moves the
+       cell to a new key and tier 1 cannot see it. Id'd cells left unmatched by
+       tier 1 pair positionally with the other half's unmatched cells under the
+       same ``slide_id``.
+    3. **Id-less remainder** — id-less non-j2 cells pair positionally across the
+       two remainder streams.
+
+    Whenever a positional stream's lengths differ (tier 2 per-``slide_id``, or
+    tier 3 whole-remainder), that tier is skipped silently rather than mis-paired
+    across the offset — a count mismatch is a *structural* problem owned by the
+    unify / id-symmetry checks (the same doctrine as the validator's
+    ``_check_split_tag_parity``). Severity is ``warning`` by design (see the
+    module docstring): the finding surfaces in verify output but never reaches
+    :func:`structural_gate`'s error subset, so it cannot block a write gate.
+    """
+    _de_preamble, de_cells = split_cells(de_text, comment_token)
+    _en_preamble, en_cells = split_cells(en_text, comment_token)
+    de_nonj2 = [c for c in de_cells if not c.metadata.is_j2]
+    en_nonj2 = [c for c in en_cells if not c.metadata.is_j2]
+
+    def _first_by_key(cells: list[RawCell]) -> dict[tuple[str, str | None], RawCell]:
+        keyed: dict[tuple[str, str | None], RawCell] = {}
+        for cell in cells:
+            sid = cell.metadata.slide_id
+            if sid:
+                keyed.setdefault((sid, role_of(cell.metadata)), cell)
+        return keyed
+
+    de_keyed = _first_by_key(de_nonj2)
+    en_keyed = _first_by_key(en_nonj2)
+
+    violations: list[VerifyViolation] = []
+
+    # Tier 1 — (slide_id, role) keyed twins. Dicts preserve document order.
+    for (sid, role), de_cell in de_keyed.items():
+        en_cell = en_keyed.get((sid, role))
+        if en_cell is None:
+            continue  # no twin under this key — tier 2 / id-asymmetry territory
+        role_label = role if role is not None else "no-role"
+        violations.extend(
+            _tag_mismatch(
+                de_cell,
+                en_cell,
+                subject=f"slide_id {sid!r} (role {role_label!r})",
+                slide_id=sid,
+                role=role,
+            )
+        )
+
+    # Tier 2 — per-slide_id positional pairing of the cells tier 1 left unmatched
+    # (a role-changing tag edit lands here). Skipped silently per slide_id when
+    # the leftover counts differ — that is a structural asymmetry, not tag parity.
+    de_leftover: dict[str, list[RawCell]] = {}
+    en_leftover: dict[str, list[RawCell]] = {}
+    for (sid, role), cell in de_keyed.items():
+        if (sid, role) not in en_keyed:
+            de_leftover.setdefault(sid, []).append(cell)
+    for (sid, role), cell in en_keyed.items():
+        if (sid, role) not in de_keyed:
+            en_leftover.setdefault(sid, []).append(cell)
+    for sid, de_orphans in de_leftover.items():
+        en_orphans = en_leftover.get(sid, [])
+        if len(de_orphans) != len(en_orphans):
+            continue
+        for de_cell, en_cell in zip(de_orphans, en_orphans, strict=True):
+            violations.extend(
+                _tag_mismatch(
+                    de_cell, en_cell, subject=f"slide_id {sid!r}", slide_id=sid, role=None
+                )
+            )
+
+    # Tier 3 — the id-less remainder streams, positionally. Skipped silently on a
+    # length mismatch (structural mismatch is another check's concern).
+    de_idless = [c for c in de_nonj2 if not c.metadata.slide_id]
+    en_idless = [c for c in en_nonj2 if not c.metadata.slide_id]
+    if len(de_idless) == len(en_idless):
+        for i, (de_cell, en_cell) in enumerate(zip(de_idless, en_idless, strict=True)):
+            violations.extend(
+                _tag_mismatch(
+                    de_cell,
+                    en_cell,
+                    subject=f"id-less cell #{i + 1} (positional pairing of the id-less cells)",
+                    slide_id=None,
+                    role=None,
+                )
+            )
+    return violations
+
+
+def _tag_mismatch(
+    de_cell: RawCell,
+    en_cell: RawCell,
+    *,
+    subject: str,
+    slide_id: str | None,
+    role: str | None,
+) -> list[VerifyViolation]:
+    """The ``tag-parity`` warning for one paired cell, or ``[]`` when the sets match."""
+    de_tags = set(de_cell.metadata.tags)
+    en_tags = set(en_cell.metadata.tags)
+    if de_tags == en_tags:
+        return []
+    return [
+        VerifyViolation(
+            severity="warning",
+            kind="tag-parity",
+            message=(
+                f"{subject} has mismatched tags: DE {sorted(de_tags)} vs "
+                f"EN {sorted(en_tags)} — tags are language-independent and must "
+                "mirror across the DE/EN twins"
+            ),
+            slide_id=slide_id,
+            role=role,
+        )
+    ]
 
 
 def structural_gate(

--- a/tests/cli/test_slides_sync_verify.py
+++ b/tests/cli/test_slides_sync_verify.py
@@ -4,8 +4,10 @@
 NOT "is it in sync?" (``report``) or "is the translation good?" (a semantic
 call). It reuses :func:`unify_texts` for byte-identity / header / alignment,
 adds an explicit ``de_id == en_id`` set-symmetry + duplicate-id check (which
-unify does not enforce), and warns on an id'd cell dropped vs git HEAD. Exit
-0 = valid (warnings allowed), 2 = structural corruption.
+unify does not enforce), warns on a cross-side tag-set mismatch between paired
+cells (Issue #615 — tags are language-independent), and warns on an id'd cell
+dropped vs git HEAD. Exit 0 = valid (warnings allowed), 2 = structural
+corruption.
 """
 
 from __future__ import annotations
@@ -24,6 +26,7 @@ from clm.slides.sync_verify import (
     dropped_id_violations,
     structural_gate,
     structural_violations,
+    tag_parity_violations,
     verify_pair,
 )
 
@@ -39,6 +42,18 @@ def _md(lang: str, sid: str, body: str) -> str:
 def _vo(lang: str, sid: str, body: str) -> str:
     """An inline voiceover companion — shares its slide's ``slide_id`` under role ``voiceover``."""
     return f'# %% [markdown] lang="{lang}" tags=["voiceover"] slide_id="{sid}"\n{body}\n'
+
+
+def _md_tags(lang: str, sid: str, tags: list[str], body: str) -> str:
+    """A localized markdown cell with an explicit tag list (tag-parity tests)."""
+    block = ", ".join(f'"{t}"' for t in tags)
+    return f'# %% [markdown] lang="{lang}" tags=[{block}] slide_id="{sid}"\n{body}\n'
+
+
+def _idless_code(lang: str, tags: list[str], body: str) -> str:
+    """An id-less localized code cell — pairs positionally, not by id."""
+    block = ", ".join(f'"{t}"' for t in tags)
+    return f'# %% lang="{lang}" tags=[{block}]\n{body}\n'
 
 
 def _shared(body: str) -> str:
@@ -130,6 +145,74 @@ class TestStructuralViolations:
         de = _half(_md("de", "s1", "Hallo"), '# %% lang="de"\nx = 1\n')
         en = _half(_md("en", "s1", "Hello"), '# %% lang="en"\nx = 1\n')
         assert structural_violations(de, en, "#") == []
+
+
+class TestTagParityViolations:
+    """Issue #615 — the cross-side tag-parity warning (tags are language-independent)."""
+
+    def test_idd_pair_with_mismatched_tags_warns(self):
+        # Same (slide_id, role) on both halves, but DE carries an extra tag.
+        de = _md_tags("de", "s1", ["slide", "alt"], "Hallo")
+        en = _md_tags("en", "s1", ["slide"], "Hello")
+        vs = structural_violations(de, en, "#")
+        assert [(v.kind, v.severity, v.slide_id) for v in vs] == [("tag-parity", "warning", "s1")]
+        msg = vs[0].message
+        assert "['alt', 'slide']" in msg  # DE tags, sorted
+        assert "['slide']" in msg  # EN tags, sorted
+        assert "'s1'" in msg
+        assert "language-independent" in msg
+
+    def test_role_changing_tag_edit_is_caught(self):
+        # The flagship #615 edit: the DE companion's notes → voiceover. The role is
+        # DERIVED from the tags, so the (slide_id, role) keys no longer match; the
+        # per-slide positional fallback must still pair and flag the twins.
+        de = _half(_md("de", "s1", "Hallo"), _md_tags("de", "s1", ["voiceover"], "# Sprechtext"))
+        en = _half(_md("en", "s1", "Hello"), _md_tags("en", "s1", ["notes"], "# Voiceover"))
+        vs = structural_violations(de, en, "#")
+        assert [(v.kind, v.severity, v.slide_id) for v in vs] == [("tag-parity", "warning", "s1")]
+        assert "['voiceover']" in vs[0].message
+        assert "['notes']" in vs[0].message
+
+    def test_matching_tags_in_different_order_is_clean(self):
+        # Tag parity compares SETS — serialization order is not doctrine.
+        de = _md_tags("de", "s1", ["alt", "slide"], "Hallo")
+        en = _md_tags("en", "s1", ["slide", "alt"], "Hello")
+        assert structural_violations(de, en, "#") == []
+
+    def test_idless_positional_mismatch_warns(self):
+        # Id-less localized code pairs positionally within the id-less remainder.
+        de = _half(_md("de", "s1", "Hallo"), _idless_code("de", ["keep"], "x = 1"))
+        en = _half(_md("en", "s1", "Hello"), _idless_code("en", ["alt"], "x = 1"))
+        vs = tag_parity_violations(de, en, "#")
+        assert [(v.kind, v.severity, v.slide_id) for v in vs] == [("tag-parity", "warning", None)]
+        assert "id-less cell #1" in vs[0].message
+        assert "['keep']" in vs[0].message
+        assert "['alt']" in vs[0].message
+
+    def test_idless_remainder_length_mismatch_is_silent(self):
+        # DE has two id-less cells, EN one: the positional part is skipped silently
+        # (a count mismatch is a structural concern owned by the unify check).
+        de = _half(
+            _md("de", "s1", "Hallo"),
+            _idless_code("de", ["keep"], "x = 1"),
+            _idless_code("de", ["alt"], "y = 2"),
+        )
+        en = _half(_md("en", "s1", "Hello"), _idless_code("en", ["other"], "x = 1"))
+        assert tag_parity_violations(de, en, "#") == []
+
+    def test_missing_twin_is_not_a_tag_question(self):
+        # s2 exists only in EN: no pair to compare — id-asymmetry owns that state.
+        de = _md("de", "s1", "Hallo")
+        en = _half(_md("en", "s1", "Hello"), _md_tags("en", "s2", ["slide", "alt"], "World"))
+        assert tag_parity_violations(de, en, "#") == []
+
+    def test_gate_is_neutral_to_tag_parity(self):
+        # Warning severity by design: the write gate (error subset) must not refuse
+        # to record a pair over a tag mismatch the apply pass is reconciling.
+        de = _md_tags("de", "s1", ["slide", "alt"], "Hallo")
+        en = _md_tags("en", "s1", ["slide"], "Hello")
+        assert structural_gate(de, en, "#") == []
+        assert structural_gate(de, en, "#", slide_id="s1") == []
 
 
 class TestStructuralGate:
@@ -246,6 +329,34 @@ class TestVerifyCli:
         pair = payload["pairs"][0]
         assert pair["ok"] is False
         assert {v["kind"] for v in pair["violations"]} == {"id-asymmetry"}
+
+    def test_tag_parity_warning_passes_and_renders(self, cli_runner, tmp_path):
+        # A tag mismatch is a warning: surfaced in the output, exit code unaffected.
+        de = _md_tags("de", "s1", ["slide", "alt"], "Hallo")
+        en = _md_tags("en", "s1", ["slide"], "Hello")
+        de_path, _en = _write(tmp_path, de, en)
+        res = cli_runner.invoke(slides_sync_group, ["verify", str(de_path)])
+        assert res.exit_code == 0, res.output
+        assert "PASS" in res.output
+        assert "1 warning" in res.output
+        assert "warning [tag-parity]" in res.output
+        assert "['alt', 'slide']" in res.output
+        assert "['slide']" in res.output
+
+    def test_tag_parity_warning_in_json(self, cli_runner, tmp_path):
+        de = _md_tags("de", "s1", ["slide", "alt"], "Hallo")
+        en = _md_tags("en", "s1", ["slide"], "Hello")
+        de_path, _en = _write(tmp_path, de, en)
+        res = cli_runner.invoke(slides_sync_group, ["verify", "--json", str(de_path)])
+        payload = json.loads(res.output[res.output.find("{") :])
+        assert payload["exit_code"] == 0
+        pair = payload["pairs"][0]
+        assert pair["ok"] is True  # a warning never fails the gate
+        violations = pair["violations"]
+        assert [(v["kind"], v["severity"], v["slide_id"]) for v in violations] == [
+            ("tag-parity", "warning", "s1")
+        ]
+        assert "language-independent" in violations[0]["message"]
 
     def test_single_half_resolves_twin(self, cli_runner, tmp_path):
         # Passing only the .de half resolves the .en twin from disk.

--- a/tests/slides/test_doc_apply.py
+++ b/tests/slides/test_doc_apply.py
@@ -1058,3 +1058,425 @@ class TestReviewRegressions:
         assert "a_mac" not in en  # the surviving EN half of slot A was removed
         assert 'b_mac("B de")' in de  # slot B's DE cell was NEVER touched
         assert 'b_mac("B en!")' in en  # slot B's edited EN cell survived
+
+
+# ---------------------------------------------------------------------------
+# Cross-side tag parity (issue #615)
+# ---------------------------------------------------------------------------
+
+
+def _ledger_entry(deck: _Deck, key: str):
+    ledger = doc_ledger.load(doc_ledger.ledger_path_for(deck.de_path))
+    return ledger.decks[doc_ledger.deck_key_for(deck.de_path)].members[key].entry
+
+
+class TestTagParity:
+    """Issue #615: cross-side tag parity is a first-class diff aspect.
+
+    Tags are language-independent and mirror across the twins, but the
+    localized path used to compare each side only against its own recorded
+    fingerprint — a one-sided tag edit coinciding with body drift was
+    silently banked by ``confirm``, leaving report clean while ``validate``
+    flagged the pair forever. These are the apply-level round trips for the
+    F1 (``conflict_tags`` / ``mirror_tags`` aspect rows) + F2 (recording
+    guards) fixes.
+    """
+
+    DE_PLAIN = '# %% [markdown] lang="de" slide_id="s0-m"'
+    DE_TAGGED = '# %% [markdown] lang="de" tags=["voiceover"] slide_id="s0-m"'
+
+    def _divergent_baseline_deck(self, tmp_path: Path) -> _Deck:
+        """A recorded baseline that ITSELF carries the cross-side divergence —
+        the damaged end state #615 used to leave behind."""
+        deck = _Deck(
+            tmp_path,
+            _build(
+                HEADER_DE,
+                _slide("s0", "de", "Titel"),
+                _shared_code("x"),
+                '# %% [markdown] lang="de" tags=["notes"] slide_id="s0-m"\n# DE Text\n\n',
+            ),
+            _build(
+                HEADER_EN,
+                _slide("s0", "en", "Title"),
+                _shared_code("x"),
+                '# %% [markdown] lang="en" tags=["voiceover"] slide_id="s0-m"\n# EN text\n\n',
+            ),
+        )
+        deck.record()
+        return deck
+
+    def test_615_confirm_lands_the_mirrored_tags_in_one_pass(self, tmp_path: Path):
+        # The issue's exact shape: both bodies drifted off base AND the DE
+        # side carries a one-sided tag edit. The tag aspect is its own
+        # mechanical row; `confirm` answers the body row in the SAME pass
+        # (the guard sees the in-pass mirror) and the banked entry is in
+        # tag parity — never the silently-divergent #615 end state.
+        deck = _deck(tmp_path)
+        deck.edit_de(self.DE_PLAIN, self.DE_TAGGED)
+        deck.edit_de("DE Text", "DE Text NEU")
+        deck.edit_en("EN text", "EN text NEW")
+        _, diff = deck.diff()
+        assert {(i.key, i.action) for i in diff.items} == {
+            ("id:s0-m", "mirror_tags"),
+            ("id:s0-m", "verify_translation"),
+        }, [(i.key, i.action, i.detail) for i in diff.items]
+        outcome = deck.apply(_decision("id:s0-m", choice="confirm"))
+        assert outcome.all_applied, outcome.to_payload()
+        en = deck.en_path.read_text(encoding="utf-8")
+        assert 'tags=["voiceover"]' in en  # the tag line mirrored...
+        assert "EN text NEW" in en  # ...and the EN body was untouched
+        entry = _ledger_entry(deck, "id:s0-m")
+        assert entry.de_tags == entry.en_tags == ("voiceover",)
+        deck.assert_converged()
+
+    def test_confirm_on_a_cold_member_with_divergent_tags_is_rejected(self, tmp_path: Path):
+        # S4: a cold two-sided member has no baseline, so no tag row can be
+        # framed for it — the confirm guard is the only thing standing
+        # between the agent and banking a report-silent divergence.
+        deck = _deck(tmp_path)
+        deck.write_de(
+            *DE_PARTS,
+            '# %% [markdown] lang="de" tags=["notes"] slide_id="s0-new"\n# Neu\n\n',
+        )
+        deck.write_en(*EN_PARTS, _localized("s0-new", "en", "New"))
+        _, diff = deck.diff()
+        assert [(i.key, i.action) for i in diff.items] == [("id:s0-new", "verify_cold")]
+        outcome = deck.apply(_decision("id:s0-new", choice="confirm"))
+        result = next(r for r in outcome.results if r.key == "id:s0-new")
+        assert result.status == "rejected"
+        assert "tag sets diverge cross-side" in result.reason
+        _, diff = deck.diff()
+        assert not diff.is_clean  # nothing was banked
+
+    def test_baseline_carried_divergence_frames_conflict_tags_and_converges(self, tmp_path: Path):
+        deck = self._divergent_baseline_deck(tmp_path)
+        _, diff = deck.diff()
+        assert [(i.key, i.action, i.direction) for i in diff.items] == [
+            ("id:s0-m", "conflict_tags", "none")
+        ], [(i.key, i.action, i.detail) for i in diff.items]
+        assert "the recorded baseline itself carries" in diff.items[0].detail
+        entry_before = _ledger_entry(deck, "id:s0-m")
+        outcome = deck.apply(_decision("id:s0-m", choice="de"))
+        assert outcome.all_applied, outcome.to_payload()
+        assert outcome.wrote  # the EN tag line was mirrored...
+        assert 'tags=["notes"]' in deck.en_path.read_text(encoding="utf-8")
+        # ...but NOTHING was recorded this pass — the old baseline stands.
+        assert _ledger_entry(deck, "id:s0-m") == entry_before
+        assert entry_before.en_tags == ("voiceover",)
+        # Second pass: the move is now attributable (EN off base, DE at base)
+        # — an idempotent mechanical mirror that lands and records.
+        _, diff = deck.diff()
+        assert [(i.key, i.action, i.direction) for i in diff.items] == [
+            ("id:s0-m", "mirror_tags", "en_to_de")
+        ], [(i.key, i.action, i.detail) for i in diff.items]
+        assert deck.apply().all_applied
+        deck.assert_converged()
+
+    def test_landed_mirror_tags_never_blesses_the_pending_body_row(self, tmp_path: Path):
+        # S3: the mechanical tag mirror lands while the framed body row is
+        # unanswered — recording is deferred, the ledger entry stays at its
+        # old baseline, and the member re-frames next pass.
+        deck = _deck(tmp_path)
+        deck.edit_de(self.DE_PLAIN, self.DE_TAGGED)
+        deck.edit_de("DE Text", "DE Text NEU")
+        entry_before = _ledger_entry(deck, "id:s0-m")
+        _, diff = deck.diff()
+        assert {(i.key, i.action) for i in diff.items} == {
+            ("id:s0-m", "mirror_tags"),
+            ("id:s0-m", "translate_edit"),
+        }, [(i.key, i.action, i.detail) for i in diff.items]
+        outcome = deck.apply()  # no decision: the body row stays pending
+        results = [r for r in outcome.results if r.key == "id:s0-m"]
+        assert sorted(r.status for r in results) == ["applied", "pending"]
+        landed = next(r for r in results if r.status == "applied")
+        assert "recording deferred" in landed.reason
+        assert 'tags=["voiceover"]' in deck.en_path.read_text(encoding="utf-8")
+        assert _ledger_entry(deck, "id:s0-m") == entry_before
+        # Next pass: the mirrored twin's fingerprint is off base too, so the
+        # pair frames as one verify_translation whose confirm converges.
+        _, diff = deck.diff()
+        assert [(i.key, i.action, i.direction) for i in diff.items] == [
+            ("id:s0-m", "verify_translation", "both")
+        ], [(i.key, i.action, i.detail) for i in diff.items]
+        outcome = deck.apply(_decision("id:s0-m", choice="confirm"))
+        assert outcome.all_applied, outcome.to_payload()
+        deck.assert_converged()
+
+    FORK_CELL = '# %% [markdown] tags=["keep"] slide_id="s0-f"\n# gemeinsam\n\n'
+
+    def _forking_deck(self, tmp_path: Path, *, en_tags: str = "voiceover") -> _Deck:
+        deck = _Deck(
+            tmp_path,
+            _build(HEADER_DE, _slide("s0", "de", "Titel"), self.FORK_CELL, _shared_code("x")),
+            _build(HEADER_EN, _slide("s0", "en", "Title"), self.FORK_CELL, _shared_code("x")),
+        )
+        deck.record()
+        deck.edit_de(
+            '# %% [markdown] tags=["keep"] slide_id="s0-f"\n# gemeinsam',
+            '# %% [markdown] lang="de" tags=["notes"] slide_id="s0-f"\n# DE Gabel',
+        )
+        deck.edit_en(
+            '# %% [markdown] tags=["keep"] slide_id="s0-f"\n# gemeinsam',
+            f'# %% [markdown] lang="en" tags=["{en_tags}"] slide_id="s0-f"\n# EN fork',
+        )
+        return deck
+
+    def test_fork_with_divergent_tag_moves_banks_nothing_until_answered(self, tmp_path: Path):
+        # F1 fork-time tag check: record_fork is the one row that could
+        # legitimize divergent tags as a trusted per-language baseline, so
+        # both halves moving their tags differently co-emits a framed
+        # conflict_tags — and F2's unresolved-key guard defers the upsert.
+        deck = self._forking_deck(tmp_path)
+        _, diff = deck.diff()
+        assert {(i.key, i.action) for i in diff.items} == {
+            ("id:s0-f", "conflict_tags"),
+            ("id:s0-f", "record_fork"),
+        }, [(i.key, i.action, i.detail) for i in diff.items]
+        tag_item = next(i for i in diff.items if i.action == "conflict_tags")
+        assert tag_item.direction == "both"
+        assert "the forking halves carry divergent tag sets" in tag_item.detail
+        entry_before = _ledger_entry(deck, "id:s0-f")
+        outcome = deck.apply()  # conflict unanswered
+        landed = next(r for r in outcome.results if r.status != "pending")
+        assert "recording deferred" in landed.reason
+        assert _ledger_entry(deck, "id:s0-f") == entry_before  # nothing banked
+        # Answering the conflict mirrors the tag line, but an ANSWERED
+        # conflict_tags still defers same-key recordings (the review's
+        # critical finding: a co-landed row must never bank state a framed
+        # tag row's co-emission rule may have suppressed) — record_fork
+        # reports "deferred" and the tag-consistent fork banks on the NEXT
+        # pass, exactly as the design's fork test plan words it.
+        outcome = deck.apply(_decision("id:s0-f", choice="de"))
+        fork_result = next(r for r in outcome.results if r.action == "record_fork")
+        assert fork_result.status == "deferred", outcome.to_payload()
+        assert "recording deferred" in fork_result.reason
+        en = deck.en_path.read_text(encoding="utf-8")
+        assert 'tags=["notes"]' in en  # the DE tag set mirrored...
+        assert "EN fork" in en  # ...and the forked EN body survived
+        assert _ledger_entry(deck, "id:s0-f") == entry_before  # not yet banked
+        outcome = deck.apply()  # second pass: the clean fork records
+        assert outcome.all_applied, outcome.to_payload()
+        entry = _ledger_entry(deck, "id:s0-f")
+        assert entry.langness == "localized"
+        assert entry.de_tags == entry.en_tags == ("notes",)
+        deck.assert_converged()
+
+    def test_conflict_tags_answer_mirrors_only_the_tag_line(self, tmp_path: Path):
+        # S2 executor regression: the de/en answer must mirror the TAG SET
+        # only — never a whole-cell propagate that would overwrite the
+        # twin's translated body with the other language.
+        deck = self._divergent_baseline_deck(tmp_path)
+        outcome = deck.apply(_decision("id:s0-m", choice="en"))
+        assert outcome.all_applied, outcome.to_payload()
+        de = deck.de_path.read_text(encoding="utf-8")
+        assert 'tags=["voiceover"]' in de  # the EN tag set landed on DE
+        assert "# DE Text" in de  # the translated body was untouched
+        assert "EN text" not in de  # no whole-cell copy
+        en = deck.en_path.read_text(encoding="utf-8")
+        assert "# EN text" in en
+        assert "DE Text" not in en
+
+    def test_body_answer_lands_on_a_twin_carrying_the_mirrored_tags(self, tmp_path: Path):
+        # S1: a one-sided DE tag+body edit resolves in ONE pass — the
+        # mechanical mirror_tags executes before the translate_edit body
+        # answer (same ordered loop), so the EN cell comes out with BOTH
+        # the mirrored tags and the new body, and the banked entry is in
+        # tag parity — never the silently-divergent #615 end state.
+        deck = _deck(tmp_path)
+        deck.edit_de(self.DE_PLAIN, self.DE_TAGGED)
+        deck.edit_de("DE Text", "DE Text NEU")
+        _, diff = deck.diff()
+        assert {(i.key, i.action) for i in diff.items} == {
+            ("id:s0-m", "mirror_tags"),
+            ("id:s0-m", "translate_edit"),
+        }, [(i.key, i.action, i.detail) for i in diff.items]
+        outcome = deck.apply(_decision("id:s0-m", body="# EN text NEW"))
+        assert outcome.all_applied, outcome.to_payload()
+        en = deck.en_path.read_text(encoding="utf-8")
+        header_line = next(line for line in en.splitlines() if 'slide_id="s0-m"' in line)
+        assert 'tags=["voiceover"]' in header_line  # the mirrored tags...
+        assert "# EN text NEW" in en  # ...AND the answered body, one cell
+        entry = _ledger_entry(deck, "id:s0-m")
+        assert entry.de_tags == entry.en_tags == ("voiceover",)
+        deck.assert_converged()
+
+    def test_fork_with_one_sided_tag_move_lands_in_one_pass(self, tmp_path: Path):
+        # F1 fork-time tag check, mechanical half: only the DE half changed
+        # its tags off the shared base, so the move is still attributable —
+        # mirror_tags co-emits with record_fork and BOTH land in one pass
+        # (two mechanical rows on one key have no decision-keying collision;
+        # no deferral).
+        deck = self._forking_deck(tmp_path, en_tags="keep")
+        _, diff = deck.diff()
+        assert {(i.key, i.action) for i in diff.items} == {
+            ("id:s0-f", "mirror_tags"),
+            ("id:s0-f", "record_fork"),
+        }, [(i.key, i.action, i.detail) for i in diff.items]
+        outcome = deck.apply()
+        assert outcome.all_applied, outcome.to_payload()
+        fork_result = next(r for r in outcome.results if r.action == "record_fork")
+        assert fork_result.status == "recorded", outcome.to_payload()
+        en = deck.en_path.read_text(encoding="utf-8")
+        assert 'tags=["notes"]' in en  # the DE tag set mirrored...
+        assert "EN fork" in en  # ...and the forked EN body survived
+        entry = _ledger_entry(deck, "id:s0-f")
+        assert entry.langness == "localized"
+        assert entry.de_tags == entry.en_tags == ("notes",)
+        deck.assert_converged()
+
+    def test_conflict_tags_suppresses_conflict_owner_until_answered(self, tmp_path: Path):
+        # Adversarial review of #615: a framed conflict_owner shares
+        # conflict_tags' exact de/en vocabulary on the same handle — one
+        # decision would silently execute BOTH mirrors. The framed tag row
+        # must suppress the owner AND body rows this pass; the answer
+        # mirrors only the tag line; the suppressed aspects re-frame next.
+        de = _build(HEADER_DE, _slide("s0", "de", "Titel"), _slide("s1", "de", "Zwei"))
+        en = _build(HEADER_EN, _slide("s0", "en", "Title"), _slide("s1", "en", "Two"))
+        deck = _Deck(tmp_path, de, en)
+        vo_dir = tmp_path / "voiceover"
+        vo_dir.mkdir()
+        de_comp = vo_dir / "voiceover_t.de.py"
+        en_comp = vo_dir / "voiceover_t.en.py"
+        de_comp.write_text(
+            _build(
+                '# %% [markdown] lang="de" tags=["notes"] slide_id="s0-vo" '
+                'for_slide="s0"\n#\n# - DE Notiz\n\n'
+            ),
+            encoding="utf-8",
+        )
+        en_comp.write_text(
+            _build(
+                '# %% [markdown] lang="en" tags=["notes"] slide_id="s0-vo" '
+                'for_slide="s0"\n#\n# - EN note\n\n'
+            ),
+            encoding="utf-8",
+        )
+        deck.record()
+        # DE: owner AND tags AND body all move; EN: tags and body move
+        # differently — every aspect of the member diverges cross-side.
+        de_comp.write_text(
+            de_comp.read_text(encoding="utf-8")
+            .replace('tags=["notes"]', 'tags=["voiceover"]')
+            .replace('for_slide="s0"', 'for_slide="s1"')
+            .replace("- DE Notiz", "- DE Notiz v2"),
+            encoding="utf-8",
+        )
+        en_comp.write_text(
+            en_comp.read_text(encoding="utf-8")
+            .replace('tags=["notes"]', 'tags=["alt"]')
+            .replace("- EN note", "- EN note v2"),
+            encoding="utf-8",
+        )
+        _, diff = deck.diff()
+        assert [(i.key, i.action, i.direction) for i in diff.items] == [
+            ("id:s0-vo", "conflict_tags", "both")
+        ], [(i.key, i.action, i.detail) for i in diff.items]
+        entry_before = _ledger_entry(deck, "id:s0-vo")
+        outcome = deck.apply(_decision("id:s0-vo", choice="de"))
+        assert outcome.all_applied, outcome.to_payload()
+        en_after = en_comp.read_text(encoding="utf-8")
+        assert 'tags=["voiceover"]' in en_after  # ONLY the tag line mirrored
+        assert 'for_slide="s0"' in en_after  # the owner was NOT mirrored
+        assert "- EN note v2" in en_after  # the body was untouched
+        assert _ledger_entry(deck, "id:s0-vo") == entry_before  # nothing recorded
+        _, diff = deck.diff()  # next pass: the suppressed aspects re-frame
+        assert {(i.key, i.action) for i in diff.items} == {
+            ("id:s0-vo", "conflict_owner"),
+            ("id:s0-vo", "verify_translation"),
+        }, [(i.key, i.action, i.detail) for i in diff.items]
+
+    HZ_A = '# %% [markdown] tags=["alt"]\n# HZ A\n\n'
+    HZ_B = '# %% [markdown] tags=["alt"]\n# HZ B\n\n'
+
+    def test_pool_conflict_tags_answer_touches_only_the_target_slot(self, tmp_path: Path):
+        # The pool path end-to-end: answering the pos:-keyed conflict_tags
+        # mirrors ONE slot's tag line (the neighboring slot byte-identical),
+        # records nothing that pass, and the NEXT pass converges through the
+        # pool residue branch (record_tags — the pool twin of
+        # _tags_only_change) instead of mis-framing translate_edit.
+        deck = _Deck(
+            tmp_path,
+            _build(self.HZ_A, self.HZ_B, HEADER_DE, _slide("s0", "de", "Titel")),
+            _build(self.HZ_A, self.HZ_B, HEADER_EN, _slide("s0", "en", "Title")),
+        )
+        deck.record()
+        deck.edit_de('tags=["alt"]\n# HZ A', 'tags=["beta"]\n# HZ A')
+        deck.edit_en('tags=["alt"]\n# HZ A', 'tags=["gamma"]\n# HZ A')
+        _, diff = deck.diff()
+        assert [(i.key, i.action, i.direction) for i in diff.items] == [
+            ("pos:~header/markdown/0", "conflict_tags", "both")
+        ], [(i.key, i.action, i.detail) for i in diff.items]
+        slot_a_before = _ledger_entry(deck, "pos:~header/markdown/0")
+        slot_b_before = _ledger_entry(deck, "pos:~header/markdown/1")
+        de_before = deck.de_path.read_text(encoding="utf-8")
+        en_before = deck.en_path.read_text(encoding="utf-8")
+        outcome = deck.apply(_decision("pos:~header/markdown/0", choice="de"))
+        assert outcome.all_applied, outcome.to_payload()
+        # ONLY the target slot's EN tag line changed — byte-precise.
+        assert deck.de_path.read_text(encoding="utf-8") == de_before
+        assert deck.en_path.read_text(encoding="utf-8") == en_before.replace(
+            'tags=["gamma"]', 'tags=["beta"]'
+        )
+        # ...and NOTHING was recorded this pass.
+        assert _ledger_entry(deck, "pos:~header/markdown/0") == slot_a_before
+        assert _ledger_entry(deck, "pos:~header/markdown/1") == slot_b_before
+        # Next pass: the slot's tags-only movement is mechanical (the pool
+        # residue branch), never a translate_edit of an untouched body.
+        _, diff = deck.diff()
+        assert [(i.key, i.action, i.direction) for i in diff.items] == [
+            ("pos:~header/markdown/0", "record_tags", "both")
+        ], [(i.key, i.action, i.detail) for i in diff.items]
+        assert deck.apply().all_applied
+        deck.assert_converged()
+
+    def test_deferred_stamp_keeps_the_divergent_pos_baseline(self, tmp_path: Path):
+        # _sweep_migrated_pos regression (adversarial review of #615): a
+        # shared positional cell RECORDED with a base-carried cross-side
+        # divergence gets a slide_id stamped on the DE side only. The stamp
+        # is mechanical and lands, but the pending_divergence row on the
+        # same member stays pending — recording defers, and the migration
+        # sweep must NOT destroy the pos: entry: it IS the surviving old
+        # baseline evidencing the divergence.
+        deck = _Deck(
+            tmp_path,
+            _build(
+                HEADER_DE,
+                _slide("s0", "de", "Titel"),
+                '# %% tags=["keep", "alt"]\nx = 1\n\n',  # header (tags) diverge...
+                _localized("s0-m", "de", "DE Text"),
+            ),
+            _build(
+                HEADER_EN,
+                _slide("s0", "en", "Title"),
+                '# %% tags=["keep"]\nx = 1\n\n',  # ...the bodies are identical
+                _localized("s0-m", "en", "EN text"),
+            ),
+        )
+        deck.record()  # the baseline banks the in-flight divergence
+        deck.edit_de(
+            '# %% tags=["keep", "alt"]\nx = 1',
+            '# %% tags=["keep", "alt"] slide_id="x-cell"\nx = 1',
+        )
+        _, diff = deck.diff()
+        assert {(i.key, i.action) for i in diff.items} == {
+            ("id:x-cell", "stamp_twin_id"),
+            ("id:x-cell", "pending_divergence"),
+        }, [(i.key, i.action, i.detail) for i in diff.items]
+        outcome = deck.apply()  # no decisions: the divergence stays pending
+        results = {r.action: r for r in outcome.results}
+        assert results["stamp_twin_id"].status == "applied"
+        assert "recording deferred" in results["stamp_twin_id"].reason
+        assert results["pending_divergence"].status == "pending"
+        assert 'slide_id="x-cell"' in deck.en_path.read_text(encoding="utf-8")
+        ledger = doc_ledger.load(doc_ledger.ledger_path_for(deck.de_path))
+        members = ledger.decks["slides_t"].members
+        assert "pos:s0/code/0" in members, sorted(members)  # the baseline SURVIVED
+        entry = members["pos:s0/code/0"].entry
+        assert entry.de_fp != entry.en_fp  # ...still carrying the divergence
+        assert "id:x-cell" not in members  # the stamp banked nothing yet
+        _, diff = deck.diff()  # the divergence is still framed, never silent
+        assert not diff.is_clean
+        assert any(i.action == "pending_divergence" for i in diff.items), [
+            (i.key, i.action, i.detail) for i in diff.items
+        ]

--- a/tests/slides/test_sync_diff.py
+++ b/tests/slides/test_sync_diff.py
@@ -12,6 +12,7 @@ individually so a classification regression names the broken row.
 
 from __future__ import annotations
 
+import attrs
 import pytest
 
 from clm.slides.bilingual_doc import BilingualDeck
@@ -1039,3 +1040,214 @@ class TestAdversarialReviewRegressions:
         diff = _diff(base, de.replace("x = 1", "x = 2"), en)
         item = _only_item(diff)
         assert item.action == "propagate_shared_edit"
+
+
+class TestTagParity:
+    """Cross-side tag parity as an orthogonal aspect row (issue #615).
+
+    Tags are language-independent and mirror across the twins (§3.1); the
+    differ checks the pair invariant on localized members (and headers)
+    regardless of body drift, instead of only in the narrow bodies-at-base
+    states that let #615's one-sided tag edit vanish into the body row.
+    """
+
+    DE_M = '# %% [markdown] lang="de" slide_id="s0-m"'
+    EN_M = '# %% [markdown] lang="en" slide_id="s0-m"'
+
+    def test_615_tag_edit_plus_body_drift_coemits_mirror_and_verify(self):
+        """The #615 shape: both bodies off base + a one-sided DE tag edit
+        must frame BOTH aspects — never fold the tag delta into the body
+        row where confirm would bank the divergence."""
+        base = _snapshot(DE0, EN0)
+        de = DE0.replace(self.DE_M, self.DE_M.replace(" slide_id", ' tags=["notes"] slide_id'))
+        de = de.replace("# DE Text", "# DE Text v2")
+        en = EN0.replace("# EN text", "# EN text v2")
+        diff = _diff(base, de, en)
+        assert {(i.key, i.action) for i in diff.items} == {
+            ("id:s0-m", "mirror_tags"),
+            ("id:s0-m", "verify_translation"),
+        }, [(i.key, i.action) for i in diff.items]
+        mirror = next(i for i in diff.items if i.action == "mirror_tags")
+        assert (mirror.outcome, mirror.direction, mirror.side) == ("mechanical", "de_to_en", "de")
+
+    def test_baseline_carried_tag_divergence_frames_conflict_tags(self):
+        """The post-#615-damage state: the ledger itself carries
+        de_tags != en_tags and nothing moved — never in_sync again."""
+        de = DE0.replace(self.DE_M, self.DE_M.replace(" slide_id", ' tags=["notes"] slide_id'))
+        base = _snapshot(de, EN0)  # baseline banks the divergence
+        item = _only_item(_diff(base, de, EN0))  # unchanged input
+        assert (item.outcome, item.action) == ("conflict", "conflict_tags")
+        assert item.direction == "none"
+        assert item.key == "id:s0-m"
+
+    def test_both_sides_tags_moved_differently_is_conflict_tags_not_shared(self):
+        """S2 regression: conflict_shared's propagate/body answers copy
+        whole cells — body-destroying on a localized pair. The framed tag
+        row must be conflict_tags."""
+        base = _snapshot(DE0, EN0)
+        de = DE0.replace(self.DE_M, self.DE_M.replace(" slide_id", ' tags=["notes"] slide_id'))
+        en = EN0.replace(self.EN_M, self.EN_M.replace(" slide_id", ' tags=["alt"] slide_id'))
+        item = _only_item(_diff(base, de, en))
+        assert (item.outcome, item.action) == ("conflict", "conflict_tags")
+        assert item.direction == "both"
+
+    def test_conflict_tags_suppresses_the_framed_body_row(self):
+        """Two framed rows on one key cannot both be answered (decision
+        documents are keyed by handle alone): the framed conflict_tags
+        suppresses verify_translation this pass; the body row re-frames
+        once the tags are reconciled."""
+        base = _snapshot(DE0, EN0)
+        de = DE0.replace(self.DE_M, self.DE_M.replace(" slide_id", ' tags=["notes"] slide_id'))
+        de = de.replace("# DE Text", "# DE Text v2")
+        en = EN0.replace(self.EN_M, self.EN_M.replace(" slide_id", ' tags=["alt"] slide_id'))
+        en = en.replace("# EN text", "# EN text v2")
+        item = _only_item(_diff(base, de, en))
+        assert (item.outcome, item.action) == ("conflict", "conflict_tags")
+        assert item.direction == "both"
+
+    def test_fork_with_one_sided_tag_move_coemits_mirror_tags(self):
+        """record_fork legitimizes cross-side bytes as a trusted baseline —
+        a one-sided tag move off the shared base is still attributable at
+        fork time and mirrors mechanically alongside the fork record."""
+        base = _snapshot(DE0, EN0)
+        de = DE0.replace(
+            '# %% tags=["keep"]\ny = 2', '# %% lang="de" tags=["alt"] slide_id="y-cell"\ny = 2'
+        )
+        en = EN0.replace(
+            '# %% tags=["keep"]\ny = 2', '# %% lang="en" tags=["keep"] slide_id="y-cell"\ny = 2'
+        )
+        diff = _diff(base, de, en)
+        assert {(i.key, i.action) for i in diff.items} == {
+            ("id:y-cell", "mirror_tags"),
+            ("id:y-cell", "record_fork"),
+        }, [(i.key, i.action) for i in diff.items]
+        mirror = next(i for i in diff.items if i.action == "mirror_tags")
+        assert (mirror.outcome, mirror.direction, mirror.side) == ("mechanical", "de_to_en", "de")
+
+    def test_fork_with_divergent_tag_moves_coemits_conflict_tags(self):
+        base = _snapshot(DE0, EN0)
+        de = DE0.replace(
+            '# %% tags=["keep"]\ny = 2', '# %% lang="de" tags=["alt"] slide_id="y-cell"\ny = 2'
+        )
+        en = EN0.replace(
+            '# %% tags=["keep"]\ny = 2', '# %% lang="en" tags=["other"] slide_id="y-cell"\ny = 2'
+        )
+        diff = _diff(base, de, en)
+        assert {(i.key, i.action) for i in diff.items} == {
+            ("id:y-cell", "conflict_tags"),
+            ("id:y-cell", "record_fork"),
+        }, [(i.key, i.action) for i in diff.items]
+        conflict = next(i for i in diff.items if i.action == "conflict_tags")
+        assert (conflict.outcome, conflict.direction) == ("conflict", "both")
+
+    def test_none_recorded_tags_count_as_moved_and_frame_conflict_tags(self):
+        """A ledger entry whose tag fields predate tag recording (None)
+        must never be trusted as a baseline: with a cross-side divergence
+        no direction is attributable — framed, not silently mechanical."""
+        base = _snapshot(DE0, EN0)
+        base.members["id:s0-m"] = attrs.evolve(base.members["id:s0-m"], de_tags=None, en_tags=None)
+        de = DE0.replace(self.DE_M, self.DE_M.replace(" slide_id", ' tags=["notes"] slide_id'))
+        item = _only_item(_diff(base, de, EN0))
+        assert (item.outcome, item.action) == ("conflict", "conflict_tags")
+
+    @pytest.mark.parametrize("none_side", ["de", "en"])
+    def test_one_sided_none_tag_base_frames_instead_of_wiping_the_recorded_side(
+        self, none_side: str
+    ):
+        """Adversarial-review regression: ONE side's recorded tag base is
+        None (e.g. a pending twin that landed without tags) while the other
+        side carries recorded tags. The None base counts as MOVED but must
+        never become a mechanical mirror SOURCE — that mirror would wipe
+        the recorded side's tags (notes/voiceover route audiences). No
+        trusted source — framed, direction none."""
+        de = (
+            DE0.replace(self.DE_M, self.DE_M.replace(" slide_id", ' tags=["notes"] slide_id'))
+            if none_side == "en"
+            else DE0
+        )
+        en = (
+            EN0.replace(self.EN_M, self.EN_M.replace(" slide_id", ' tags=["notes"] slide_id'))
+            if none_side == "de"
+            else EN0
+        )
+        assert 'tags=["notes"]' in de + en  # exactly one side carries recorded tags
+        base = _snapshot(de, en)
+        base.members["id:s0-m"] = attrs.evolve(
+            base.members["id:s0-m"], **{f"{none_side}_tags": None}
+        )
+        item = _only_item(_diff(base, de, en))  # unchanged input
+        assert (item.outcome, item.action) == ("conflict", "conflict_tags")
+        assert item.direction == "none"
+        assert "incomplete recorded tag baseline" in item.detail
+
+    HZ = '# %% [markdown] tags=["alt"]\n# HZ\n\n'
+
+    def test_pool_baseline_carried_tag_divergence_frames_conflict_tags(self):
+        """The pool analogue of the damaged #615 end state: a warm id-less
+        localized header slot whose RECORDED baseline itself carries
+        de_tags != en_tags must frame conflict_tags — never in_sync."""
+        de = _build(self.HZ, HEADER_DE, _slide("s0", "de", "Titel"))
+        en = _build(
+            self.HZ.replace('tags=["alt"]', 'tags=["beta"]'),
+            HEADER_EN,
+            _slide("s0", "en", "Title"),
+        )
+        base = _snapshot(de, en)  # the baseline banks the divergence
+        item = _only_item(_diff(base, de, en))  # unchanged input
+        assert (item.outcome, item.action) == ("conflict", "conflict_tags")
+        assert item.direction == "none"
+        assert item.key == "pos:~header/markdown/0"
+
+    def test_pool_both_sides_tags_moved_differently_frames_conflict_tags(self):
+        """Both sides of a warm id-less header slot moved their tags off
+        the recorded base, differently: no safe mirror source (P8)."""
+        de = _build(self.HZ, HEADER_DE, _slide("s0", "de", "Titel"))
+        en = _build(self.HZ, HEADER_EN, _slide("s0", "en", "Title"))
+        base = _snapshot(de, en)
+        de2 = de.replace('tags=["alt"]', 'tags=["beta"]')
+        en2 = en.replace('tags=["alt"]', 'tags=["gamma"]')
+        item = _only_item(_diff(base, de2, en2))
+        assert (item.outcome, item.action) == ("conflict", "conflict_tags")
+        assert item.direction == "both"
+        assert item.key == "pos:~header/markdown/0"
+
+    def test_tuple_order_only_difference_normalizes_without_conflict(self):
+        """Parity is judged on tag SETS: a one-sided reorder of the same
+        tags stays on the bodies-at-base normalization path."""
+        tagged_de = self.DE_M.replace(" slide_id", ' tags=["notes", "alt"] slide_id')
+        tagged_en = self.EN_M.replace(" slide_id", ' tags=["notes", "alt"] slide_id')
+        de = DE0.replace(self.DE_M, tagged_de)
+        en = EN0.replace(self.EN_M, tagged_en)
+        base = _snapshot(de, en)
+        de2 = de.replace('tags=["notes", "alt"]', 'tags=["alt", "notes"]')
+        item = _only_item(_diff(base, de2, en))
+        assert (item.outcome, item.action) == ("mechanical", "mirror_tags")
+        assert item.direction == "de_to_en"
+
+    def test_contrast_case_bodies_at_base_one_sided_tag_edit_mirrors(self):
+        """The issue's contrast case keeps its behavior: a tag edit with
+        both bodies at base is one mechanical mirror_tags, nothing else."""
+        base = _snapshot(DE0, EN0)
+        de = DE0.replace(self.DE_M, self.DE_M.replace(" slide_id", ' tags=["notes"] slide_id'))
+        item = _only_item(_diff(base, de, EN0))
+        assert (item.outcome, item.action) == ("mechanical", "mirror_tags")
+        assert (item.direction, item.side) == ("de_to_en", "de")
+
+    def test_pool_header_slot_tag_move_emits_pool_mirror_tags_row(self):
+        """The pool path (id-less localized per-language header slot): a
+        one-sided tag move splits the cross-side parse pairing, so the
+        slot's sides live on different members — the row carries the
+        DE-carrier as member and the EN-carrier as twin."""
+        hz = '# %% [markdown] tags=["notes"]\n# HZ\n\n'
+        de = _build(hz, HEADER_DE, _slide("s0", "de", "Titel"))
+        en = _build(hz, HEADER_EN, _slide("s0", "en", "Title"))
+        base = _snapshot(de, en)
+        de2 = de.replace('tags=["notes"]\n# HZ', 'tags=["voiceover"]\n# HZ')
+        item = _only_item(_diff(base, de2, en))
+        assert (item.outcome, item.action) == ("mechanical", "mirror_tags")
+        assert item.key == "pos:~header/markdown/0"
+        assert (item.direction, item.side) == ("de_to_en", "de")
+        assert item.member is not None and item.member.de is not None
+        assert item.twin is not None and item.twin.en is not None  # pair_twin convention
+        assert item.member.de.tags == ("voiceover",)
+        assert item.twin.en.tags == ("notes",)

--- a/tests/slides/test_sync_diff_matrix.py
+++ b/tests/slides/test_sync_diff_matrix.py
@@ -20,7 +20,7 @@ Three structural guarantees, each preventing a distinct regression class:
 from __future__ import annotations
 
 import pytest
-from attrs import fields
+from attrs import evolve, fields
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
@@ -191,6 +191,94 @@ def test_action_registries_are_disjoint_and_closed():
     assert not (MECHANICAL_ACTIONS & FRAMED_ACTIONS)
     matrix_rows = {row for *_, row in _MATRIX} - {"normalize_refusal"}
     assert matrix_rows <= MECHANICAL_ACTIONS | FRAMED_ACTIONS
+    # The tag-parity aspect rows (#615) never appear in the transition
+    # matrix (they are orthogonal to langness transitions), so the walk
+    # above cannot police their registration — assert it explicitly.
+    tag_axis_rows = {row for *_, rows in _TAG_AXIS for row in rows}
+    assert tag_axis_rows <= MECHANICAL_ACTIONS | FRAMED_ACTIONS
+    assert "mirror_tags" in MECHANICAL_ACTIONS
+    assert "conflict_tags" in FRAMED_ACTIONS
+
+
+# ---------------------------------------------------------------------------
+# 1b. The tag-divergence axis (#615)
+# ---------------------------------------------------------------------------
+
+# A focused walk over the tag-parity aspect rows: shape {localized-id'd,
+# complete-fork} × move {one-sided, divergent, baseline-carried}. Unlike the
+# §7.4 matrix walk this asserts the expected *set* of rows (the fork cases
+# legitimately co-emit with record_fork). Bodies stay at base throughout —
+# the aspect row must fully account for the tag delta.
+
+_TAG_AXIS: list[tuple[str, str, frozenset[str]]] = [
+    ("localized", "one_sided", frozenset({"mirror_tags"})),
+    ("localized", "divergent", frozenset({"conflict_tags"})),
+    ("localized", "baseline_carried", frozenset({"conflict_tags"})),
+    ("fork", "one_sided", frozenset({"mirror_tags", "record_fork"})),
+    ("fork", "divergent", frozenset({"conflict_tags", "record_fork"})),
+    ("fork", "baseline_carried", frozenset({"conflict_tags", "record_fork"})),
+]
+
+
+def _tag_cell(lang: str | None, tags: tuple[str, ...], body: str) -> str:
+    tag_attr = "[" + ", ".join(f'"{t}"' for t in tags) + "]"
+    lang_attr = f' lang="{lang}"' if lang is not None else ""
+    return f'# %% [markdown]{lang_attr} tags={tag_attr} slide_id="cell-x"\n# {body}\n\n'
+
+
+@pytest.mark.parametrize(
+    ("shape", "move", "expected_actions"),
+    _TAG_AXIS,
+    ids=[f"{c[0]}-{c[1]}" for c in _TAG_AXIS],
+)
+def test_tag_divergence_axis_maps_to_expected_row_set(
+    shape: str, move: str, expected_actions: frozenset[str]
+):
+    if shape == "localized":
+        base_de = _tag_cell("de", ("notes",), "DE body")
+        base_en_tags = ("alt",) if move == "baseline_carried" else ("notes",)
+        base_en = _tag_cell("en", base_en_tags, "EN body")
+        cur_de = base_de if move == "baseline_carried" else _tag_cell("de", ("alt",), "DE body")
+        cur_en = _tag_cell("en", ("voiceover",), "EN body") if move == "divergent" else base_en
+    else:
+        base_de = base_en = _tag_cell(None, ("notes",), "shared body")
+        en_tags = ("notes",) if move == "one_sided" else ("voiceover",)
+        cur_de = _tag_cell("de", ("alt",), "shared body")
+        cur_en = _tag_cell("en", en_tags, "shared body")
+
+    base_outcome = parse_bundle(*_bundle("inline", base_de, base_en))
+    assert base_outcome.deck is not None, (
+        base_outcome.refusal.render() if base_outcome.refusal else "?"
+    )
+    base = baseline_from_deck(base_outcome.deck)
+    if shape == "fork" and move == "baseline_carried":
+        # A real shared base always records one tag tuple on both sides, so
+        # the unattributable state is the pre-tag-recording ledger shape:
+        # entries whose tag fields predate recording (``None`` = moved).
+        key = next(k for k in base.members if "cell-x" in k)
+        base.members[key] = evolve(base.members[key], de_tags=None, en_tags=None)
+
+    diff = diff_outcome(parse_bundle(*_bundle("inline", cur_de, cur_en)), base)
+    assert diff.refusal is None, diff.refusal.render() if diff.refusal else "?"
+    rows = [(i.outcome, i.action, i.key, i.direction, i.detail) for i in diff.items]
+    assert {i.action for i in diff.items} == set(expected_actions), rows
+    assert len(diff.items) == len(expected_actions), rows
+
+    by_action = {i.action: i for i in diff.items}
+    if "mirror_tags" in by_action:
+        item = by_action["mirror_tags"]
+        assert item.outcome == "mechanical"
+        assert item.direction == "de_to_en"  # the DE half is the mover throughout
+        assert item.side == "de"
+    if "conflict_tags" in by_action:
+        item = by_action["conflict_tags"]
+        assert item.outcome == "conflict"
+        assert item.side is None  # the answer names the side, not the row
+        if shape == "fork":
+            assert item.direction == "both"  # fork-time divergence is never baseline-blessed
+        else:
+            assert item.direction == ("none" if move == "baseline_carried" else "both")
+    assert all(i.action in MECHANICAL_ACTIONS | FRAMED_ACTIONS for i in diff.items)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #615.

## Problem

A one-sided tag edit (`notes` → `voiceover`) coinciding with body drift was folded into the body-centric `verify_translation` item. `confirm` then banked the pair **including the cross-side tag divergence** as the trusted baseline — after which `sync report` went silent and `sync verify` passed while `clm validate` kept flagging the pair, with no sync item left to answer.

**Root cause**: cross-side tag parity is a *pair* invariant, but the v3 differ evaluates localized members side-against-own-baseline only; the invariant was checked only incidentally, when the tag delta happened to be isolated. Full analysis and adversarial design review: `docs/claude/design/sync-tag-parity-conflicts.md` (included).

## Fix (four layers, one per gap)

- **F1 — differ**: tag parity is an orthogonal aspect row (like layout/owner). One attributable mover → mechanical `mirror_tags` co-framed next to the body row; both-moved-apart, baseline-carried (already-banked), or incomplete-tag-baseline divergences → new framed **`conflict_tags`** (`de`/`en` mirrors *only* the chosen side's tag set). Covers matched members, complete forks (`record_fork` can no longer legitimize divergent tags), and id-less positional pool slots. A framed `conflict_tags` suppresses the member's other rows for the pass — handle-keyed decision documents cannot answer two framed rows on one key (`conflict_owner` even shares the `de`/`en` vocabulary).
- **F2 — apply/ledger**: never bless the unresolved — landed rows on members with unresolved (or `conflict_tags`-answered) sibling rows defer their ledger recording; deferred record-only rows report the new honest `deferred` status; `_sweep_migrated_pos` spares deferred members' baselines; `confirm`/`keep_twin` reject while the twins' tag sets diverge.
- **F3 — verify**: new `tag-parity` warning (never gates) with three-tier pairing — `(slide_id, role)`, per-slide positional fallback (load-bearing: the `notes`→`voiceover` edit *changes* the derived role), positional id-less remainder.
- **F4 — docs**: `sync-agents`/`commands` info topics, design doc, changelog fragment.

Decks already damaged by the old behavior re-frame automatically (baseline-carried divergence → `conflict_tags`); no ledger migration needed.

## Verification

- 38 new tests (differ shapes, apply round-trips incl. two-pass sequencing convergence, matrix tag axis, verify unit+CLI); full fast suite green (8476 passed), ruff + mypy clean.
- A post-implementation **adversarial multi-agent review** (4 lenses × 2-skeptic verification) confirmed 11 findings — 1 critical (an answered `conflict_tags` let co-landed same-key rows bank the suppressed body drift), 4 major, 6 minor. All are fixed and regression-pinned in this PR; 7 further claims were refuted with reproductions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CEGVpuQxXPXibssHWf3iZ