### PR TITLE
test: close three test-integrity gaps (Phase 1 / T5, T6, T10)

### DIFF
--- a/changelog.d/670-test-integrity-t5-t6-t10.fixed.md
+++ b/changelog.d/670-test-integrity-t5-t6-t10.fixed.md
@@ -1,0 +1,13 @@
+- **Three test-integrity gaps closed.** The PlantUML and DrawIO end-to-end tests
+  logged the number of rendered images and asserted nothing, so they passed even
+  when the converter produced no output at all; they now assert that images
+  exist and carry a real PNG signature. `AssertionError` was removed from the
+  `flaky` `only_rerun` lists in `test_worker_base.py` and `test_lifecycle_mock.py`
+  — an intermittent race in the real claim/heartbeat loop surfaces as exactly
+  that exception, so retrying on it hid the class of bug those tests exist to
+  catch. PlantUML JAR discovery now happens in one place: the fallback path in
+  `tests/conftest.py` pointed at the pre-PR-#239 vendored location and matched
+  nothing, leaving local availability to depend on an import-time `os.environ`
+  mutation in `tests/workers/plantuml/test_plantuml_converter.py`, which made
+  availability collection-order-dependent under xdist. That mutation is gone and
+  the surviving fallbacks name paths that exist.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -427,17 +427,32 @@ COURSE_2_XML = """
 DATA_DIR = Path(__file__).parent / "test-data"
 
 
+# Repository root (this file lives in ``<repo>/tests/``).
+REPO_ROOT = Path(__file__).parent.parent
+
+# Where the PlantUML JAR lives in a checkout. The old discovery path pointed at
+# ``tests/services/plantuml-converter/`` — the pre-PR-#239 vendored location,
+# which no longer exists, so this fallback silently found nothing and local
+# availability depended on an import-time ``os.environ`` mutation in
+# ``tests/workers/plantuml/test_plantuml_converter.py`` (finding T10). That
+# made PlantUML availability ordering-dependent under xdist. This is now the
+# single fallback, and the test module no longer touches the environment.
+PLANTUML_JAR_CANDIDATES = [
+    REPO_ROOT / "docker" / "plantuml" / "plantuml-1.2024.6.jar",
+]
+
+
 # Configure external tool paths at module load time
 # This ensures they're available before test collection
 def _setup_external_tools():
     """Set up environment variables for external tools if not already set."""
     # PlantUML JAR path
     if "PLANTUML_JAR" not in os.environ:
-        repo_root = Path(__file__).parent
-        plantuml_jar = repo_root / "services" / "plantuml-converter" / "plantuml-1.2024.6.jar"
-        if plantuml_jar.exists():
-            os.environ["PLANTUML_JAR"] = str(plantuml_jar)
-            logging.info(f"PLANTUML_JAR set to: {plantuml_jar}")
+        for plantuml_jar in PLANTUML_JAR_CANDIDATES:
+            if plantuml_jar.exists():
+                os.environ["PLANTUML_JAR"] = str(plantuml_jar)
+                logging.info(f"PLANTUML_JAR set to: {plantuml_jar}")
+                break
 
     # Draw.io executable path
     if "DRAWIO_EXECUTABLE" not in os.environ:

--- a/tests/e2e/test_e2e_course_conversion.py
+++ b/tests/e2e/test_e2e_course_conversion.py
@@ -111,13 +111,14 @@ def check_plantuml_available() -> bool:
         except (subprocess.CalledProcessError, FileNotFoundError):
             return False
 
-    # Check default paths
+    # Check default paths. The second entry pointed at
+    # ``services/plantuml-converter/`` — the pre-PR-#239 vendored location,
+    # which no longer exists (finding T10). In practice the root
+    # ``tests/conftest.py`` sets ``PLANTUML_JAR`` before this runs, so this is
+    # a belt-and-braces fallback; it should still name a real path.
     default_paths = [
-        Path("/app/plantuml.jar"),
-        Path(__file__).parent.parent.parent
-        / "services"
-        / "plantuml-converter"
-        / "plantuml-1.2024.6.jar",
+        Path("/app/plantuml.jar"),  # container layout
+        Path(__file__).parents[2] / "docker" / "plantuml" / "plantuml-1.2024.6.jar",
     ]
     for path in default_paths:
         if path.exists():
@@ -216,6 +217,30 @@ def validate_course_output_structure(output_dir: Path, dir_name: str):
 
     logger.info(f"Validated output structure for {dir_name}")
     return shared_dir
+
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+def _assert_rendered_pngs(images: list[Path], search_root: Path, renderer: str) -> None:
+    """Assert a diagram renderer actually produced usable PNGs.
+
+    The PlantUML and DrawIO e2e tests used to ``logger.info`` the image count
+    and assert nothing (finding T5), so they passed even when the converter
+    produced no output at all — the only thing they really verified was that
+    the build did not hang. Checking the PNG signature as well as the count
+    means a zero-byte or truncated render fails here rather than surfacing as
+    a broken image in a deck.
+    """
+    assert images, (
+        f"{renderer} produced no PNG images under {search_root}. "
+        f"Files present: {sorted(p.name for p in search_root.rglob('*') if p.is_file())}"
+    )
+    for image in images:
+        data = image.read_bytes()
+        assert data.startswith(PNG_MAGIC), (
+            f"{renderer} output {image} is not a PNG ({len(data)} bytes, starts with {data[:8]!r})"
+        )
 
 
 def count_notebooks_in_dir(directory: Path) -> int:
@@ -1134,12 +1159,17 @@ async def test_course_4_single_plantuml_e2e(e2e_course_4, sqlite_backend_with_pl
     de_dir = validate_course_output_structure(output_dir, "Einfaches PlantUML-de")
     en_dir = validate_course_output_structure(output_dir, "Simple PlantUML-en")
 
-    # Check that plantuml images were generated
+    # Check that plantuml images were generated. These used to be logged and
+    # never asserted, so the test passed even when the converter produced
+    # nothing at all — the only thing it really checked was that the build did
+    # not hang (finding T5).
     de_images = list(de_dir.rglob("*.png"))
     logger.info(f"Found {len(de_images)} German images (from plantuml)")
+    _assert_rendered_pngs(de_images, de_dir, "plantuml")
 
     en_images = list(en_dir.rglob("*.png"))
     logger.info(f"Found {len(en_images)} English images (from plantuml)")
+    _assert_rendered_pngs(en_images, en_dir, "plantuml")
 
     logger.info("Course 4 (single plantuml) E2E test completed successfully")
 
@@ -1177,12 +1207,15 @@ async def test_course_5_single_drawio_e2e(e2e_course_5, sqlite_backend_with_draw
     de_dir = validate_course_output_structure(output_dir, "Einfaches Drawio-de")
     en_dir = validate_course_output_structure(output_dir, "Simple Drawio-en")
 
-    # Check that draw.io images were generated
+    # Check that draw.io images were generated. Same log-but-never-assert gap
+    # as the PlantUML test above (finding T5).
     de_images = list(de_dir.rglob("*.png"))
     logger.info(f"Found {len(de_images)} German images (from draw.io)")
+    _assert_rendered_pngs(de_images, de_dir, "draw.io")
 
     en_images = list(en_dir.rglob("*.png"))
     logger.info(f"Found {len(en_images)} English images (from draw.io)")
+    _assert_rendered_pngs(en_images, en_dir, "draw.io")
 
     logger.info("Course 5 (single draw.io) E2E test completed successfully")
 

--- a/tests/infrastructure/workers/test_lifecycle_mock.py
+++ b/tests/infrastructure/workers/test_lifecycle_mock.py
@@ -33,6 +33,13 @@ from tests.fixtures.mock_workers import MockWorker, MockWorkerConfig, MockWorker
 # regression — which fails deterministically on every retry — red. ``-rR`` in
 # addopts makes any retry visible; a test that reruns often wants a root-cause
 # fix, not more retries.
+#
+# ``AssertionError`` is deliberately NOT in this list (finding T6). An
+# intermittent race in the claim/registration loop manifests as an assertion
+# that holds on the retry, so retrying on it would hide exactly the class of
+# production bug these tests exist to catch. Environment flakes — a locked
+# SQLite file, a denied unlink, a starved poll — raise their own exception
+# types, which stay listed.
 pytestmark = [
     pytest.mark.serial("workerpool"),
     pytest.mark.flaky(
@@ -41,7 +48,6 @@ pytestmark = [
         only_rerun=[
             "OSError",
             "PermissionError",
-            "AssertionError",
             "OperationalError",
             "TimeoutError",
         ],

--- a/tests/infrastructure/workers/test_worker_base.py
+++ b/tests/infrastructure/workers/test_worker_base.py
@@ -22,13 +22,19 @@ from clm.infrastructure.workers.worker_base import Worker
 # red, and ``-rR`` in addopts surfaces any retry). See the same marker on
 # ``test_lifecycle_mock.py`` for the rationale; do not widen it without fixing
 # the underlying contention.
+#
+# ``AssertionError`` is deliberately NOT in this list (finding T6). These tests
+# exercise the real claim/heartbeat loop, and an intermittent race in that loop
+# manifests as exactly one thing: an assertion that holds on the retry. Retrying
+# on it turns the suite's only signal for that class of production bug into
+# noise. Environment flakes — a locked SQLite file, a denied unlink, a starved
+# poll — raise their own exception types, which stay listed.
 pytestmark = pytest.mark.flaky(
     reruns=2,
     reruns_delay=1,
     only_rerun=[
         "OSError",
         "PermissionError",
-        "AssertionError",
         "OperationalError",
         "TimeoutError",
     ],

--- a/tests/workers/plantuml/test_plantuml_converter.py
+++ b/tests/workers/plantuml/test_plantuml_converter.py
@@ -7,7 +7,6 @@ This module tests the PlantUML conversion functionality including:
 - Error handling
 """
 
