### PR TITLE
test: make the CLI build integration tests able to fail (Phase 1 / T4)

### DIFF
--- a/changelog.d/669-cli-integration-tests-that-cannot-fail.fixed.md
+++ b/changelog.d/669-cli-integration-tests-that-cannot-fail.fixed.md
@@ -1,0 +1,13 @@
+- **The CLI build integration tests can now fail.** Every functional assertion in
+  `tests/cli/test_cli_integration.py` was wrapped in `if result.exit_code == 0:`,
+  one assertion was a literal tautology (`assert "does not exist" in output or
+  exit_code != 0`, immediately after asserting `exit_code != 0`), and the course
+  output check globbed `kurs-2-*` — a pattern that has matched nothing since the
+  three-tier default output structure landed. The suite reported green for
+  "CLI → Backend → Workers → Output" while only detecting argument-parsing typos.
+  Build success and the produced output tree are now asserted directly,
+  `--clear-cache` is verified against a seeded sentinel row with a
+  no-flag control run, and each error case asserts its specific diagnostic. The
+  tests also pin `--cache-db-path` under `tmp_path`; they previously wrote a
+  multi-megabyte `clm_cache.db` into the working tree and shared it across xdist
+  workers.

--- a/tests/cli/test_cli_integration.py
+++ b/tests/cli/test_cli_integration.py
@@ -5,15 +5,193 @@ These tests run the CLI with real backend and worker processes.
 They verify that the full CLI → Backend → Workers → Output pipeline works.
 
 Mark with @pytest.mark.integration to run separately from unit tests.
