### PR TITLE
fix(build): recover in-flight jobs when a worker dies mid-build (#617)

### DIFF
--- a/changelog.d/617-orphan-pool-shutdown.fixed.md
+++ b/changelog.d/617-orphan-pool-shutdown.fixed.md
@@ -1,0 +1,14 @@
+- Fixed intermittent `worker died mid-job (orphaned at pool shutdown)` failures
+  in an otherwise uninterrupted build (issue #617). When a worker process died
+  or hung mid-job, nothing marked a *busy* worker dead, so the completion loop's
+  dead-worker requeue never fired and the job lingered in `processing` until the
+  teardown sweep stamped it an orphan — misattributed to an innocent slide file.
+  The worker health monitor is now started for the build pool (scoped to the
+  build's own session), so a worker whose process is gone is detected and its
+  in-flight job is requeued for retry on another worker. In addition:
+  `reset_hung_jobs` now clears `started_at` so a legitimately-requeued job is
+  never mis-stamped as an orphan; job submission registers the job for the
+  completion poll under `asyncio.shield`, so a cancelled submission can never
+  leave a worker-claimable but untracked row; and any orphan still discovered at
+  teardown is folded into the build summary (and forces a non-zero exit) instead
+  of being silently banked in the jobs DB.

--- a/docs/claude/handovers/issue-triage-2026-07-handover.md
+++ b/docs/claude/handovers/issue-triage-2026-07-handover.md
@@ -3,12 +3,12 @@
 **Status**: Triage COMPLETE; execution IN PROGRESS — Phases 1–5 DONE
 (#600, #539, #524/#382/#362, #568, #559); **Phase 7 fully DONE**
 (#609/#610/#611 via PRs #624/#625/#626 on 2026-07-11; #615 landed via
-PR #628, merged 2026-07-11 — see the Phase 7 block); **Phase 8 #620 DONE**
-(job session ownership, 2026-07-12 — see the Phase 8 block). Next up
-**Phase 8 #617** (own-pool teardown orphaning), then Phase 6 (design
-tier). This document is the source of truth for working through the
-open-issue backlog in priority order. Update phase statuses here as issues
-land.
+PR #628, merged 2026-07-11 — see the Phase 7 block); **Phase 8 DONE**
+(#620 job session ownership + #617 orphan-pool-shutdown, 2026-07-12 — see
+the Phase 8 block). Next up **Phase 6 (design tier)** — start with the
+#383+#381 verify-then-close pass. This document is the source of truth for
+working through the open-issue backlog in priority order. Update phase
+statuses here as issues land.
 
 ## 1. Feature Overview
 
@@ -383,7 +383,30 @@ amendments-log row for ANY engine change). #609/#610 have documented
 workarounds in their issue bodies — as with #600, the workaround is the
 oracle for what the fixed flow should converge to.
 
-### Phase 8 [IN PROGRESS — #620 DONE, #617 TODO] — Build reliability: job/session ownership (#620, #617)
+### Phase 8 [DONE] — Build reliability: job/session ownership (#620, #617)
+
+**#617 DONE (2026-07-12, "Full" scope)**: root cause (via a dedicated
+investigation) — nothing marked a *busy* worker dead, so a worker that died or
+hung mid-job left its job stuck in `processing`; the completion loop's
+dead-worker requeue (`_cleanup_dead_worker_jobs`, gated on `workers.status =
+'dead'`) never fired, and the job lingered until the teardown
+`mark_orphaned_jobs_failed` sweep stamped it. The dormant `WorkerPoolManager`
+health monitor was never started in the build path. Fixed in four layers:
+(1) **liveness recovery** — `start_managed_workers` now starts the health
+monitor (`start_monitoring`), scoped to the build's own `session_id` (mirrors
+#597/#620; never reaps a concurrent build's workers, and only marks dead on a
+real `is_worker_running` process check — the missing-executor branch now skips
+instead of killing); a dead worker's in-flight job is then requeued for retry.
+(2) **`reset_hung_jobs`** now clears `started_at`/`worker_id` so a
+legitimately-requeued job is never mis-stamped an orphan by the teardown scan.
+(3) **submit race** — job submission registers the job in `active_jobs` under
+`asyncio.shield`, so a cancelled submission can't leave a worker-claimable but
+untracked row. (4) **reporting** — `stop_managed_workers` returns its orphans;
+`main_build` folds any into the summary (`_record_teardown_orphans`) and marks
+it timed-out, forcing a non-zero exit instead of silently banking them. Tests:
+monitor session-scoping (`test_pool_manager`), `reset_hung` started_at
+(`test_job_queue`), stop-returns-orphans (`test_lifecycle_manager`),
+`_record_teardown_orphans` (`test_build_abort_summary`). Shipped as its own PR.
 
 **#620 DONE (2026-07-12)**: implemented exactly the planned fix direction —
 session id on job rows + claim filter — as its own PR. Schema v11 adds
@@ -415,11 +438,12 @@ diagnostic even names the suspected race.
   `execution_mode`, #594/#599 added ownership for *workers*, jobs had
   none. Fixed by stamping jobs with the owning build session and filtering
   claims by it (see the resolution note above).
-- **#617**: intermittent `worker died mid-job (orphaned at pool
+- **#617 [DONE]**: intermittent `worker died mid-job (orphaned at pool
   shutdown)` failing a batch of jobs mid-stage in a single uninterrupted
   Direct-mode build (8 of 38 jobs in the observed run; byte-identical
-  re-run clean). Root cause unknown — may fall out of (or be illuminated
-  by) the #620 ownership work, which is why they share a phase.
+  re-run clean). Root cause was the absence of any busy-worker liveness
+  recovery; fixed by wiring the session-scoped health monitor plus three
+  hardening layers (see the resolution note above).
 
 ### Phase 6 [TODO] — Design-tier work (when capacity allows)
 
@@ -477,26 +501,24 @@ OpenAI-compatible client, zero new deps) or close as status-quo.
 - **Phase 7 fully DONE** (2026-07-11): #609 via PR #624, #610 via
   PR #625, #611 via PR #626, **#615 via PR #628** (resolution details in
   the Phase 7 block). All four issues CLOSED.
-- **Phase 8 #620 DONE** (2026-07-12): job session ownership — schema v11
-  `jobs.session_id`, stamp on submit, session-filtered claim (resolution
-  details in the Phase 8 block). #617 still open.
+- **Phase 8 DONE** (2026-07-12): #620 job session ownership (schema v11
+  `jobs.session_id`, stamp on submit, session-filtered claim) + #617
+  orphan-pool-shutdown (session-scoped health monitor for busy-worker
+  liveness recovery, `reset_hung_jobs` started_at clear, shielded submit
+  registration, teardown orphans folded into the summary/exit). Resolution
+  details in the Phase 8 block.
 - No blockers, no pending decisions. Remaining, in priority order:
-  Phase 8 **#617** (own-pool teardown orphaning — investigate as its own
-  PR), Phase 6 design tier (#383+#381 — start with a verify-then-close
-  pass, see the Phase 3 resolution note — plus #484, #167), #614 before
-  the next harvest round.
+  Phase 6 design tier (#383+#381 — start with a verify-then-close pass,
+  see the Phase 3 resolution note — plus #484, #167), #614 before the next
+  harvest round.
 
 ## 5. Next Steps
 
-**Phases 1–5 and 7 are DONE; Phase 8 #620 is DONE — next is Phase 8
-#617** (own-pool teardown orphaning: a build's own in-flight jobs marked
-`worker died mid-job (orphaned at pool shutdown)` mid-stage in an
-uninterrupted Direct build). Investigate the `mark_orphaned_jobs_failed`
-timing vs. pool teardown across stage boundaries; ship as its own PR (the
-#620 ownership work may illuminate it). Then Phase 6a (#383+#381 — START
-with a verify-then-close pass against commit 90518611, see the Phase 3
-resolution note). Schedule #614 just before the next big harvest round.
-The plan below documents how Phase 1 was executed (kept for reference):
+**Phases 1–5, 7, and 8 are DONE — next is Phase 6a (#383+#381)**, which
+should START with a verify-then-close pass against commit 90518611 (see the
+Phase 3 resolution note) rather than a fresh design effort, then #484 and
+#167. Schedule #614 just before the next big harvest round. The plan below
+documents how Phase 1 was executed (kept for reference):
 
 1. Read memory topics `project_sync_one_sided_cold` and
    `project_sync_v3_design_audit`, plus the sync v3 design note (find via
@@ -560,12 +582,18 @@ their listed sites — see each phase's resolution block for what changed:
   test_job_queue.py` + `test_schema.py`, `tests/infrastructure/backends/
   test_sqlite_backend_resilience.py`; version-canary bumped in
   `test_worker_heartbeats.py`