-import os
 import re
 import sys
 from pathlib import Path
@@ -21,32 +20,24 @@ def _can_import_plantuml():
     """Check if plantuml_converter can be imported."""
     try:
         # The module validates JAR path at import time
-        from clm.workers.plantuml import plantuml_converter
+        from clm.workers.plantuml import plantuml_converter  # noqa: F401
 
         return True
     except (FileNotFoundError, ImportError):
         return False
 
 
-# Try to find the PlantUML JAR
-def _find_plantuml_jar():
-    """Find PlantUML JAR in known locations."""
-    possible_paths = [
-        Path(__file__).parents[4] / "docker" / "plantuml" / "plantuml-1.2024.6.jar",
-        Path(__file__).parents[4] / "plantuml-1.2024.6.jar",
-    ]
-    for path in possible_paths:
-        if path.exists():
-            return str(path)
-    return None
-
-
-# Set the environment variable if needed
-_jar_path = _find_plantuml_jar()
-if _jar_path and not _can_import_plantuml():
-    os.environ["PLANTUML_JAR"] = _jar_path
-
-# Now try to import
+# ``PLANTUML_JAR`` is resolved once, in the root ``tests/conftest.py``
+# (``PLANTUML_JAR_CANDIDATES``), which pytest imports before any test module.
+#
+# This module used to mutate ``os.environ["PLANTUML_JAR"]`` at *import* time
+# from its own candidate list — whose paths were one directory level too high
+# (``parents[4]``, i.e. above the repository) and therefore never matched
+# anyway. Under xdist that arrangement made PlantUML availability depend on
+# collection order: whether this module happened to be imported before another
+# module that reads the variable (finding T10). Discovery now happens in
+# exactly one place and no test module writes to the environment at import
+# time.
 HAS_PLANTUML = _can_import_plantuml()
 
 # Skip module if PlantUML not available


