### PR TITLE
feat(slides): report skipped interleaving on split halves (#631)

### DIFF
--- a/changelog.d/631-interleaving-skip-notice.changed.md
+++ b/changelog.d/631-interleaving-skip-notice.changed.md
@@ -1,0 +1,4 @@
+- `clm slides normalize`: an explicit `--operations interleaving` on a
+  language-split half (`*.de.py` / `*.en.py`) is no longer a silent no-op —
+  the intentional skip (#611) is now reported as a `[SKIPPED]` line (a
+  `notices` array in `--json`), without affecting status or exit code (#631).

--- a/src/clm/cli/commands/slides/normalize.py
+++ b/src/clm/cli/commands/slides/normalize.py
@@ -412,6 +412,11 @@ def _resolve_slides_dir(data_dir: Path | None, spec_file: Path) -> Path:
 def _print_human_readable(result: NormalizationResult, dry_run: bool) -> None:
     prefix = "[DRY RUN] " if dry_run else ""
 
+    # #631: explicitly requested operations that were intentionally skipped —
+    # informational only, no effect on status or exit code.
+    for n in result.notices:
+        click.echo(f"[SKIPPED] {n.file}: {n.message}")
+
     if not result.changes and not result.review_items:
         click.echo(f"{prefix}No changes needed.")
         return
@@ -455,5 +460,9 @@ def _result_to_dict(result: NormalizationResult) -> dict:
                 if v is not None
             }
             for r in result.review_items
+        ]
+    if result.notices:
+        d["notices"] = [
+            {"file": n.file, "operation": n.operation, "message": n.message} for n in result.notices
         ]
     return d

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1431,6 +1431,13 @@ check, so every half produced a guaranteed `count_mismatch` review and exit 2
 owned by `clm slides sync verify`. This makes `normalize --dry-run` usable as
 a scripted drift gate on split decks (exit 0 when clean).
 
+The skip is silent on a default run, but an **explicit** request — `--operations
+interleaving` (or any explicit list naming it) on a split half — reports it
+(since CLM {version}, issue #631): human output prints a `[SKIPPED] <file>: …`
+line and `--json` carries a `notices` array (`file`, `operation`, `message`).
+Notices are informational only — status stays `clean` and the exit code is
+unchanged.
+
 The `placeholder_start` operation (since CLM {version}) fixes a recurring
 workshop mis-tag (issue #233): a code cell tagged `start` whose entire body is
 a solution placeholder (`# Your solution here`, `pass`, `...`) followed by a

--- a/src/clm/mcp/tools.py
+++ b/src/clm/mcp/tools.py
@@ -583,6 +583,10 @@ def _normalization_result_to_dict(result: NormalizationResult) -> dict:
             }
             for r in result.review_items
         ]
+    if result.notices:
+        d["notices"] = [
+            {"file": n.file, "operation": n.operation, "message": n.message} for n in result.notices
+        ]
     return d
 
 

--- a/src/clm/slides/normalizer.py
+++ b/src/clm/slides/normalizer.py
@@ -70,12 +70,27 @@ class ReviewItem:
 
 
 @dataclass
+class Notice:
+    """An explicitly requested operation that was intentionally skipped (#631).
+
+    Purely informational: notices never affect :attr:`NormalizationResult.status`
+    or the CLI exit code — they only keep an explicit request from looking like
+    a silent no-op.
+    """
+
+    file: str
+    operation: str
+    message: str
+
+
+@dataclass
 class NormalizationResult:
     """Result of normalizing one or more slide files."""
 
     files_modified: int = 0
     changes: list[Change] = field(default_factory=list)
     review_items: list[ReviewItem] = field(default_factory=list)
+    notices: list[Notice] = field(default_factory=list)
 
     @property
     def status(self) -> str:
@@ -1006,6 +1021,7 @@ def normalize_file(
 
     all_changes: list[Change] = []
     all_review: list[ReviewItem] = []
+    all_notices: list[Notice] = []
 
     # Apply operations in deterministic order. Preamble-code wrapping runs first
     # so every later pass (interleaving, slide_ids, cell_spacing) sees the
@@ -1032,15 +1048,30 @@ def normalize_file(
     # could emit is structural noise (a guaranteed ``count_mismatch`` per half,
     # exit 2) — skipped on the same signal the validator's bilingual pairing
     # checks use; cross-half parity is owned by ``clm slides sync`` (#611).
-    if "interleaving" in op_set and split_lang_suffix(path) is None:
-        cells, interleave_changes, interleave_reviews = _apply_interleaving(
-            cells,
-            file_str,
-            canonicalize_start_completed=canonicalize_start_completed,
-            confirmed_pairings=confirmed_pairings,
-        )
-        all_changes.extend(interleave_changes)
-        all_review.extend(interleave_reviews)
+    if "interleaving" in op_set:
+        if split_lang_suffix(path) is None:
+            cells, interleave_changes, interleave_reviews = _apply_interleaving(
+                cells,
+                file_str,
+                canonicalize_start_completed=canonicalize_start_completed,
+                confirmed_pairings=confirmed_pairings,
+            )
+            all_changes.extend(interleave_changes)
+            all_review.extend(interleave_reviews)
+        elif operations is not None and "interleaving" in operations:
+            # #631: the skip is silent on a default run, but an EXPLICITLY
+            # requested interleaving pass must say why nothing happened.
+            all_notices.append(
+                Notice(
+                    file=file_str,
+                    operation="interleaving",
+                    message=(
+                        "interleaving skipped: language-split half — a "
+                        "single-language file has no within-file DE/EN pairs; "
+                        "cross-half parity is owned by `clm slides sync`"
+                    ),
+                )
+            )
 
     if "slide_ids" in op_set:
         slide_id_changes, slide_id_reviews = _apply_slide_ids(cells, path, assign_options)
@@ -1063,6 +1094,7 @@ def normalize_file(
         files_modified=1 if modified else 0,
         changes=all_changes,
         review_items=all_review,
+        notices=all_notices,
     )
 
 
@@ -1111,6 +1143,7 @@ def normalize_files(
         combined.files_modified += result.files_modified
         combined.changes.extend(result.changes)
         combined.review_items.extend(result.review_items)
+        combined.notices.extend(result.notices)
 
     return combined
 
@@ -1146,5 +1179,6 @@ def normalize_course(
                 combined.files_modified += result.files_modified
                 combined.changes.extend(result.changes)
                 combined.review_items.extend(result.review_items)
+                combined.notices.extend(result.notices)
 
     return combined

--- a/tests/cli/test_normalize_slides.py
+++ b/tests/cli/test_normalize_slides.py
@@ -30,6 +30,30 @@ class TestNormalizeSlidesCmd:
         assert result.exit_code == 0
         assert "No changes needed" in result.output
 
+    def test_explicit_interleaving_on_split_half_reports_skip(self, tmp_path):
+        # Regression test for #631: `--operations interleaving` on a split half
+        # is intentionally skipped (#611) but must SAY so — exit 0 either way.
+        path = _write_slide(
+            tmp_path / "slides_test.de.py",
+            '# %% [markdown] lang="de" tags=["slide"]\n# # Folie\n',
+        )
+        runner = CliRunner()
+        result = runner.invoke(normalize_slides_cmd, [str(path), "--operations", "interleaving"])
+        assert result.exit_code == 0, result.output
+        assert "[SKIPPED]" in result.output
+        assert "split half" in result.output
+
+        as_json = runner.invoke(
+            normalize_slides_cmd, [str(path), "--operations", "interleaving", "--json"]
+        )
+        assert as_json.exit_code == 0, as_json.output
+        data = json.loads(as_json.output)
+        assert data["status"] == "clean"
+        notices = data["notices"]
+        assert len(notices) == 1
+        assert notices[0]["operation"] == "interleaving"
+        assert "split half" in notices[0]["message"]
+
     def test_confirm_pairs_applies_interleave_and_converges(self, tmp_path):
         # #236 agent flow over the CLI: --json worklist → --confirm-pairs (stdin) →
         # reordered + exit 0 → a plain re-run is clean.

--- a/tests/slides/test_normalizer.py
+++ b/tests/slides/test_normalizer.py
@@ -628,6 +628,44 @@ class TestInterleaving:
             assert result.review_items == [], (name, result.review_items)
             assert result.status == "clean"
 
+    def test_explicit_interleaving_on_split_half_emits_skip_notice(self, tmp_path):
+        # Regression test for #631: an EXPLICIT `--operations interleaving`
+        # request on a language-split half must not be a silent no-op — the
+        # skip is surfaced as a notice (status/exit code stay clean, #611).
+        text = '# %% [markdown] lang="de" tags=["slide"]\n# # Folie 1\n'
+        path = _write_slide(tmp_path / "slides_test.de.py", text)
+        result = normalize_file(path, operations=["interleaving"], dry_run=True)
+
+        assert result.review_items == []
+        assert result.status == "clean"
+        assert len(result.notices) == 1, result.notices
+        notice = result.notices[0]
+        assert notice.operation == "interleaving"
+        assert notice.file == str(path)
+        assert "split half" in notice.message
+
+    def test_default_run_on_split_half_emits_no_notice(self, tmp_path):
+        # #631: only an explicit request gets the notice — a default run (or
+        # explicit `all`) over split decks stays quiet, as intended by #611.
+        text = '# %% [markdown] lang="de" tags=["slide"]\n# # Folie 1\n'
+        path = _write_slide(tmp_path / "slides_test.de.py", text)
+        for ops in (None, ["all"]):
+            result = normalize_file(path, operations=ops, dry_run=True)
+            assert result.notices == [], (ops, result.notices)
+
+    def test_explicit_interleaving_on_bilingual_file_emits_no_notice(self, tmp_path):
+        # #631: the notice fires only when the pass is actually skipped.
+        text = (
+            '# %% [markdown] lang="de" tags=["slide"]\n'
+            "# # Folie\n"
+            "\n"
+            '# %% [markdown] lang="en" tags=["slide"]\n'
+            "# # Slide\n"
+        )
+        path = _write_slide(tmp_path / "slides_test.py", text)
+        result = normalize_file(path, operations=["interleaving"], dry_run=True)
+        assert result.notices == []
+
     def test_split_half_still_runs_other_operations(self, tmp_path):
         # Only the DE/EN interleaving pass is exempt on split halves — the
         # mechanical single-file passes must still run.


### PR DESCRIPTION
## Summary

Fixes #631.

**Root cause**: the split-half interleaving gate added in PR #626 (for #611) drops the operation without recording anything in the `NormalizationResult`, so an explicit `clm slides normalize --operations interleaving <deck>.de.py` surfaced as a bare "No changes needed." — a silent no-op with no signal that the skip was intentional.

## Change

- New `Notice` dataclass + `NormalizationResult.notices` — purely informational; never affects `status` or exit codes.
- `normalize_file` records a notice when interleaving is skipped on a split half **and** was explicitly requested (`operations` names `interleaving`); default and `all` runs stay quiet, as intended by #611.
- Notices propagate through `normalize_files` / `normalize_course` and surface as `[SKIPPED] <file>: …` in human output and a `notices` array in `--json` and MCP output.
- `clm info commands` (#611 paragraph) now documents the explicit-request case, per the issue's second suggestion.

## Testing

- Regression tests (`# Regression test for #631`) in `tests/slides/test_normalizer.py` (notice on explicit request; none on default/`all`/bilingual) and `tests/cli/test_normalize_slides.py` (human `[SKIPPED]` line + JSON `notices`, exit 0) — all failed before the fix.
- Full fast suite: 8497 passed. Ruff + mypy clean. Exercised the real CLI end-to-end on a split half (explicit, `--json`, and default runs).

Adversarial review skipped: small, isolated, additive change outside `core/`/`infrastructure/`, pinned by regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014KY31SMnGjrfQc6aC6bWey
