### PR TITLE
fix(workers): compute heartbeat staleness in UTC and ungate liveness checks (#617 follow-up)

### DIFF
--- a/changelog.d/617-monitor-tz-and-busy-heartbeat.fixed.md
+++ b/changelog.d/617-monitor-tz-and-busy-heartbeat.fixed.md
@@ -1,0 +1,11 @@
+- Fixed the worker health monitor's heartbeat staleness check comparing the
+  UTC database timestamp against local time (follow-up to issue #617 /
+  PR #636). West of UTC every heartbeat looked perpetually fresh, silently
+  disabling the mid-build worker-liveness recovery; east of UTC everything
+  always looked stale, spamming warnings. Staleness is now computed in UTC.
+  The monitor also no longer gates its process-liveness check on heartbeat
+  staleness: busy workers only heartbeat between jobs, so a stale heartbeat is
+  the normal mid-job state — liveness is now checked unconditionally each
+  cycle, stale-heartbeat log lines are DEBUG for busy workers (still WARNING
+  for idle ones), and the Docker zero-CPU "hung" heuristic still requires a
+  stale heartbeat before pulling container stats.

--- a/docs/claude/handovers/pr636-review-findings-handover.md
+++ b/docs/claude/handovers/pr636-review-findings-handover.md
@@ -1,6 +1,7 @@
 # Handover: PR #636 Adversarial-Review Findings (worker liveness follow-ups)
 
-**Status**: Not started — findings identified 2026-07-12, no fixes implemented yet.
+**Status**: Phases 1+2 DONE (2026-07-12, PR A — monitor correctness); next is
+Phase 3 (session-scope `mark_orphaned_jobs_failed`), then Phases 4+5.
 This document is the source of truth for addressing the five findings from the
 post-merge adversarial review of PR #636 (the issue #617 fix, merged as
 `f96f8ab6` / commit `d5467df7`).
@@ -72,7 +73,15 @@ summary table. That is acceptable; Phase 4 only fixes the wording/visibility.
 
 ## 3. Phase Breakdown
 
-### Phase 1 [TODO] — Fix the timezone bug in `_is_heartbeat_stale` (Finding 1, HIGH) — **ACTIVE PHASE**
+### Phase 1 [DONE] — Fix the timezone bug in `_is_heartbeat_stale` (Finding 1, HIGH)
+
+**Resolution (2026-07-12)**: naive timestamps are now tagged UTC
+(`replace(tzinfo=timezone.utc)`) and compared against
+`datetime.now(timezone.utc)`; tz-aware timestamps honored as-is; parse errors
+still stale. The pre-existing `test_pool_manager_is_heartbeat_stale` (which
+seeded *local* naive timestamps and was itself tz-dependent) was rewritten
+host-TZ-independent with naive-UTC, tz-aware, and malformed cases. Original
+plan below kept for reference.
 
 - **What**: `_is_heartbeat_stale`
   (`src/clm/infrastructure/workers/pool_manager.py:946-963`) parses the UTC DB
@@ -102,7 +111,19 @@ summary table. That is acceptable; Phase 4 only fixes the wording/visibility.
   `datetime.now(timezone.utc)` and force-tags the parsed value with
   `timezone.utc` at `discovery.py:135` — that is the correct pattern to copy).
 
-### Phase 2 [TODO] — Stop gating liveness on heartbeats busy workers never send (Finding 2, MEDIUM)
+### Phase 2 [DONE] — Stop gating liveness on heartbeats busy workers never send (Finding 2, MEDIUM)
+
+**Resolution (2026-07-12)**: took the recommended direction. `_monitor_health`
+now runs `is_worker_running` unconditionally per cycle (executor-type
+resolution and the missing-executor skip moved ahead of it); stale-heartbeat
+logging is DEBUG for `busy` workers, WARNING for others; the Docker stats pull
+is gated on staleness AND the every-5th-cycle throttle, and the hung heuristic
+(CPU<1% + busy) is unchanged. New tests: dead-worker-with-fresh-heartbeat is
+reaped; live busy worker with stale heartbeat stays `busy` with zero WARNING
+lines; stale zero-CPU docker worker still goes `hung`. Helper generalized to
+`_seed_busy_worker(..., heartbeat_age_seconds=, execution_mode=)` (seeded via
+SQLite UTC `datetime('now', ...)`, host-TZ-independent) with a shared
+`_run_monitor_until` runner. Original plan below kept for reference.
 
 - **What**: once Phase 1 makes staleness *accurate*, every busy worker on a
   >30s job legitimately trips the stale gate each 10s cycle:
