### PR TITLE
fix(sync): guard §7.3 key migration behind a pool side deficit (#644)

### DIFF
--- a/changelog.d/644-idkeyed-mirror-remove.fixed.md
+++ b/changelog.d/644-idkeyed-mirror-remove.fixed.md
@@ -1,0 +1,7 @@
+- **sync v3**: a brand-new one-sided id-keyed shared cell whose body is
+  byte-identical to an un-id'd positional cell still present in the pool was
+  misframed as mechanical `mirror_remove` — `apply` then deleted the
+  freshly-authored cell from its authoring side. The §7.3 pos→id key
+  migration now requires the positional pool to actually be missing a cell
+  on every side the id'd member populates, so the new cell frames
+  `copy_new_shared` as documented (#644).

--- a/src/clm/slides/sync_diff.py
+++ b/src/clm/slides/sync_diff.py
@@ -738,8 +738,21 @@ class _Differ:
         matches by body fingerprint on either side, because a fork always
         rewrites the header (the new ``lang=`` attribute is exactly the
         §7.3 intent channel) while a pure fork keeps the bodies.
+
+        A stamp necessarily takes the cell OUT of the positional pool, so a
+        migration is only plausible when the pool is missing a cell on every
+        side this member populates. Without that guard, a brand-new id'd
+        cell byte-identical to a positional cell still present in the pool
+        would steal that cell's base entry and be misframed as a one-sided
+        removal — ``apply`` then deletes the freshly-authored cell from its
+        authoring side (issue #644).
         """
         assert self.base is not None
+        for side in _SIDES:
+            if member.side(side) is not None and not self._pool_side_deficit(
+                group, member.kind, side
+            ):
+                return None
         base_group = self._base_group_for(group)
         fps = self._member_fps(member)
         body_fps = {_body_fp(cell) for cell in (member.de, member.en) if cell is not None}

--- a/tests/slides/test_sync_diff.py
+++ b/tests/slides/test_sync_diff.py
@@ -1010,6 +1010,54 @@ class TestAdversarialReviewRegressions:
         assert by_key["id:y-assign"].action == "stamp_vs_new"
         assert by_key["id:y-check"].action == "stamp_vs_new"
 
+    def test_644_new_id_cell_byte_identical_to_pos_cell_is_copy_new_shared(self):
+        """Regression test for #644: a brand-new one-sided id-keyed cell whose
+        body is byte-identical to a pos cell still present on BOTH sides must
+        frame ``copy_new_shared`` — not steal that cell's base entry via the
+        §7.3 key migration and conclude ``mirror_remove`` (which would delete
+        the freshly-authored cell from its authoring side on apply)."""
+        base = _snapshot(DE0, EN0)
+        base.complete = False
+        new = '# %% tags=["keep"] slide_id="y-bonus"\ny = 2\n\n'
+        en = EN0.replace(_shared_code("y", 2), _shared_code("y", 2) + new)
+        diff = _diff(base, DE0, en)
+        by_key = {i.key: i for i in diff.items}
+        item = by_key.get("id:y-bonus")
+        assert item is not None, [(i.key, i.action) for i in diff.items]
+        assert (item.outcome, item.action) == ("add", "copy_new_shared"), (
+            item.outcome,
+            item.action,
+            item.detail,
+        )
+        assert item.direction == "en_to_de"
+        # The untouched positional `y = 2` twin keeps its own entry — no churn.
+        assert not any(i.key.startswith("pos:") for i in diff.items), [
+            (i.key, i.action) for i in diff.items
+        ]
+
+    def test_644_de_side_authoring_mirror_case(self):
+        """#644 neighbor: same shape authored on the DE side."""
+        base = _snapshot(DE0, EN0)
+        base.complete = False
+        new = '# %% tags=["keep"] slide_id="x-bonus"\nx = 1\n\n'
+        de = DE0.replace(_shared_code("x"), _shared_code("x") + new)
+        diff = _diff(base, de, EN0)
+        by_key = {i.key: i for i in diff.items}
+        item = by_key.get("id:x-bonus")
+        assert item is not None, [(i.key, i.action) for i in diff.items]
+        assert (item.outcome, item.action) == ("add", "copy_new_shared")
+        assert item.direction == "de_to_en"
+
+    def test_644_true_id_stamp_still_migrates_when_pos_cell_left_the_pool(self):
+        """#644 guard must not break the genuine §7.3 stamp: when the pos cell
+        actually left the pool (stamped in place on both sides) the key still
+        migrates."""
+        base = _snapshot(DE0, EN0)
+        de = DE0.replace('# %% tags=["keep"]\nx = 1', '# %% tags=["keep"] slide_id="x-cell"\nx = 1')
+        en = EN0.replace('# %% tags=["keep"]\nx = 1', '# %% tags=["keep"] slide_id="x-cell"\nx = 1')
+        item = _only_item(_diff(base, de, en))
+        assert (item.outcome, item.action) == ("transition", "record_key_migration")
+
     def test_conflicting_stamp_shape_stays_ambiguous_alignment(self):
         """The rival-id shapes must NOT gain ``stamp_vs_new``'s treat_as_new
         answer: copying a cell that already claimed a base entry under a


### PR DESCRIPTION
## Summary

Fixes #644 — `clm slides sync` (v3 ledger engine) framed a brand-new, one-sided, id-keyed shared cell as mechanical `mirror_remove (de_to_en)` when its body was byte-identical to an un-id'd positional cell in the same pool; `apply` then deleted the freshly-authored cell from the side it was authored on.

## Root cause

`_match_key_migration` (the §7.3 pos→id key migration) matched a positional base entry purely by content fingerprint, without checking that the positional cell actually **left** the pool. The new id'd cell stole the still-present positional cell's base entry, so it classified as base-shared/current-one-sided → `mirror_remove` — for a member that never existed on DE and has no ledger entry.

## Fix

A genuine id stamp necessarily takes the cell out of the positional pool, so the migration now requires `_pool_side_deficit` (already used by the #600 `stamp_vs_new` framing) on every side the id'd member populates. Without a deficit the member falls through to `_diff_unmatched_current` and frames `copy_new_shared`, as documented in `clm info sync-agents`.

## Tests

- `test_644_new_id_cell_byte_identical_to_pos_cell_is_copy_new_shared` — the issue's repro (EN-side authoring); failed before the fix with the exact `mirror_remove` misframing.
- `test_644_de_side_authoring_mirror_case` — DE-side neighbor.
- `test_644_true_id_stamp_still_migrates_when_pos_cell_left_the_pool` — the genuine §7.3 stamp still records `record_key_migration`.

Full fast suite: 8539 passed. Slides suite: 1721 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mrbSye33jewcoztmFxZed
