### PR TITLE
test: repair the two mixed-mode Docker tests unskipped by the T1 fix

### DIFF
--- a/changelog.d/668-mixed-mode-docker-tests.fixed.md
+++ b/changelog.d/668-mixed-mode-docker-tests.fixed.md
@@ -1,0 +1,11 @@
+- **Repaired the two mixed-mode Docker worker tests unskipped by the T1 fix.**
+  `test_mixed_worker_modes` hard-coded the image tag `drawio-converter:latest`,
+  which CLM has not published since the images gained their `clm-` prefix — the
+  Docker client tried to *pull* it and the test died on `ImageNotFound`. It now
+  resolves the tag from the CI-built and published candidates the way the e2e
+  lifecycle test does, and skips with a stated reason when no image is present
+  instead of quietly degrading to a direct-only run.
+  `test_stale_worker_cleanup_mixed_mode` inserted its "stale" worker rows
+  without a `last_heartbeat`, so the column defaulted to the current timestamp
+  and the direct worker was correctly judged *healthy* and kept; the rows now
+  carry a genuinely old heartbeat.

--- a/tests/infrastructure/workers/test_direct_integration.py
+++ b/tests/infrastructure/workers/test_direct_integration.py
@@ -28,6 +28,49 @@ print("Hello, World!")
 """
 
 
+# A heartbeat far enough in the past that no staleness threshold can call it
+# fresh, and unambiguous regardless of the UTC-vs-local skew in the health
+# checks (finding C8).
+ANCIENT_TIMESTAMP = "1970-01-01 00:00:00"
+
+# Image tags CLM's DrawIO worker may be published under: the CI-built test tag
+# first, then the published image. Mirrors ``tests/e2e/test_e2e_lifecycle.py``.
+DRAWIO_IMAGE_CANDIDATES = [
+    "clm-drawio-converter:test",
+    "docker.io/mhoelzl/clm-drawio-converter:latest",
+]
+
+
+def _docker_daemon_available() -> bool:
+    """Return True when a Docker daemon answers a ping."""
+    try:
+        import docker
+
+        docker.from_env().ping()
+        return True
+    except Exception:
+        return False
+
+
+def _find_docker_image(candidates: list[str]) -> str | None:
+    """Return the first locally-present image tag from *candidates*."""
+    try:
+        import docker
+
+        client = docker.from_env()
+        client.ping()
+    except Exception:
+        return None
+
+    for tag in candidates:
+        try:
+            client.images.get(tag)
+            return tag
+        except Exception:
+            continue
+    return None
+
+
 def _submit_notebook_job(
     job_queue: JobQueue,
     input_file: Path,
@@ -473,29 +516,29 @@ class TestMixedModeIntegration:
     def test_mixed_worker_modes(self, db_path, workspace_path):
         """Test running both Docker and direct workers simultaneously.
 