-- `#617` (Phase 8, TODO) → `job_queue.mark_orphaned_jobs_failed`
-  (`ORPHAN_ERROR_MESSAGE`) and its caller
-  `WorkerLifecycleManager.stop_managed_workers` — trace teardown timing vs.
-  stage boundaries; `worker_base._convert_path_to_container()` was where
-  #620's misattributed error surfaced (kept here for the #617 investigator);
-  #594/#599 PRs are the ownership pattern
+- `#617` (Phase 8, DONE) → `src/clm/infrastructure/workers/pool_manager.py`
+  (`_monitor_health` session-scoped + skip-on-missing-executor),
+  `src/clm/infrastructure/workers/lifecycle_manager.py`
+  (`start_managed_workers` starts the monitor; `stop_managed_workers` returns
+  its orphans), `src/clm/infrastructure/database/job_queue.py`
+  (`reset_hung_jobs` clears `started_at`),
+  `src/clm/infrastructure/backends/sqlite_backend.py` (shielded submit
+  registration), `src/clm/cli/commands/build.py` (`_record_teardown_orphans`
+  + the `main_build` finally wiring). The existing `_cleanup_dead_worker_jobs`
+  requeue (already in the completion loop, gated on `workers.status='dead'`)
+  is what the monitor now feeds. Tests in `test_pool_manager.py`,
+  `test_lifecycle_manager.py`, `test_job_queue.py`, `test_build_abort_summary.py`
 - `#484` → `src/clm/infrastructure/backends/sqlite_backend.py`
   (`_execute_operation_impl`, poll loop `record_write` at ~:564),
   `src/clm/core/output_write_registry.py` (:292,294 hash-in-critical-section)

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -11,7 +11,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from time import time
-from typing import Literal
+from typing import Any, Literal
 
 import click
 from attrs import evolve
