### PR TITLE
test: resurrect the 8 permanently-skipped Direct-mode worker tests (Phase 1 / T1)

### DIFF
--- a/changelog.d/667-resurrect-direct-worker-tests.fixed.md
+++ b/changelog.d/667-resurrect-direct-worker-tests.fixed.md
@@ -1,0 +1,12 @@
+- **Eight Direct-mode worker integration tests run again.** `test_direct_integration.py`
+  gated its entire module on `find_spec("drawio_converter")` and
+  `find_spec("plantuml_converter")` — top-level module names that stopped
+  existing when the workers were folded into `clm.workers.*`, so worker
+  startup/registration, concurrent claiming, health monitoring, graceful
+  shutdown and the high-concurrency job tests had been silently skipped
+  everywhere, including CI. The probes now name the real packages. Resurrecting
+  them exposed a stale job payload in two of the tests (`{"kernel": …}`
+  predates `NotebookPayload`'s required descriptor fields, so the job always
+  failed validation); they now submit a real `NotebookPayload`. A new
+  `test_worker_module_probes.py` fails loudly if a skip guard is ever pointed at
+  a module that does not resolve.

--- a/tests/infrastructure/workers/test_direct_integration.py
+++ b/tests/infrastructure/workers/test_direct_integration.py
@@ -4,8 +4,6 @@ These tests verify that workers can run directly as subprocesses
 and process actual jobs end-to-end.
 """
 
-import json
-import sys
 import tempfile
 import time
 from importlib.util import find_spec
@@ -15,8 +13,54 @@ import pytest
 
 from clm.infrastructure.database.job_queue import JobQueue
 from clm.infrastructure.database.schema import init_database
+from clm.infrastructure.messaging.notebook_classes import NotebookPayload
 from clm.infrastructure.workers.pool_manager import WorkerPoolManager
 from clm.infrastructure.workers.worker_executor import WorkerConfig
+
+# A minimal jupytext percent-format slide source — CLM's actual notebook input
+# format. Deliberately trivial so the kernel round-trip is fast.
+NOTEBOOK_SOURCE = """# %% [markdown] lang="en" tags=["slide"]
+#
+# # Test Notebook
+
+# %% tags=["keep"]
+print("Hello, World!")
+"""
+
+
+def _submit_notebook_job(
+    job_queue: JobQueue,
+    input_file: Path,
+    output_file: Path,
+    source: str = NOTEBOOK_SOURCE,
+) -> int:
+    """Submit a notebook job carrying a *valid* ``NotebookPayload``.
+
+    These tests used to hand-roll ``payload={"kernel": "python3", "timeout": 60}``,
+    which has not been a valid notebook payload since ``NotebookPayload`` gained
+    its required ``kind``/``prog_lang``/``language``/``format`` descriptors. The
+    job failed with a ``ValidationError`` — invisible, because the whole module
+    was skipped (stale ``find_spec`` guards). Build the real payload object so
+    the test cannot drift away from the worker's contract again.
+    """
+    payload = NotebookPayload(
+        data=source,
+        input_file=str(input_file),
+        input_file_name=input_file.name,
+        output_file=str(output_file),
+        correlation_id=f"direct-integration-{output_file.stem}",
+        kind="completed",
+        prog_lang="python",
+        language="en",
+        format="notebook",
+    )
+    return job_queue.add_job(
+        job_type="notebook",
+        input_file=str(input_file),
+        output_file=str(output_file),
+        content_hash=payload.content_hash(),
+        payload=payload.model_dump(mode="json"),
+    )
 
 
 def _wait_for_registered_workers(
@@ -66,8 +110,8 @@ def check_worker_module_available(module_name: str) -> bool:
 
 # Check availability of worker modules
 NOTEBOOK_WORKER_AVAILABLE = check_worker_module_available("clm.workers.notebook")
-DRAWIO_WORKER_AVAILABLE = check_worker_module_available("drawio_converter")
-PLANTUML_WORKER_AVAILABLE = check_worker_module_available("plantuml_converter")
+DRAWIO_WORKER_AVAILABLE = check_worker_module_available("clm.workers.drawio")
+PLANTUML_WORKER_AVAILABLE = check_worker_module_available("clm.workers.plantuml")
 
 # Skip all integration tests if notebook worker is not available
 pytestmark = pytest.mark.skipif(
@@ -190,39 +234,15 @@ class TestDirectWorkerIntegration:
         Note: This test creates a simple test notebook job.
         """
         # Create a test notebook file
