### PR TITLE
fix(sync): keep shared cells interleaved when >=2 slides split one run (#646)

### DIFF
--- a/changelog.d/646-group-split-interleave.fixed.md
+++ b/changelog.d/646-group-split-interleave.fixed.md
@@ -1,0 +1,6 @@
+- **`slides sync`**: mirroring a group split with **two or more** id'd slides
+  interleaved into one run of id-less shared cells no longer clumps the
+  inserted slides adjacently on the twin (with the shared cells trailing after
+  all of them). The writer's mirrored insert now skips past target-only cells
+  whose content matches the source cells the insert was placed after, so each
+  shared cell stays under the slide it moved into (#646).

--- a/src/clm/slides/doc_write.py
+++ b/src/clm/slides/doc_write.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from attrs import define, field
 
 from clm.slides.bilingual_doc import BilingualDeck, Lang, Member, SideCell
+from clm.slides.doc_identity import content_fingerprint
 from clm.slides.doc_lenses import LoadedBundle
 
 __all__ = [
@@ -133,6 +134,15 @@ class DeckEmitter:
         Walk backwards from the member's position in the *source* stream to
         the nearest member that also has a cell in the target stream; insert
         right after it (or at the top of the file when none precedes it).
+
+        Source-only members between that predecessor and the inserted member
+        may be the source's copies of target-only cells sitting just past the
+        insertion point — the group-split shape (#646): a slide inserted into
+        a run of id-less shared cells re-homes the run's tail on the source
+        side while the twin's copies stay un-paired. The insert additionally
+        skips past each such target-only cell whose content matches one of
+        the interposed source cells, so ≥2 interleaved inserts keep the
+        source's ordering instead of clumping after the predecessor.
         """
         source_stream = self.streams.get((source, part), [])
         target_stream = self.streams.setdefault((target, part), [])
@@ -141,13 +151,31 @@ class DeckEmitter:
         except StopIteration:
             raise DeckWriteError("the source cell is not in its own stream (writer bug)") from None
         insert_at = 0
-        for prev in reversed(source_stream[:pos]):
+        anchor = -1
+        for k in range(pos - 1, -1, -1):
+            prev = source_stream[k]
             for j, m in enumerate(target_stream):
                 if m is prev:
                     insert_at = j + 1
+                    anchor = k
                     break
             if insert_at:
                 break
+        interposed: list[str] = []
+        for m in source_stream[anchor + 1 : pos]:
+            cell = m.side(source)
+            if cell is not None and m.side(target) is None:
+                interposed.append(content_fingerprint(cell))
+        while interposed and insert_at < len(target_stream):
+            candidate = target_stream[insert_at]
+            cell = candidate.side(target)
+            if candidate.side(source) is not None or cell is None:
+                break
+            fp = content_fingerprint(cell)
+            if fp not in interposed:
+                break
+            interposed.remove(fp)
+            insert_at += 1
         target_stream.insert(insert_at, member)
         self.set_side(member, target, new_cell)
 

--- a/tests/slides/test_doc_apply.py
+++ b/tests/slides/test_doc_apply.py
@@ -1340,6 +1340,69 @@ class TestRemoveVsSplit:
         assert sim.similar("x" * 3000, "x" * 3000) is False  # oversized skipped
 
 
+class TestGroupSplitInterleave:
+    """Regression tests for #646: when ≥2 id'd slides are interleaved into a
+    single run of id-less shared cells, mirroring the inserts on the twin
+    must keep each shared cell under the slide it moved into. The buggy
+    writer anchored each insert after the nearest mirrored predecessor
+    only, so the second insert landed directly after the first and the
+    twin's shared cells clumped after all the inserted slides.
+    """
+
+    def _interleaved_deck(self, tmp_path: Path) -> _Deck:
+        code = (_shared_code("x"), _shared_code("y", 2), _shared_code("z", 3))
+        deck = _Deck(
+            tmp_path,
+            _build(HEADER_DE, _slide("s0", "de", "Titel"), *code),
+            _build(HEADER_EN, _slide("s0", "en", "Title"), *code),
+        )
+        deck.record()
+        # EN interleaves TWO new id'd slides into the run: m1 before y
+        # (splitting y into group m1), m2 before z (splitting z into m2).
+        deck.write_en(
+            HEADER_EN,
+            _slide("s0", "en", "Title"),
+            _shared_code("x"),
+            _slide("m1", "en", "Middle 1"),
+            _shared_code("y", 2),
+            _slide("m2", "en", "Middle 2"),
+            _shared_code("z", 3),
+        )
+        return deck
+
+    def test_twin_keeps_the_shared_cells_interleaved(self, tmp_path: Path):
+        deck = self._interleaved_deck(tmp_path)
+        outcome = deck.apply(
+            _decision("id:m1", body="#\n# # Mitte 1") | _decision("id:m2", body="#\n# # Mitte 2")
+        )
+        statuses = _statuses(outcome)
+        assert statuses["id:m1"] == "applied", outcome.to_payload()
+        assert statuses["id:m2"] == "applied", outcome.to_payload()
+        de = deck.de_path.read_text(encoding="utf-8")
+        markers = ("x = 1", "# Mitte 1", "y = 2", "# Mitte 2", "z = 3")
+        order = [de.index(m) for m in markers]
+        assert order == sorted(order), de
+
+    def test_interleaved_split_converges_after_confirming(self, tmp_path: Path):
+        # The full #630 resolution loop, with two inserts: mirror both
+        # slides, re-report (framing flips to verify_cold under the new
+        # groups), confirm — and the deck converges with the DE cells in
+        # the EN order.
+        deck = self._interleaved_deck(tmp_path)
+        deck.apply(
+            _decision("id:m1", body="#\n# # Mitte 1") | _decision("id:m2", body="#\n# # Mitte 2")
+        )
+        _, diff = deck.diff()
+        actions = {(i.key, i.action) for i in diff.items}
+        assert not any(a in ("mirror_remove", "remove_vs_split") for _, a in actions), actions
+        cold = [i.key for i in diff.items if i.action == "verify_cold"]
+        assert sorted(cold) == ["pos:m1/code/0", "pos:m2/code/0"]
+        confirms = {key: doc_apply.Decision(key=key, choice="confirm") for key in cold}
+        outcome = deck.apply(confirms)
+        assert outcome.all_applied, outcome.to_payload()
+        deck.assert_converged()
+
+
 class TestDecisionParsing:
     def test_wrong_top_level_shape_error_teaches_the_schema(self):
         # The first error an agent sees must show the whole document shape —


### PR DESCRIPTION
## Summary

`clm slides sync` mis-mirrored a group split when **two or more** id'd slides
were interleaved into a single run of id-less shared cells: on the twin side
the inserted slides landed adjacent to each other and every shared cell
clumped after all of them, instead of each shared cell staying under the
slide it moved into. A single insert was handled correctly.

## Root cause

`DeckEmitter.insert_mirrored` (`src/clm/slides/doc_write.py`) placed each new
twin cell right after the **nearest preceding source-stream member that has a
target-side cell**. After a group split, the run's shared cells are un-paired
(source-only on the edited side, target-only on the twin), so for the second
inserted slide the nearest mirrored predecessor is the *first* inserted slide
— and the insert landed before the twin's shared cells that the source order
says come first.

## Fix

The mirrored insert now additionally skips past target-only cells whose
content fingerprint matches a source-only cell sitting between the mirrored
predecessor and the inserted member on the source side (the split-off run's
twin copies), so the twin keeps the source's interleaving. Matching uses
`content_fingerprint` from `doc_identity` (the sync-free identity layer —
the import-cleanliness contract for `doc_write` is untouched).

## Tests

- `TestGroupSplitInterleave::test_twin_keeps_the_shared_cells_interleaved`
  pins the twin's cell order for the ≥2-insert shape (failed before the fix
  with the exact clumped layout from the issue).
- `TestGroupSplitInterleave::test_interleaved_split_converges_after_confirming`
  drives the full #630 resolution loop (mirror both inserts → re-report →
  confirm the `verify_cold` rows) to convergence.
- End-to-end repro from the issue verified fixed via the real
  `record`/`apply` CLI flow. Fast suite: 8541 passed.

Fixes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018h3HpaRid2BJYfv42zPwXb
