### PR TITLE
fix(workers): session-scope the teardown orphan sweep (#617/#636 follow-up)

### DIFF
--- a/changelog.d/617-orphan-sweep-session-scope.fixed.md
+++ b/changelog.d/617-orphan-sweep-session-scope.fixed.md
@@ -1,0 +1,5 @@
+- The teardown orphan sweep (`mark_orphaned_jobs_failed`) is now scoped to the
+  build's own session: a build finishing first in a shared jobs DB no longer
+  marks a concurrent build's in-flight jobs as failed, nor folds them into its
+  own summary and exit code (#617/#636 follow-up, Finding 3). Maintenance
+  callers (`clm workers` reap) keep the unscoped sweep.

--- a/docs/claude/handovers/pr636-review-findings-handover.md
+++ b/docs/claude/handovers/pr636-review-findings-handover.md
@@ -1,7 +1,7 @@
 # Handover: PR #636 Adversarial-Review Findings (worker liveness follow-ups)
 
-**Status**: Phases 1+2 DONE (2026-07-12, PR A — monitor correctness); next is
-Phase 3 (session-scope `mark_orphaned_jobs_failed`), then Phases 4+5.
+**Status**: Phases 1+2 DONE (2026-07-12, PR A #639, merged); Phase 3 DONE
+(2026-07-12, PR B — orphan sweep session scoping); next is Phases 4+5 (PR C).
 This document is the source of truth for addressing the five findings from the
 post-merge adversarial review of PR #636 (the issue #617 fix, merged as
 `f96f8ab6` / commit `d5467df7`).
@@ -145,7 +145,22 @@ SQLite UTC `datetime('now', ...)`, host-TZ-independent) with a shared
   alive); a dead process is still reaped within one cycle; the Docker hung
   heuristic still fires for a genuinely stale+idle-CPU busy container.
 
-### Phase 3 [TODO] — Session-scope `mark_orphaned_jobs_failed` (Finding 3, MEDIUM)
+### Phase 3 [DONE] — Session-scope `mark_orphaned_jobs_failed` (Finding 3, MEDIUM)
+
+**Resolution (2026-07-12)**: implemented as planned (PR B, branch
+`claude/pr636-phase3-orphan-sweep-scope`). `mark_orphaned_jobs_failed` takes
+an optional `session_id`; when given, the orphan SELECT adds strict
+`AND session_id = ?` (NULL-session rows are left to the unscoped maintenance
+sweep — `clm workers` reap is unchanged). `stop_managed_workers` passes
+`self.session_id` (always non-None). The predicted gotcha was real:
+`_seed_inflight_job` seeded NULL session_ids, so it now stamps a fixed
+`SESSION_ID` that the orphan tests also pass to the manager ctor. New tests:
+scoped-reaps-only-own-session, scoped-ignores-NULL-session-rows,
+unscoped-reaps-all; the returns-orphans lifecycle test gained a
+foreign-session row that must be neither reaped nor reported. Nuance: a
+NULL-session job claimed by a build's worker now survives that build's
+teardown sweep (intentional; the unscoped reap cleans it up). Original plan
+below kept for reference.
 
 - **What**: `JobQueue.mark_orphaned_jobs_failed`
   (`src/clm/infrastructure/database/job_queue.py:415-` , SELECT at :451-459)
@@ -244,18 +259,23 @@ SQLite UTC `datetime('now', ...)`, host-TZ-independent) with a shared
   early paths — none of those need changes. **Phases 1+2 implemented**
   (2026-07-12) on branch `claude/pr636-findings-monitor-correctness` (PR A:
   `src/clm/infrastructure/workers/pool_manager.py` + its tests + changelog
-  fragment `changelog.d/617-monitor-tz-and-busy-heartbeat.fixed.md`); see the
-  phase resolution notes.
-- **In progress**: nothing (PR A in review/auto-merge).
+  fragment `changelog.d/617-monitor-tz-and-busy-heartbeat.fixed.md`) — merged
+  as PR #639. **Phase 3 implemented** (2026-07-12) on branch
+  `claude/pr636-phase3-orphan-sweep-scope` (PR B: `job_queue.py`,
+  `lifecycle_manager.py`, their tests, fragment
+  `changelog.d/617-orphan-sweep-session-scope.fixed.md`); see the phase
+  resolution notes.
+- **In progress**: nothing (PR B in review/auto-merge).
 - **Blockers / open questions**:
   - Phase 2 design choice (unconditional process check vs. background
     heartbeat thread) — recommendation is the former; confirm with maintainer
     only if they push back in PR review.
   - Phase 5.2 (reused-worker gap): accept-and-document vs. new issue —
     default to accept-and-document.