@@ -1664,6 +1664,44 @@ async def watch_and_rebuild(course: Course, backend, config: BuildConfig):
         observer.join()
 
 
+def _record_teardown_orphans(summary: BuildSummary, orphans: list[dict[str, Any]]) -> None:
+    """Fold pool-teardown orphan jobs into an already-finalized build summary.
+
+    ``JobQueue.mark_orphaned_jobs_failed`` runs at pool teardown — after
+    ``finish_build`` has rendered the summary — so its orphans would otherwise
+    never influence the exit policy, and the build could exit 0 with a
+    silently-incomplete output tree. Each orphan becomes an infrastructure
+    ``BuildError`` and the summary is marked timed-out, giving the same
+    unconditional non-zero exit a per-stage job timeout gets (issue #617).
+    """
+    from clm.cli.build_data_classes import BuildError
+
+    for orphan in orphans:
+        summary.errors.append(
+            BuildError(
+                error_type="infrastructure",
+                category="orphaned_job",
+                severity="error",
+                file_path=str(orphan.get("input_file", "unknown")),
+                message=(
+                    "Worker died mid-job and the job was orphaned when the "
+                    "worker pool stopped; the output for this file was not "
+                    "produced."
+                ),
+                actionable_guidance=(
+                    "A worker process stopped before finishing this job (a "
+                    "mid-build crash or a shutdown race), so the job never "
+                    "completed. Re-run the build; the input file is not at "
+                    "fault. See issue #617."
+                ),
+                job_id=orphan.get("id"),
+            )
+        )
+    # Orphaned jobs mean the output tree is incomplete — force an unconditional
+    # non-zero exit, matching how a per-stage worker-job timeout is treated.
+    summary.timed_out = True
+
+
 async def main_build(
     ctx,
     spec_file,
@@ -1979,8 +2017,17 @@ async def main_build(
             output_formatter.show_startup_message("Stopping workers...")
             logger.info("Stopping managed workers...")
             try:
-                lifecycle_manager.stop_managed_workers(started_workers)
+                orphaned_jobs = lifecycle_manager.stop_managed_workers(started_workers)
                 logger.info(f"Stopped {len(started_workers)} worker(s)")
+                # Orphans are discovered only after the pool stops — i.e. after
+                # finish_build already rendered the summary. Fold them into the
+                # summary here so they still drive the exit policy instead of
+                # being silently banked in the jobs DB (issue #617). Orphaned
+                # jobs mean the output tree is incomplete, so mark the summary
+                # timed-out for an unconditional non-zero exit, matching the
+                # per-stage-timeout policy.
+                if orphaned_jobs and summary is not None:
+                    _record_teardown_orphans(summary, orphaned_jobs)
             except Exception as e:
                 logger.error(f"Failed to stop workers: {e}", exc_info=True)
         if mitm_manager is not None:

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -367,13 +367,37 @@ class SqliteBackend(LocalOpsBackend):
         # thread-safe (the DB result-cache replay above, db_manager.get_result,
         # stays on the loop for the same reason).
         _offload_t0 = profiler_now() if profiler.enabled else 0.0
-        outcome, job_id = await asyncio.get_running_loop().run_in_executor(
-            self._ensure_submit_executor(),
-            self._submit_job_blocking,
-            payload,
-            job_type,
-            force_execution,
-        )
+
+        async def _submit_and_track() -> tuple[str, int | None]:
+            outcome_, job_id_ = await asyncio.get_running_loop().run_in_executor(
+                self._ensure_submit_executor(),
+                self._submit_job_blocking,
+                payload,
+                job_type,
+                force_execution,
+            )
+            # Register the job in active_jobs INSIDE this shielded coroutine, so
+            # a cancellation of the caller (e.g. a sibling submission op raising
+            # and tearing down the stage TaskGroup) can never leave the
+            # just-INSERTed, worker-claimable 'pending' row untracked. An
+            # untracked row is never waited on, lingers in 'processing', and is
+            # stamped "worker died mid-job (orphaned at pool shutdown)" by the
+            # teardown sweep (issue #617). A jobcache_hit has no DB row to track.
+            if outcome_ == "submitted" and job_id_ is not None:
+                self.active_jobs[job_id_] = {
+                    "job_type": job_type,
+                    "input_file": str(payload.input_file),
+                    "output_file": str(payload.output_file),
+                    "correlation_id": getattr(payload, "correlation_id", None),
+                }
+            return outcome_, job_id_
+
+        # shield() lets the submit+register run to completion even if the caller
+        # is cancelled mid-await: the submit thread's INSERT is not cancellable
+        # once started, so the active_jobs registration must be equally
+        # uncancellable or the row is stranded (issue #617). On the happy path
+        # this is equivalent to awaiting the coroutine directly.
+        outcome, job_id = await asyncio.shield(_submit_and_track())
         if profiler.enabled:
             profiler.record_submit_offload(profiler_now() - _offload_t0)
 
@@ -422,16 +446,11 @@ class SqliteBackend(LocalOpsBackend):
                     )
             return True
 
-        # outcome == "submitted": the job is in the jobs DB. Register it for the
-        # poll loop and report it — all loop-confined state.
+        # outcome == "submitted": the job is in the jobs DB and already
+        # registered in active_jobs by the shielded submit above. Report it —
+        # all loop-confined state.
         assert job_id is not None
         correlation_id = getattr(payload, "correlation_id", None)
-        self.active_jobs[job_id] = {
-            "job_type": job_type,
-            "input_file": str(payload.input_file),
-            "output_file": str(payload.output_file),
-            "correlation_id": correlation_id,
-        }
 
         # Track in progress tracker
         if self.progress_tracker:

--- a/src/clm/infrastructure/database/job_queue.py
+++ b/src/clm/infrastructure/database/job_queue.py
@@ -683,13 +683,18 @@ class JobQueue:
         cursor = conn.execute(
             """
             UPDATE jobs
-            SET status = 'pending', worker_id = NULL
+            SET status = 'pending', worker_id = NULL, started_at = NULL
             WHERE status = 'processing'
             AND started_at < datetime('now', '-' || ? || ' seconds')
             """,
             (timeout_seconds,),
         )
         # No commit() needed - connection is in autocommit mode
+        # started_at is cleared (like _cleanup_dead_worker_jobs) so a
+        # legitimately-requeued job is a clean 'pending' row again. Leaving
+        # started_at set made mark_orphaned_jobs_failed (which reaps
+        # started_at-set, non-terminal rows) later mis-stamp it as an orphan
+        # (issue #617).
         return cursor.rowcount
 
     def clear_old_completed_jobs(self, days: int = 7) -> int:

--- a/src/clm/infrastructure/workers/lifecycle_manager.py
+++ b/src/clm/infrastructure/workers/lifecycle_manager.py
@@ -228,6 +228,16 @@ class WorkerLifecycleManager:
         # Start pools
         self.pool_manager.start_pools()
 
+        # Start health monitoring (issue #617). A worker that dies mid-job
+        # otherwise leaves its job stuck in 'processing' — nothing marked a
+        # busy worker dead, so the completion loop's dead-worker requeue never
+        # fired and the job lingered until the teardown orphan sweep stamped it
+        # "worker died mid-job (orphaned at pool shutdown)". The monitor detects
+        # the death by process liveness, marks the worker 'dead', and the build
+        # loop then requeues the job for retry on another worker. It scans only
+        # this session's workers and is stopped/joined by stop_pools().
+        self.pool_manager.start_monitoring()
+
         # Collect worker info for tracking
         self.managed_workers = self._collect_worker_info()
 
@@ -238,23 +248,30 @@ class WorkerLifecycleManager:
         logger.info(f"Started {len(self.managed_workers)} managed worker(s)")
         return self.managed_workers
 
-    def stop_managed_workers(self, workers: list[WorkerInfo]) -> None:
+    def stop_managed_workers(self, workers: list[WorkerInfo]) -> list[dict[str, Any]]:
         """Stop managed workers.
 
         Args:
             workers: List of workers to stop
+
+        Returns:
+            The list of in-flight jobs orphaned at pool stop (each a dict as
+            returned by :meth:`JobQueue.mark_orphaned_jobs_failed`). Empty on a
+            clean shutdown. The build surfaces a non-empty result so orphans
+            discovered at teardown still reach the summary and exit policy
+            (issue #617) rather than being silently banked in the jobs DB.
         """
         if not self.config.auto_stop:
             logger.info("Auto-stop is disabled, keeping workers running")
-            return
+            return []
 
         if not workers:
             logger.debug("No workers to stop")
-            return
+            return []
 
         if not self.pool_manager:
             logger.debug("No pool manager to stop")
-            return
+            return []
 
         start_time = time.time()
 
@@ -301,6 +318,8 @@ class WorkerLifecycleManager:
         # Clear tracked workers if they match
         if self.managed_workers == workers:
             self.managed_workers.clear()
+
+        return orphans
 
     def _adjust_configs_for_reuse(self, configs: list[WorkerConfig]) -> list[WorkerConfig]:
         """Adjust worker counts based on existing healthy workers.

--- a/src/clm/infrastructure/workers/pool_manager.py
+++ b/src/clm/infrastructure/workers/pool_manager.py
@@ -835,13 +835,28 @@ class WorkerPoolManager:
         while self.running:
             try:
                 conn = self.job_queue._get_conn()
-                cursor = conn.execute(
-                    """
-                    SELECT id, worker_type, container_id, status, last_heartbeat
-                    FROM workers
-                    WHERE status IN ('busy', 'idle')
-                    """
-                )
+                # Scope health checks to THIS pool's own session (issue #617,
+                # mirroring the #597/#620 ownership rule). The monitor marks
+                # unresponsive workers 'dead', which the build's completion loop
+                # then requeues jobs from; without the session filter a build
+                # would reap a concurrent build's workers in a shared jobs DB.
+                if self.session_id is not None:
+                    cursor = conn.execute(
+                        """
+                        SELECT id, worker_type, container_id, status, last_heartbeat
+                        FROM workers
+                        WHERE status IN ('busy', 'idle') AND session_id = ?
+                        """,
+                        (self.session_id,),
+                    )
+                else:
+                    cursor = conn.execute(
+                        """
+                        SELECT id, worker_type, container_id, status, last_heartbeat
+                        FROM workers
+                        WHERE status IN ('busy', 'idle')
+                        """
+                    )
 
                 # Increment stats check counter for throttling
                 stats_check_counter += 1
@@ -865,14 +880,15 @@ class WorkerPoolManager:
                         executor_type = "direct" if is_direct else "docker"
 
                         if executor_type not in self.executors:
-                            logger.warning(
-                                f"No executor available for type {executor_type}, "
-                                f"marking worker as dead"
+                            # A missing executor is NOT evidence the worker died
+                            # — this pool simply has no executor of that mode to
+                            # check it (e.g. a legacy/foreign row that slipped the
+                            # session filter). Skip it rather than reap a worker
+                            # we cannot verify (issue #617).
+                            logger.debug(
+                                f"No {executor_type} executor in this pool to check "
+                                f"worker {worker_id}; skipping (not ours to reap)."
                             )
-                            conn.execute(
-                                "UPDATE workers SET status = 'dead' WHERE id = ?", (worker_id,)
-                            )
-                            conn.commit()
                             continue
 
                         executor = self.executors[executor_type]

--- a/tests/cli/test_build_abort_summary.py
+++ b/tests/cli/test_build_abort_summary.py
@@ -152,3 +152,31 @@ class TestWiring:
             "renders 'Build completed successfully' for a failed build and "
             "runs the stale-output sweep on an incomplete write registry."
         )
+
+
+class TestRecordTeardownOrphans:
+    """Pool-teardown orphans must reach the exit policy even though they are
+    discovered after finish_build has rendered the summary (issue #617)."""
+
+    def test_orphans_are_recorded_as_errors_and_force_nonzero_exit(self):
+        from clm.cli.commands.build import _record_teardown_orphans
+
+        summary = BuildSummary(duration=1.0, total_files=3)
+        assert summary.timed_out is False
+        assert summary.errors == []
+
+        orphans = [
+            {"id": 7, "input_file": "slides/a.de.py", "status": "processing", "worker_id": 3},
+            {"id": 8, "input_file": "slides/a.en.py", "status": "pending", "worker_id": 4},
+        ]
+        _record_teardown_orphans(summary, orphans)
+
+        # Marked timed-out so the CLI exits non-zero unconditionally (an
+        # incomplete output tree), matching the per-stage-timeout policy.
+        assert summary.timed_out is True
+        assert len(summary.errors) == 2
+        categories = {e.category for e in summary.errors}
+        assert categories == {"orphaned_job"}
+        assert {e.job_id for e in summary.errors} == {7, 8}
+        assert {e.error_type for e in summary.errors} == {"infrastructure"}
+        assert any("a.de.py" in e.file_path for e in summary.errors)

--- a/tests/infrastructure/database/test_job_queue.py
+++ b/tests/infrastructure/database/test_job_queue.py
@@ -1035,3 +1035,36 @@ def test_mark_orphaned_jobs_failed_ignores_pending_without_started_at(job_queue)
     stats = job_queue.get_job_stats()
     assert stats["pending"] == 1
     assert stats["failed"] == 0
+
+
+def test_reset_hung_jobs_clears_started_at(job_queue):
+    """A hung job reset to pending must have started_at cleared, so the teardown
+    orphan sweep never mis-stamps a legitimately-requeued job as an orphan
+    (issue #617). Before the fix, reset_hung_jobs left started_at set."""
+    job_id = job_queue.add_job(
+        job_type="notebook",
+        input_file="hung.py",
+        output_file="hung.ipynb",
+        content_hash="hung",
+        payload={},
+    )
+    # Claim it (sets started_at, status='processing'), then backdate started_at
+    # past the hung window so reset_hung_jobs picks it up.
+    job_queue.get_next_job("notebook")
+    conn = job_queue._get_conn()
+    conn.execute(
+        "UPDATE jobs SET started_at = datetime('now', '-3600 seconds') WHERE id = ?",
+        (job_id,),
+    )
+
+    assert job_queue.reset_hung_jobs(timeout_seconds=600) == 1
+
+    job = job_queue.get_job(job_id)
+    assert job is not None
+    assert job.status == "pending"
+    assert job.started_at is None
+    assert job.worker_id is None
+
+    # The requeued job must NOT be reaped as an orphan by the teardown sweep.
+    assert job_queue.mark_orphaned_jobs_failed() == []
+    assert job_queue.get_job(job_id).status == "pending"

--- a/tests/infrastructure/workers/test_lifecycle_manager.py
+++ b/tests/infrastructure/workers/test_lifecycle_manager.py
@@ -699,6 +699,38 @@ class TestStopManagedWorkers:
         assert "orphaned/example.py" in orphan_warnings[0].message
         assert f"#{orphan_id}" in orphan_warnings[0].message
 
+    def test_stop_returns_orphans_for_the_build_to_surface(
+        self, db_path, workspace_path, mock_config
+    ):
+        """stop_managed_workers returns the orphaned jobs so the build can fold
+        them into the summary/exit policy instead of silently banking them in
+        the jobs DB (issue #617)."""
+        orphan_id = self._seed_inflight_job(db_path, "orphaned/example.py")
+
+        with patch("clm.infrastructure.workers.lifecycle_manager.DirectWorkerExecutor"):
+            manager = WorkerLifecycleManager(
+                config=mock_config,
+                db_path=db_path,
+                workspace_path=workspace_path,
+            )
+            manager.pool_manager = MagicMock()
+            orphans = manager.stop_managed_workers([self._make_worker_info()])
+
+        assert [o["id"] for o in orphans] == [orphan_id]
+        assert orphans[0]["input_file"] == "orphaned/example.py"
+
+    def test_stop_returns_empty_list_on_clean_shutdown(self, db_path, workspace_path, mock_config):
+        """A clean shutdown (no in-flight jobs) returns an empty list, not None,
+        so the build's `if orphans:` guard is safe (issue #617)."""
+        with patch("clm.infrastructure.workers.lifecycle_manager.DirectWorkerExecutor"):
+            manager = WorkerLifecycleManager(
+                config=mock_config,
+                db_path=db_path,
+                workspace_path=workspace_path,
+            )
+            manager.pool_manager = MagicMock()
+            assert manager.stop_managed_workers([self._make_worker_info()]) == []
+
     def test_stop_passes_orphan_metadata_to_log_pool_stopped(
         self, db_path, workspace_path, mock_config
     ):

--- a/tests/infrastructure/workers/test_pool_manager.py
+++ b/tests/infrastructure/workers/test_pool_manager.py
@@ -586,6 +586,75 @@ def test_pool_manager_start_monitoring(db_path, workspace_path, worker_configs):
         manager.monitor_thread.join(timeout=1)
 
 
+def _seed_stale_busy_direct_worker(db_path, session_id, container_id):
+    """Insert a busy direct worker with a stale heartbeat (issue #617 tests)."""
+    jq = JobQueue(db_path)
+    try:
+        cur = jq._get_conn().execute(
+            """
+            INSERT INTO workers (worker_type, container_id, status, session_id,
+                                 execution_mode, last_heartbeat)
+            VALUES ('notebook', ?, 'busy', ?, 'direct', datetime('now', '-120 seconds'))
+            """,
+            (container_id, session_id),
+        )
+        worker_id = cur.lastrowid
+        assert worker_id is not None
+        return worker_id
+    finally:
+        jq.close()
+
+
+def _worker_status(db_path, worker_id):
+    jq = JobQueue(db_path)
+    try:
+        row = (
+            jq._get_conn()
+            .execute("SELECT status FROM workers WHERE id = ?", (worker_id,))
+            .fetchone()
+        )
+        return row[0] if row else None
+    finally:
+        jq.close()
+
+
+def test_monitor_health_reaps_only_own_session_dead_workers(
+    db_path, workspace_path, worker_configs
+):
+    """The health monitor marks a worker dead only when its process is gone,
+    and only for THIS session's workers — never a concurrent build's in a
+    shared jobs DB (issue #617; mirrors the #597/#620 ownership rule)."""
+    with patch("docker.from_env"):
+        manager = WorkerPoolManager(
+            db_path=db_path,
+            workspace_path=workspace_path,
+            worker_configs=worker_configs,
+            session_id="session-A",
+        )
+
+    # A direct executor that reports every process as no longer running.
+    dead_executor = MagicMock()
+    dead_executor.is_worker_running.return_value = False
+    manager.executors["direct"] = dead_executor
+
+    own = _seed_stale_busy_direct_worker(db_path, "session-A", "direct-own")
+    foreign = _seed_stale_busy_direct_worker(db_path, "session-B", "direct-foreign")
+
+    manager.running = True
+    thread = threading.Thread(target=manager._monitor_health, args=(0.05,), daemon=True)
+    thread.start()
+    try:
+        deadline = time.time() + 5.0
+        while time.time() < deadline and _worker_status(db_path, own) != "dead":
+            time.sleep(0.05)
+    finally:
+        manager.running = False
+        thread.join(timeout=2)
+
+    assert _worker_status(db_path, own) == "dead"
+    assert _worker_status(db_path, foreign) == "busy"
+
+
 @pytest.mark.slow
 def test_pool_manager_parallel_startup_performance(db_path, workspace_path):
     """Test that parallel startup is significantly faster than sequential would be."""


### PR DESCRIPTION
Closes #617.

## Problem

An uninterrupted `clm build` (Direct mode, `--notebook-workers 8`) intermittently failed a batch of jobs with `worker died mid-job (orphaned at pool shutdown)` (8 of 38 jobs in the observed run; a byte-identical re-run was clean).

## Root cause

Nothing marked a **busy** worker dead. When a worker process died or hung mid-job, its job stayed `processing`; the completion loop's dead-worker requeue (`_cleanup_dead_worker_jobs`, gated on `workers.status='dead'`) never fired, so the job lingered until the teardown `mark_orphaned_jobs_failed` sweep stamped it — misattributed to an innocent slide file. The `WorkerPoolManager` health monitor that would have marked such a worker dead (via process liveness) **was never started in the build path** (only in the module's `__main__` demo).

## Fix — four layers

1. **Liveness recovery (the core fix).** `start_managed_workers` now starts the health monitor. `_monitor_health` is **scoped to the build's own `session_id`** (mirrors the #597/#620 ownership rule — it never reaps a concurrent build's workers in a shared jobs DB) and only marks a worker dead on a real `is_worker_running` process check; the "missing executor" branch now **skips** instead of killing. A dead worker's in-flight job is then requeued by the existing completion-loop cleanup and retried on another worker.
2. **`reset_hung_jobs`** now clears `started_at`/`worker_id` (like `_cleanup_dead_worker_jobs`) so a legitimately-requeued job is never mis-stamped an orphan by the teardown scan.
3. **Submit race.** Job submission registers the job in `active_jobs` under `asyncio.shield`, so a cancelled submission (e.g. a sibling op tearing down the stage `TaskGroup`) can never leave a worker-claimable but untracked `pending` row. Happy-path behavior is unchanged.
4. **Reporting.** `stop_managed_workers` returns its orphans; `main_build` folds any into the build summary (`_record_teardown_orphans`) and marks it timed-out, forcing a non-zero exit instead of silently banking them.

Root cause was pinned by a dedicated multi-file investigation; the exact live surfacing path (a swallowed per-stage timeout vs. the submit race) can't be fully disambiguated from static analysis, but all candidate paths converge on this fix surface. Scope chosen: **"Full"** (all four layers).

## Tests

- `test_pool_manager`: monitor reaps only this session's dead-process workers, never a foreign session's.
- `test_job_queue`: `reset_hung_jobs` clears `started_at` and the requeued job is not reaped as an orphan.
- `test_lifecycle_manager`: `stop_managed_workers` returns its orphans (and `[]` on a clean shutdown).
- `test_build_abort_summary`: `_record_teardown_orphans` records infra errors and forces a non-zero exit.
- Full affected suite green (workers + backends + database + CLI build = **958 passed**); ruff + format + mypy clean. No regressions from wiring the previously-dormant monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWFuj48yQQU2vDSHt6VHWs