-        test_notebook = workspace_path / "test.ipynb"
-        notebook_content = {
-            "cells": [
-                {
-                    "cell_type": "code",
-                    "execution_count": None,
-                    "metadata": {},
-                    "outputs": [],
-                    "source": ["print('Hello, World!')"],
-                }
-            ],
-            "metadata": {
-                "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}
-            },
-            "nbformat": 4,
-            "nbformat_minor": 4,
-        }
-
-        with open(test_notebook, "w") as f:
-            json.dump(notebook_content, f)
+        test_notebook = workspace_path / "test.py"
+        test_notebook.write_text(NOTEBOOK_SOURCE, encoding="utf-8")
 
         # Create output path
         output_file = workspace_path / "output.ipynb"
 
         # Add job to queue
         job_queue = JobQueue(db_path)
-        job_id = job_queue.add_job(
-            job_type="notebook",
-            input_file=str(test_notebook),
-            output_file=str(output_file),
-            content_hash="test-hash-123",
-            payload={"kernel": "python3", "timeout": 60},
-        )
+        job_id = _submit_notebook_job(job_queue, test_notebook, output_file)
 
         # Start worker
         config = WorkerConfig(worker_type="notebook", count=1, execution_mode="direct")
@@ -234,24 +254,27 @@ class TestDirectWorkerIntegration:
         try:
             manager.start_pools()
 
-            # Wait for job to be processed (max 30 seconds)
-            max_wait = 30
+            # Wait for job to be processed. A cold kernel start can take a
+            # while on a loaded machine, so this is generous rather than tight.
+            max_wait = 120
             start_time = time.time()
             job_status = "pending"
+            job_error: str | None = None
 
             while time.time() - start_time < max_wait:
                 conn = job_queue._get_conn()
-                cursor = conn.execute("SELECT status FROM jobs WHERE id = ?", (job_id,))
+                cursor = conn.execute("SELECT status, error FROM jobs WHERE id = ?", (job_id,))
                 row = cursor.fetchone()
                 if row:
-                    job_status = row[0]
+                    job_status, job_error = row[0], row[1]
                     if job_status in ("completed", "failed"):
                         break
 
                 time.sleep(0.5)
 
-            # Verify job was completed
-            assert job_status == "completed", f"Job status: {job_status}"
+            # Verify job was completed. Surface the recorded error — without it
+            # a payload-contract regression reads as a bare "failed != completed".
+            assert job_status == "completed", f"Job status: {job_status}; error: {job_error}"
 
             # Verify output file exists
             assert output_file.exists(), "Output file not created"