-- **Tests**: repo suite green at `f96f8ab6` (PR #636's CI passed). NOTE: the
-  new monitor test is latently host-TZ-dependent (see Phase 1) — it passes
-  here and on CI but would fail west of UTC; that is itself part of Finding 1.
+- **Tests**: repo suite green through PR #639; Phase 3 slice
+  (`test_job_queue.py`, `test_lifecycle_manager.py`, `test_workers_reap.py`)
+  green with ruff + mypy clean. The formerly host-TZ-dependent monitor test
+  was fixed in Phase 1.
 - **Worktree note**: review was done in worktree `ancient-painting-charm`,
   whose branch `worktree-ancient-painting-charm` was reset to `origin/master`
   (`f96f8ab6`). Start fix work by branching off it:
@@ -264,9 +284,9 @@ SQLite UTC `datetime('now', ...)`, host-TZ-independent) with a shared
 
 ## 5. Next Steps
 
-**Start Phase 3** (session-scope `mark_orphaned_jobs_failed`) — see the Phase 3
-block for the full plan; branch fresh off `origin/master` once PR A has
-merged. Then Phases 4+5 as PR C.
+**Start Phase 4** (honest orphan exit message) together with Phase 5 as PR C —
+see the Phase 4/5 blocks for the full plans; branch fresh off `origin/master`
+once PR B has merged.
 
 ## 6. Key Files & Architecture
 

--- a/src/clm/infrastructure/database/job_queue.py
+++ b/src/clm/infrastructure/database/job_queue.py
@@ -412,7 +412,7 @@ class JobQueue:
     # free-form sentence.
     ORPHAN_ERROR_MESSAGE = "worker died mid-job (orphaned at pool shutdown)"
 
-    def mark_orphaned_jobs_failed(self) -> list[dict[str, Any]]:
+    def mark_orphaned_jobs_failed(self, session_id: str | None = None) -> list[dict[str, Any]]:
         """Detect and fail any jobs that were in flight when the pool stopped.
 
         An "orphan" is a row in the ``jobs`` table that was claimed by a
@@ -436,6 +436,16 @@ class JobQueue:
         At that point no worker is alive, so there is no race with a
         worker that is about to commit its own terminal update.
 
+        Args:
+            session_id: When given, only jobs stamped with this
+                ``jobs.session_id`` are considered — a build tearing down
+                must not reap a concurrent build's in-flight jobs in a
+                shared jobs DB (the #597/#620 ownership rule, mirroring
+                the health monitor's session scoping). ``None`` keeps the
+                unscoped sweep for maintenance callers (``clm workers``
+                reap), which also covers legacy rows whose
+                ``session_id`` is NULL.
+
         Returns:
             List of dicts describing each orphan row that was marked
             failed, in the shape ``{"id": int, "input_file": str,
@@ -448,8 +458,7 @@ class JobQueue:
         conn = self._get_conn()
         conn.execute("BEGIN IMMEDIATE")
         try:
-            cursor = conn.execute(
-                """
+            query = """
                 SELECT id, input_file, status, worker_id
                 FROM jobs
                 WHERE started_at IS NOT NULL
@@ -457,7 +466,11 @@ class JobQueue:
                   AND cancelled_at IS NULL
                   AND status IN ('processing', 'pending')
                 """
-            )
+            params: tuple[Any, ...] = ()
+            if session_id is not None:
+                query += " AND session_id = ?"
+                params = (session_id,)
+            cursor = conn.execute(query, params)
             rows = cursor.fetchall()
 
             if not rows:

--- a/src/clm/infrastructure/workers/lifecycle_manager.py
+++ b/src/clm/infrastructure/workers/lifecycle_manager.py
@@ -288,10 +288,14 @@ class WorkerLifecycleManager:
         # race with us) and before log_pool_stopped() so the orphan count
         # can be included in the pool_stopped event metadata. Without this
         # pass, orphans would stay stuck in "processing" status forever and
-        # ``clm status`` would silently under-report failures.
+        # ``clm status`` would silently under-report failures. Scoped to this
+        # manager's session so a concurrent build's in-flight jobs in a shared
+        # jobs DB are never reaped or reported here (#597/#620 ownership rule).
         orphans: list[dict[str, Any]] = []
         try:
-            orphans = self.event_logger.job_queue.mark_orphaned_jobs_failed()
+            orphans = self.event_logger.job_queue.mark_orphaned_jobs_failed(
+                session_id=self.session_id
+            )
         except Exception as exc:
             # Never let orphan detection break pool teardown — downstream
             # cleanup (log_pool_stopped, managed_workers clearing) must