### PR DESCRIPTION
Phase 1 of the 2026-07-24 adversarial review remediation plan — findings **T5**,
**T6** and **T10**. Test-only; no production code touched.

## T5 — an e2e test that logged instead of asserting

`test_course_4_single_plantuml_e2e` computed the rendered-image count and passed
it to `logger.info`. No assertion followed, so the test passed even if PlantUML
produced nothing at all — the only property it really checked was that the build
did not hang.

`test_course_5_single_drawio_e2e`, two functions further down, had the identical
hole. The review named only PlantUML; fixing one and leaving the other would be
odd, so both are fixed via one `_assert_rendered_pngs()` helper that asserts the
images exist **and** start with the PNG magic bytes — a zero-byte or truncated
render now fails in CI rather than surfacing as a broken image in a deck.

Mutation-checked: globbing a suffix that does not exist →
`AssertionError: plantuml produced no PNG images under ...`.

## T6 — `flaky` swallowing `AssertionError`

`test_worker_base.py` and `test_lifecycle_mock.py` drive the *real*
claim/heartbeat loop. An intermittent race there manifests as exactly one thing:
an assertion that happens to hold on the retry. Listing `AssertionError` in
`only_rerun` turned the suite's only signal for that bug class into noise.

Removed from both lists. The genuine environment flakes — `OSError`,
`PermissionError`, `OperationalError`, `TimeoutError` — keep their retries, and
the comments now state why the list stops where it does. The surrounding
discipline here was already good (no global reruns, scoped exceptions, `-rR` in
addopts); this is the one entry that did not belong.

## T10 — PlantUML JAR discovery was three stale paths and an import side effect

| Site | Looked at | Exists? |
|---|---|---|
| `tests/conftest.py:437` | `tests/services/plantuml-converter/plantuml-1.2024.6.jar` | no (pre-PR-#239 vendored location) |
| `tests/e2e/test_e2e_course_conversion.py:118` | `<root>/services/plantuml-converter/…` | no |
| `tests/workers/plantuml/test_plantuml_converter.py:35-36` | `parents[4]/docker/plantuml/…` | no — one level **above** the repository |

So every fallback missed, and the third site additionally mutated
`os.environ["PLANTUML_JAR"]` **at import time**. Under xdist that made PlantUML
availability depend on whether that module was collected before whatever read
the variable.

Discovery now lives in one place — `PLANTUML_JAR_CANDIDATES` in the root
conftest, pointing at the real `docker/plantuml/plantuml-1.2024.6.jar`. The
import-time mutation is gone and the e2e fallback names a path that exists.

Verified with `PLANTUML_JAR` unset from the environment:

```
env -u PLANTUML_JAR pytest tests/workers/plantuml/ -n0
  PlantUML: ✓ Available
  53 passed
```

## Verification

```
pytest tests/infrastructure/workers/test_worker_base.py tests/infrastructure/workers/test_lifecycle_mock.py -m ""   40 passed
pytest ...::test_course_4_single_plantuml_e2e ...::test_course_5_single_drawio_e2e -m ""                            2 passed
env -u PLANTUML_JAR pytest tests/workers/plantuml/                                                                  53 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEAsC4QkeoDw34FEBNdh1K