@@ -217,11 +238,15 @@ summary table. That is acceptable; Phase 4 only fixes the wording/visibility.
 ## 4. Current Status
 
 - **Completed**: adversarial review of merged PR #636 (2026-07-12), all five
-  findings verified directly against the code at `f96f8ab6` (no fixes
-  written). The review confirmed what *does* hold up: `reset_hung_jobs`
-  clearing, shield semantics, missing-executor skip, and `stop_managed_workers`
-  returning `[]` on all early paths — none of those need changes.
-- **In progress**: nothing.
+  findings verified directly against the code at `f96f8ab6`. The review
+  confirmed what *does* hold up: `reset_hung_jobs` clearing, shield semantics,
+  missing-executor skip, and `stop_managed_workers` returning `[]` on all
+  early paths — none of those need changes. **Phases 1+2 implemented**
+  (2026-07-12) on branch `claude/pr636-findings-monitor-correctness` (PR A:
+  `src/clm/infrastructure/workers/pool_manager.py` + its tests + changelog
+  fragment `changelog.d/617-monitor-tz-and-busy-heartbeat.fixed.md`); see the
+  phase resolution notes.
+- **In progress**: nothing (PR A in review/auto-merge).
 - **Blockers / open questions**:
   - Phase 2 design choice (unconditional process check vs. background
     heartbeat thread) — recommendation is the former; confirm with maintainer
@@ -239,21 +264,9 @@ summary table. That is acceptable; Phase 4 only fixes the wording/visibility.
 
 ## 5. Next Steps
 
-**Start Phase 1.** Concretely:
-
-1. `git switch -c claude/pr636-review-findings-phase1` (or per-phase naming).
-2. Fix `_is_heartbeat_stale` (`pool_manager.py:946-963`) to compare in UTC —
-   copy the pattern at `discovery.py:135,183`
-   (`datetime.fromisoformat(...).replace(tzinfo=timezone.utc)` vs
-   `datetime.now(timezone.utc)`).
-3. Add host-TZ-independent unit tests for `_is_heartbeat_stale` in
-   `tests/infrastructure/workers/test_pool_manager.py`.
-4. Re-run `test_monitor_health_reaps_only_own_session_dead_workers` and the
-   monitor start/stop tests; then continue into Phase 2 in the same PR.
-5. Gotchas: do not change the DB write side (UTC in DB is load-bearing for
-   `_get_available_workers`); `datetime.fromisoformat` accepts SQLite's
-   space-separated format on Python ≥3.11 (project floor is 3.12 — fine);
-   parse errors must still return `True` (stale) as today.
+**Start Phase 3** (session-scope `mark_orphaned_jobs_failed`) — see the Phase 3
+block for the full plan; branch fresh off `origin/master` once PR A has
+merged. Then Phases 4+5 as PR C.
 
 ## 6. Key Files & Architecture
 

--- a/src/clm/infrastructure/workers/pool_manager.py
+++ b/src/clm/infrastructure/workers/pool_manager.py
@@ -16,7 +16,7 @@ import time
 import uuid
 import weakref
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
@@ -868,72 +868,91 @@ class WorkerPoolManager:
                     status = row[3]
                     last_heartbeat = row[4]
 
