### PR TITLE
docs: adversarial review findings and phased remediation plan

### DIFF
--- a/docs/claude/adversarial-review-2026-07-24.md
+++ b/docs/claude/adversarial-review-2026-07-24.md
@@ -1,0 +1,481 @@
+# Adversarial Review — CLM 1.21.1 (2026-07-24)
+
+Five independent adversarial reviewers attacked the codebase along separate
+axes: architecture/design, concurrency/correctness, the slides sync engine,
+security/robustness, and testing strategy. Each was instructed to assume the
+design is flawed until proven otherwise and to discard any finding it could not
+confirm in code. Sync-engine findings were reproduced end-to-end with scripts;
+the top security findings were re-verified by hand in the project venv.
+
+This document records findings as they stood on 2026-07-24.
+
+**Fixed since**: S1 (cassette YAML RCE) and C1 (WAL on network-shared
+databases) shipped in **1.22.1** via PR #658. Everything else below is still
+open — see
+`docs/claude/handovers/adversarial-review-remediation-handover.md` for the
+phased plan and the maintainer's settled decisions.
+
+---
+
+## Top 10 by expected damage
+
+| # | Sev | Finding | Location |
+|---|-----|---------|----------|
+| 1 | Critical | Cassettes parsed with PyYAML's **unsafe** `CLoader` → RCE from a committed course-repo file | `infrastructure/http_replay_mitm/vcr_format.py:46,319` |
+| 2 | Critical | Worker API binds `0.0.0.0:8765`, no auth, stores/serves **pickles** → LAN- and browser-reachable RCE | `infrastructure/api/server.py:22-23`, `worker_routes.py:363-394` |
+| 3 | Critical | `clm.core` ↔ `clm.infrastructure` is a module-level import **cycle**; the documented "core has ZERO infrastructure dependencies" is false | `core/course.py:53-56`, `architecture.md:88` |
+| 4 | High | WAL mode unconditionally enabled on a jobs DB explicitly shared across machines over SMB → claim atomicity broken, DB corruption | `infrastructure/database/schema.py:193` |
+| 5 | High | Workers never heartbeat **while processing**; any job >30s looks dead → spurious build failures, cross-build worker deletion | `infrastructure/workers/worker_base.py:645-790` |
+| 6 | High | `reset_hung_jobs` resets at 600s with **no liveness check** → double execution, torn output, poisoned result cache | `infrastructure/database/job_queue.py:650-670` |
+| 7 | High | `mirror_remove` lacks the carried-divergence guard the edit paths have → mechanically deletes unique surviving content | `slides/sync_diff.py:1203-1215`, `:1911-1922` |
+| 8 | High | Ledger `record` gate never inlines voiceover companions the way `verify` does → diverged companions blessed as verified | `cli/commands/slides/sync_v3.py:239-250` |
+| 9 | High | `test_direct_integration.py` — 8 Direct-mode worker tests — permanently skipped everywhere via renamed module names | `tests/infrastructure/workers/test_direct_integration.py:69-70` |
+| 10 | High | `.clm-include` ledger drives an unvalidated `shutil.rmtree`; absolute/`..` `as_path` escapes the topic dir | `cli/commands/course/sync_includes.py:429-436` |
+
+---
+
+## 1. Security
+
+Threat model: malicious course content (notebook *execution* is expected and
+excluded), the local web servers, the MCP surface, secrets leakage, unsafe file
+ops.
+
+### S1 — CRITICAL: unsafe YAML loader on committed cassettes
+
+`vcr_format.py:46` imports `CLoader`, whose MRO reaches `UnsafeConstructor`
+*before* `SafeConstructor`. Verified in the project venv: a cassette line
+`a: !!python/object/apply:os.getenv ["COMPUTERNAME"]` executes during
+`yaml.load`, before any schema check. The `except Exception → "treating as
+empty"` handler at `http_replay_cassette.py:212` then swallows any error, so a
+build continues silently.
+
+Reachability is what makes this critical rather than theoretical:
+`.gitignore:280` explicitly **un-ignores** `**/.clm/cassettes/`, so cassettes
+are tracked, committed, rarely-reviewed files (~400 MiB per project notes);
+replay defaults to `new-episodes` for local builds (`build.py:52-76`); and the
+host `clm build` process itself parses them (`build.py:2001`). A one-line PR to
+a course repo executes code as the maintainer on the next build — no notebook
+runs.
+
+**Fix:** `from yaml import CSafeLoader as _Loader`. The format is scalars, maps,
+lists and `!!binary`, all SafeLoader-supported. Add a safe-load round-trip test.
+
+### S2 — CRITICAL: unauthenticated worker API serving pickles on all interfaces
+
+`server.py:22-23` binds `0.0.0.0:8765` "for Docker access"; `worker_routes.py`
+contains **zero** `Depends` (verified by grep). `POST /cache/executed_notebook`
+gzip-decompresses the body and stores it verbatim; those bytes are later
+`pickle.loads`-ed on the host (`sqlite_backend.py:575`,
+`executed_notebook_cache.py:130`). The cache key is not secret — the equally
+unauthenticated `POST /jobs/claim` hands out `input_file` and `content_hash`.
+
+Two attack positions: anyone on the LAN, and **any web page the developer
+visits** — a `fetch(..., {mode:'no-cors'})` with `Content-Type: text/plain` is a
+simple request needing no preflight, and the handler ignores content type.
+
+**Fix:** bind `127.0.0.1` and publish explicitly to containers; add the
+per-build token `studio/auth.py` already implements; replace pickle with JSON
+(`NotebookNode` is a dict subclass).
+
+### S3 — HIGH: `/process` uploads any local file to a third party via plain CSRF
+
+`recordings/web/routes.py:567-602` takes `raw_path` from a form, checks only
+`exists()`, and submits it; with the Auphonic backend that streams the file to
+auphonic.com. The **sibling** endpoint `/open-explorer` (`:794-804`) does
+`resolve(strict=True)` + `relative_to(root)` — the omission is inconsistent, not
+deliberate. The recordings app has no auth and no CSRF protection on any
+mutating route, all `Form(...)`-based, i.e. reachable by a cross-origin
+auto-submitting form.
+
+### S4 — HIGH: `.clm-include` ledger → unvalidated `rmtree`
+
+`sync_includes.py:429-436` computes `topic_dir / entry.as_path` with `as_path`
+unvalidated. `Path.__truediv__` **discards** the left operand when the right is
+absolute, so `{"as_path": "C:/Users/tc/Programming"}` targets that literally;
+`../../../..` works too. The module docstring promises the opposite. The
+correct normalizer already exists for spec `<include>` paths
+(`course_spec.py:88-140`).
+
+### S5 — HIGH: repo-local `clm.toml` chooses which executable `clm build` runs
+
+`config.py:936-947` discovers config by walking up from cwd — including a file
+shipped inside the course repo. `drawio_converter.py:14,47` runs
+`external_tools.drawio_executable` verbatim, with no validation at all. Clone a
+course repo, run `clm build`, and a repo-supplied binary executes on the first
+`.drawio` file. Same shape: `notebook_kernel_python` (`kernel_env.py:165`), and
+spec-supplied `repository_base` reaching `git clone` — Git's `ext::` transport
+executes its argument (`git.py:215,796`).
+
+### S6 — MEDIUM-HIGH: `clm serve` — CORS `*` with credentials, unauthenticated WebSocket, no Host validation
+
+`web/app.py:127-136` defaults `cors_origins=["*"]` with
+`allow_credentials=True`, so Starlette echoes any requesting Origin.
+`api/websocket.py:110-126` accepts **any** `/ws` connection with no token and no
+origin check, and `subscribe` accepts arbitrary channel names — WebSockets are
+CORS-exempt, so any page can subscribe to `"studio"` and receive sync progress
+and deck-change events, bypassing the bearer token `studio/auth.py` calls "the
+real access gate". Neither app installs `TrustedHostMiddleware`.
+
+### S7 — MEDIUM: Studio `render-cell` is unsandboxed Jinja on a request body
+
+`web/studio/render.py:55-71` uses a plain `jinja2.Environment` and
+`from_string()` on client text; SSTI reproduced against the real function. The
+module docstring advertises this as the "no-execution" render tier. Token-gated,
+but the token is accepted as a `?token=` query param (`auth.py:78-80`), so it
+lands in QR deep links, browser history and uvicorn access logs. Chained XSS:
+`static/studio/app.js:45-47` — `esc()` does not escape quotes and its output is
+interpolated into an `href`, reaching `innerHTML` at `:315`.
+
+### S8 — MEDIUM: MCP mutating tools have no containment check
+
+`mcp/tools.py:939-942` — `_resolve_under` is a bare join: no `resolve()`, no
+`relative_to`, no `commonpath`. Inlined in every mutating handler.
+`voiceover_inline(file=<absolute path>)` rewrites that deck and `unlink()`s its
+companion. The correct check already exists at `web/studio/service.py:131-141`.
+
+### S9 — MEDIUM: cassette scrubbing is a request-only denylist
+
+`cassette_format.py:72-74` misses `api-key` (Azure OpenAI), `x-goog-api-key`
+(Gemini), `proxy-authorization`, `x-amz-security-token`; misses Gemini's
+`?key=`, `?access_token=`, `?subscription-key=`, `?X-Amz-Signature=`; filters
+body params only for an exact `application/json` compare, so
+`application/json; charset=utf-8` gets none; and **never filters responses** —
+`Set-Cookie` and OAuth token bodies are committed verbatim. Related: the
+mitmproxy CA **private key** lands inside the course repo working tree by
+default (`build.py:313-316`), unignored, and mitmproxy's `umask_secret()` is a
+no-op on Windows.
+
+### S10 — MEDIUM: Docker mode is not a containment boundary
+
+`worker_executor.py:314-341` mounts the **entire course repo including `.git/`**
+read-write as `/source`; no `user` is set and no Dockerfile has a `USER`, so
+containers run as uid 0; `extra_hosts` maps `host.docker.internal`. A malicious
+cell can rewrite `.git/hooks/post-checkout` (host execution at next git op) or
+reach `host.docker.internal:8765` (finding S2). The `course.py:340`
+"refuse to bind-mount an entire volume" guard has three verified gaps: the
+`len(resolved)==1` early return skips it, `data_dir` has no guard at all, and it
+is only consulted when `_build_has_docker_notebook_worker` is true — a detector
+that returns `False` on any exception.
+
+### S11 — MEDIUM: spec-driven writes escape the output root
+
+`dir_group.py:75-84,94` appends raw `<name>`/`<subdir>` text to output paths
+with no sanitization (section names *are* sanitized — the asymmetry looks like
+an oversight), so `<name><de>../../..</de></name>` copies into the source tree.
+`<output-target><path>` is validated only for emptiness, and the sweep keeps
+only `.git/**` with no marker-file precondition — a one-character typo
+(`<path>.</path>`) empties whatever directory resolves there. `sanitize_file_name`
+does not reject `..` (verified: `sanitize_file_name('..') == '..'`).
+
+### S12 — MEDIUM: `clm config show --json` prints every secret in cleartext
+
+`config.py:504,600,692` — LLM api_key, Auphonic api_key, OBS password are plain
+`str`, no `SecretStr`, no custom `__repr__`. This is exactly the output pasted
+into bug reports and agent transcripts.
+
+### Verified clean (the named suspects)
+
+No `shell=True`, `os.system`, or `os.popen` anywhere. `clm run` confines a
+malicious spec to `[sys.executable, "-m", "clm", ...]`. Cassette replay **is**
+host-validated (scheme/host/port/path/query in the match key) — a cassette for
+`evil.example` can never be served for `api.openai.com`. XXE not exploitable
+(stdlib ElementTree); billion-laughs works but is a local hang only. No pickle
+outside the three cache sites; no `eval`/`exec` on content-derived strings. No
+`verify=False`. GitLab/GitHub tokens pass only the *variable name* in argv. No
+docker socket mount, no `privileged`.
+
+---
+
+## 2. Concurrency & correctness
+
+**Verified sound first:** the local claim path is atomic — `get_next_job`
+(`job_queue.py:254-322`) wraps SELECT+UPDATE in `BEGIN IMMEDIATE`, so two
+workers on the same machine cannot double-claim. Everything below is a real gap,
+and all of it concerns the *shared jobs DB* scenario the schema explicitly
+supports (v10 `execution_mode` tags, `session_id` ownership columns).
+
+- **C1 CRITICAL — WAL over SMB.** `schema.py:193` sets `journal_mode=WAL`
+  persistently. WAL coordination lives in the memory-mapped `-shm` file; over
+  SMB each machine maps its own incoherent copy, which SQLite documents as
+  unsupported. No UNC/network guard exists anywhere. Machine B's
+  `BEGIN IMMEDIATE` can claim a row A already claimed, against a stale snapshot;
+  interleaved checkpoints can corrupt the file. This amplifies every finding
+  below.
+- **C2 HIGH — no heartbeat while processing.** `worker_base.py:645-790` updates
+  the heartbeat only in the idle-poll branch and the post-job `finally`. During a
+  multi-minute notebook the worker looks dead. Three confirmed consequences:
+  (a) `_get_available_workers` (`sqlite_backend.py:1241-1254`) counts only
+  workers seen in the last 30s, so submitting deck N+1 while all workers are
+  busy raises `RuntimeError("No workers available")`; (b)
+  `cleanup_stale_workers` (`pool_manager.py:279-294`) hard-DELETEs any direct
+  worker not in `healthy_ids` **with no session filter**, so a second build
+  deletes the first build's busy worker rows; (c) persistent workers get
+  duplicated.
+- **C3 HIGH — `reset_hung_jobs` is liveness-blind.** `job_queue.py:650-670`
+  resets anything `processing` >600s with no worker check, and it runs on every
+  build start *and* end (both default-on). A job 11 minutes into a heavy deck —
+  well inside the 20-minute `max_wait_for_completion_duration` — flips to
+  `pending`, a second worker claims it, and both write `job.output_file` via the
+  non-atomic `open(path,"w")` in `notebook_worker.py:264`. Then
+  `_persist_result_to_cache` reads the torn file back and stores it keyed by
+  content hash: **the corruption is replayed as a cache hit on every future
+  build**.
+- **C4 HIGH — `mark_orphaned_jobs_failed` is unscoped.**
+  `job_queue.py:428-467` fails *every* non-terminal started job at pool
+  shutdown. Its docstring's safety argument holds only single-session. Build A's
+  teardown marks build B's live job failed; B reports a spurious error, then B's
+  worker finishes and flips the row back to completed.
+- **C5 HIGH — `update_job_status` has no fencing.** `job_queue.py:340-386` and
+  `worker_routes.py:149` do `UPDATE jobs SET status=? WHERE id=?` with no
+  `AND worker_id=?` / `AND status='processing'`. This is the missing guard that
+  lets C3/C4 corrupt state rather than merely waste work.
+- **C6 MEDIUM-HIGH — job-cache hit validates existence, never content.**
+  `sqlite_backend.py:484-493` short-circuits on a `results_cache` row plus
+  `output_path.exists()`. Nothing checks the bytes match the hash, so a stale or
+  torn output ships as a hit.
+- **C7 MEDIUM — dead-worker recovery can never fire during a build.**
+  `_cleanup_dead_worker_jobs` requires `workers.status='dead'`, but
+  `start_monitoring` is only called from a `__main__` demo (`pool_manager.py:1228`),
+  direct workers DELETE their row, and the query is an INNER JOIN on a row that
+  may be gone. An OOM-killed worker hangs the build for the full 1200s timeout;
+  the 5-second cleanup poll is dead code in production.
+- **C8 MEDIUM — latent timezone bug.** `_is_heartbeat_stale`
+  (`pool_manager.py:941-943`) compares a UTC `CURRENT_TIMESTAMP` against local
+  `datetime.now()` — on a CEST host every heartbeat reads ~7200s stale.
+  `discovery.py:183` does it correctly; the two have drifted. Harmless only
+  because monitoring is never started (C7).
+- **C9 MEDIUM — no terminal handling for `cancelled` or attempts-exhausted
+  jobs** in `wait_for_completion` → 20-minute stalls.
+- **C10 MEDIUM — blocking SQLite on async loops.** `worker_routes.py:88-192` are
+  `async def` but run blocking SQLite with a 30s busy timeout on the uvicorn
+  loop, so one held write lock freezes all Docker-worker traffic *including
+  heartbeats* — feeding C2. `_can_replay_from_cache` unpickles a multi-MB BLOB
+  on the build's event loop merely to test existence.
+- **C11 LOW-MEDIUM — worker output write is truncate-in-place**, unlike the
+  host's `atomic_write_bytes` (temp + `os.replace` + retry). This is the
+  amplifier that turns C3 into durable cache poisoning.
+- **C12 LOW — `JobQueue.close()` closes only the calling thread's connection**,
+  leaving submit-executor and cache-writer connections to GC; on Windows that
+  pins `-wal`/`-shm` so the subsequent `wal_checkpoint(TRUNCATE)` silently
+  no-ops (issue #144's symptom, via a different door).
+
+---
+
+## 3. Slides sync engine
+
+All findings reproduced end-to-end against the real code, not read from it.
+
+- **Y1 HIGH — `mirror_remove` has no carried-divergence guard.** Every shared
+  *edit* path refuses verbatim propagation when the baseline itself carried a
+  divergence (`sync_diff.py:992/1025`, `:1979` — "no side is a safe verbatim
+  source"). The *removal* paths (`:1203-1215`, `:1911-1922`) check only that the
+  surviving side sits on its own fingerprint. Reproduced: a shared companion
+  recorded divergent (DE real content, EN placeholder); EN deletes the
+  placeholder; plain `apply` emits `mirror_remove` as MECHANICAL and **empties
+  the DE cell containing content that never existed on EN**. Exit 0, report
+  clean afterward.
+- **Y2 HIGH — the ledger write gate never reads the companions.**
+  `structural_gate` (`sync_v3.py:239-250`, `:375-385`) is called with only the
+  two deck-half texts, while the `verify` verb first runs `project_pair` to
+  inline companions (the #501 fix). Its docstring claims gate and CLI "can never
+  drift" — they have: **verify FAILS on a byte-diverged shared companion while
+  record blesses it**. This is what arms Y1 and Y6, and `cold_sweep_hint`
+  actively steers agents to run `record` wholesale on cold decks.
+- **Y3 HIGH — decision keying is not item keying.** `Decision`
+  (`doc_apply.py:100-115`) has no action field and `parse_decisions` rejects
+  duplicate keys, but the differ legitimately emits several framed items per
+  member handle. Reproduced: answering `{"key":"id:n1","choice":"de"}` to settle
+  an *owner* conflict also lands on the co-keyed *content* conflict and
+  overwrites the EN author's rewritten note body. Violates the §8 per-item
+  contract — a *valid* answer lands on an item the judge never addressed.
+- **Y4 MEDIUM-HIGH — decisions carry no fingerprint binding.** `apply
+  --decisions` re-diffs from current files but validates only shape. Reproduced:
+  DE edited to v2 → report frames `translate_edit` → agent translates v2 → DE
+  edited to v3 before apply → the v2 translation lands and the ledger records it
+  as **verified**; next report is CLEAN and the v3 edit is never surfaced again.
+  Defeats the ledger's fail-safe staleness property in exactly the window agents
+  operate in.
+- **Y5 MEDIUM-HIGH — `stamp_twin_id` stamps positionally-guessed, never-verified
+  twins.** `pair_positionally` (`doc_lenses.py:505-522`) adopts an id-less
+  localized twin purely by pool order, and `_emit_pending_id_stamps`
+  (`sync_diff.py:417-435`) emits the stamp mechanically **regardless of ledger
+  trust**. Reproduced: two localized cells added per side, EN twins id-less and
+  swapped → `slide_id="apples"` is stamped onto the oranges text. Since P2 makes
+  the id *the* identity, this is permanent identity corruption, later bankable
+  as verified.
+- **Y6 MEDIUM — preamble propagation lacks the divergence guard** cells have;
+  the check exists only in the neither-moved branch (`sync_diff.py:2561-2570`).
+  A trivial DE kernel-metadata edit replaces the entire EN preamble.
+  CLI-reachable for companions via Y2.
+- **Y7 MEDIUM — one-sided rename+edit executes destructive mechanics.** The
+  design claims a hand rename drops to cold; true only when content is untouched.
+  Rename+edit defeats both rival checks and yields `mirror_remove` +
+  `copy_new_shared`. The `#600` deficit guard (`:565-586`) counts only `pos:`
+  base entries, so an id-keyed base cell missing on one side never triggers
+  `stamp_vs_new`. The strip-id variant leaves the pair structurally corrupt and
+  fails the post-apply gate — files mutated, ledger unsaved, manual cleanup.
+- **Y8 MEDIUM-LOW — `_align_pool`'s lone-candidate claim** (`:1693-1697`) binds
+  any single unmatched new cell as "the landed twin" with no content affinity;
+  the offered resolution overwrites a genuinely-new unrelated cell. Framed, so
+  misleading rather than silent.
+- **Y9 LOW — hardening notes.** `record` never consults the diff (a warm deck
+  with pending conflicts can be wholesale-blessed); `verify_cold` `confirm`
+  accepts a byte-diverged shared member for companions; `apply` writes files
+  *before* the structural verify, and Y7 shows apply can itself create the
+  gate-failing state.
+
+**Checked and sound:** per-side pool alignment (phantom-slot exclusion,
+unique-fp move detection); the #566 one-sided add routing; #600 pool freezing
+(over-drops to cold, fail-safe); hash-version cold-drop; ledger load
+fail-safety; `rename-id`'s fingerprint-carrying migration; re-parse gate +
+atomic writes; `--since` staying read-only; duplicate-id refusals per side.
+
+---
+
+## 4. Architecture
+
+The documented four-layer architecture does not exist in the code. The
+individual modules are often well-written; the *boundaries* are fiction.
+
+- **A1 CRITICAL — core↔infrastructure is a package-level cycle.**
+  `architecture.md:88` claims "The core layer has ZERO dependencies on
+  infrastructure. It can be tested in complete isolation." In fact
+  `core/course.py:53-56`, `core/course_file.py:8-10`, `core/dir_group.py:9-10`
+  and every file in `core/operations/` import infrastructure at module level,
+  while infrastructure imports core back (`backend.py:10-11`,
+  `local_ops_backend.py:37`). The doc explicitly targets AI agents, so a wrong
+  architecture doc is worse than none.
+- **A2 CRITICAL — infrastructure imports the CLI layer at runtime.**
+  Module-level: `dummy_backend.py:7`, `local_ops_backend.py:36` import
+  `clm.cli.build_data_classes.BuildWarning`. Lazy: `sqlite_backend.py:874,998,1698,1804`,
+  `worker_base.py:758` (inside the worker loop), `progress_tracker.py:356`,
+  `db_operations.py:336`. The abstract `Backend` interface itself references a
+  `clm.cli` type. `build_data_classes.py` (329 lines of dataclasses) and
+  `error_categorizer.py` (702 lines of business logic) are misfiled — every
+  worker process executes CLI-layer code. The fix is mechanical.
+- **A3 HIGH — core imports workers and optional extensions.**
+  `core/course.py:548,637,641`, `core/operations/build_jupyterlite_site.py:26,39`,
+  `core/cmake_export.py:34-36`, `core/course_files/notebook_file.py:128`, and
+  spec parsing itself (`course_spec.py:2599` → `clm.slides.sidecar_layout`). No
+  ImportError today only because those extension modules happen to be
+  stdlib-only — luck, not design, and nothing enforces it.
+- **A4 HIGH — the build engine lives in the CLI layer.**
+  `cli/commands/build.py` is 2694 lines of which the Click command starts at
+  :2071; everything before it is orchestration (`process_course_with_backend`,
+  `watch_and_rebuild`, worker startup, mitmproxy bring-up, cleanup sweeps).
+  Nothing else — MCP, web studio, tests, a future API — can run a build without
+  going through a Click module.
+- **A5 HIGH — voiceover business logic in the CLI**, via private imports:
+  `cli/commands/voiceover.py:557-847` imports `_langfuse_configured` from
+  `infrastructure.llm.client` and `_decode_alignment` from `voiceover.cache`,
+  while `clm.voiceover.merge` exists precisely to hold this.
+- **A6 HIGH — `path_utils` is a 785-line god module in the wrong layer**,
+  imported by 43 files. It holds the purest domain vocabulary in the system —
+  `Lang`, `Format`, `Kind`, `OutputSpec`, `output_specs()`, `output_path_for()` —
+  inside `infrastructure.utils`, and core imports those types back up. Most of
+  the A1 cycle flows through this one file.
+- **A7 MEDIUM — three parallel config mechanisms:** Pydantic `ClmConfig` with a
+  4-level hierarchy; `sidecar_layout.py:26-89`'s own resolver reading
+  `[tool.clm]` in **pyproject.toml** (a file `ClmConfig` knows nothing about);
+  and raw `os.environ` reads in 36 files including `build.py`'s private
+  `_resolve_*` family that bypasses `get_config()` entirely.
+- **A8 MEDIUM — the jobs-DB path has two env names and two defaults.** Host uses
+  `CLM_JOBS_DB_PATH` (default `clm_jobs.db`); workers use bare `DB_PATH` with the
+  *container* default `/db/jobs.db` even in direct mode. It works only because
+  `worker_executor` always injects it; any other spawn path silently polls an
+  empty queue — a known incident class in this repo's history.
+- **A9 MEDIUM — ~12 cross-module underscore-private imports**, worst being
+  `mcp/tools.py:391` → a CLI command's private helper.
+- **A10 MEDIUM — `architecture.md` is materially wrong** beyond A1: a claimed
+  "service registry" directory that holds one file, a layer diagram matching no
+  import structure, undocumented env vars, and orchestration attributed to
+  `Course.process()`.
+- **A11/A12 LOW —** three-class `Backend` ladder with one production impl and a
+  test-only `DummyBackend` shipped in the package; `docker`, `fastapi`,
+  `uvicorn`, `watchdog` unconditional in the "core" install.
+
+---
+
+## 5. Testing
+
+~451 test files, ~155k LOC. The suite's problem is not volume — it is that
+several of the most critical paths are guarded by tests that run nowhere or
+cannot fail.
+
+- **T1 HIGH — 8 Direct-mode integration tests permanently skipped everywhere.**
+  `test_direct_integration.py:69-70` gates on `find_spec("drawio_converter")`
+  and `find_spec("plantuml_converter")` — top-level modules folded into
+  `clm.workers.*` long ago. Verified: both return `None` in this venv, and in CI
+  too. Dead: worker startup/registration, concurrent claiming, health
+  monitoring, graceful shutdown, mixed worker modes, stale cleanup — exactly the
+  PR #564/#595 territory. Same stale flags in `test_lifecycle_integration.py:76-77`.
+  **Fixing two module names resurrects all 8.**
+- **T2 HIGH — `slow` is a "runs nowhere" tier.** CI excludes `slow` from all
+  three non-docker steps and the local default excludes it too, yet ~32 tests
+  carry it without `docker`: all 7 **cache-equivalence** tests
+  (`test_cache_equivalence.py:67-341` — the only proof that cached-notebook reuse
+  is byte-identical to direct execution, i.e. the guard against C6-class silent
+  wrong output), the two **worker-reuse-across-builds** e2e tests covering the
+  PR #595 bug, and all 18 real-subprocess CLI tests.
+- **T3 HIGH — pre-push build-pipeline coverage is 100% mock.**
+  `test_build_command.py:1159-1278` replaces `Course`, both backends,
+  `BuildReporter`, `init_database`, and makes `execution_stages()` return `[]`.
+  It delegates real coverage to `test_cli_subprocess.py` — which runs nowhere
+  (T2). The 72-second gate developers trust cannot catch broken stage
+  sequencing, backend wiring, or job submission in a 2694-line file.
+- **T4 MEDIUM-HIGH — CI "integration" tests for the build CLI cannot fail.**
+  `test_cli_integration.py:55-68` wraps every functional assertion in
+  `if result.exit_code == 0:`; `:400-402` is a literal tautology; `:196-198`
+  passes on any failure; `test_build_with_clear_cache` never verifies the cache
+  was cleared. Green checkmarks for "CLI → Backend → Workers → Output" that
+  detect only argument-parsing typos.
+- **T5 MEDIUM — the PlantUML e2e test logs but never asserts** that images were
+  produced (`test_e2e_course_conversion.py` ~:1105-1143 — `logger.info` on the
+  PNG count, no assertion).
+- **T6 MEDIUM — `flaky` retries swallow `AssertionError` on tests of the real
+  worker base** (`test_worker_base.py:26-35`), which is precisely how an
+  intermittent race regression in production claim/heartbeat code manifests. The
+  surrounding discipline (no global reruns, scoped exceptions) is otherwise good.
+- **T7 MEDIUM — `MockWorker` reimplements claiming with pre-v10 SQL**
+  (`tests/fixtures/mock_workers.py:212-226`): no `execution_mode` filter, no
+  session ownership. The tier meant to test real claiming with real workers
+  together is T1's dead file, so the drift is uncompensated.
+- **T8 MEDIUM — autouse env-neutralizers make prod defaults a monoculture:**
+  heartbeat slow-write threshold 50ms→30s suite-wide, pool-size caps pinned to
+  128, `CLM_*_DB_PATH` cleared. Each is documented and reasonable in isolation;
+  each leaves the *interaction* (e.g. clamp firing during managed-worker startup
+  mid-build) invisible.
+- **T9/T10 LOW —** sync full-corpus gates are triple-gated to manual-only;
+  constructor-echo tests inflate apparent build-reporting coverage; the conftest
+  `PLANTUML_JAR` path still points at the de-vendored (PR #239) location, so
+  local availability now depends on an import-time `os.environ` mutation in
+  another test module — ordering-dependent under xdist.
+
+**Genuinely strong:** sync diff/apply unit coverage (76 + 51 fast tests — the
+best-guarded critical path), job-claiming mode-tag tests against real SQLite,
+`_can_replay_from_cache` gating, and golden-fixture handling (committed goldens,
+no auto-bless flag, drift fails loudly — no circularity found).
+
+---
+
+## Suggested order of work
+
+1. **`CSafeLoader`** (S1) — one line, removes an RCE reachable by PR.
+2. **Worker API** (S2) — bind loopback, add the existing token pattern, drop
+   pickle for JSON.
+3. **Fencing + scoping in the job queue** (C5, C3, C4, C2) — add
+   `AND worker_id=? AND status='processing'` to status updates, a liveness check
+   before reset, session scoping on orphan-marking and stale-worker deletion, and
+   a heartbeat during `process_job`. These are one coherent piece of work.
+4. **WAL guard** (C1) — refuse or downgrade `journal_mode` on network paths, and
+   document the constraint.
+5. **Sync gate + removal guard** (Y2 then Y1) — projecting the pair in
+   `structural_gate` closes the door that makes Y1 and Y6 reachable.
+6. **Containment checks** (S4, S8, S3) — one shared normalizer; correct
+   implementations already exist in `course_spec.py` and `studio/service.py`.
+7. **Test resurrection** (T1, T2) — fix two module names, re-triage every `slow`
+   marker; cheapest confidence recovered per hour of the whole list.
+8. **Layering** (A2 then A6) — move `build_data_classes` + `error_categorizer`
+   out of `clm.cli`, extract the domain types from `path_utils`, then add an
+   `import-linter` contract to CI so the boundaries cannot silently regress. Fix
+   `architecture.md` to describe reality until then.

--- a/docs/claude/handovers/adversarial-review-remediation-handover.md
+++ b/docs/claude/handovers/adversarial-review-remediation-handover.md
@@ -1,0 +1,653 @@
+# Adversarial Review Remediation — Handover
+
+**Created**: 2026-07-24 | **Status**: Phase 0 DONE (released 1.22.1); Phase 1 next | **Owner**: unassigned
+
+Remediation plan for the adversarial review of 2026-07-24. Findings, evidence
+and reproduction details live in **`docs/claude/adversarial-review-2026-07-24.md`** —
+this document does not repeat them; it says what to *do*, in what order, under
+which constraints.
+
+Every design decision in §2 was made explicitly by the maintainer on 2026-07-24
+after being walked through the alternatives. **They are settled. Do not
+relitigate them** — if you believe one is wrong, stop and raise it rather than
+quietly implementing something else.
+
+---
+
+## 1. How to use this document
+
+1. Read §2 (decisions) — they constrain everything.
+2. Find the lowest-numbered phase in §4 that is not `DONE`.
+3. Read that phase in full, including its **Landmines**, before touching code.
+4. Work the phase, update its status line here, and record anything surprising
+   in the phase's **Notes** subsection.
+5. Ship per `AGENTS.md` (branch `claude/…`, changelog fragment in
+   `changelog.d/` — **never** the `[Unreleased]` section, update the matching
+   `clm info` topic for any CLI/spec/behavior change). The `ship-a-pr` skill
+   encodes the repo-specific landmines.
+
+Phases are ordered by risk × independence. Later phases assume earlier ones
+landed; §4 states dependencies explicitly where they are hard.
+
+---
+
+## 2. Decisions register (settled 2026-07-24)
+
+| # | Decision | Chosen | Rationale / constraint it imposes |
+|---|----------|--------|------------------------------------|
+| D1 | Cassette RCE release posture | **Patch release now, changelog only** | Ship 1.21.2 with the fix noted as a security fix. No GHSA/CVE — this is effectively single-maintainer tooling; formal disclosure would advertise the vector faster than it would protect anyone. |
+| D2 | Worker API network exposure | **Loopback + Docker gateway by default; binding wider is an explicit opt-in that requires a token** | The safe posture must be what you get by accident. See D5 — this API becomes the cross-machine DB owner, so the opt-in path is a first-class supported mode, not an escape hatch. |
+| D3 | Executed-notebook cache payload | **Replace pickle with JSON** | Removes the deserialization-RCE class outright rather than defending it with a secret. Accepts larger/slower payloads and a cache-format migration. |
+| D4 | Recordings + `clm serve` auth | **Origin/Sec-Fetch-Site checks + loopback bind + TrustedHostMiddleware + CORS default off `*`** | Kills CSRF and DNS rebinding with zero added UX friction. Explicitly *not* protecting against same-machine actors. |
+| D5 | Shared jobs DB across machines | **Route cross-machine access through the worker API** (one DB owner) | Long-term target. Makes the worker API load-bearing for correctness — its auth story (D2) and the queue-correctness work (Phase 5) are prerequisites. |
+| D6 | Interim shared-DB posture | **Force `journal_mode=DELETE` on network paths now** | Stopgap shipped in Phase 0, deliberately throwaway. Removes the `-shm` incoherence corruption vector while D5 is built. Accepts a performance hit on Z:. |
+| D7 | Docker containment | **Per-worker mount mode + non-root `USER`** | `/source` read-only for the notebook worker (which runs untrusted code); read-write retained for PlantUML/DrawIO, which genuinely generate images into the source tree (`worker_executor.py:340` says so explicitly). |
+| D8 | Sync `record` gate | **Strict, with an explicit escape hatch** | Gate must project companions exactly as `verify` does. Provide a documented override flag that **logs loudly** when used, so it cannot quietly become the normal path. |
+| D9 | Decision-document format | **Add an action discriminator to the key** (breaking) | Restores the documented per-item contract. Requires the sync info topic, downstream course-repo agent docs, and any saved decision documents to be updated in lockstep. |
+| D10 | Architecture remediation scope | **Full re-layering, including extracting build orchestration — gated behind test coverage** | The test prerequisite (D11) is a *hard gate*: no re-layering commit lands before Phase 7 is complete and green. |
+| D11 | Re-layering test prerequisite | **All four**: golden e2e characterization suite, layer-boundary contract tests, real unmocked build-pipeline tests in the fast suite, and a coverage threshold on the modules being moved | Phase 7 exists solely to satisfy this. It is the largest single investment in the plan and it is deliberate. |
+| D12 | Test policy | **Fix the dead tests + add a nightly CI job for the `slow` tier** | Recovers lost coverage without lengthening PR CI. Nightly failures need a watcher — see Phase 1 landmines. |
+
+**Session scope note**: the maintainer chose *handover document only* for the
+session that produced this plan. No code was changed on 2026-07-24. Phase 0 is
+genuinely un-started.
+
+---
+
+## 3. Current risk posture (as of 2026-07-24)
+
+Live and unmitigated until Phase 0 ships:
+
+- **A working RCE** reachable by a one-line edit to any committed cassette in
+  any course repo, triggered by a normal `clm build` on the maintainer's
+  machine. Verified by execution, not inference.
+- **An unauthenticated pickle-accepting HTTP service on all interfaces**
+  whenever a Docker-mode build runs, reachable both from the LAN and from any
+  web page open in the maintainer's browser.
+- **Silent cross-build job corruption** on the shared Z: jobs DB, including a
+  path where a torn output file is persisted into the content-keyed cache and
+  replayed as a valid hit indefinitely.
+- **Two confirmed sync data-loss paths** (`mirror_remove` without the
+  divergence guard; one decision answer landing on an unaddressed item).
+
+---
+
+## 4. Phase plan
+
+### Phase 0 — Emergency patch → release 1.22.1  ▸ STATUS: DONE
+
+> **Completed 2026-07-25.** Both fixes implemented with 17 regression tests.
+> PR #658 merged (all CI green including Docker). Release PR #659 merged;
+> `pytest -m "not docker"` was 8704 passed / 0 failed before the bump.
+>
+> **Note on the version**: master released **1.22.0** while this plan was being
+> written, so the patch release is **1.22.1**, not 1.21.2 as originally stated.
+> Master also moved to schema v11 (`jobs.session_id`); the branch was merged
+> with master and re-verified against it.
+>
+> Docs shipped beyond the plan's list, because the change is user-visible and
+> the release rules require docs first: a "Databases on network shares" section
+> in `docs/user-guide/configuration.md` (including the non-obvious point that a
+> RAM disk on a local drive letter is *local* and keeps WAL, so the documented
+> `Z:\clm_jobs.db` RAM-disk setup is unaffected), and a troubleshooting entry
+> for the new "still in WAL mode" error.
+
+**Goal**: close the confirmed RCE and the shared-DB corruption vector, ship
+today. Nothing else rides along — this release must be reviewable in one sitting.
+
+**Work**
+
+1. **S1 — cassette YAML loader.** `src/clm/infrastructure/http_replay_mitm/vcr_format.py:46`
+   → `from yaml import CSafeLoader as _Loader` (and the pure-Python fallback at
+   `:49` → `SafeLoader`). Remove the now-false `# noqa: S506 — trusted repo files`
+   comment at `:319`; the premise of that comment is exactly what the review
+   disproved.
+   - **Regression test** (required): a cassette containing
+     `!!python/object/apply:os.getenv [...]` must raise a YAML constructor error,
+     not execute. Assert on the exception, and assert the sentinel side effect
+     did **not** occur — a test that only checks "raises" would still pass if a
+     future loader executed *and then* raised.
+   - **Verify the format still round-trips**: the cassette format uses scalars,
+     maps, lists and `!!binary`. `CSafeLoader` supports all four, but run the
+     existing cassette golden-fixture tests to confirm, since those goldens are
+     the canary for emitter/parser drift.
+   - Check the other two load sites named in the review (`addon.py:546`,
+     `cassette_doctor.py:355`) route through the same `_Loader`; fix any that
+     don't.
+2. **C1-interim (D6) — network-path journaling.** `src/clm/infrastructure/database/schema.py:193`.
+   Detect UNC/network paths (`\\server\share`, and mapped drives — on Windows use
+   `GetDriveType`; do not rely on the path string alone, since `Z:` looks local)
+   and use `journal_mode=DELETE` with a generous `busy_timeout` instead of WAL.
+   Log once, at INFO, which mode was chosen and why.
+   - **Landmine**: `journal_mode` is *persistent* in the DB file. An existing Z:
+     DB is already in WAL mode, and a fresh `PRAGMA journal_mode=DELETE` on it
+     will fail while any other connection holds it. Handle the failure path
+     explicitly — refuse to proceed with a clear message rather than silently
+     continuing in WAL.
+3. Changelog fragments in `changelog.d/` (type `security` for S1, `fixed` for
+   the journaling change).
+4. Release 1.21.2 per `docs/developer-guide/releasing.md` — docs first, full
+   `pytest -m "not docker"` green locally, then land the `Bump version …` commit
+   on master **as a merge commit**. Publishing is automated; never run
+   `uv publish` or `gh release create` by hand.
+
+**Acceptance**: the exploit test fails before the fix and passes after; a build
+against a network-path jobs DB reports DELETE journaling; 1.22.1 is on PyPI with
+CI green for the tagged commit.
+
+**Explicitly out of scope here**: everything else. Resist bundling.
+
+**Notes from the implementation (2026-07-24)**
+
+- The five `journal_mode=WAL` call sites had to be unified, not just
+  `schema.py`. `journal_mode` is a persistent property of the database *file*,
+  so leaving the other four setting WAL would have silently undone the safe
+  mode. They now all route through `database/journal_mode.py`.
+- Verifying "the test fails before the fix" by running the suite with the
+  vulnerable loader restored is itself an exploit execution, and was blocked by
+  a tool-permission classifier — correctly. The teeth of the test were confirmed
+  structurally instead: `CLoader` and `Loader` both fail the safe-loader
+  allowlist and both *are* subclasses of `UnsafeConstructor`, and the payload's
+  execution under `CLoader` had already been demonstrated during the review. If
+  you need to re-verify behaviourally, do it in a throwaway subprocess, not by
+  reverting the source fix.
+- The YAML **dumper** is still `CDumper`. Not part of this vulnerability (the
+  RCE is on load), and a safe dumper refuses types the current one accepts
+  (notably tuples), so it needs its own change with its own testing.
+
+---
+
+### Phase 1 — Test resurrection  ▸ STATUS: not started
+
+**Goal**: stop flying blind. This is cheap, high-yield, and every later phase
+depends on it — especially Phase 5, which modifies the exact code the dead tests
+covered.
+
+**Work**
+
+1. **T1 — 8 permanently-skipped tests.** `tests/infrastructure/workers/test_direct_integration.py:69-70`:
+   `check_worker_module_available("drawio_converter")` → `"clm.workers.drawio"`,
+   `"plantuml_converter"` → `"clm.workers.plantuml"`. Same stale flags at
+   `tests/infrastructure/workers/test_lifecycle_integration.py:76-77`.
+   - **Expect failures.** These tests have not run since the module rename;
+     assume some are stale or broken rather than assuming the code is fine.
+     Triage each: a genuine product bug gets its own issue and a fix in Phase 5;
+     a stale test gets updated. **Do not delete a failing test to get green** —
+     that is how they died the first time.
+2. **T2/D12 — nightly `slow` job.** Add a scheduled workflow running
+   `pytest -m "slow and not docker"`. Route failures somewhere you will actually
+   see them (see landmine below).
+3. **T4 — tests that cannot fail.** `tests/cli/test_cli_integration.py`: remove
+   the `if result.exit_code == 0:` wrappers (`:55-68`), fix the tautology at
+   `:400-402`, fix `assert x or result.exit_code != 0` at `:196-198`, and make
+   `test_build_with_clear_cache` actually assert the cache was cleared. If a test
+   genuinely cannot assert success in CI (missing workers), mark it skipped for a
+   stated reason — a skip is honest, a swallowed assertion is not.
+4. **T5** — add the missing `assert len(de_images) > 0` in the PlantUML e2e test
+   (`tests/e2e/test_e2e_course_conversion.py` ~`:1105-1143`).
+5. **T6** — drop `AssertionError` from the `only_rerun` list in
+   `tests/infrastructure/workers/test_worker_base.py:26-35` and
+   `test_lifecycle_mock.py:36-49`. Keep the OSError/PermissionError/OperationalError
+   entries; those are genuine environment flakes. An intermittent race in the
+   production claim loop *is* an intermittent `AssertionError` — that is signal,
+   not noise.
+6. **T7** — bring `tests/fixtures/mock_workers.py:212-226` to v10 parity
+   (`execution_mode` filter, session-ownership semantics), or better, have
+   MockWorker call the real `JobQueue.get_next_job` so it cannot drift again.
+7. **T10** — remove the dead `PLANTUML_JAR` discovery path in
+   `tests/conftest.py:437` (points at the pre-PR-#239 vendored location) and
+   replace the import-time `os.environ` mutation in
+   `tests/workers/plantuml/test_plantuml_converter.py:31-47` with a proper
+   fixture. Under xdist the current arrangement is ordering-dependent.
+8. **T8** — leave the autouse neutralizers in place (they are justified), but
+   document each with a comment naming the single test that covers the real
+   production value, and add one interaction test where the gap is widest (the
+   pool-size clamp firing during managed-worker startup).
+
+**Landmines**
+- A nightly job nobody reads is worse than no job: it manufactures the feeling
+  of coverage. Decide *now* where failures surface (issue auto-filed, or a
+  notification you actually receive) and write that into the workflow.
+- `-n auto` OOMs locally on the e2e tests; use `-n 4`. Known, recorded in
+  project memory.
+
+**Acceptance**: 8 previously-dead tests run and pass (or have issues filed for
+genuine bugs they exposed); no test in `tests/cli/test_cli_integration.py`
+passes when the build is broken; nightly workflow green and its failure route
+verified by deliberately breaking a test once.
+
+---
+
+### Phase 2 — Network-facing security  ▸ STATUS: not started
+**Depends on**: Phase 1 (you are about to change Docker-mode networking and the
+cache format; the worker tests must be alive first).
+
+**Goal**: no CLM service is reachable, or actionable, by a party that has not
+been explicitly granted access.
+
+**Work**
+
+1. **S2 + D2 + D3 — worker API.** `src/clm/infrastructure/api/server.py:22-23`,
+   `worker_routes.py`.
+   - Default bind: `127.0.0.1` **plus** the Docker bridge gateway address so
+     containers keep working. Binding to anything else requires an explicit
+     config/flag **and** a configured token; refuse to start otherwise with a
+     clear error. This opt-in mode is the supported path for D5 — name and
+     document it as such (e.g. "coordinator mode"), not as a debug escape hatch.
+   - Auth: per-build bearer token on **every** route. Reuse the constant-time
+     comparison in `src/clm/web/studio/auth.py`; do **not** reimplement it, and
+     do **not** accept the token as a query parameter (that is S7's leak).
+     Inject it into workers via the environment the same way `DB_PATH` is.
+   - **D3**: replace the pickle payload on `/cache/executed_notebook` (both
+     directions) with JSON. `NotebookNode` is a dict subclass, so
+     `nbformat.writes`/`reads` is the natural carrier. Update the three consumers
+     (`sqlite_backend.py:575`, `notebook_worker.py:107`,
+     `api_executed_notebook_cache.py:68`) and bump the cache schema/version so
+     old pickled entries are invalidated rather than misread.
+   - **Landmine**: `executed_notebook_cache.py` stores raw bytes; make sure the
+     *stored* format changes too, not just the wire format, or you leave a
+     pickle-loading path alive behind an auth wall.
+2. **S3 + D4 — recordings dashboard.** `src/clm/recordings/web/routes.py:567-602`:
+   apply the containment check its own sibling `/open-explorer` (`:794-804`)
+   already implements — `resolve(strict=True)` + `relative_to(root)` — before
+   `/process` submits anything. Then add origin checking to every mutating route
+   and `TrustedHostMiddleware` to the app.
+   - **Landmine**: `/arm` accepts `course_slug` and reaches `get_state_path`
+     unfiltered (verified: `get_state_path('../../../evil')` escapes). Sanitize
+     it here, not only in the generic path fix in Phase 4.
+3. **S6 + D4 — `clm serve`.** `src/clm/web/app.py:127-136`: default
+   `cors_origins` to the serve origin (never `["*"]` with
+   `allow_credentials=True`). `src/clm/web/api/websocket.py:110-126`: require the
+   bearer token **before** `accept()`, and validate channel names against a known
+   set. Add `TrustedHostMiddleware`.
+   - WebSockets bypass CORS entirely — this is why the token check must precede
+     `accept()` rather than sitting on the HTTP routes.
+4. **S7 — studio render.** `src/clm/web/studio/render.py:55-71` →
+   `jinja2.SandboxedEnvironment`. Fix `esc()` in
+   `src/clm/web/static/studio/app.js:45-47` to escape quotes (its output is
+   interpolated into an `href`). Stop accepting `?token=` after the initial
+   exchange (`auth.py:78-80`) — it currently lands in QR deep links, browser
+   history and uvicorn access logs.
+   - Update the module docstring: it currently advertises a "no-execution" tier
+     that executes. Either the claim or the behavior has to change; this makes
+     the claim true.
+
+**Acceptance**: a cross-origin page cannot drive any mutating route on either
+app; `/ws` rejects an unauthenticated connection before accept; the worker API
+refuses a non-loopback bind without a token; no pickle remains on any API or
+cache path; SSTI proof-of-concept from the review no longer executes.
+
+---
+
+### Phase 3 — Sync engine correctness  ▸ STATUS: not started
+**Depends on**: Phase 1 (sync unit coverage is the best in the repo — keep it
+that way and extend it here).
+
+**Goal**: no path silently destroys authored content. Order within this phase
+matters: **D8 first**, because the gate is what creates the divergent baselines
+the other bugs consume.
+
+**Work**
+
+1. **Y2 + D8 — the ledger write gate.** `src/clm/cli/commands/slides/sync_v3.py:239-250`
+   and `:375-385`: `structural_gate` must run on the **projected** pair (companions
+   inlined via `project_pair`), exactly as `verify_pair` does
+   (`sync_verify.py:329-333`). Add the documented override flag; make it log at
+   WARNING with the specific divergence it is overriding.
+   - Fix the docstring claiming gate and CLI "can never drift" — make it true, or
+     delete the claim. Better: have both call one function so the claim is
+     structurally guaranteed.
+   - **Migration**: decks with existing diverged companions will start failing
+     `record`. Before shipping, sweep the course repos (PythonCourses, CppCourses,
+     CSharpCourses) to size the blast radius, and prepare the fix-forward
+     instructions. The `cold_sweep_hint` in `doc_report.py:85` actively steers
+     agents toward wholesale `record` — re-word it once the gate is strict.
+2. **Y1 — `mirror_remove` divergence guard.** `src/clm/slides/sync_diff.py:1203-1215`
+   and `:1911-1922`: a two-sided base with `entry.de_fp != entry.en_fp` must
+   downgrade `mirror_remove` from MECHANICAL to a framed `remove_vs_edit` /
+   `pending_divergence`. This mirrors the guard the edit paths already have at
+   `:992/1025` and `:1979` — reuse that predicate rather than writing a second
+   one.
+3. **Y3 + D9 — decision keying.** `src/clm/slides/doc_apply.py:100-115`,
+   `:199-200`, `:1296-1347`: keys become key+action so each framed question is
+   answered independently.
+   - **Breaking.** Update in lockstep: `src/clm/cli/info_topics/` (the sync
+     topic), the downstream agent docs in the course repos, and any saved
+     decision documents. Per `AGENTS.md`, a stale info topic makes downstream
+     agents produce wrong output — treat it as part of the fix, not follow-up.
+   - Add a clear rejection message for old-format keys pointing at the migration,
+     rather than silently accepting them (which would preserve the bug).
+4. **Y5 — trust-gate `stamp_twin_id`.** `sync_diff.py:417-435`: do not emit a
+   mechanical id stamp for a member whose pairing came from
+   `pair_positionally` (`doc_lenses.py:505-522`) and is not ledger-known at that
+   pairing. Frame it instead. Since P2 makes the id *the* identity, a wrong stamp
+   is the worst corruption in the system and it currently requires no judgment.
+5. **Y4 — bind decisions to fingerprints.** A decision should carry the moved
+   side's fingerprint from the report it answered; on mismatch, reject with
+   "re-run report" rather than applying a stale translation and recording it as
+   verified (`doc_apply.py:1399`).
+6. **Y6 — preamble divergence guard.** `sync_diff.py:2560-2599`: extend the
+   carried-divergence check from the neither-moved branch to the one-side-moved
+   branch, matching the cell path at `:1025`.
+7. **Y7 — rename+edit.** `sync_diff.py:1149-1227`, `:565-586`: `_pool_side_deficit`
+   counts only `pos:` base entries, so an id-keyed base cell missing on one side
+   never triggers `stamp_vs_new`. Widen it, and make rename+edit drop to cold
+   rather than emitting `mirror_remove` + `copy_new_shared`.
+8. **Y8** — require content affinity before `_align_pool`'s lone-candidate claim
+   (`:1693-1697`).
+9. **Y9** — hardening: warn when `record` runs on a deck with pending framed
+   items; reject `confirm` on a byte-diverged shared companion member.
+
+**Landmines**
+- Reproduction scripts for Y1–Y5 were written during the review but not kept.
+  Rebuild them as **regression tests** — each finding's scenario is stated
+  precisely enough in the review doc to reconstruct.
+- Inline∘extract is **not** byte-identity (recorded in project memory). Do not
+  "fix" a spurious diff by assuming it is.
+- `apply` writes files *before* the structural verify, so a gate failure leaves
+  files mutated and the ledger unsaved. Y7's strip-id variant can *create* that
+  state. Consider whether the write should move after the verify — but treat that
+  as its own change with its own testing, not a drive-by.
+
+**Acceptance**: each of Y1–Y8 has a regression test that fails before the fix;
+`record` and `verify` provably agree on the same projected pair; course repos
+migrated to the new decision format.
+
+---
+
+### Phase 4 — Filesystem containment & secrets  ▸ STATUS: not started
+
+**Goal**: content and config from a course repo cannot reach outside the paths
+CLM owns, and secrets stay out of logs and commits.
+
+**Work**
+
+1. **S4 — `.clm-include` `rmtree`.** `src/clm/cli/commands/course/sync_includes.py:429-436`:
+   validate `as_path` before use. `Path.__truediv__` discards the left operand
+   when the right is absolute — that is the whole bug. The correct normalizer
+   already exists for spec `<include>` paths (`course_spec.py:88-140`): normalize
+   separators, reject absolute, reject any `..` part, then `resolve()` and confirm
+   containment under `topic_dir`. **Reuse it; do not write a second one.**
+2. **S8 — MCP containment.** `src/clm/mcp/tools.py:939-942`: `_resolve_under` is
+   a bare join. Lift the correct implementation from
+   `src/clm/web/studio/service.py:131-141` (resolve-then-parents-membership —
+   symlink-correct and not spoofable by a sibling prefix) and apply it to every
+   mutating handler (`:536`, `:612-614`, `:668`, `:734`, `:777`, `:864-866`,
+   `:924-926`, `:1554`). Apply to read-only handlers too: they hand file contents
+   to a model, which is a prompt-injection exfiltration path.
+3. **S11 — spec-driven writes.** Sanitize `<dir-group><name>` and `<subdir>`
+   (`src/clm/core/dir_group.py:75-84,94`) the way section names already are —
+   the asymmetry is an oversight, not a design. Validate `<output-target><path>`
+   beyond emptiness. Make `sanitize_file_name` reject `.` and `..`
+   (`text_utils.py:56-70`). Consider requiring a marker file (e.g.
+   `.clm-manifest.json`) before the sweep will empty a directory — a
+   one-character typo (`<path>.</path>`) currently reaches the sweep.
+4. **S5 — repo-supplied executables.** `config.py:936-947` discovers config from
+   inside the course repo, and `drawio_converter.py:14,47` runs the resulting
+   path with no validation. **Open sub-decision** (recommendation:
+   repo-local config may not set executable paths at all — those come from user
+   or system config only; if that proves too restrictive, require an explicit
+   allowlist or an interactive confirmation). Same treatment for
+   `notebook_kernel_python` (`kernel_env.py:165`). Separately, add a scheme
+   allowlist for spec-supplied `repository_base` before it reaches `git` —
+   Git's `ext::` transport executes its argument (`git.py:215,796`).
+5. **S10 + D7 — Docker.** `worker_executor.py:314-341`: mount `/source`
+   read-only for the notebook worker; keep read-write for PlantUML/DrawIO (the
+   comment at `:340` explains why they need it). Add a non-root `USER` to the
+   images and verify generated-image ownership still works. Fix the three
+   verified gaps in the `course.py:340` whole-volume guard: the `len(resolved)==1`
+   early return skips it, `data_dir` has no guard at all, and
+   `_build_has_docker_notebook_worker` returns `False` on any exception.
+6. **S9 — cassette scrubbing.** `cassette_format.py:72-74`: add `api-key`
+   (Azure OpenAI), `x-goog-api-key` (Gemini), `proxy-authorization`,
+   `x-amz-security-token`, `x-auth-token`; add `key`, `access_token`, `apikey`,
+   `subscription-key`, `X-Amz-Signature` to query filtering; match content-type
+   by prefix so `application/json; charset=utf-8` is filtered; **add a
+   response-side filter** (`addon.py:459-465` passes no filter hook, so
+   `Set-Cookie` and OAuth token bodies are committed verbatim).
+   - **Landmine**: this changes recorded bytes. The golden pin test and existing
+     cassettes need re-recording — plan it as part of the change.
+   - Also move the mitmproxy CA **private key** out of the course-repo working
+     tree (`build.py:313-316`), or ignore it explicitly. `umask_secret()` is a
+     no-op on Windows, and with `CLM_JOBS_DB_PATH=Z:\…` the key lands on a share.
+7. **S12 — secrets in config output.** `config.py:504,600,692`: make the LLM key,
+   Auphonic key and OBS password `SecretStr`. `clm config show --json` is exactly
+   what gets pasted into bug reports and agent transcripts. Add `--reveal` if you
+   need the values. Also `chmod 0600` the Google refresh token
+   (`cohort_calendar/google_sync.py:236-238`).
+
+**Acceptance**: a spec or ledger containing `..` or an absolute path cannot write
+or delete outside the output root; MCP tools refuse paths outside `data_dir`; a
+recorded cassette contains no Azure/Gemini key and no `Set-Cookie`;
+`clm config show --json` shows no cleartext secret.
+
+---
+
+### Phase 5 — Job-queue correctness  ▸ STATUS: not started
+**Depends on**: Phase 1 (T1's resurrected tests cover exactly this code).
+
+**Goal**: no job runs twice, no build interferes with another, no corrupted
+output enters the cache. Treat C5+C3+C4+C2 as **one coherent change** — fixing
+any one alone leaves the others able to produce the same outcome.
+
+**Work**
+
+1. **C5 — fencing.** `job_queue.py:340-386` and `worker_routes.py:149`: add
+   `AND worker_id = ? AND status = 'processing'` to status updates. This is the
+   guard that turns C3/C4 from corruption into merely wasted work.
+2. **C3 — liveness before reset.** `job_queue.py:650-670`: do not reset a
+   `processing` job to `pending` without checking the owning worker is actually
+   dead. Runs on every build start *and* end, both default-on, so this fires
+   routinely.
+3. **C4 — scope orphan marking.** `job_queue.py:428-467`: restrict to the
+   session's own worker ids. The docstring's safety argument holds only
+   single-session; the shared DB makes it false.
+4. **C2 — heartbeat while processing.** `worker_base.py:645-790`: heartbeat from
+   within `process_job` or a side thread. Then scope `cleanup_stale_workers`
+   deletions by session (`pool_manager.py:279-294` currently hard-DELETEs with no
+   ownership filter — the #594/#595 fix covered reuse counting, not deletion).
+5. **C6 — content-verify cache hits.** `sqlite_backend.py:484-493`: existence is
+   not equality. Store the output's own digest in `result_metadata` and compare,
+   or re-hash on hit.
+6. **C7 — dead-worker recovery.** `start_monitoring` is only called from a
+   `__main__` demo (`pool_manager.py:1228`), so `_cleanup_dead_worker_jobs` can
+   never fire during a build and the 5-second cleanup poll is dead code. Wire
+   monitoring into the build path — **but fix C8 first or it will mass-kill
+   workers on day one.**
+7. **C8 — timezone.** `pool_manager.py:941-943` compares a UTC `CURRENT_TIMESTAMP`
+   against local `datetime.now()`; on a CEST host every heartbeat reads ~7200s
+   stale. `discovery.py:183` does it correctly — converge on that.
+8. **C9** — treat `cancelled` and attempts-exhausted as terminal in
+   `wait_for_completion`; scope `cancel_jobs_for_file` to the cancelling build.
+9. **C10** — offload blocking SQLite off the uvicorn loop in `worker_routes.py:88-192`;
+   make `_can_replay_from_cache` probe existence without unpickling a multi-MB
+   BLOB on the build's event loop.
+10. **C11** — use `atomic_write_bytes` (temp + `os.replace` + retry) for worker
+    output writes (`notebook_worker.py:264`), matching the host path. This is the
+    amplifier that makes C3 durable.
+11. **C12** — close every thread's connection in `JobQueue.close()`, not just the
+    caller's; otherwise `wal_checkpoint(TRUNCATE)` silently no-ops on Windows
+    (issue #144's symptom via a different door).
+
+**Acceptance**: a job cannot be claimed twice under a forced-interleaving test;
+one build's start/teardown provably cannot alter another session's jobs; a
+deliberately torn output file is rejected rather than cached.
+
+---
+
+### Phase 6 — Cross-machine coordination via the worker API (D5)  ▸ STATUS: not started
+**Depends on**: Phase 2 (auth + coordinator-mode binding) and Phase 5 (the queue
+semantics being replicated must be correct first).
+
+**Goal**: replace the D6 stopgap. One machine owns the jobs DB file; every other
+machine goes through the API. No SQLite file is ever opened over a network share.
+
+**Sketch** (design work is part of this phase, not settled here):
+- Coordinator mode: the owning machine binds per D2 with a token; participants
+  are configured with its URL.
+- All queue operations used cross-machine must exist as API routes with the same
+  atomicity guarantees the local `BEGIN IMMEDIATE` path provides.
+- Failure modes need explicit answers: coordinator unreachable mid-build,
+  coordinator restart with in-flight jobs, participant crash.
+- Remove the Phase 0 journaling stopgap once this lands, and re-enable WAL for
+  the (now always local) DB file.
+
+**Landmine**: this makes the worker API load-bearing for build correctness, not
+just convenience. Its test coverage must be real before it carries this weight —
+which is another reason Phase 1 precedes everything.
+
+---
+
+### Phase 7 — Re-layering prerequisites (D11)  ▸ STATUS: not started
+
+**Hard gate**: no Phase 8 commit lands until all four items below are complete
+and green. This is the maintainer's explicit condition on D10.
+
+1. **Golden end-to-end build characterization suite.** Reference courses built
+   end-to-end, full output trees snapshotted, asserted byte-identical across a
+   refactor.
+   - **Prerequisite within the prerequisite**: the known build nondeterminism
+     must be fixed or normalized first — jupytext `cell_metadata_filter`
+     set-ordering, and the PNG race between static and PlantUML on a shared path
+     (both recorded in project memory). Goldens over nondeterministic output
+     produce flapping tests, which get muted, which returns you to Phase 1's
+     problem.
+2. **Layer-boundary contract tests.** Pin what core exposes, what a backend must
+   implement, and what the worker Pydantic boundary accepts — *before* moving
+   anything beneath them. These stay valuable afterward as the executable
+   statement of the new design.
+3. **Real unmocked build-pipeline tests in the fast suite (T3).** Replace the
+   fully-mocked `main_build` coverage (`tests/cli/test_build_command.py:1159-1278`
+   currently stubs `Course`, both backends, `BuildReporter`, `init_database`, and
+   makes `execution_stages()` return `[]`). Exercise real stage sequencing,
+   backend wiring and job submission against a temp DB.
+   - Keep the fast suite fast. If it grows past roughly two minutes, people
+     start bypassing the pre-push hook, and the gate stops existing.
+4. **Coverage threshold on the modules being moved.** `build.py`, `course.py`,
+   `path_utils.py`, the backends. Set the bar in CI.
+   - **Landmine**: this codebase already contains tautological tests
+     (Phase 1/T4), so a coverage number can be met without safety existing.
+     Pair the threshold with a mutation-testing spot-check, or at minimum review
+     the new tests for assertions that can actually fail.
+
+**Acceptance**: all four in place; the golden suite passes twice in a row on
+unchanged code (proving determinism) before it is trusted as a refactor gate.
+
+---
+
+### Phase 8 — Full re-layering (D10)  ▸ STATUS: blocked on Phase 7
+
+**Goal**: the architecture the docs describe. Work strictly in dependency order,
+one PR per step, golden suite green after each.
+
+1. **A2 — move `build_data_classes.py` and `error_categorizer.py` out of
+   `clm.cli`** into infrastructure. Mechanical, and it alone kills the
+   infrastructure→CLI cycle (`dummy_backend.py:7`, `local_ops_backend.py:36`,
+   `sqlite_backend.py:874/998/1698/1804`, `worker_base.py:758`,
+   `progress_tracker.py:356`, `db_operations.py:336`).
+2. **A6 — extract the domain vocabulary from `path_utils`** (`Lang`, `Format`,
+   `Kind`, `OutputSpec`, `output_specs()`, `output_path_for()`) into `clm.core`.
+   43 files import this module; most of the core↔infrastructure cycle flows
+   through it.
+3. **A1/A3 — break the remaining cycles**: core's module-level infrastructure
+   imports (`core/course.py:53-56`, `course_file.py:8-10`, `dir_group.py:9-10`,
+   all of `core/operations/`), core's imports of `clm.workers` and of extension
+   modules (including spec parsing depending on `clm.slides.sidecar_layout` at
+   `course_spec.py:2599`).
+4. **A11 — import-linter contract in CI.** Add it as soon as the first contract
+   is true, not at the end — each subsequent step then cannot regress.
+5. **A4 — extract build orchestration** from `cli/commands/build.py` (2694 lines;
+   the Click command starts at :2071 — everything before it is the engine) into a
+   callable core API. This is what unlocks programmatic builds for MCP, the web
+   studio and tests. Highest risk step; do it last and lean on the golden suite.
+6. **A5** — move voiceover merge/propagation logic out of
+   `cli/commands/voiceover.py` into `clm.voiceover`, removing the private-symbol
+   imports (`_langfuse_configured`, `_decode_alignment`).
+7. **A7** — unify the three config mechanisms (`ClmConfig`, `sidecar_layout`'s
+   `[tool.clm]` pyproject reader, and raw `os.environ` in 36 files including
+   `build.py`'s `_resolve_*` family).
+8. **A8** — one name and one default for the jobs-DB path (`CLM_JOBS_DB_PATH`
+   host-side vs bare `DB_PATH` defaulting to the container path `/db/jobs.db`
+   worker-side).
+9. **A9** — remove the ~12 cross-module underscore-private imports, worst being
+   `mcp/tools.py:391` → a CLI command's private helper.
+10. **A10 — rewrite `architecture.md`** to describe what now exists.
+    **Do this incrementally as each step lands**, not at the end. The doc is
+    currently wrong in ways that actively mislead agents (a "service registry"
+    directory holding one file, a layer diagram matching no import structure,
+    undocumented env vars, orchestration attributed to `Course.process()`), and
+    per `AGENTS.md` agents are told to trust it.
+11. **A12** — move `docker`, `fastapi`, `uvicorn`, `watchdog` behind extras with
+    lazy imports; `DummyBackend` (`dummy_backend.py:19`, never instantiated in
+    `src/`) moves to `tests/`.
+
+**Landmine**: if Phase 8 stalls partway — a real risk for a project this size —
+the *docs must not* describe the end state as if it arrived. Update A10
+incrementally so the doc is always true of the current code.
+
+---
+
+## 5. Finding coverage map
+
+Every finding from the review, and where it is handled. IDs match
+`docs/claude/adversarial-review-2026-07-24.md`.
+
+| Finding | Phase | Finding | Phase | Finding | Phase |
+|---|---|---|---|---|---|
+| S1 | 0 | C1 | 0 (interim) → 6 (final) | Y1 | 3 |
+| S2 | 2 | C2 | 5 | Y2 | 3 |
+| S3 | 2 | C3 | 5 | Y3 | 3 |
+| S4 | 4 | C4 | 5 | Y4 | 3 |
+| S5 | 4 | C5 | 5 | Y5 | 3 |
+| S6 | 2 | C6 | 5 | Y6 | 3 |
+| S7 | 2 | C7 | 5 | Y7 | 3 |
+| S8 | 4 | C8 | 5 | Y8 | 3 |
+| S9 | 4 | C9 | 5 | Y9 | 3 |
+| S10 | 4 | C10 | 5 | A1 | 8 |
+| S11 | 4 | C11 | 5 | A2 | 8 |
+| S12 | 4 | C12 | 5 | A3 | 8 |
+| T1 | 1 | T5 | 1 | A4 | 8 |
+| T2 | 1 | T6 | 1 | A5 | 8 |
+| T3 | 7 | T7 | 1 | A6 | 8 |
+| T4 | 1 | T8 | 1 | A7 | 8 |
+| T9 | 1 | T10 | 1 | A8 | 8 |
+| | | | | A9 | 8 |
+| | | | | A10 | 8 |
+| | | | | A11 | 8 |
+| | | | | A12 | 8 |
+
+**Deliberately accepted, not fixed**: billion-laughs XML expansion in spec
+parsing (local hang/OOM only, LOW for a local tool); cassette response-header
+CRLF replay into the kernel's HTTP client (noted under S9 — fix opportunistically
+if touching that code).
+
+---
+
+## 6. Open sub-decisions (for the implementing session)
+
+Small enough to decide in flight; recommendations given, but flag them in the PR
+so the maintainer can object:
+
+1. **S5 scope** — recommendation: repo-local config may not set executable paths
+   at all (user/system config only). Fall back to an allowlist if too restrictive.
+2. **S11 sweep marker** — recommendation: require `.clm-manifest.json` (or
+   equivalent) before the sweep will empty a directory.
+3. **D8 override flag name** — something that reads as dangerous at a glance;
+   `--allow-diverged-companion` rather than `--force`.
+4. **D3 cache migration** — recommendation: bump the cache version so old pickled
+   entries are ignored, rather than writing a converter for a cache that
+   regenerates itself.
+
+---
+
+## 7. Related documents
+
+- `docs/claude/adversarial-review-2026-07-24.md` — findings, evidence,
+  reproduction details. The authority for *why* each item is here.
+- `AGENTS.md` — branch/commit/PR conventions, changelog fragments, the info-topic
+  maintenance rule.
+- `docs/developer-guide/releasing.md` — Phase 0's release procedure.
+- `docs/developer-guide/architecture.md` — **currently inaccurate**; Phase 8/A10
+  fixes it.
+- `docs/developer-guide/caching.md`, `docs/developer-guide/testing.md` — context
+  for Phases 5 and 1 respectively.


### PR DESCRIPTION
Documentation only — no code changes.

Records a five-agent adversarial review of 1.21.1 (architecture, concurrency,
sync engine, security, testing) and the remediation plan derived from it.

## Two documents

- **`docs/claude/adversarial-review-2026-07-24.md`** — findings with evidence.
  Sync-engine findings were reproduced end-to-end with scripts; the top security
  findings were re-verified by hand. Includes a "verified clean" section, since
  knowing what was checked and found sound is as useful as the findings.
- **`docs/claude/handovers/adversarial-review-remediation-handover.md`** — an
  eight-phase plan with the maintainer's settled decisions, per-phase landmines,
  and a table mapping every finding to a phase.

## Why now and not earlier

The two critical findings — the cassette YAML RCE and WAL journaling on
network-shared databases — are already fixed and released in **1.22.1**
(PR #658). These documents contain a working exploit, so publishing them while
the only released version was still vulnerable would have been irresponsible.
Both are annotated as fixed.

## Decisions recorded

Twelve, made explicitly after walking through the alternatives, each with its
rationale so later sessions implement rather than relitigate. The consequential
ones:

- Cross-machine jobs-DB access moves to **worker-API coordination**, not
  WAL-over-SMB. The journaling change in 1.22.1 is an explicit interim stopgap.
- The worker API becomes loopback-by-default with an opt-in wider bind that
  requires a token — reconciling its new role as DB coordinator with the
  hardening it needs.
- The executed-notebook cache drops **pickle for JSON**, removing the
  deserialization-RCE class rather than defending it with a secret.
- **Full re-layering is approved but hard-gated** behind four test
  prerequisites. The build pipeline's entire pre-push coverage is currently
  mocked, so refactoring it without a characterization suite would be
  unguarded.

## Note for whoever picks this up

Phase 1 is the cheapest item on the list: two stale module names in
`test_direct_integration.py` have kept eight Direct-mode worker tests skipped
in every suite, including CI. Fixing the strings resurrects them — and they
cover exactly the code Phase 5 modifies. Expect some to fail; the plan says to
triage rather than delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEAsC4QkeoDw34FEBNdh1K