-        Note: This test will skip Docker workers if Docker is not available.
+        The image tag used to be hard-coded to ``drawio-converter:latest``,
+        which has not been a tag CLM builds since the images gained their
+        ``clm-`` prefix. The docker client then tried to *pull* it and the test
+        died on ``ImageNotFound``. Resolve the tag the same way the e2e
+        lifecycle test does — and skip outright when no image is present rather
+        than degrading to a direct-only run, since mixed mode is the subject.
         """
-        configs = [WorkerConfig(worker_type="notebook", count=1, execution_mode="direct")]
-
-        # Try to add Docker worker if Docker is available
-        try:
-            import docker
-
-            docker_client = docker.from_env()
-            docker_client.ping()
-
-            # Docker is available, add docker worker
-            configs.append(
-                WorkerConfig(
-                    worker_type="drawio",
-                    count=1,
-                    execution_mode="docker",
-                    image="drawio-converter:latest",
-                )
+        drawio_image = _find_docker_image(DRAWIO_IMAGE_CANDIDATES)
+        if drawio_image is None:
+            pytest.skip(
+                f"No DrawIO worker image available (looked for "
+                f"{', '.join(DRAWIO_IMAGE_CANDIDATES)}). Run: clm docker build"
             )
-            has_docker = True
-        except Exception:
-            has_docker = False
+
+        configs = [
+            WorkerConfig(worker_type="notebook", count=1, execution_mode="direct"),
+            WorkerConfig(
+                worker_type="drawio",
+                count=1,
+                execution_mode="docker",
+                image=drawio_image,
+            ),
+        ]
 
         manager = WorkerPoolManager(
             db_path=db_path, workspace_path=workspace_path, worker_configs=configs
@@ -503,13 +546,8 @@ class TestMixedModeIntegration:
 
         try:
             manager.start_pools()
-            # Wait for at least the direct worker to activate; docker workers
-            # take longer and we tolerate either outcome below.
-            _wait_for_registered_workers(
-                manager,
-                expected_count=2 if has_docker else 1,
-                timeout=30.0,
-            )
+            # Docker workers take longer to activate than direct ones.
+            _wait_for_registered_workers(manager, expected_count=2, timeout=60.0)
 
             # Check database
             conn = manager.job_queue._get_conn()
@@ -518,47 +556,50 @@ class TestMixedModeIntegration:
             )
             workers = cursor.fetchall()
 
-            # Should have at least the direct worker
-            assert len(workers) >= 1
-
-            # Check direct worker
             direct_workers = [w for w in workers if w[1].startswith("direct-")]
             assert len(direct_workers) == 1
             assert direct_workers[0][0] == "notebook"
 
-            if has_docker:
-                # Check docker worker
-                docker_workers = [w for w in workers if not w[1].startswith("direct-")]
-                assert len(docker_workers) == 1
-                assert docker_workers[0][0] == "drawio"
+            docker_workers = [w for w in workers if not w[1].startswith("direct-")]
+            assert len(docker_workers) == 1
+            assert docker_workers[0][0] == "drawio"
 
         finally:
             manager.stop_pools()
 
     def test_stale_worker_cleanup_mixed_mode(self, db_path, workspace_path):
         """Test that stale worker cleanup handles both modes correctly."""
-        # Check if Docker is available
-        try:
-            import docker
-
-            docker_client = docker.from_env()
-            docker_client.ping()
-        except Exception:
+        if not _docker_daemon_available():
             pytest.skip("Docker daemon not available")
 
-        # Manually insert stale workers of both types
+        # Manually insert stale workers of both types.
+        #
+        # ``last_heartbeat`` must be set explicitly: the column defaults to
+        # CURRENT_TIMESTAMP, so rows inserted without it are *fresh*, not
+        # stale. ``WorkerDiscovery`` has no executor for a hand-inserted direct
+        # worker and falls back to heartbeat age, so the "stale" direct worker
+        # was judged healthy and kept — the assertion below then failed on a
+        # test that had never actually created the state it names.
         conn = JobQueue(db_path)._get_conn()
 
         # Add stale direct worker
         conn.execute(
-            "INSERT INTO workers (worker_type, container_id, status) VALUES (?, ?, ?)",
-            ("notebook", "direct-notebook-0-stale123", "idle"),
+            "INSERT INTO workers (worker_type, container_id, status, last_heartbeat, started_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (
+                "notebook",
+                "direct-notebook-0-stale123",
+                "idle",
+                ANCIENT_TIMESTAMP,
+                ANCIENT_TIMESTAMP,
+            ),
         )
 
         # Add stale docker worker (non-existent container)
         conn.execute(
-            "INSERT INTO workers (worker_type, container_id, status) VALUES (?, ?, ?)",
-            ("drawio", "nonexistent-container-id", "idle"),
+            "INSERT INTO workers (worker_type, container_id, status, last_heartbeat, started_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("drawio", "nonexistent-container-id", "idle", ANCIENT_TIMESTAMP, ANCIENT_TIMESTAMP),
         )
 
         conn.commit()


### PR DESCRIPTION
Follow-up to #667. Pointing `test_direct_integration.py`'s `find_spec` guards at
the real worker packages un-skipped the whole module — including
`TestMixedModeIntegration`, whose two Docker-marked tests then failed the
**Docker Integration Tests** job on master. Both were stale in ways the permanent
skip had hidden. This is the triage the Phase 1 plan asks for; both turned out to
be stale tests, not product bugs.

## `test_mixed_worker_modes`

Hard-coded `image="drawio-converter:latest"`. CLM has not published that tag since
the images gained their `clm-` prefix: CI builds `clm-drawio-converter:test`, and
the published image is `docker.io/mhoelzl/clm-drawio-converter:latest`. The Docker
client therefore attempted a registry **pull**:

```
docker.errors.ImageNotFound: 404 ... pull access denied for drawio-converter,
repository does not exist or may require 'docker login'
```

Now resolved from the same candidate list `tests/e2e/test_e2e_lifecycle.py` uses,
and **skipped with a stated reason** when no image is available rather than
degrading to a direct-only run — mixed mode is the entire subject of the test.

## `test_stale_worker_cleanup_mixed_mode`

Inserted its two "stale" worker rows without `last_heartbeat`, so the column took
its `CURRENT_TIMESTAMP` default and the rows were **fresh**. `WorkerDiscovery` has
no executor for a hand-inserted direct worker and falls back to heartbeat age, so
it correctly reported that worker healthy and `cleanup_stale_workers` correctly
kept it:

```
Worker 1 is direct worker direct-notebook-0-stale123, still healthy, keeping it
Worker 2 container nonexistent- not found, removing worker record
AssertionError: assert 1 == 0
```

The test asserted removal of state it had never created. The rows now carry an
unambiguously old heartbeat — which also keeps the test honest under the
UTC-vs-local skew in the health checks (finding C8, Phase 5).

## Verification

Run locally against a **real container** (`docker.io/mhoelzl/clm-drawio-converter:latest`
resolved, `clm-drawio-worker-0` started):

```
pytest tests/infrastructure/workers/test_direct_integration.py::TestMixedModeIntegration -m ""
2 passed
```

Confirmed before the fix that both failed for the reasons above, and that
supplying a genuinely old heartbeat makes cleanup remove both rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEAsC4QkeoDw34FEBNdh1K