@@ -333,32 +356,13 @@ class TestDirectWorkerIntegration:
         Args:
             worker_count: Number of concurrent notebook workers (2, 8, 16, or 32)
         """
-        # Create test notebook file
-        test_notebook = workspace_path / "test.ipynb"
-        notebook_content = {
-            "cells": [
-                {
-                    "cell_type": "code",
-                    "execution_count": None,
-                    "metadata": {},
-                    "outputs": [],
-                    "source": ["print('Test notebook')"],
-                }
-            ],
-            "metadata": {
-                "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}
-            },
-            "nbformat": 4,
-            "nbformat_minor": 4,
-        }
-
-        with open(test_notebook, "w") as f:
-            json.dump(notebook_content, f)
-
         # Create job queue
         job_queue = JobQueue(db_path)
 
-        # Submit multiple jobs (2x worker count to ensure concurrency)
+        # Submit multiple jobs (2x worker count to ensure concurrency).
+        # Every job gets *distinct* content: identical sources would be served
+        # from the worker's executed-notebook cache after the first job, which
+        # would quietly turn this concurrency test into a cache-lookup test.
         num_jobs = worker_count * 2
         job_ids = []
         output_files = []
@@ -367,14 +371,13 @@ class TestDirectWorkerIntegration:
             output_file = workspace_path / f"output_{i}.ipynb"
             output_files.append(output_file)
 
-            job_id = job_queue.add_job(
-                job_type="notebook",
-                input_file=str(test_notebook),
-                output_file=str(output_file),
-                content_hash=f"test-hash-{i}",
-                payload={"kernel": "python3", "timeout": 60},
+            test_notebook = workspace_path / f"test_{i}.py"
+            source = NOTEBOOK_SOURCE + f'\nprint("job {i}")\n'
+            test_notebook.write_text(source, encoding="utf-8")
+
+            job_ids.append(
+                _submit_notebook_job(job_queue, test_notebook, output_file, source=source)
             )
-            job_ids.append(job_id)
 
         # Start workers
         config = WorkerConfig(worker_type="notebook", count=worker_count, execution_mode="direct")

--- a/tests/infrastructure/workers/test_lifecycle_integration.py
+++ b/tests/infrastructure/workers/test_lifecycle_integration.py
@@ -71,10 +71,11 @@ def check_worker_module_available(module_name: str) -> bool:
         return False
 
 
-# Check availability of worker modules
+# Check availability of worker modules. Only the notebook worker is exercised
+# here (every config below sets ``plantuml_count``/``drawio_count`` to 0), so
+# only that flag exists — the drawio/plantuml flags that used to sit here were
+# never read, and pointed at pre-rename top-level module names.
 NOTEBOOK_WORKER_AVAILABLE = check_worker_module_available("clm.workers.notebook")
-DRAWIO_WORKER_AVAILABLE = check_worker_module_available("drawio_converter")
-PLANTUML_WORKER_AVAILABLE = check_worker_module_available("plantuml_converter")
 
 # Skip all integration tests if notebook worker is not available
 pytestmark = pytest.mark.skipif(

--- a/tests/infrastructure/workers/test_worker_module_probes.py
+++ b/tests/infrastructure/workers/test_worker_module_probes.py
@@ -1,0 +1,61 @@
+"""Guard against skip guards that can never be satisfied.
+
+``test_direct_integration.py`` skipped its *entire* module — 8 Direct-mode
+integration tests covering worker startup/registration, concurrent claiming,
+health monitoring and graceful shutdown — for as long as it took nobody to
+notice, because its ``find_spec`` probes named ``drawio_converter`` and
+``plantuml_converter``: top-level modules that were folded into
+``clm.workers.*`` long ago. A stale probe is invisible in a test report,
+because "skipped" reads as "not applicable in this environment" rather than
+"permanently dead".
+
+The worker packages are *always* part of the installed ``clm`` distribution —
+the optional extras add third-party dependencies, not these modules — so
+``find_spec`` on them cannot legitimately fail. Anything the probes protect
+against is therefore a rename, which is exactly what these assertions catch.
+
+Keep this test in sync with the ``check_worker_module_available`` call sites
+if a new worker package is added.
+"""
+
+from importlib.util import find_spec
+
+import pytest
+
+# Every module name passed to a ``check_worker_module_available`` /
+# ``find_spec`` skip guard anywhere in the test suite.
+PROBED_WORKER_MODULES = [
+    "clm.workers.notebook",
+    "clm.workers.drawio",
+    "clm.workers.plantuml",
+]
+
+
+@pytest.mark.parametrize("module_name", PROBED_WORKER_MODULES)
+def test_probed_worker_module_resolves(module_name: str) -> None:
+    """A skip guard naming a nonexistent module silently kills its tests."""
+    assert find_spec(module_name) is not None, (
+        f"{module_name!r} does not resolve. Some test module gates its "
+        f"tests on this name via find_spec and is now permanently skipped. "
+        f"Update the probe rather than leaving it stale."
+    )
+
+
+def test_direct_integration_module_is_not_skipped() -> None:
+    """The availability flags in ``test_direct_integration`` must all be true.
+
+    Asserted on the real module attributes, not recomputed here, so a future
+    edit to the probe names is caught at the place it happens.
+    """
+    from tests.infrastructure.workers import test_direct_integration as mod
+
+    assert mod.NOTEBOOK_WORKER_AVAILABLE
+    assert mod.DRAWIO_WORKER_AVAILABLE
+    assert mod.PLANTUML_WORKER_AVAILABLE
+
+
+def test_lifecycle_integration_module_is_not_skipped() -> None:
+    """Same for ``test_lifecycle_integration``'s single availability flag."""
+    from tests.infrastructure.workers import test_lifecycle_integration as mod
+
+    assert mod.NOTEBOOK_WORKER_AVAILABLE


