### PR TITLE
fix(build,workers): honest orphan exit message + monitor/teardown polish (#617/#636 follow-up)

### DIFF
--- a/changelog.d/617-orphan-message-and-monitor-polish.fixed.md
+++ b/changelog.d/617-orphan-message-and-monitor-polish.fixed.md
@@ -1,0 +1,11 @@
+- The build's exit message now distinguishes teardown-orphaned jobs from
+  per-stage timeouts: instead of the misleading "one or more worker jobs
+  timed out … see the error summary above", orphaned jobs get a dedicated
+  message naming the affected input files (#617/#636 follow-up, Finding 4).
+- `stop_pools()` now interrupts the health monitor's between-cycle wait via a
+  stop event, so the monitor thread is actually joined at teardown instead of
+  lingering up to one check interval (#617/#636 follow-up, Finding 5.1).
+- A job submission abandoned by a cancelled caller no longer triggers
+  asyncio's "exception was never retrieved" warning at teardown; the shielded
+  task's exception is retrieved and debug-logged (#617/#636 follow-up,
+  Finding 5.3).

--- a/docs/claude/handovers/pr636-review-findings-handover.md
+++ b/docs/claude/handovers/pr636-review-findings-handover.md
@@ -1,7 +1,9 @@
 # Handover: PR #636 Adversarial-Review Findings (worker liveness follow-ups)
 
-**Status**: Phases 1+2 DONE (2026-07-12, PR A #639, merged); Phase 3 DONE
-(2026-07-12, PR B — orphan sweep session scoping); next is Phases 4+5 (PR C).
+**Status**: ALL PHASES DONE (2026-07-12). PR A #639 (Phases 1+2, monitor
+correctness, merged), PR B #641 (Phase 3, orphan sweep session scoping,
+merged), PR C (Phases 4+5, orphan exit message + polish). Once PR C merges,
+this handover is complete and can be retired.
 This document is the source of truth for addressing the five findings from the
 post-merge adversarial review of PR #636 (the issue #617 fix, merged as
 `f96f8ab6` / commit `d5467df7`).
@@ -185,7 +187,20 @@ below kept for reference.
   keep passing; the manager's session_id comes from `mock_config`/ctor, so
   trace how `WorkerLifecycleManager.session_id` is populated first.
 
-### Phase 4 [TODO] — Honest orphan exit message (Finding 4, LOW)
+### Phase 4 [DONE] — Honest orphan exit message (Finding 4, LOW)
+
+**Resolution (2026-07-12)**: implemented per plan (PR C, branch
+`claude/pr636-phase45-orphan-reporting-polish`). New pure helper
+`_format_exit_failure(summary)` in `build.py` partitions `summary.errors` for
+`category == "orphaned_job"`: orphans get a dedicated message naming the
+count and input files ("orphaned at pool shutdown … produced no output");
+otherwise the original timed-out message is kept verbatim. The exit block
+calls the helper; `timed_out = True` remains the exit-forcing mechanism and
+the #90/#143 exit-policy ordering is untouched. Tests in
+`test_build_abort_summary.py` (`TestFormatExitFailure`) cover both branches.
+Limitation accepted: when a genuine timeout AND orphans co-occur, the message
+mentions only the orphans (the flag can't distinguish; both exit 1). Original
+plan below kept for reference.
 
 - **What**: the exit block at `src/clm/cli/commands/build.py:2662-2669` prints
   "one or more worker jobs **timed out** … See the error summary **above**"
@@ -210,7 +225,23 @@ below kept for reference.
   `_format_exit_failure(summary) -> str` makes this testable without a CLI
   run).
 
-### Phase 5 [TODO] — Minor loose ends (Finding 5, LOW)
+### Phase 5 [DONE] — Minor loose ends (Finding 5, LOW)
+
+**Resolution (2026-07-12)**: all three items shipped with Phase 4 (PR C).
+(1) Event approach taken: `WorkerPoolManager._monitor_stop_event` is waited
+on between monitor cycles (`wait(check_interval)` replaces `time.sleep`),
+set in `stop_pools`/`_emergency_stop`, cleared in `start_monitoring`; the
+5s join now succeeds, making the lifecycle_manager comment true as written.
+Test: `test_stop_pools_joins_monitor_promptly_despite_long_interval`
+(300s interval, join must not time out). (2) Reused-worker gap: accepted and
+documented via a comment at the reuse early-return in
+`lifecycle_manager.py` (monitoring foreign-session workers would violate the
+ownership rule); note posted to issue #617. (3) Shield noise: submission task
+is created via `asyncio.ensure_future` with a done-callback that retrieves
+and debug-logs the exception, then `asyncio.shield(task)` is awaited. Tests:
+abandoned-after-cancel exception is retrieved (caplog on the DEBUG line);
+non-cancelled path still propagates the raise. Original plan below kept for
+reference.
 
 1. **Monitor join guarantee overstated**: `stop_pools`
    (`pool_manager.py:1044-1056`) joins the monitor with `timeout=5` while the