-                    # Check if heartbeat is stale (no update in 30 seconds)
-                    if self._is_heartbeat_stale(last_heartbeat, 30):
-                        logger.warning(
-                            f"Worker {worker_id} ({worker_type}) has stale heartbeat "
-                            f"(last: {last_heartbeat})"
+                    # Determine executor type and get executor
+                    is_direct = executor_id.startswith("direct-")
+                    executor_type = "direct" if is_direct else "docker"
+
+                    if executor_type not in self.executors:
+                        # A missing executor is NOT evidence the worker died
+                        # — this pool simply has no executor of that mode to
+                        # check it (e.g. a legacy/foreign row that slipped the
+                        # session filter). Skip it rather than reap a worker
+                        # we cannot verify (issue #617).
+                        logger.debug(
+                            f"No {executor_type} executor in this pool to check "
+                            f"worker {worker_id}; skipping (not ours to reap)."
                         )
+                        continue
 
-                        # Determine executor type and get executor
-                        is_direct = executor_id.startswith("direct-")
-                        executor_type = "direct" if is_direct else "docker"
+                    executor = self.executors[executor_type]
 
-                        if executor_type not in self.executors:
-                            # A missing executor is NOT evidence the worker died
-                            # — this pool simply has no executor of that mode to
-                            # check it (e.g. a legacy/foreign row that slipped the
-                            # session filter). Skip it rather than reap a worker
-                            # we cannot verify (issue #617).
-                            logger.debug(
-                                f"No {executor_type} executor in this pool to check "
-                                f"worker {worker_id}; skipping (not ours to reap)."
+                    try:
+                        # Liveness first, and unconditionally: workers only
+                        # update their heartbeat while idle-polling or when
+                        # returning to idle, so a busy worker's heartbeat goes
+                        # stale on any job longer than the threshold. Gating
+                        # the process check on staleness would either skip dead
+                        # workers (fresh heartbeat, just died) or do nothing
+                        # extra — the check is cheap (process poll / container
+                        # inspect), so run it every cycle.
+                        if not executor.is_worker_running(executor_id):
+                            logger.error(
+                                f"Worker {worker_id} ({executor_type}) is not running, "
+                                f"marking as dead"
                             )
+                            conn.execute(
+                                "UPDATE workers SET status = 'dead' WHERE id = ?", (worker_id,)
+                            )
+                            conn.commit()
                             continue
 
-                        executor = self.executors[executor_type]
+                        # A stale heartbeat on a BUSY worker is the normal
+                        # state mid-job (see above), so it is only worth DEBUG;
+                        # an IDLE worker heartbeats every couple of seconds, so
+                        # staleness there is a real anomaly and stays WARNING.
+                        heartbeat_stale = self._is_heartbeat_stale(last_heartbeat, 30)
+                        if heartbeat_stale:
+                            log = logger.debug if status == "busy" else logger.warning
+                            log(
+                                f"Worker {worker_id} ({worker_type}, {status}) has "
+                                f"stale heartbeat (last: {last_heartbeat})"
+                            )
 
-                        # Check if worker process/container is still running
-                        try:
-                            if not executor.is_worker_running(executor_id):
+                        # Hung detection (Docker only): a busy container with a
+                        # stale heartbeat AND ~zero CPU is likely wedged. Stats
+                        # are throttled to every 5th check to reduce Docker API
+                        # calls, and only fetched when the staleness gate is
+                        # open — a fresh heartbeat proves the worker is fine.
+                        stats = None
+                        if (
+                            heartbeat_stale
+                            and executor_type == "docker"
+                            and stats_check_counter % 5 == 0
+                        ):
+                            stats = executor.get_worker_stats(executor_id)
+
+                        if stats and executor_type == "docker":
+                            cpu_percent = stats.get("cpu_percent", 0.0)
+
+                            # If CPU < 1% and status is busy, worker is likely hung
+                            if cpu_percent < 1.0 and status == "busy":
                                 logger.error(
-                                    f"Worker {worker_id} ({executor_type}) is not running, "
-                                    f"marking as dead"
+                                    f"Worker {worker_id} appears hung "
+                                    f"(CPU: {cpu_percent:.1f}%, status: busy)"
                                 )
                                 conn.execute(
-                                    "UPDATE workers SET status = 'dead' WHERE id = ?", (worker_id,)
+                                    "UPDATE workers SET status = 'hung' WHERE id = ?",
+                                    (worker_id,),
                                 )
                                 conn.commit()
-                                continue
 
-                            # Get worker stats (throttled to every 5th check to reduce Docker API calls)
-                            # This reduces overhead by 80% while still detecting hung workers
-                            stats = None
-                            if stats_check_counter % 5 == 0:
-                                stats = executor.get_worker_stats(executor_id)
+                                # Optionally restart hung workers
+                                # self._restart_worker(worker_id, executor_id, worker_type)
 
-                            if stats and executor_type == "docker":
-                                cpu_percent = stats.get("cpu_percent", 0.0)
-
-                                # If CPU < 1% and status is busy, worker is likely hung
-                                if cpu_percent < 1.0 and status == "busy":
-                                    logger.error(
-                                        f"Worker {worker_id} appears hung "
-                                        f"(CPU: {cpu_percent:.1f}%, status: busy)"
-                                    )
-                                    conn.execute(
-                                        "UPDATE workers SET status = 'hung' WHERE id = ?",
-                                        (worker_id,),
-                                    )
-                                    conn.commit()
-
-                                    # Optionally restart hung workers
-                                    # self._restart_worker(worker_id, executor_id, worker_type)
-
-                        except Exception as e:
-                            logger.error(
-                                f"Error checking worker {worker_id} health: {e}", exc_info=True
-                            )
+                    except Exception as e:
+                        logger.error(
+                            f"Error checking worker {worker_id} health: {e}", exc_info=True
+                        )
 
                 time.sleep(check_interval)
 
@@ -955,8 +974,13 @@ class WorkerPoolManager:
         """
         try:
             heartbeat_time = datetime.fromisoformat(last_heartbeat)
-            now = datetime.now()
-            age = (now - heartbeat_time).total_seconds()
+            if heartbeat_time.tzinfo is None:
+                # SQLite CURRENT_TIMESTAMP writes naive UTC strings; comparing
+                # against local time made every heartbeat look hours stale east
+                # of UTC and *never* stale west of it (which silently disabled
+                # the monitor there).
+                heartbeat_time = heartbeat_time.replace(tzinfo=timezone.utc)
+            age = (datetime.now(timezone.utc) - heartbeat_time).total_seconds()
             return age > threshold_seconds
         except Exception as e:
             logger.error(f"Error parsing heartbeat timestamp: {e}")

--- a/tests/infrastructure/workers/test_pool_manager.py
+++ b/tests/infrastructure/workers/test_pool_manager.py
@@ -1,5 +1,6 @@
 """Tests for pool_manager module."""
 
+import logging
 import tempfile
 import threading
 import time
@@ -359,23 +360,36 @@ def test_pool_manager_get_worker_stats(db_path, workspace_path, worker_configs):
 
 
 def test_pool_manager_is_heartbeat_stale():
-    """Test heartbeat staleness detection."""
-    from datetime import datetime, timedelta
+    """Heartbeat staleness must be computed in UTC, independent of the host
+    timezone. SQLite CURRENT_TIMESTAMP writes naive UTC strings; comparing them
+    against local time made every heartbeat look hours stale east of UTC and
+    never stale west of it (silently disabling the monitor there) — the
+    PR #636 review's Finding 1."""
+    from datetime import datetime, timedelta, timezone
 
     with patch("docker.from_env"):
         manager = WorkerPoolManager(
             db_path=Path("dummy.db"), workspace_path=Path("/tmp"), worker_configs=[]
         )
 
-        # Fresh heartbeat
-        now = datetime.now()
-        fresh_heartbeat = now.isoformat()
-        assert not manager._is_heartbeat_stale(fresh_heartbeat, 30)
+        now_utc = datetime.now(timezone.utc)
 
-        # Stale heartbeat (40 seconds ago)
-        stale_time = now - timedelta(seconds=40)
-        stale_heartbeat = stale_time.isoformat()
-        assert manager._is_heartbeat_stale(stale_heartbeat, 30)
+        # Fresh naive-UTC heartbeat, in SQLite's "YYYY-MM-DD HH:MM:SS" shape.
+        fresh = now_utc.strftime("%Y-%m-%d %H:%M:%S")
+        assert not manager._is_heartbeat_stale(fresh, 30)
+
+        # Stale naive-UTC heartbeat (40 seconds ago).
+        stale = (now_utc - timedelta(seconds=40)).strftime("%Y-%m-%d %H:%M:%S")
+        assert manager._is_heartbeat_stale(stale, 30)
+
+        # Timezone-aware timestamps are honored as-is.
+        aware_fresh = now_utc.isoformat()
+        assert not manager._is_heartbeat_stale(aware_fresh, 30)
+        aware_stale = (now_utc - timedelta(seconds=40)).isoformat()
+        assert manager._is_heartbeat_stale(aware_stale, 30)
+
+        # Unparseable timestamps are treated as stale.
+        assert manager._is_heartbeat_stale("not-a-timestamp", 30)
 
 
 def test_pool_manager_calculate_cpu_percent():
@@ -586,17 +600,22 @@ def test_pool_manager_start_monitoring(db_path, workspace_path, worker_configs):
         manager.monitor_thread.join(timeout=1)
 
 
-def _seed_stale_busy_direct_worker(db_path, session_id, container_id):
-    """Insert a busy direct worker with a stale heartbeat (issue #617 tests)."""
+def _seed_busy_worker(
+    db_path, session_id, container_id, *, heartbeat_age_seconds=120, execution_mode="direct"
+):
+    """Insert a busy worker with a heartbeat aged by the given amount
+    (issue #617 / PR #636-review tests). SQLite datetime('now') is UTC, the
+    same clock CURRENT_TIMESTAMP heartbeats use, so these tests are
+    host-timezone-independent."""
     jq = JobQueue(db_path)
     try:
         cur = jq._get_conn().execute(
             """
             INSERT INTO workers (worker_type, container_id, status, session_id,
                                  execution_mode, last_heartbeat)
-            VALUES ('notebook', ?, 'busy', ?, 'direct', datetime('now', '-120 seconds'))
+            VALUES ('notebook', ?, 'busy', ?, ?, datetime('now', ? || ' seconds'))
             """,
-            (container_id, session_id),
+            (container_id, session_id, execution_mode, str(-heartbeat_age_seconds)),
         )
         worker_id = cur.lastrowid
         assert worker_id is not None
@@ -637,22 +656,117 @@ def test_monitor_health_reaps_only_own_session_dead_workers(
     dead_executor.is_worker_running.return_value = False
     manager.executors["direct"] = dead_executor
 
-    own = _seed_stale_busy_direct_worker(db_path, "session-A", "direct-own")
-    foreign = _seed_stale_busy_direct_worker(db_path, "session-B", "direct-foreign")
+    own = _seed_busy_worker(db_path, "session-A", "direct-own")
+    foreign = _seed_busy_worker(db_path, "session-B", "direct-foreign")
 
+    _run_monitor_until(manager, lambda: _worker_status(db_path, own) == "dead")
+
+    assert _worker_status(db_path, own) == "dead"
+    assert _worker_status(db_path, foreign) == "busy"
+
+
+def _run_monitor_until(manager, condition, timeout=5.0):
+    """Run _monitor_health in a thread until `condition()` or timeout."""
     manager.running = True
     thread = threading.Thread(target=manager._monitor_health, args=(0.05,), daemon=True)
     thread.start()
     try:
-        deadline = time.time() + 5.0
-        while time.time() < deadline and _worker_status(db_path, own) != "dead":
+        deadline = time.time() + timeout
+        while time.time() < deadline and not condition():
             time.sleep(0.05)
     finally:
         manager.running = False
         thread.join(timeout=2)
 
-    assert _worker_status(db_path, own) == "dead"
-    assert _worker_status(db_path, foreign) == "busy"
+
+def test_monitor_health_reaps_dead_worker_with_fresh_heartbeat(
+    db_path, workspace_path, worker_configs
+):
+    """The liveness check must not be gated on heartbeat staleness: a worker
+    whose process is gone is reaped even while its last heartbeat is recent
+    (PR #636 review, Finding 2 — liveness is checked unconditionally)."""
+    with patch("docker.from_env"):
+        manager = WorkerPoolManager(
+            db_path=db_path,
+            workspace_path=workspace_path,
+            worker_configs=worker_configs,
+            session_id="session-A",
+        )
+
+    dead_executor = MagicMock()
+    dead_executor.is_worker_running.return_value = False
+    manager.executors["direct"] = dead_executor
+
+    worker = _seed_busy_worker(db_path, "session-A", "direct-own", heartbeat_age_seconds=0)
+
+    _run_monitor_until(manager, lambda: _worker_status(db_path, worker) == "dead")
+
+    assert _worker_status(db_path, worker) == "dead"
+
+
+def test_monitor_health_leaves_live_busy_worker_alone(
+    db_path, workspace_path, worker_configs, caplog
+):
+    """A busy worker on a long job stops heartbeating (heartbeats are only
+    sent while idle), so a stale heartbeat with a live process is the NORMAL
+    mid-job state: the worker must not be marked dead or hung, and the
+    staleness must not spam WARNING logs (PR #636 review, Finding 2)."""
+    with patch("docker.from_env"):
+        manager = WorkerPoolManager(
+            db_path=db_path,
+            workspace_path=workspace_path,
+            worker_configs=worker_configs,
+            session_id="session-A",
+        )
+
+    live_executor = MagicMock()
+    live_executor.is_worker_running.return_value = True
+    manager.executors["direct"] = live_executor
+
+    worker = _seed_busy_worker(db_path, "session-A", "direct-own", heartbeat_age_seconds=120)
+
+    with caplog.at_level(logging.WARNING, logger="clm.infrastructure.workers.pool_manager"):
+        # Let several monitor cycles run; the condition never becomes true.
+        _run_monitor_until(manager, lambda: _worker_status(db_path, worker) != "busy", timeout=0.5)
+
+    assert _worker_status(db_path, worker) == "busy"
+    assert live_executor.is_worker_running.called
+    stale_warnings = [
+        r for r in caplog.records if "stale heartbeat" in r.message and r.levelno >= logging.WARNING
+    ]
+    assert stale_warnings == []
+
+
+def test_monitor_health_marks_stale_zero_cpu_docker_worker_hung(
+    db_path, workspace_path, worker_configs
+):
+    """The Docker hung heuristic must survive the Finding-2 restructuring: a
+    busy container with a stale heartbeat and ~zero CPU is still marked
+    'hung' (stats are throttled to every 5th cycle, so give it a few)."""
+    with patch("docker.from_env"):
+        manager = WorkerPoolManager(
+            db_path=db_path,
+            workspace_path=workspace_path,
+            worker_configs=worker_configs,
+            session_id="session-A",
+        )
+
+    docker_executor = MagicMock()
+    docker_executor.is_worker_running.return_value = True
+    docker_executor.get_worker_stats.return_value = {"cpu_percent": 0.0}
+    manager.executors["docker"] = docker_executor
+
+    worker = _seed_busy_worker(
+        db_path,
+        "session-A",
+        "container-abc123",
+        heartbeat_age_seconds=120,
+        execution_mode="docker",
+    )
+
+    _run_monitor_until(manager, lambda: _worker_status(db_path, worker) == "hung")
+
+    assert _worker_status(db_path, worker) == "hung"
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Phases 1+2 ("PR A", monitor correctness) of the PR #636 adversarial-review remediation plan (`docs/claude/handovers/pr636-review-findings-handover.md`, landed in #637).

## Finding 1 (HIGH): `_is_heartbeat_stale` timezone bug

`workers.last_heartbeat` is written by SQLite `CURRENT_TIMESTAMP` (naive UTC), but `_is_heartbeat_stale` compared it against local `datetime.now()`:

- **West of UTC**: age was negative → heartbeats never stale → the health monitor #636 wired up never checked anything, silently re-opening the #617 hole there.
- **East of UTC** (CEST): everything always looked ≥2h stale → the monitor "worked", but only because the gate was permanently open — with a WARNING per busy worker per 10s cycle.

Fixed by tagging naive timestamps as UTC and comparing against `datetime.now(timezone.utc)` (the same pattern `discovery.py` already uses). The DB write side is untouched — UTC in the DB is load-bearing for other readers.

## Finding 2 (MEDIUM): liveness was gated on heartbeats busy workers never send

Workers only update `last_heartbeat` while idle-polling or on the busy→idle transition, so once staleness is computed *correctly*, every job longer than 30s trips the stale gate each cycle. Restructured `_monitor_health`:

- `is_worker_running` now runs **unconditionally** each cycle (cheap: process poll / container inspect) — a dead worker is reaped even while its last heartbeat is recent.
- Stale-heartbeat logging is DEBUG for `busy` workers (the normal mid-job state), still WARNING for idle ones (real anomaly — idle workers heartbeat every ~2s).
- The Docker zero-CPU hung heuristic still requires a stale heartbeat before pulling (throttled) container stats, unchanged in behavior.

## Tests

- `test_pool_manager_is_heartbeat_stale` rewritten host-TZ-independent (it previously seeded *local* timestamps and only passed on UTC-or-east machines — it would have failed west of UTC); now covers naive-UTC, tz-aware, and malformed inputs.
- New: dead worker with a **fresh** heartbeat is reaped; live busy worker with a stale heartbeat stays `busy` with zero WARNING lines; stale zero-CPU docker worker is still marked `hung`; existing session-scoping test unchanged and green.
- `tests/infrastructure/workers/` suite: 44 passed. ruff + format + mypy clean.

Handover updated (Phases 1+2 → DONE; next is Phase 3, session-scoping `mark_orphaned_jobs_failed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3aUDhPsn1MDNR7Qf1V1Xb