### PR DESCRIPTION
Phase 1 (test resurrection) of the 2026-07-24 adversarial review remediation
plan — finding **T1**. Plan: `docs/claude/handovers/adversarial-review-remediation-handover.md`.

## The problem

`tests/infrastructure/workers/test_direct_integration.py` gated its **entire
module** on `find_spec("drawio_converter")` and `find_spec("plantuml_converter")`
— top-level module names that stopped existing when the converters were folded
into `clm.workers.*`. Both probes returned `None` everywhere, CI included, so
these were skipped indefinitely:

- worker startup and DB registration
- multi-worker startup across worker types
- real job processing end-to-end
- health monitoring
- graceful shutdown
- the four `high_concurrency_notebook_workers` parametrisations (2/8/16/32)

A stale probe is invisible in a test report: "skipped" reads as "not applicable
in this environment", not "permanently dead".

`test_lifecycle_integration.py` carried the same two stale flags, but never read
them — removed rather than repaired.

## What resurrecting them exposed

A second, hidden regression. `test_direct_worker_processes_job` and
`test_high_concurrency_notebook_workers` submitted
`payload={"kernel": "python3", "timeout": 60}`, which has not been a valid
notebook payload since `NotebookPayload` gained its required
`kind`/`prog_lang`/`language`/`format` descriptors:

```
4 validation errors for NotebookPayload
kind        Field required
prog_lang   Field required
language    Field required
format      Field required
```

Every one of those jobs failed. Triaged as a **stale test**, not a product bug —
`Payload.from_job_payload` deliberately raises on a missing descriptor ("the
host always sets them, so a gap means a genuinely malformed job that should fail
loudly"), and the host does set them. Fixed by building a real `NotebookPayload`
over a jupytext percent source through one helper, so the tests cannot drift away
from the worker contract again.

## Changes

- Probes point at `clm.workers.drawio` / `clm.workers.plantuml`.
- `_submit_notebook_job()` helper builds and dumps a real `NotebookPayload`.
- Completion assertion now reports the recorded job `error`, so a future
  payload-contract break reads as the validation error rather than a bare
  `'failed' != 'completed'`.
- High-concurrency jobs get **distinct content per job**. Identical sources
  would have been served from the worker's executed-notebook cache after the
  first job, quietly turning a concurrency test into a cache-lookup test.
- Job wait widened 30s → 120s (cold kernel start on a loaded CI runner).
- New `tests/infrastructure/workers/test_worker_module_probes.py`: asserts every
  module name used by a skip guard resolves, and that both integration modules'
  availability flags are true. This is the guard against T1 recurring — the
  worker packages always ship with `clm`, so a probe failure can only mean a
  rename.

## Verification

```
pytest tests/infrastructure/workers/test_direct_integration.py -m "not docker and not slow"   5 passed
pytest ...::test_high_concurrency_notebook_workers -m ""                                      4 passed
pytest tests/infrastructure/workers/test_lifecycle_integration.py -m "not docker"             6 passed
pytest tests/infrastructure/workers/test_worker_module_probes.py                              5 passed
```

Fast suite green (pre-push hook). CI runs the 5 non-slow tests under
`-m "integration and not docker and not slow"`; the 4 slow ones are covered by
the nightly job coming in T2.

## Notes

- Test-only change; no production code touched. No adversarial review run — the
  blast radius is the test suite itself and every affected test was executed.
- `test_direct_worker_health_monitoring` is the one place `start_monitoring()`
  runs outside a `__main__` demo. It passes on a CEST host despite finding **C8**
  (UTC `CURRENT_TIMESTAMP` vs local `datetime.now()`) because a stale heartbeat
  only warns for direct workers — hung-marking is Docker-only. C8 stays in
  Phase 5 as planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEAsC4QkeoDw34FEBNdh1K
