### PR TITLE
fix(build): scope job claiming to the owning build session (#620)

### DIFF
--- a/changelog.d/620-job-session-ownership.fixed.md
+++ b/changelog.d/620-job-session-ownership.fixed.md
@@ -1,0 +1,10 @@
+- Fixed a killed or concurrent build poisoning another build's jobs (issue
+  #620). Jobs in the shared jobs DB carried no session ownership, so a worker
+  would claim any pending same-type/same-mode job — including one submitted by a
+  different build whose workspace it cannot address — and fail it in Docker mode
+  with `... is not in the subpath of ...`, misattributed to an innocent slide
+  file. Jobs are now stamped with their owning build session (`jobs.session_id`,
+  mirroring the `workers.session_id` ownership added in #594): a worker claims
+  only its own session's jobs plus unowned (`NULL`) legacy jobs, and a worker
+  with no session stays unrestricted so a build can never deadlock on its own
+  jobs.

--- a/docs/claude/handovers/issue-triage-2026-07-handover.md
+++ b/docs/claude/handovers/issue-triage-2026-07-handover.md
@@ -1,12 +1,14 @@
 # Open-Issue Triage & Execution Plan (2026-07-10) — Handover
 
 **Status**: Triage COMPLETE; execution IN PROGRESS — Phases 1–5 DONE
-(#600, #539, #524/#382/#362, #568, #559); Phase 7 DONE except #615
-(#609/#610/#611 via PRs #624/#625/#626 on 2026-07-11; #615 is owned by
-another session — see the Phase 7 block). Next up **Phase 8 (#620/#617
-build reliability)**, then Phase 6 (design tier). This document is the
-source of truth for working through the open-issue backlog in priority
-order. Update phase statuses here as issues land.
+(#600, #539, #524/#382/#362, #568, #559); **Phase 7 fully DONE**
+(#609/#610/#611 via PRs #624/#625/#626 on 2026-07-11; #615 landed via
+PR #628, merged 2026-07-11 — see the Phase 7 block); **Phase 8 #620 DONE**
+(job session ownership, 2026-07-12 — see the Phase 8 block). Next up
+**Phase 8 #617** (own-pool teardown orphaning), then Phase 6 (design
+tier). This document is the source of truth for working through the
+open-issue backlog in priority order. Update phase statuses here as issues
+land.
 
 ## 1. Feature Overview
 
@@ -301,14 +303,24 @@ intrinsically bigger work. **Execution order: Phase 7 → Phase 8 →
 Phase 6.** (#614 is deferred like the rest of #568's fixes 2–4 that it
 tracks: schedule it just before the next big harvest round.)
 
-### Phase 7 [DONE except #615] — Sync agent-loop regressions + normalize gate (#609, #610, #615, #611)
+### Phase 7 [DONE] — Sync agent-loop regressions + normalize gate (#609, #610, #615, #611)
 
-**Resolution (2026-07-11)**: #609, #610, #611 shipped (PRs #624, #625,
-#626); **#615 deliberately left untouched** — another session owns it (its
-branch `claude/issue-615-tag-parity-design` carries a root-cause analysis
-and design; no fix landed as of this session's end, issue still OPEN).
-Check #615 before starting Phase 8; if abandoned, its design branch is the
-starting point.
+**Resolution (2026-07-11)**: all four shipped. #609, #610, #611 via PRs
+#624, #625, #626; **#615 via PR #628** (merged 2026-07-11 from branch
+`claude/issue-615-tag-parity-design`, which another session had scoped as a
+root-cause analysis + design, then completed to a full fix). #615 fix
+(four layers): tag parity is now an orthogonal aspect row in the v3 differ
+— one attributable mover frames a mechanical `mirror_tags`; both-moved /
+baseline-carried / incomplete-baseline divergences frame a new
+`conflict_tags` (mirrors only the chosen side's tag set, suppresses the
+member's other rows for the pass); apply/ledger never blesses members with
+unresolved sibling rows (new honest `deferred` record status);
+`sync verify` gains a non-gating `tag-parity` warning with three-tier
+pairing; `sync-agents`/`commands` info topics + design doc
+`docs/claude/design/sync-tag-parity-conflicts.md` + changelog fragment.
+Decks damaged by the old banking behavior re-frame automatically — no
+ledger migration. Shipped with 38 new tests + a post-implementation
+adversarial multi-agent review (11 findings fixed).
 
 - **#609 (PR #624)**: root cause — the `id:title` member is a *single-line
   j2 macro cell*: its `# {{ header_de(…) }}` line is simultaneously the
@@ -371,19 +383,38 @@ amendments-log row for ANY engine change). #609/#610 have documented
 workarounds in their issue bodies — as with #600, the workaround is the
 oracle for what the fixed flow should converge to.
 
-### Phase 8 [TODO] — Build reliability: job/session ownership (#620, #617)
+### Phase 8 [IN PROGRESS — #620 DONE, #617 TODO] — Build reliability: job/session ownership (#620, #617)
+
+**#620 DONE (2026-07-12)**: implemented exactly the planned fix direction —
+session id on job rows + claim filter — as its own PR. Schema v11 adds
+`jobs.session_id`; `add_job` stamps it and the backend forwards its
+`worker_session_id` (already wired from `lifecycle_manager.session_id`) on
+every submit; `get_next_job` resolves the claiming worker's own
+`workers.session_id` and filters `(session_id IS NULL OR session_id = ?)`.
+The one filter site covers **both** claim paths (Direct `worker_base`,
+Docker `worker_routes`) since both pass `worker_id` and the query runs
+host-side. A worker with no resolvable session stays unrestricted (legacy /
+tests), so a build can never deadlock on its own jobs; a killed/concurrent
+build's residue (different session) is simply never claimed and sits
+harmless. The issue's **optional** extras were deliberately deferred: fix #2
+(requeue an unmappable job instead of failing it — largely moot once foreign
+jobs aren't claimed, and a naive requeue risks silent retry loops) and fix #3
+(dead-session sweep — unsafe without real dead-session detection). Shipped
+with schema-migration, session-filter, and backend-wiring tests (the schema
+version-canary in `test_worker_heartbeats.py` bumped to 11). **#617 (own-pool
+teardown orphaning) is next — investigate as its own PR.**
 
 Investigate together — likely the same #564/#594/#599 family, and #617's
 diagnostic even names the suspected race.
 
-- **#620**: `jobs` rows carry no session ownership, so workers claim a
-  killed/concurrent build's pending jobs and fail them with
+- **#620 [DONE]**: `jobs` rows carried no session ownership, so workers claimed a
+  killed/concurrent build's pending jobs and failed them with
   `is not in the subpath of` path errors attributed to innocent slide
-  files (a killed Docker build deterministically poisons the next one).
-  This is the residual half of #564's gap: #564 filtered claiming by
-  `execution_mode`, #594/#599 added ownership for *workers*, jobs still
-  have none. Fix direction is clear (session/build id on job rows +
-  claim filter).
+  files (a killed Docker build deterministically poisoned the next one).
+  This was the residual half of #564's gap: #564 filtered claiming by
+  `execution_mode`, #594/#599 added ownership for *workers*, jobs had
+  none. Fixed by stamping jobs with the owning build session and filtering
+  claims by it (see the resolution note above).
 - **#617**: intermittent `worker died mid-job (orphaned at pool
   shutdown)` failing a batch of jobs mid-stage in a single uninterrupted
   Direct-mode build (8 of 38 jobs in the observed run; byte-identical
@@ -443,22 +474,26 @@ OpenAI-compatible client, zero new deps) or close as status-quo.
 - **Post-triage issues folded in** (2026-07-11): #609, #610, #611, #615
   (sync/normalize — Phase 7), #617, #620 (build reliability — Phase 8),
   #614 (deferred harvest follow-up, tracks #568 fixes 2–4). See §3a.
-- **Phase 7 DONE except #615** (2026-07-11): #609 via PR #624, #610 via
-  PR #625, #611 via PR #626 (resolution details in the Phase 7 block).
-  #615 is owned by another session (design branch
-  `claude/issue-615-tag-parity-design`); still OPEN at session end.
+- **Phase 7 fully DONE** (2026-07-11): #609 via PR #624, #610 via
+  PR #625, #611 via PR #626, **#615 via PR #628** (resolution details in
+  the Phase 7 block). All four issues CLOSED.
+- **Phase 8 #620 DONE** (2026-07-12): job session ownership — schema v11
+  `jobs.session_id`, stamp on submit, session-filtered claim (resolution
+  details in the Phase 8 block). #617 still open.
 - No blockers, no pending decisions. Remaining, in priority order:
-  #615 (other session; verify before Phase 8), Phase 8 (#620/#617),
-  Phase 6 design tier (#383+#381 — start with a verify-then-close pass,
-  see the Phase 3 resolution note — plus #484, #167), #614 before the
-  next harvest round.
+  Phase 8 **#617** (own-pool teardown orphaning — investigate as its own
+  PR), Phase 6 design tier (#383+#381 — start with a verify-then-close
+  pass, see the Phase 3 resolution note — plus #484, #167), #614 before
+  the next harvest round.
 
 ## 5. Next Steps
 
-**Phases 1–5 and 7 (minus #615) are DONE — next is Phase 8 (§3a):
-#620/#617 job-ownership work, investigated together.** First check
-whether #615 landed (another session owns it; branch
-`claude/issue-615-tag-parity-design`). Then Phase 6a (#383+#381 — START
+**Phases 1–5 and 7 are DONE; Phase 8 #620 is DONE — next is Phase 8
+#617** (own-pool teardown orphaning: a build's own in-flight jobs marked
+`worker died mid-job (orphaned at pool shutdown)` mid-stage in an
+uninterrupted Direct build). Investigate the `mark_orphaned_jobs_failed`
+timing vs. pool teardown across stage boundaries; ship as its own PR (the
+#620 ownership work may illuminate it). Then Phase 6a (#383+#381 — START
 with a verify-then-close pass against commit 90518611, see the Phase 3
 resolution note). Schedule #614 just before the next big harvest round.
 The plan below documents how Phase 1 was executed (kept for reference):
@@ -516,11 +551,21 @@ their listed sites — see each phase's resolution block for what changed:
   not re-located during this fold-in, start from the issues' repro output
 - `#611` (Phase 7) → `src/clm/slides/normalizer.py` review pass; copy the
   split-file exemption from `src/clm/slides/validator.py`
-- `#620/#617` (Phase 8) → job claiming in
-  `src/clm/infrastructure/backends/sqlite_backend.py` and the jobs schema
-  (no session column today); `worker_base._convert_path_to_container()`
-  is where #620's misattributed error surfaces; #594/#599 PRs are the
-  pattern for the ownership half already done for workers
+- `#620` (Phase 8, DONE) → `src/clm/infrastructure/database/schema.py`
+  (`jobs.session_id` column + v10→v11 migration, `DATABASE_VERSION`),
+  `src/clm/infrastructure/database/job_queue.py` (`add_job` stamp +
+  `get_next_job` session-filter, `Job.session_id`),
+  `src/clm/infrastructure/backends/sqlite_backend.py` (`_submit_job_blocking`
+  forwards `worker_session_id`). Tests: `tests/infrastructure/database/
+  test_job_queue.py` + `test_schema.py`, `tests/infrastructure/backends/
+  test_sqlite_backend_resilience.py`; version-canary bumped in
+  `test_worker_heartbeats.py`
+- `#617` (Phase 8, TODO) → `job_queue.mark_orphaned_jobs_failed`
+  (`ORPHAN_ERROR_MESSAGE`) and its caller
+  `WorkerLifecycleManager.stop_managed_workers` — trace teardown timing vs.
+  stage boundaries; `worker_base._convert_path_to_container()` was where
+  #620's misattributed error surfaced (kept here for the #617 investigator);
+  #594/#599 PRs are the ownership pattern
 - `#484` → `src/clm/infrastructure/backends/sqlite_backend.py`
   (`_execute_operation_impl`, poll loop `record_write` at ~:564),
   `src/clm/core/output_write_registry.py` (:292,294 hash-in-critical-section)

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -516,6 +516,11 @@ class SqliteBackend(LocalOpsBackend):
             payload=payload_dict,
             correlation_id=correlation_id,
             execution_mode=self.worker_execution_modes.get(job_type),
+            # Stamp the owning build session so only this build's workers claim
+            # the job (issue #620). Mirrors the worker-row session stamping the
+            # same lifecycle manager applies (issue #594); None (tests, legacy
+            # callers) leaves the job claimable by any worker.
+            session_id=self.worker_session_id,
         )
         return ("submitted", job_id)
 

--- a/src/clm/infrastructure/database/job_queue.py
+++ b/src/clm/infrastructure/database/job_queue.py
@@ -38,6 +38,7 @@ class Job:
     correlation_id: str | None = None
     cancelled_at: datetime | None = None
     cancelled_by: str | None = None
+    session_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Convert job to dictionary."""
@@ -115,6 +116,7 @@ class JobQueue:
         priority: int = 0,
         correlation_id: str | None = None,
         execution_mode: str | None = None,
+        session_id: str | None = None,
     ) -> int:
         """Add a new job to the queue.
 
@@ -132,6 +134,10 @@ class JobQueue:
                 Direct worker from a concurrent build sharing the same jobs
                 DB can never claim them (it may lack the required toolchain,
                 e.g. the xeus-cpp kernel).
+            session_id: Owning build session (the submitting
+                WorkerLifecycleManager's session_id). Stamped so only workers
+                of the same session claim the job; None lets any worker claim
+                it (legacy / tests). See :meth:`get_next_job` and issue #620.
 
         Returns:
             Job ID
@@ -141,8 +147,9 @@ class JobQueue:
             """
             INSERT INTO jobs (
                 job_type, status, input_file, output_file,
-                content_hash, payload, priority, correlation_id, execution_mode
-            ) VALUES (?, 'pending', ?, ?, ?, ?, ?, ?, ?)
+                content_hash, payload, priority, correlation_id, execution_mode,
+                session_id
+            ) VALUES (?, 'pending', ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 job_type,
@@ -153,6 +160,7 @@ class JobQueue:
                 priority,
                 correlation_id,
                 execution_mode,
+                session_id,
             ),
         )
         # No commit() needed - connection is in autocommit mode
@@ -256,27 +264,39 @@ class JobQueue:
         # Use explicit transaction to atomically get and update job
         conn.execute("BEGIN IMMEDIATE")
         try:
-            if execution_mode is None:
-                cursor = conn.execute(
-                    """
-                    SELECT * FROM jobs
-                    WHERE status = 'pending' AND job_type = ? AND attempts < max_attempts
-                    ORDER BY priority DESC, created_at ASC
-                    LIMIT 1
-                    """,
-                    (job_type,),
-                )
-            else:
-                cursor = conn.execute(
-                    """
-                    SELECT * FROM jobs
-                    WHERE status = 'pending' AND job_type = ? AND attempts < max_attempts
-                    AND (execution_mode IS NULL OR execution_mode = ?)
-                    ORDER BY priority DESC, created_at ASC
-                    LIMIT 1
-                    """,
-                    (job_type, execution_mode),
-                )
+            # Session ownership (issue #620): resolve the claiming worker's own
+            # build session from its workers row, then hand it only jobs stamped
+            # with that same session (plus NULL legacy jobs). This stops a worker
+            # from draining a killed or concurrent build's still-pending jobs —
+            # which reference a workspace it cannot address and would fail with
+            # "is not in the subpath of" against an innocent slide file. A worker
+            # with no session (worker_id None, or a self-registered / legacy
+            # worker row whose session_id is NULL) is left unrestricted, so a
+            # build whose workers happen to be unstamped can never deadlock on
+            # its own jobs.
+            worker_session_id: str | None = None
+            if worker_id is not None:
+                worker_row = conn.execute(
+                    "SELECT session_id FROM workers WHERE id = ?", (worker_id,)
+                ).fetchone()
+                if worker_row is not None:
+                    worker_session_id = worker_row["session_id"]
+
+            conditions = ["status = 'pending'", "job_type = ?", "attempts < max_attempts"]
+            params: list[Any] = [job_type]
+            if execution_mode is not None:
+                conditions.append("(execution_mode IS NULL OR execution_mode = ?)")
+                params.append(execution_mode)
+            if worker_session_id is not None:
+                conditions.append("(session_id IS NULL OR session_id = ?)")
+                params.append(worker_session_id)
+
+            where_clause = " AND ".join(conditions)
+            cursor = conn.execute(
+                f"SELECT * FROM jobs WHERE {where_clause} "  # noqa: S608 — literal predicates, bound params
+                "ORDER BY priority DESC, created_at ASC LIMIT 1",
+                params,
+            )
             row = cursor.fetchone()
 
             if not row:
@@ -310,6 +330,7 @@ class JobQueue:
                 priority=row["priority"],
                 worker_id=worker_id,
                 correlation_id=row["correlation_id"] if "correlation_id" in row.keys() else None,
+                session_id=row["session_id"] if "session_id" in row.keys() else None,
             )
 
             logger.info(
@@ -513,6 +534,7 @@ class JobQueue:
             if row["cancelled_at"]
             else None,
             cancelled_by=row["cancelled_by"] if "cancelled_by" in row.keys() else None,
+            session_id=row["session_id"] if "session_id" in row.keys() else None,
         )
 
     def get_job_statuses_batch(self, job_ids: list[int]) -> dict[int, tuple[str, str | None]]:
@@ -642,6 +664,7 @@ class JobQueue:
                     correlation_id=row["correlation_id"]
                     if "correlation_id" in row.keys()
                     else None,
+                    session_id=row["session_id"] if "session_id" in row.keys() else None,
                 )
             )
 

--- a/src/clm/infrastructure/database/schema.py
+++ b/src/clm/infrastructure/database/schema.py
@@ -8,7 +8,7 @@ workers.
 import sqlite3
 from pathlib import Path
 
-DATABASE_VERSION = 10
+DATABASE_VERSION = 11
 
 SCHEMA_SQL = """
 -- Jobs table (replaces message queue)
@@ -47,6 +47,16 @@ CREATE TABLE IF NOT EXISTS jobs (
     -- from stealing jobs that need a toolchain only the Docker image has,
     -- such as the xeus-cpp C++ kernel.
     execution_mode TEXT,
+
+    -- Owning build session (v11): the session_id of the WorkerLifecycleManager
+    -- that submitted this job, mirroring workers.session_id (issue #594). A
+    -- worker claims only jobs whose session matches its own (plus NULL legacy
+    -- jobs), so a killed or concurrent build's still-pending jobs — which
+    -- reference a workspace this worker cannot address — are never stolen and
+    -- failed with "is not in the subpath of" against an innocent slide file
+    -- (issue #620). NULL means any worker of the matching job_type/mode may
+    -- claim it (legacy / tests).
+    session_id TEXT,
 
     FOREIGN KEY (worker_id) REFERENCES workers(id)
 );
@@ -444,4 +454,19 @@ def migrate_database(conn: sqlite3.Connection, from_version: int, to_version: in
             if "duplicate column name" not in str(e).lower():
                 raise
         conn.execute("INSERT OR IGNORE INTO schema_version (version) VALUES (10)")
+        conn.commit()
+
+    # Migration from v10 to v11: jobs carry the owning build session
+    # (session_id) so a worker claims only its own session's jobs (or NULL
+    # legacy jobs) and never steals a killed/concurrent build's pending jobs
+    # that reference a workspace it cannot address. See the column comment in
+    # SCHEMA_SQL and issue #620.
+    if from_version < 11 <= to_version:
+        try:
+            conn.execute("ALTER TABLE jobs ADD COLUMN session_id TEXT")
+        except sqlite3.OperationalError as e:
+            # Column might already exist (fresh SCHEMA_SQL ran first)
+            if "duplicate column name" not in str(e).lower():
+                raise
+        conn.execute("INSERT OR IGNORE INTO schema_version (version) VALUES (11)")
         conn.commit()

--- a/tests/infrastructure/backends/test_sqlite_backend_resilience.py
+++ b/tests/infrastructure/backends/test_sqlite_backend_resilience.py
@@ -732,6 +732,29 @@ async def test_activation_timeout_dead_marking_respects_ownership(temp_db, temp_
 
 
 @pytest.mark.asyncio
+async def test_submitted_job_is_stamped_with_worker_session_id(temp_db, temp_workspace):
+    """Issue #620: the backend stamps its build session onto every submitted
+    job, so only this build's own workers can claim it — a killed or concurrent
+    build's workers (a different session) never drain and fail it against an
+    innocent slide file."""
+    backend = _backend(temp_db, temp_workspace, worker_session_id="session-A")
+    try:
+        status, job_id = backend._submit_job_blocking(_MockPayload(), "notebook")
+        assert status == "submitted"
+        assert job_id is not None
+
+        queue = JobQueue(temp_db)
+        try:
+            job = queue.get_job(job_id)
+            assert job is not None
+            assert job.session_id == "session-A"
+        finally:
+            queue.close()
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_get_available_workers_no_queue(temp_db, temp_workspace):
     backend = _backend(temp_db, temp_workspace)
     try:

--- a/tests/infrastructure/database/test_job_queue.py
+++ b/tests/infrastructure/database/test_job_queue.py
@@ -173,6 +173,151 @@ def test_get_next_job_without_mode_claims_tagged_jobs(job_queue):
     assert job_queue.get_next_job("notebook") is not None
 
 
+def _register_worker(job_queue, session_id, container_id, execution_mode="direct"):
+    """Insert a worker row so get_next_job can resolve its owning session.
+
+    Session-ownership claiming (issue #620) keys off the claiming worker's own
+    ``workers.session_id``, so these tests must materialise a worker row.
+    """
+    conn = job_queue._get_conn()
+    cursor = conn.execute(
+        """
+        INSERT INTO workers (worker_type, container_id, status, session_id, execution_mode)
+        VALUES ('notebook', ?, 'idle', ?, ?)
+        """,
+        (container_id, session_id, execution_mode),
+    )
+    worker_id = cursor.lastrowid
+    assert worker_id is not None
+    return worker_id
+
+
+def test_add_job_stamps_session_id(job_queue):
+    """add_job records the owning build session on the job row (issue #620)."""
+    job_id = job_queue.add_job(
+        job_type="notebook",
+        input_file="test.py",
+        output_file="test.ipynb",
+        content_hash="abc123",
+        payload={},
+        session_id="session-A",
+    )
+
+    job = job_queue.get_job(job_id)
+    assert job is not None
+    assert job.session_id == "session-A"
+
+
+def test_get_next_job_session_ownership(job_queue):
+    """A worker claims only jobs stamped with its own build session (issue #620).
+
+    A killed or concurrent build's still-pending jobs belong to a different
+    session and reference a workspace this worker cannot address; letting it
+    claim them makes it fail an innocent slide file with "is not in the subpath
+    of".
+    """
+    job_a = job_queue.add_job(
+        job_type="notebook",
+        input_file="a.py",
+        output_file="a.ipynb",
+        content_hash="a",
+        payload={},
+        session_id="session-A",
+    )
+
+    # A worker owned by session B must NOT claim session A's job.
+    worker_b = _register_worker(job_queue, "session-B", "container-b")
+    assert job_queue.get_next_job("notebook", worker_id=worker_b) is None
+
+    # A worker owned by session A claims it.
+    worker_a = _register_worker(job_queue, "session-A", "container-a")
+    claimed = job_queue.get_next_job("notebook", worker_id=worker_a)
+    assert claimed is not None
+    assert claimed.id == job_a
+
+
+def test_get_next_job_untagged_session_claimable_by_any_worker(job_queue):
+    """A job with no owning session (legacy / tests) is claimable by any worker."""
+    job_queue.add_job(
+        job_type="notebook",
+        input_file="a.py",
+        output_file="a.ipynb",
+        content_hash="a",
+        payload={},
+        # No session_id — legacy / unowned job.
+    )
+
+    worker_b = _register_worker(job_queue, "session-B", "container-b")
+    assert job_queue.get_next_job("notebook", worker_id=worker_b) is not None
+
+
+def test_get_next_job_sessionless_claimer_is_unrestricted(job_queue):
+    """A claimer with no resolvable session claims any job, session-owned or not.
+
+    worker_id=None (no worker row) and a worker row whose session_id is NULL
+    both fall back to pre-#620 claim-anything behaviour, so a build whose
+    workers happen to be unstamped can never deadlock on its own jobs.
+    """
+    job_queue.add_job(
+        job_type="notebook",
+        input_file="a.py",
+        output_file="a.ipynb",
+        content_hash="a",
+        payload={},
+        session_id="session-A",
+    )
+    job_queue.add_job(
+        job_type="notebook",
+        input_file="b.py",
+        output_file="b.ipynb",
+        content_hash="b",
+        payload={},
+        session_id="session-A",
+    )
+
+    # No worker row at all → unrestricted.
+    assert job_queue.get_next_job("notebook") is not None
+    # A worker row with a NULL session → also unrestricted.
+    legacy_worker = _register_worker(job_queue, None, "container-legacy")
+    assert job_queue.get_next_job("notebook", worker_id=legacy_worker) is not None
+
+
+def test_get_next_job_worker_claims_own_and_null_but_not_foreign(job_queue):
+    """A session-owned worker sees its own + NULL jobs, never another session's."""
+    own = job_queue.add_job(
+        job_type="notebook",
+        input_file="own.py",
+        output_file="own.ipynb",
+        content_hash="own",
+        payload={},
+        session_id="session-A",
+    )
+    legacy = job_queue.add_job(
+        job_type="notebook",
+        input_file="legacy.py",
+        output_file="legacy.ipynb",
+        content_hash="legacy",
+        payload={},
+    )
+    foreign = job_queue.add_job(
+        job_type="notebook",
+        input_file="foreign.py",
+        output_file="foreign.ipynb",
+        content_hash="foreign",
+        payload={},
+        session_id="session-B",
+    )
+
+    worker_a = _register_worker(job_queue, "session-A", "container-a")
+    claimed_ids = set()
+    while (job := job_queue.get_next_job("notebook", worker_id=worker_a)) is not None:
+        claimed_ids.add(job.id)
+
+    assert own in claimed_ids
+    assert legacy in claimed_ids
+    assert foreign not in claimed_ids
+
+
 def test_get_next_job_priority(job_queue):
     """Test that jobs are retrieved by priority."""
     # Add low priority job

--- a/tests/infrastructure/database/test_schema.py
+++ b/tests/infrastructure/database/test_schema.py
@@ -741,6 +741,53 @@ class TestMigrateDatabase:
         finally:
             conn.close()
 
+    def test_migrate_v10_to_v11_adds_session_id_column(self, tmp_path):
+        """Migration from v10 to v11 adds the jobs.session_id column.
+
+        The column stamps a job with the owning build session so a worker
+        claims only its own session's jobs (issue #620).
+        """
+        db_path = tmp_path / "test.db"
+        conn = sqlite3.connect(str(db_path))
+
+        # Minimal v10 jobs table without session_id.
+        conn.execute("""
+            CREATE TABLE jobs (
+                id INTEGER PRIMARY KEY,
+                job_type TEXT NOT NULL,
+                status TEXT NOT NULL,
+                execution_mode TEXT,
+                completed_at TIMESTAMP
+            )
+        """)
+        conn.execute(
+            "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TIMESTAMP)"
+        )
+        conn.execute("INSERT INTO schema_version (version) VALUES (10)")
+        conn.commit()
+
+        migrate_database(conn, 10, 11)
+
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(jobs)").fetchall()}
+        assert "session_id" in columns
+        assert get_schema_version(conn) == 11
+
+        conn.close()
+
+    def test_migrate_v10_to_v11_handles_existing_column(self, tmp_path):
+        """v10→v11 migration is a no-op when session_id already exists."""
+        db_path = tmp_path / "test.db"
+        # A freshly initialized DB already has the column via SCHEMA_SQL.
+        init_database(db_path)
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            migrate_database(conn, 10, 11)  # Should not raise
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(jobs)").fetchall()}
+            assert "session_id" in columns
+        finally:
+            conn.close()
+
     def test_init_database_adds_v9_indexes_to_existing_v8_db(self, tmp_path):
         """init_database upgrades a pre-v9 database in place.
 

--- a/tests/infrastructure/database/test_worker_heartbeats.py
+++ b/tests/infrastructure/database/test_worker_heartbeats.py
@@ -116,7 +116,7 @@ def _read_heartbeat(db_path: Path, worker_id: int) -> dict | None:
 class TestHeartbeatSchema:
     def test_schema_version_is_current(self, db_path: Path) -> None:
         """After init the schema is at the documented latest version."""
-        assert DATABASE_VERSION == 10
+        assert DATABASE_VERSION == 11
 
     def test_table_exists_with_expected_columns(self, db_path: Path) -> None:
         conn = sqlite3.connect(str(db_path))


### PR DESCRIPTION
Closes #620.

## Problem

Jobs in the shared jobs DB carried no session ownership, so a worker would claim **any** pending same-type/same-mode job — including one submitted by a *different* build whose workspace it cannot address — and fail it in Docker mode with `... is not in the subpath of ...`, misattributed to an innocent slide file. A killed Docker build thus **deterministically poisoned the next one** (issue's manifestation A). This is the residual half of #564's gap: #564 filtered claiming by `execution_mode` and #594/#599 added ownership for *workers*, but jobs had none.

## Fix — stamp jobs with their owning build session + filter claims by it

- **Schema v11**: `jobs.session_id` column + `v10→v11` migration; `DATABASE_VERSION → 11`.
- **Stamp on submit**: `add_job(session_id=…)`; the backend forwards its `worker_session_id` (already wired from `lifecycle_manager.session_id`) on every submit.
- **Filter on claim**: `get_next_job` resolves the claiming worker's own `workers.session_id` and adds `(session_id IS NULL OR session_id = ?)`. The one filter site covers **both** claim paths (Direct `worker_base`, Docker `worker_routes`) since both pass `worker_id` and the query runs host-side.
- **No deadlock**: a worker with no resolvable session (worker_id `None`, or a self-registered/legacy worker with `NULL` session) stays unrestricted, so a build can never deadlock on its own jobs. A killed/concurrent build's residue (different session) is simply never claimed and sits harmless.

The issue's **optional** extras are deliberately deferred: fix #2 (requeue an unmappable job instead of failing it — largely moot once foreign jobs aren't claimed, and a naive requeue risks silent retry loops) and fix #3 (dead-session sweep — unsafe without real dead-session detection).

## Tests

- `test_schema.py`: `v10→v11` migration adds the column + is idempotent.
- `test_job_queue.py`: stamp on `add_job`; session filter across own / foreign / `NULL` / session-less claimers.
- `test_sqlite_backend_resilience.py`: backend forwards `worker_session_id` onto submitted jobs.
- Schema version-canary in `test_worker_heartbeats.py` bumped to 11.
- Broad sweep (database + backends + api + workers) green; ruff + ruff-format + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWFuj48yQQU2vDSHt6VHWs