--- a/tests/infrastructure/database/test_job_queue.py
+++ b/tests/infrastructure/database/test_job_queue.py
@@ -903,7 +903,7 @@ def test_remove_missing_skips_pending_jobs(job_queue, tmp_path):
 # ============================================================================
 
 
-def _claim(job_queue, worker_id: int = 1) -> Job:
+def _claim(job_queue, worker_id: int = 1, session_id: str | None = None) -> Job:
     """Add a pending job and immediately claim it, returning the in-flight Job."""
     job_queue.add_job(
         job_type="notebook",
@@ -911,6 +911,7 @@ def _claim(job_queue, worker_id: int = 1) -> Job:
         output_file=f"test-{worker_id}.ipynb",
         content_hash=f"hash-{worker_id}",
         payload={},
+        session_id=session_id,
     )
     claimed = job_queue.get_next_job(worker_id=worker_id, job_type="notebook")
     assert claimed is not None, "get_next_job should claim the pending job we just added"
@@ -1035,6 +1036,45 @@ def test_mark_orphaned_jobs_failed_ignores_pending_without_started_at(job_queue)
     stats = job_queue.get_job_stats()
     assert stats["pending"] == 1
     assert stats["failed"] == 0
+
+
+def test_mark_orphaned_jobs_failed_scoped_reaps_only_own_session(job_queue):
+    """A session-scoped sweep must only reap its own session's in-flight jobs.
+
+    Concurrent builds A and B share a jobs DB; when A tears down first it must
+    not fail B's genuinely in-flight jobs (#597/#620 ownership rule)."""
+    job_a = _claim(job_queue, worker_id=10, session_id="session-a")
+    job_b = _claim(job_queue, worker_id=11, session_id="session-b")
+
+    orphans = job_queue.mark_orphaned_jobs_failed(session_id="session-a")
+
+    assert [o["id"] for o in orphans] == [job_a.id]
+    assert job_queue.get_job(job_a.id).status == "failed"
+    # B's in-flight job is untouched — still processing, no error stamped.
+    row_b = job_queue.get_job(job_b.id)
+    assert row_b.status == "processing"
+    assert row_b.error is None
+
+
+def test_mark_orphaned_jobs_failed_scoped_ignores_null_session_rows(job_queue):
+    """Strict scoping: rows with NULL session_id are left to the unscoped
+    maintenance sweep (``clm workers`` reap), not claimed by a build."""
+    job_null = _claim(job_queue, worker_id=12, session_id=None)
+
+    orphans = job_queue.mark_orphaned_jobs_failed(session_id="session-a")
+
+    assert orphans == []
+    assert job_queue.get_job(job_null.id).status == "processing"
+
+
+def test_mark_orphaned_jobs_failed_unscoped_reaps_all_sessions(job_queue):
+    """Without a session_id the sweep keeps its original cross-session reach."""
+    job_a = _claim(job_queue, worker_id=13, session_id="session-a")
+    job_null = _claim(job_queue, worker_id=14, session_id=None)
+
+    orphans = job_queue.mark_orphaned_jobs_failed()
+
+    assert {o["id"] for o in orphans} == {job_a.id, job_null.id}
 
 
 def test_reset_hung_jobs_clears_started_at(job_queue):

--- a/tests/infrastructure/workers/test_lifecycle_manager.py
+++ b/tests/infrastructure/workers/test_lifecycle_manager.py
@@ -598,16 +598,26 @@ class TestStopManagedWorkers:
             config={},
         )
 
+    # Session the orphan tests run under: the manager is constructed with it
+    # and _seed_inflight_job stamps it on the jobs rows, because the teardown
+    # sweep is session-scoped (only a build's own in-flight jobs are reaped).
+    SESSION_ID = "test-orphan-session"
+
     @staticmethod
-    def _seed_inflight_job(db_path, input_file: str) -> int:
+    def _seed_inflight_job(db_path, input_file: str, session_id: str | None = None) -> int:
         """Insert a jobs row that looks like a worker claimed it and died.
 
         The real code path would go through JobQueue.get_next_job, but
         building a full worker+jobs fixture is overkill for this test.
         An explicit INSERT keeps the setup obvious and matches the shape
-        the orphan query looks for.
+        the orphan query looks for. ``session_id`` defaults to the class
+        SESSION_ID so the row belongs to the manager under test; pass a
+        different value to simulate a concurrent build's job.
         """
         from clm.infrastructure.database.job_queue import JobQueue
+
+        if session_id is None:
+            session_id = TestStopManagedWorkers.SESSION_ID
 
         jq = JobQueue(db_path)
         try:
@@ -616,14 +626,14 @@ class TestStopManagedWorkers:
                 """
                 INSERT INTO jobs (
                     job_type, status, input_file, output_file, content_hash,
-                    payload, started_at, worker_id
+                    payload, started_at, worker_id, session_id
                 )
                 VALUES (
                     'notebook', 'processing', ?, 'out.ipynb', 'hash',
-                    '{}', CURRENT_TIMESTAMP, 42
+                    '{}', CURRENT_TIMESTAMP, 42, ?
                 )
                 """,
-                (input_file,),
+                (input_file, session_id),
             )
             job_id = cursor.lastrowid
             assert job_id is not None
@@ -670,6 +680,7 @@ class TestStopManagedWorkers:
                 config=mock_config,
                 db_path=db_path,
                 workspace_path=workspace_path,
+                session_id=self.SESSION_ID,
             )
             manager.pool_manager = MagicMock()
 
@@ -704,20 +715,37 @@ class TestStopManagedWorkers:
     ):
         """stop_managed_workers returns the orphaned jobs so the build can fold
         them into the summary/exit policy instead of silently banking them in
-        the jobs DB (issue #617)."""
+        the jobs DB (issue #617). A concurrent build's in-flight job must NOT
+        appear in the returned orphans (session-scoped sweep, #597/#620)."""
+        from clm.infrastructure.database.job_queue import JobQueue
+
         orphan_id = self._seed_inflight_job(db_path, "orphaned/example.py")
+        foreign_id = self._seed_inflight_job(
+            db_path, "foreign/other-build.py", session_id="some-other-session"
+        )
 
         with patch("clm.infrastructure.workers.lifecycle_manager.DirectWorkerExecutor"):
             manager = WorkerLifecycleManager(
                 config=mock_config,
                 db_path=db_path,
                 workspace_path=workspace_path,
+                session_id=self.SESSION_ID,
             )
             manager.pool_manager = MagicMock()
             orphans = manager.stop_managed_workers([self._make_worker_info()])
 
         assert [o["id"] for o in orphans] == [orphan_id]
         assert orphans[0]["input_file"] == "orphaned/example.py"
+
+        # The foreign session's in-flight job was neither reaped nor reported.
+        jq = JobQueue(db_path)
+        try:
+            foreign_row = jq.get_job(foreign_id)
+        finally:
+            jq.close()
+        assert foreign_row is not None
+        assert foreign_row.status == "processing"
+        assert foreign_row.error is None
 
     def test_stop_returns_empty_list_on_clean_shutdown(self, db_path, workspace_path, mock_config):
         """A clean shutdown (no in-flight jobs) returns an empty list, not None,
@@ -743,6 +771,7 @@ class TestStopManagedWorkers:
                 config=mock_config,
                 db_path=db_path,
                 workspace_path=workspace_path,
+                session_id=self.SESSION_ID,
             )
             manager.pool_manager = MagicMock()
 


### PR DESCRIPTION
## Summary

Follow-up to #617/#636, addressing **Finding 3 (MEDIUM)** from the post-merge adversarial review of PR #636 (remediation plan: `docs/claude/handovers/pr636-review-findings-handover.md`, Phase 3; Phases 1+2 landed in #639).

`JobQueue.mark_orphaned_jobs_failed` reaped **every** non-terminal started job in a shared jobs DB. With concurrent builds A and B, A finishing first would (a) mark B's genuinely in-flight jobs `failed` with the orphan message — breaking B (pre-existing bug) — and (b) fold B's jobs into **A's** summary and force A to exit non-zero for jobs that were never its own (reporting noise added by #636).

## Changes

- `mark_orphaned_jobs_failed` gains an optional `session_id`: when given, the orphan SELECT adds strict `AND session_id = ?`, mirroring the health monitor's #597/#620 ownership scoping. The UPDATE stays keyed by the selected ids.
- `WorkerLifecycleManager.stop_managed_workers` passes its own `session_id` (always non-None).
- `session_id=None` keeps the original unscoped sweep — the `clm workers` reap maintenance path is unchanged and still covers NULL-session/legacy rows.

Deliberate nuance: a NULL-session job claimed by a build's worker now survives that build's teardown sweep (strict scoping); the unscoped maintenance reap cleans those up. Build-path jobs are always session-stamped at submission (`sqlite_backend.py`), so this only affects rows submitted without a session.

## Tests

- `test_job_queue.py`: scoped sweep reaps only its own session; scoped sweep ignores NULL-session rows; unscoped sweep keeps cross-session reach.
- `test_lifecycle_manager.py`: the returns-orphans test seeds a foreign-session in-flight row and asserts it is neither reaped nor reported; `_seed_inflight_job` now stamps a session matching the manager under test.
- Affected slice: 97 passed; ruff + mypy clean; fast suite green on the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3aUDhPsn1MDNR7Qf1V1Xb