+
+**These tests must be able to fail.** They previously wrapped every functional
+assertion in ``if result.exit_code == 0:``, so a build that crashed on every
+invocation would still produce a green checkmark for
+"CLI → Backend → Workers → Output" (finding T4 of the 2026-07-24 adversarial
+review). A real build of ``test-spec-2`` succeeds both locally and in CI, so
+success is asserted directly. If one of these ever legitimately cannot run in
+some environment, skip it with a stated reason — a skip is honest, a swallowed
+assertion is not.
 """
 
-import shutil
+import sqlite3
 from pathlib import Path
 
 import pytest
 from click.testing import CliRunner
+from click.testing import Result as CliResult
 
 from clm.cli.main import cli
+
+# Committed test fixtures. These ship with the repository, so a missing file is
+# a broken checkout, not an environment CLM should quietly skip around.
+SPEC_FILE = Path("test-data/course-specs/test-spec-2.xml")
+DATA_DIR = Path("test-data")
+
+# Course name from test-spec-2.xml, in both languages.
+COURSE_DIR_DE = "Kurs 2-de"
+COURSE_DIR_EN = "Kurs 2-en"
+
+# A cache row no build can produce: seeded before a run so the test can tell
+# whether ``--clear-cache`` actually dropped the table.
+SENTINEL_FILE_PATH = "::clear-cache-sentinel::"
+
+
+def _require_test_data() -> None:
+    """Fail loudly if the committed fixtures are missing.
+
+    This used to be ``pytest.skip("Test data not available")``. A skip on data
+    that is checked into the repository can only ever mean "these tests are
+    silently not running", which is the exact failure mode finding T1
+    documented for the worker integration suite.
+    """
+    assert SPEC_FILE.exists(), (
+        f"Committed test fixture {SPEC_FILE} is missing (cwd={Path.cwd()}). "
+        f"These tests must run from the repository root."
+    )
+    assert DATA_DIR.is_dir(), f"Committed test data directory {DATA_DIR} is missing."
+
+
+def _invoke_build(
+    runner: CliRunner,
+    tmp_path: Path,
+    *,
+    output_dir: Path | None = None,
+    cache_db: Path | None = None,
+    jobs_db: Path | None = None,
+    spec_file: Path = SPEC_FILE,
+    data_dir: Path = DATA_DIR,
+    build_args: list[str] | None = None,
+) -> CliResult:
+    """Invoke ``clm build`` with every database path pinned under *tmp_path*.
+
+    Pinning the *cache* DB matters and was previously missing: the option
+    defaults to ``clm_cache.db`` anchored at the discovered project root
+    (``main.py:_anchor_default``), so these tests wrote a multi-megabyte cache
+    database into the working tree and shared it across xdist workers.
+    """
+    return runner.invoke(
+        cli,
+        [
+            "--jobs-db-path",
+            str(jobs_db or tmp_path / "jobs.db"),
+            "--cache-db-path",
+            str(cache_db or tmp_path / "cache.db"),
+            "--telemetry-db-path",
+            str(tmp_path / "telemetry.db"),
+            "build",
+            str(spec_file),
+            "--data-dir",
+            str(data_dir),
+            "--output-dir",
+            str(output_dir or tmp_path / "output"),
+            "--log-level",
+            "WARNING",
+            *(build_args or []),
+        ],
+    )
+
+
+def _assert_build_succeeded(result: CliResult) -> None:
+    """Assert the build exited cleanly, showing why when it did not."""
+    assert result.exit_code == 0, (
+        f"clm build exited {result.exit_code}\n"
+        f"--- output ---\n{result.output}\n"
+        f"--- exception ---\n{result.exception!r}"
+    )
+
+
+def _tree_summary(output_dir: Path, limit: int = 40) -> str:
+    """Render the produced tree, so a failure says what *was* built."""
+    if not output_dir.exists():
+        return "<output dir does not exist>"
+    files = sorted(str(p.relative_to(output_dir)) for p in output_dir.rglob("*") if p.is_file())
+    if not files:
+        return "<no files>"
+    suffix = f"\n  … (+{len(files) - limit} more)" if len(files) > limit else ""
+    return "\n  " + "\n  ".join(files[:limit]) + suffix
+
+
+def _assert_course_output_present(output_dir: Path) -> None:
+    """Assert the build produced the expected course tree, not just a directory.
+
+    The previous version globbed ``output_dir/kurs-2-*`` — a pattern that has
+    matched nothing since the three-tier default output structure landed
+    (PR #386) — and then only asserted *inside* ``if course_dirs:``, so it
+    could not fail either way.
+    """
+    assert output_dir.is_dir(), f"{output_dir} was not created"
+
+    trainer = output_dir / "trainer"
+    assert trainer.is_dir(), f"no trainer/ tier under {output_dir}: {_tree_summary(output_dir)}"
+
+    for course_dir in (COURSE_DIR_DE, COURSE_DIR_EN):
+        assert (trainer / course_dir).is_dir(), (
+            f"missing {course_dir} under {trainer}: {_tree_summary(output_dir)}"
+        )
+
+    # One representative artefact per output format, proving the notebook
+    # worker actually ran rather than the tree merely being scaffolded.
+    en_slides = trainer / COURSE_DIR_EN / "Slides"
+    expected = [
+        en_slides / "Html" / "Completed" / "Week 1" / "01 Slides from Test 3.html",
+        en_slides / "Notebooks" / "Completed" / "Week 1" / "01 Slides from Test 3.ipynb",
+        en_slides / "Python" / "Completed" / "Week 1" / "01 Slides from Test 3.py",
+    ]
+    missing = [str(p.relative_to(output_dir)) for p in expected if not p.is_file()]
+    assert not missing, f"missing build outputs {missing}: {_tree_summary(output_dir)}"
+
+
+def _seed_cache_sentinel(cache_db: Path) -> None:
+    """Insert a row into the cache DB that no build could ever write.
+
+    The schema mirrors ``DatabaseManager.init_db``; only the columns the
+    assertions read are populated.
+    """
+    cache_db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(cache_db)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS processed_files (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                file_path TEXT,
+                content_hash TEXT,
+                correlation_id TEXT,
+                result BLOB,
+                output_metadata TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO processed_files (file_path, content_hash, output_metadata) "
+            "VALUES (?, ?, ?)",
+            (SENTINEL_FILE_PATH, "sentinel", "sentinel"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _cache_row_counts(cache_db: Path) -> tuple[int, int]:
+    """Return ``(sentinel_rows, genuine_rows)`` in the cache DB."""
+    assert cache_db.exists(), f"cache database {cache_db} was never created"
+    conn = sqlite3.connect(cache_db)
+    try:
+        sentinel = conn.execute(
+            "SELECT COUNT(*) FROM processed_files WHERE file_path = ?",
+            (SENTINEL_FILE_PATH,),
+        ).fetchone()[0]
+        genuine = conn.execute(
+            "SELECT COUNT(*) FROM processed_files WHERE file_path != ?",
+            (SENTINEL_FILE_PATH,),
+        ).fetchone()[0]
+        return sentinel, genuine
+    finally:
+        conn.close()
 
 
 @pytest.mark.integration
@@ -21,181 +199,91 @@ class TestCliWithSqliteBackend:
     """Integration tests using SQLite backend (no external dependencies)"""
 
     def test_build_simple_course_with_sqlite(self, tmp_path):
-        """Test building a simple course via CLI with SQLite backend"""
+        """A full CLI build of test-spec-2 succeeds and produces the course tree."""
+        _require_test_data()
         runner = CliRunner()
-
-        # Use test-spec-2 which is a simple course
-        spec_file = Path("test-data/course-specs/test-spec-2.xml")
-        data_dir = Path("test-data")
         output_dir = tmp_path / "output"
 
-        if not spec_file.exists():
-            pytest.skip("Test data not available")
-
-        result = runner.invoke(
-            cli,
-            [
-                "--jobs-db-path",
-                str(tmp_path / "test.db"),
-                "build",
-                str(spec_file),
-                "--data-dir",
-                str(data_dir),
-                "--output-dir",
-                str(output_dir),
-                "--log-level",
-                "WARNING",  # Reduce log noise in tests
-                "--ignore-cache",  # Don't use cache for clean test
-            ],
+        result = _invoke_build(
+            runner, tmp_path, output_dir=output_dir, build_args=["--ignore-cache"]
         )
 
-        # The command should complete successfully
-        # Note: This might fail if workers aren't available, but that's expected
-        # We're mainly testing that the CLI invocation works
-        if result.exit_code != 0:
-            print("STDOUT:", result.output)
-            # Allow failure if it's due to missing workers or execution issues
-            # but not due to argument parsing
-            assert "no such option" not in result.output.lower()
-            assert "missing argument" not in result.output.lower()
-
-        # If successful, verify output structure exists
-        if result.exit_code == 0:
-            assert output_dir.exists()
-            # Check for course output directories
-            course_dirs = list(output_dir.glob("kurs-2-*"))
-            if course_dirs:  # Only check if course was processed
-                assert len(course_dirs) > 0
+        _assert_build_succeeded(result)
+        _assert_course_output_present(output_dir)
 
     def test_build_with_clear_cache(self, tmp_path):
-        """Test that --clear-cache flag works correctly"""
+        """``--clear-cache`` drops existing cache rows; without it they survive.
+
+        Asserting on a sentinel row is what makes this test able to fail: the
+        build repopulates ``processed_files`` immediately after clearing it, so
+        a plain row count proves nothing. The no-flag run is the control — the
+        pair fails if ``--clear-cache`` becomes a no-op *or* if clearing starts
+        happening unconditionally.
+        """
+        _require_test_data()
         runner = CliRunner()
+        cache_db = tmp_path / "cache.db"
 
-        spec_file = Path("test-data/course-specs/test-spec-2.xml")
-        data_dir = Path("test-data")
-        output_dir = tmp_path / "output"
-        db_path = tmp_path / "test.db"
+        # --- with --clear-cache: the pre-existing row must be gone -----------
+        _seed_cache_sentinel(cache_db)
+        assert _cache_row_counts(cache_db) == (1, 0)
 
-        if not spec_file.exists():
-            pytest.skip("Test data not available")
-
-        # First run - creates database
-        result1 = runner.invoke(
-            cli,
-            [
-                "--jobs-db-path",
-                str(db_path),
-                "build",
-                str(spec_file),
-                "--data-dir",
-                str(data_dir),
-                "--output-dir",
-                str(output_dir),
-                "--log-level",
-                "ERROR",
-                "--clear-cache",
-            ],
+        result = _invoke_build(
+            runner,
+            tmp_path,
+            output_dir=tmp_path / "output-cleared",
+            cache_db=cache_db,
+            jobs_db=tmp_path / "jobs-cleared.db",
+            build_args=["--clear-cache"],
         )
+        _assert_build_succeeded(result)
 
-        # Verify no argument errors
-        assert "no such option" not in result1.output.lower()
+        sentinel, genuine = _cache_row_counts(cache_db)
+        assert sentinel == 0, "--clear-cache did not drop the pre-existing cache rows"
+        assert genuine > 0, "the build did not repopulate the cache after clearing it"
 
-        # Second run - should reinitialize database
-        result2 = runner.invoke(
-            cli,
-            [
-                "--jobs-db-path",
-                str(db_path),
-                "build",
-                str(spec_file),
-                "--data-dir",
-                str(data_dir),
-                "--output-dir",
-                str(output_dir),
-                "--log-level",
-                "ERROR",
-                "--clear-cache",
-            ],
+        # --- without --clear-cache: the same row must survive ----------------
+        _seed_cache_sentinel(cache_db)
+        result = _invoke_build(
+            runner,
+            tmp_path,
+            output_dir=tmp_path / "output-kept",
+            cache_db=cache_db,
+            jobs_db=tmp_path / "jobs-kept.db",
         )
+        _assert_build_succeeded(result)
 
-        # Verify no argument errors
-        assert "no such option" not in result2.output.lower()
+        sentinel, genuine = _cache_row_counts(cache_db)
+        assert sentinel == 1, "a build without --clear-cache dropped existing cache rows"
+        assert genuine > 0
 
     def test_build_with_custom_db_path(self, tmp_path):
-        """Test that custom database path is used correctly"""
+        """Custom database paths are honoured and the build still succeeds."""
+        _require_test_data()
         runner = CliRunner()
 
-        spec_file = Path("test-data/course-specs/test-spec-2.xml")
-        data_dir = Path("test-data")
-        output_dir = tmp_path / "output"
-        db_path = tmp_path / "custom" / "my_cache.db"
-        db_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_db = tmp_path / "custom" / "my_cache.db"
+        jobs_db = tmp_path / "custom" / "my_jobs.db"
+        cache_db.parent.mkdir(parents=True, exist_ok=True)
 
-        if not spec_file.exists():
-            pytest.skip("Test data not available")
+        result = _invoke_build(runner, tmp_path, cache_db=cache_db, jobs_db=jobs_db)
 
-        result = runner.invoke(
-            cli,
-            [
-                "--jobs-db-path",
-                str(db_path),
-                "build",
-                str(spec_file),
-                "--data-dir",
-                str(data_dir),
-                "--output-dir",
-                str(output_dir),
-                "--log-level",
-                "ERROR",
-            ],
-        )
-
-        # Verify no argument parsing errors
-        assert "no such option" not in result.output.lower()
-
-        # If build was successful, database should exist at custom path
-        if result.exit_code == 0:
-            assert db_path.exists()
+        _assert_build_succeeded(result)
+        assert cache_db.exists(), f"cache database not created at {cache_db}"
+        assert _cache_row_counts(cache_db)[1] > 0, "custom cache database was never populated"
 
     def test_build_output_directory_creation(self, tmp_path):
-        """Test that output directory is created if it doesn't exist"""
+        """A non-existent output directory is created by the build."""
+        _require_test_data()
         runner = CliRunner()
-
-        spec_file = Path("test-data/course-specs/test-spec-2.xml")
-        data_dir = Path("test-data")
         output_dir = tmp_path / "new_output_dir"
-
-        if not spec_file.exists():
-            pytest.skip("Test data not available")
-
-        # Output dir doesn't exist yet
         assert not output_dir.exists()
 
-        result = runner.invoke(
-            cli,
-            [
-                "--jobs-db-path",
-                str(tmp_path / "test.db"),
-                "build",
-                str(spec_file),
-                "--data-dir",
-                str(data_dir),
-                "--output-dir",
-                str(output_dir),
-                "--log-level",
-                "ERROR",
-            ],
-        )
+        result = _invoke_build(runner, tmp_path, output_dir=output_dir)
 
-        # Verify no argument errors
-        assert "no such option" not in result.output.lower()
-
-        # Output directory should be created (even if processing fails)
-        # Note: The output dir is created in the main() function
-        # This might not happen if parsing fails early
-        if "does not exist" not in result.output.lower():
-            # If no error about directory, it should have been created
-            assert output_dir.exists() or result.exit_code != 0
+        _assert_build_succeeded(result)
+        assert output_dir.is_dir(), "output directory was not created"
+        _assert_course_output_present(output_dir)
 
 
 @pytest.mark.integration
@@ -272,70 +360,33 @@ class TestCliBuildWithDifferentOptions:
     """Test various CLI build option combinations"""
 
     def test_build_with_ignore_cache_flag(self, tmp_path):
-        """Test that --ignore-cache flag is accepted and works"""
+        """``--ignore-cache`` still produces a complete build."""
+        _require_test_data()
         runner = CliRunner()
-
-        spec_file = Path("test-data/course-specs/test-spec-2.xml")
-        data_dir = Path("test-data")
         output_dir = tmp_path / "output"
 
-        if not spec_file.exists():
-            pytest.skip("Test data not available")
-
-        result = runner.invoke(
-            cli,
-            [
-                "--jobs-db-path",
-                str(tmp_path / "test.db"),
-                "build",
-                str(spec_file),
-                "--data-dir",
-                str(data_dir),
-                "--output-dir",
-                str(output_dir),
-                "--ignore-cache",
-                "--log-level",
-                "ERROR",
-            ],
+        result = _invoke_build(
+            runner, tmp_path, output_dir=output_dir, build_args=["--ignore-cache"]
         )
 
-        # Verify no argument errors
-        assert "no such option" not in result.output.lower()
-        assert "missing argument" not in result.output.lower()
+        _assert_build_succeeded(result)
+        _assert_course_output_present(output_dir)
 
     def test_build_all_boolean_flags_together(self, tmp_path):
-        """Test combining multiple boolean flags"""
+        """Combining the boolean build flags still produces a complete build."""
+        _require_test_data()
         runner = CliRunner()
-
-        spec_file = Path("test-data/course-specs/test-spec-2.xml")
-        data_dir = Path("test-data")
         output_dir = tmp_path / "output"
 
-        if not spec_file.exists():
-            pytest.skip("Test data not available")
-
-        result = runner.invoke(
-            cli,
-            [
-                "--jobs-db-path",
-                str(tmp_path / "test.db"),
-                "build",
-                str(spec_file),
-                "--data-dir",
-                str(data_dir),
-                "--output-dir",
-                str(output_dir),
-                "--ignore-cache",
-                "--clear-cache",
-                "--print-correlation-ids",
-                "--log-level",
-                "ERROR",
-            ],
+        result = _invoke_build(
+            runner,
+            tmp_path,
+            output_dir=output_dir,
+            build_args=["--ignore-cache", "--clear-cache", "--print-correlation-ids"],
         )
 
-        # Verify no argument parsing errors
-        assert "no such option" not in result.output.lower()
-        assert "missing argument" not in result.output.lower()
+        _assert_build_succeeded(result)
+        _assert_course_output_present(output_dir)
 
 
 @pytest.mark.integration
@@ -343,60 +394,38 @@ class TestCliErrorHandling:
     """Test CLI error handling and edge cases"""
 
     def test_build_with_invalid_spec_file_content(self, tmp_path):
-        """Test that CLI handles invalid XML spec files gracefully"""
+        """An unparseable spec file fails with a spec-file diagnostic, not a traceback."""
         runner = CliRunner()
 
         spec_file = tmp_path / "invalid.xml"
         spec_file.write_text("This is not valid XML")
         data_dir = tmp_path / "data"
         data_dir.mkdir()
-        output_dir = tmp_path / "output"
 
-        result = runner.invoke(
-            cli,
-            [
-                "--jobs-db-path",
-                str(tmp_path / "test.db"),
-                "build",
-                str(spec_file),
-                "--data-dir",
-                str(data_dir),
-                "--output-dir",
-                str(output_dir),
-                "--log-level",
-                "ERROR",
-            ],
-        )
+        result = _invoke_build(runner, tmp_path, spec_file=spec_file, data_dir=data_dir)
 
-        # Should fail, but gracefully
         assert result.exit_code != 0
+        output = result.output.lower()
+        assert "spec file error" in output, result.output
+        assert "xml parsing error" in output, result.output
 
     def test_build_with_nonexistent_data_dir(self, tmp_path):
-        """Test that CLI handles non-existent data directory"""
+        """A non-existent ``--data-dir`` is rejected by Click's own validation.
+
+        The old assertion was ``assert "does not exist" in output or exit_code != 0``
+        immediately after ``assert exit_code != 0`` — a tautology that passed on
+        any failure whatsoever, including an unrelated crash.
+        """
         runner = CliRunner()
 
         spec_file = tmp_path / "test.xml"
         spec_file.write_text('<?xml version="1.0"?><course><name>Test</name></course>')
         data_dir = tmp_path / "nonexistent_data"
-        output_dir = tmp_path / "output"
 
-        result = runner.invoke(
-            cli,
-            [
-                "--jobs-db-path",
-                str(tmp_path / "test.db"),
-                "build",
-                str(spec_file),
-                "--data-dir",
-                str(data_dir),
-                "--output-dir",
-                str(output_dir),
-                "--log-level",
-                "ERROR",
-            ],
-        )
+        result = _invoke_build(runner, tmp_path, spec_file=spec_file, data_dir=data_dir)
 
-        # Should fail because data dir doesn't exist
-        assert result.exit_code != 0
-        # Click validation should catch this
-        assert "does not exist" in result.output.lower() or result.exit_code != 0
+        # A Click usage error, not a generic failure.
+        assert result.exit_code == 2, result.output
+        output = result.output.lower()
+        assert "--data-dir" in output, result.output
+        assert "does not exist" in output, result.output


### PR DESCRIPTION
Phase 1 of the 2026-07-24 adversarial review remediation plan — finding **T4**.

`tests/cli/test_cli_integration.py` claimed to cover
"CLI → Backend → Workers → Output" and could only detect argument-parsing typos.

## What could not fail

| Line | Problem |
|---|---|
| `:55-68` | every functional assertion inside `if result.exit_code == 0:` |
| `:400-402` | `assert "does not exist" in output or exit_code != 0`, immediately after `assert exit_code != 0` — a tautology |
| `:66-68` | globbed `output_dir/kurs-2-*`, which has matched nothing since the three-tier default output structure (PR #386), then asserted only *inside* `if course_dirs:` |
| `:196-198` | `assert output_dir.exists() or result.exit_code != 0` |
| `test_build_with_clear_cache` | never verified anything was cleared |

A real build of `test-spec-2` exits 0 and produces 111 files locally and in CI,
so success is asserted directly. No test was deleted or marked skipped.

## What replaced it

- `_assert_build_succeeded` — hard `exit_code == 0`, printing the output and the
  exception when it fails.
- `_assert_course_output_present` — asserts the `trainer/` tier, both course
  directories, and one representative artefact per output format
  (`.html` / `.ipynb` / `.py`). That last part is what proves the notebook worker
  ran rather than the tree merely being scaffolded. Failures print the tree that
  *was* built.
- `test_build_with_clear_cache` — seeds a sentinel row into `processed_files`
  that no build could write, then runs **with** and **without** the flag. A plain
  row count proves nothing, because the build repopulates the table immediately
  after clearing it; the contrast fails both if `--clear-cache` becomes a no-op
  and if clearing starts happening unconditionally.
- Error cases assert their specific diagnostic (`spec file error` +
  `xml parsing error`; Click exit code 2 + `--data-dir` + `does not exist`).
- `pytest.skip("Test data not available")` on fixtures committed to the
  repository became an assertion. A skip there can only mean the tests are
  silently not running — the T1 failure mode.

## Bonus: repo pollution

These tests left `--cache-db-path` at its default, which `main.py:_anchor_default`
anchors to the discovered **project root**. Each run wrote a ~4.6 MB
`clm_cache.db` into the working tree (gitignored, so invisible in `git status`)
and shared it across xdist workers. All three database paths are now pinned under
`tmp_path`.

## Verification

```
pytest tests/cli/test_cli_integration.py -m ""     10 passed in 120s
```

Mutation-checked — both new assertion families have teeth:

- corrupting the expected output filename →
  `AssertionError: missing build outputs ['trainer\Kurs 2-en\...MUTANT.html']`
- dropping `--clear-cache` from the invocation →
  `AssertionError: --clear-cache did not drop the pre-existing cache rows`

Runtime went 105s → 121s serially (the tests now do real work instead of
short-circuiting); this module is `integration`-marked, so it is outside the
72-second pre-push gate.

Test-only change; no production code touched. No adversarial review run.

## Note, not fixed here

`test-data/course-specs/test-spec-6-failing.xml` is referenced by no test at all.
Building it takes 263s and exits **0** — which is correct, since `--fail-on-error`
defaults off. Recording it here rather than expanding this PR's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEAsC4QkeoDw34FEBNdh1K