@@ -263,9 +294,14 @@ below kept for reference.
   as PR #639. **Phase 3 implemented** (2026-07-12) on branch
   `claude/pr636-phase3-orphan-sweep-scope` (PR B: `job_queue.py`,
   `lifecycle_manager.py`, their tests, fragment
-  `changelog.d/617-orphan-sweep-session-scope.fixed.md`); see the phase
-  resolution notes.
-- **In progress**: nothing (PR B in review/auto-merge).
+  `changelog.d/617-orphan-sweep-session-scope.fixed.md`) — merged as PR #641.
+  **Phases 4+5 implemented** (2026-07-12) on branch
+  `claude/pr636-phase45-orphan-reporting-polish` (PR C: `build.py`,
+  `pool_manager.py`, `lifecycle_manager.py`, `sqlite_backend.py`, their
+  tests, fragment
+  `changelog.d/617-orphan-message-and-monitor-polish.fixed.md`); see the
+  phase resolution notes.
+- **In progress**: nothing (PR C in review/auto-merge).
 - **Blockers / open questions**:
   - Phase 2 design choice (unconditional process check vs. background
     heartbeat thread) — recommendation is the former; confirm with maintainer
@@ -284,9 +320,10 @@ below kept for reference.
 
 ## 5. Next Steps
 
-**Start Phase 4** (honest orphan exit message) together with Phase 5 as PR C —
-see the Phase 4/5 blocks for the full plans; branch fresh off `origin/master`
-once PR B has merged.
+None — all five findings are addressed. Once PR C merges, retire this
+handover (`/retire-handover`) or archive it; the only open follow-up is the
+accepted-and-documented reused-worker liveness gap (Phase 5.2), tracked by
+the note on issue #617.
 
 ## 6. Key Files & Architecture
 

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -1702,6 +1702,33 @@ def _record_teardown_orphans(summary: BuildSummary, orphans: list[dict[str, Any]
     summary.timed_out = True
 
 
+def _format_exit_failure(summary: BuildSummary) -> str:
+    """Compose the exit-time failure message for a ``timed_out`` summary.
+
+    ``summary.timed_out`` is set by two distinct paths: a genuine per-stage
+    worker-job timeout (issue #143), and :func:`_record_teardown_orphans`,
+    which reuses the flag as its exit-forcing mechanism (issue #617). Orphans
+    are appended *after* finish_build rendered the summary, so for them the
+    generic "timed out … see the error summary above" message is wrong on
+    both counts — nothing about them appears above, and they did not time
+    out. Name the orphaned inputs directly instead.
+    """
+    orphans = [e for e in summary.errors if e.category == "orphaned_job"]
+    if orphans:
+        files = ", ".join(e.file_path for e in orphans)
+        return (
+            f"\nBuild failed: {len(orphans)} worker job(s) were orphaned at "
+            f"pool shutdown (worker died mid-job) and produced no output: "
+            f"{files}. The output tree is incomplete; re-run the build. "
+            f"See issue #617."
+        )
+    return (
+        "\nBuild failed: one or more worker jobs timed out and did "
+        "not complete. The output tree is incomplete. See the error "
+        "summary above."
+    )
+
+
 async def main_build(
     ctx,
     spec_file,
@@ -2659,13 +2686,11 @@ def build(
     # independent of --fail-on-error. Pending jobs mean the output tree is
     # incomplete, so the build must never look successful. This is checked
     # before the --fail-on-error gate because it is unconditional.
+    # Teardown orphans reuse the timed_out flag as their exit-forcing
+    # mechanism but need a different message — _format_exit_failure
+    # distinguishes the two cases (issue #617 follow-up).
     if summary is not None and summary.timed_out:
-        click.echo(
-            "\nBuild failed: one or more worker jobs timed out and did "
-            "not complete. The output tree is incomplete. See the error "
-            "summary above.",
-            err=True,
-        )
+        click.echo(_format_exit_failure(summary), err=True)
         sys.exit(1)
 
     resolved_fail_on_error = _resolve_fail_on_error(fail_on_error, resolved_http_replay_mode)

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -396,8 +396,25 @@ class SqliteBackend(LocalOpsBackend):
         # is cancelled mid-await: the submit thread's INSERT is not cancellable
         # once started, so the active_jobs registration must be equally
         # uncancellable or the row is stranded (issue #617). On the happy path
-        # this is equivalent to awaiting the coroutine directly.
-        outcome, job_id = await asyncio.shield(_submit_and_track())
+        # this is equivalent to awaiting the coroutine directly. The task is
+        # created explicitly with a done-callback that retrieves its exception:
+        # when the caller is cancelled and the shielded task *then* raises,
+        # nobody awaits it, and asyncio would log "exception was never
+        # retrieved" at teardown.
+        submit_task = asyncio.ensure_future(_submit_and_track())
+
+        def _retrieve_abandoned_exception(task: asyncio.Task) -> None:
+            if task.cancelled():
+                return
+            exc = task.exception()
+            if exc is not None:
+                # On the non-cancelled path the shield await re-raises this
+                # to the caller too; retrieving it here only silences the
+                # abandoned-task warning, it does not swallow the error.
+                logger.debug(f"Shielded job submission raised: {exc!r}")
+
+        submit_task.add_done_callback(_retrieve_abandoned_exception)
+        outcome, job_id = await asyncio.shield(submit_task)
         if profiler.enabled:
             profiler.record_submit_offload(profiler_now() - _offload_t0)
 

--- a/src/clm/infrastructure/workers/lifecycle_manager.py
+++ b/src/clm/infrastructure/workers/lifecycle_manager.py
@@ -196,6 +196,13 @@ class WorkerLifecycleManager:
 
         if not worker_configs:
             logger.info("No workers to start (sufficient workers already running)")
+            # Known gap, accepted (#617 follow-up, Finding 5.2): on this path
+            # no pool_manager is created, so the health monitor never runs and
+            # a reused worker that dies mid-job is only caught by the teardown
+            # orphan sweep, not requeued mid-build. Monitoring cannot help
+            # anyway: reused workers belong to another session (or are
+            # shareable), and the monitor deliberately scans only its own
+            # session's workers (#597/#620 ownership rule).
             # Return information about existing healthy workers
             return self._collect_reused_worker_info()
 

--- a/src/clm/infrastructure/workers/pool_manager.py
+++ b/src/clm/infrastructure/workers/pool_manager.py
@@ -173,6 +173,11 @@ class WorkerPoolManager:
         self.executors: dict[str, WorkerExecutor] = {}  # execution_mode -> executor
         self.running = True
         self.monitor_thread: threading.Thread | None = None
+        # Interrupts the monitor loop's between-cycle wait so stop_pools()
+        # can actually join the thread promptly (the wait is check_interval
+        # seconds — longer than the join timeout — so a plain sleep made the
+        # join time out and the daemon thread linger up to one interval).
+        self._monitor_stop_event = threading.Event()
 
         # Worker API server for Docker communication (started when needed)
         self._api_server: WorkerApiServer | None = None
@@ -817,6 +822,7 @@ class WorkerPoolManager:
             logger.warning("Monitor thread already running")
             return
 
+        self._monitor_stop_event.clear()
         self.monitor_thread = threading.Thread(
             target=self._monitor_health, args=(check_interval,), daemon=True
         )
@@ -954,11 +960,11 @@ class WorkerPoolManager:
                             f"Error checking worker {worker_id} health: {e}", exc_info=True
                         )
 
-                time.sleep(check_interval)
+                self._monitor_stop_event.wait(check_interval)
 
             except Exception as e:
                 logger.error(f"Health monitoring error: {e}", exc_info=True)
-                time.sleep(check_interval)
+                self._monitor_stop_event.wait(check_interval)
 
         logger.info("Health monitor stopped")
 
@@ -1071,6 +1077,10 @@ class WorkerPoolManager:
 
         logger.info("Stopping worker pools")
         self.running = False
+        # Wake the monitor loop out of its between-cycle wait so the join
+        # below completes promptly instead of timing out against a sleep
+        # that outlasts it.
+        self._monitor_stop_event.set()
 
         # Disable atexit cleanup since we're doing graceful shutdown
         _atexit_cleanup_disabled = True
@@ -1126,6 +1136,7 @@ class WorkerPoolManager:
         called during interpreter shutdown when logging is unavailable.
         """
         self.running = False
+        self._monitor_stop_event.set()
 
         # Don't wait for monitor thread - we're exiting anyway
 

--- a/tests/cli/test_build_abort_summary.py
+++ b/tests/cli/test_build_abort_summary.py
@@ -180,3 +180,39 @@ class TestRecordTeardownOrphans:
         assert {e.job_id for e in summary.errors} == {7, 8}
         assert {e.error_type for e in summary.errors} == {"infrastructure"}
         assert any("a.de.py" in e.file_path for e in summary.errors)
+
+
+class TestFormatExitFailure:
+    """The exit-time failure message must distinguish teardown orphans from
+    genuine per-stage timeouts (#617/#636 follow-up, Finding 4): orphans are
+    appended after finish_build rendered the summary, so 'timed out … see the
+    error summary above' is wrong on both counts for them."""
+
+    def test_orphans_produce_dedicated_message_naming_the_files(self):
+        from clm.cli.commands.build import _format_exit_failure, _record_teardown_orphans
+
+        summary = BuildSummary(duration=1.0, total_files=3)
+        orphans = [
+            {"id": 7, "input_file": "slides/a.de.py", "status": "processing", "worker_id": 3},
+            {"id": 8, "input_file": "slides/a.en.py", "status": "pending", "worker_id": 4},
+        ]
+        _record_teardown_orphans(summary, orphans)
+
+        message = _format_exit_failure(summary)
+
+        assert "orphaned" in message
+        assert "2 worker job(s)" in message
+        assert "slides/a.de.py" in message
+        assert "slides/a.en.py" in message
+        assert "timed out" not in message
+
+    def test_genuine_timeout_keeps_the_timeout_message(self):
+        from clm.cli.commands.build import _format_exit_failure
+
+        summary = BuildSummary(duration=1.0, total_files=3, timed_out=True)
+
+        message = _format_exit_failure(summary)
+
+        assert "timed out" in message
+        assert "See the error summary above" in message
+        assert "orphaned" not in message

--- a/tests/infrastructure/backends/test_sqlite_backend_submission_offload.py
+++ b/tests/infrastructure/backends/test_sqlite_backend_submission_offload.py
@@ -142,6 +142,66 @@ async def test_submission_does_not_starve_the_event_loop(backend):
 
 
 @pytest.mark.asyncio
+async def test_abandoned_shielded_submission_exception_is_retrieved(backend, caplog):
+    """When the caller is cancelled and the shielded submission task then
+    raises, the done-callback must retrieve the exception (debug-logging it)
+    so asyncio never emits "exception was never retrieved" at teardown
+    (#617/#636 follow-up, Finding 5.3)."""
+    import logging
+
+    release = threading.Event()
+
+    def failing_submit(self, payload, job_type, force_execution=False):
+        release.wait(5)
+        raise RuntimeError("submit exploded after the caller was cancelled")
+
+    try:
+        with patch.object(SqliteBackend, "_submit_job_blocking", failing_submit):
+            with caplog.at_level(
+                logging.DEBUG, logger="clm.infrastructure.backends.sqlite_backend"
+            ):
+                op_task = asyncio.ensure_future(
+                    backend.execute_operation(_MockOperation(), _MockPayload())
+                )
+                await asyncio.sleep(0.05)  # let the submission start and block
+                op_task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await op_task
+
+                # Now let the abandoned shielded task raise, and wait for the
+                # done-callback to retrieve and log the exception.
+                release.set()
+                for _ in range(100):
+                    if any(
+                        "Shielded job submission raised" in rec.message for rec in caplog.records
+                    ):
+                        break
+                    await asyncio.sleep(0.02)
+
+        assert any("Shielded job submission raised" in rec.message for rec in caplog.records), (
+            "the abandoned shielded task's exception was never retrieved"
+        )
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_submission_exception_still_propagates_to_caller(backend):
+    """Retrieving the exception in the done-callback must not swallow it on
+    the normal (non-cancelled) path — the caller still sees the raise."""
+
+    def failing_submit(self, payload, job_type, force_execution=False):
+        raise RuntimeError("submit exploded")
+
+    try:
+        with patch.object(SqliteBackend, "_submit_job_blocking", failing_submit):
+            with pytest.raises(RuntimeError, match="submit exploded"):
+                await backend.execute_operation(_MockOperation(), _MockPayload())
+    finally:
+        await backend.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_submission_semaphore_gate_is_installed(backend):
     """execute_operation is gated by a bounded concurrency semaphore."""
     await backend.execute_operation(_MockOperation(), _MockPayload())

--- a/tests/infrastructure/workers/test_pool_manager.py
+++ b/tests/infrastructure/workers/test_pool_manager.py
@@ -600,6 +600,32 @@ def test_pool_manager_start_monitoring(db_path, workspace_path, worker_configs):
         manager.monitor_thread.join(timeout=1)
 
 
+def test_stop_pools_joins_monitor_promptly_despite_long_interval(
+    db_path, workspace_path, worker_configs
+):
+    """stop_pools() must stop and join the monitor thread even when the check
+    interval far exceeds the 5s join timeout: the stop event interrupts the
+    between-cycle wait (#617/#636 follow-up, Finding 5.1). Before the fix the
+    join timed out and the daemon thread lingered up to one interval."""
+    with patch("docker.from_env"):
+        manager = WorkerPoolManager(
+            db_path=db_path, workspace_path=workspace_path, worker_configs=worker_configs
+        )
+
+    manager.start_monitoring(check_interval=300)
+    assert manager.monitor_thread is not None
+    assert manager.monitor_thread.is_alive()
+
+    start = time.time()
+    manager.stop_pools()
+    elapsed = time.time() - start
+
+    assert not manager.monitor_thread.is_alive(), (
+        "monitor thread still alive after stop_pools() — the between-cycle wait was not interrupted"
+    )
+    assert elapsed < 5, f"stop_pools took {elapsed:.1f}s — join must not time out"
+
+
 def _seed_busy_worker(
     db_path, session_id, container_id, *, heartbeat_age_seconds=120, execution_mode="direct"
 ):


### PR DESCRIPTION
## Summary

Final PR (C of A/B/C) for the post-merge adversarial review of PR #636, addressing **Findings 4 and 5** (remediation plan: `docs/claude/handovers/pr636-review-findings-handover.md`, Phases 4+5). Findings 1–3 landed in #639 and #641. This completes the #636 review remediation.

## Changes

**Finding 4 (LOW) — honest orphan exit message.** The exit block printed "one or more worker jobs **timed out** … See the error summary **above**" for teardown orphans, where neither clause is true: orphans are appended *after* finish_build rendered the summary, and they didn't time out. A new pure helper `_format_exit_failure(summary)` partitions `summary.errors` for `category == "orphaned_job"` and prints a dedicated message with the count and orphaned input files. `timed_out = True` remains the exit-forcing mechanism; the #90/#143-sensitive exit-policy ordering is untouched.

**Finding 5.1 — monitor join guarantee made true.** `stop_pools()` joined the monitor with `timeout=5` while the loop slept `check_interval=10`, so the join frequently timed out and the daemon thread lingered up to one interval. The between-cycle `time.sleep` is now `self._monitor_stop_event.wait(check_interval)`; the event is set in `stop_pools`/`_emergency_stop` and cleared in `start_monitoring`, so the join completes promptly and the "stopped/joined by stop_pools()" comment is now accurate.

**Finding 5.2 — reused-worker liveness gap: accept and document.** When all workers are reused, no `pool_manager` (and hence no monitor) exists. Monitoring cannot help there — reused workers belong to another session and the monitor deliberately scans only its own session's workers (#597/#620 ownership rule). Documented at the reuse early-return in `lifecycle_manager.py`; noted on issue #617.

**Finding 5.3 — shield exception noise.** If the caller of the shielded submission is cancelled and the inner task then raises, asyncio logged "exception was never retrieved" at teardown. The task is now created explicitly with a done-callback that retrieves and debug-logs the exception; the non-cancelled path still propagates the raise to the caller.

## Tests

- `TestFormatExitFailure`: orphan message names the files and never says "timed out"; genuine timeouts keep the original message.
- `test_stop_pools_joins_monitor_promptly_despite_long_interval`: 300s check interval, `stop_pools` must join in <5s.
- `test_abandoned_shielded_submission_exception_is_retrieved` + `test_submission_exception_still_propagates_to_caller`.
- Affected slice: 64 passed; ruff + mypy clean; fast suite green on the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3aUDhPsn1MDNR7Qf1V1Xb