### PR TITLE
test: claim through the real JobQueue in MockWorker (Phase 1 / T7)

### DIFF
--- a/changelog.d/671-mockworker-claiming-parity.fixed.md
+++ b/changelog.d/671-mockworker-claiming-parity.fixed.md
@@ -1,0 +1,9 @@
+- **`MockWorker` now claims jobs through the real `JobQueue.get_next_job`.** Its
+  hand-rolled `UPDATE … RETURNING` had drifted from the production claim path in
+  six ways — no `execution_mode` filter (PR #564's cross-mode job-theft guard),
+  no session-ownership filter (issue #620), no `attempts < max_attempts` guard,
+  no `attempts` increment, no `started_at` stamp and no `priority` ordering —
+  and wrote the container-id *string* into the integer `jobs.worker_id` column.
+  Terminal status now goes through `update_job_status` for the same reason. A
+  new `test_mock_worker_claiming_parity.py` pins each recovered property so the
+  fixture cannot drift again.

--- a/tests/fixtures/mock_workers.py
+++ b/tests/fixtures/mock_workers.py
@@ -21,6 +21,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
+from clm.infrastructure.database.job_queue import Job, JobQueue
+
 logger = logging.getLogger(__name__)
 
 # Generous ceiling for registration waits. The waits below return as soon as
@@ -55,6 +57,15 @@ class MockWorkerConfig:
     workspace_path: Path | None = None
     validate_paths: bool = False
     data_dir: Path | None = None
+    # Execution mode this worker registers under and claims with. Mock workers
+    # are their own mode, so a mock never steals a job a real Docker/Direct
+    # worker must run. Jobs with a NULL ``execution_mode`` stay claimable by
+    # anyone, which is what the mock tests submit.
+    execution_mode: str = "mock"
+    # Build session this worker belongs to (issue #620). ``None`` registers an
+    # unstamped worker, which the real queue leaves unrestricted — the legacy
+    # behaviour most mock tests want. Set it to exercise session ownership.
+    session_id: str | None = None
 
 
 @dataclass
@@ -164,9 +175,15 @@ class MockWorker:
         conn = self._get_conn()
         try:
             cursor = conn.execute(
-                """INSERT INTO workers (worker_type, container_id, status, execution_mode)
-                   VALUES (?, ?, 'idle', 'mock')""",
-                (self.config.worker_type, self.container_id),
+                """INSERT INTO workers
+                   (worker_type, container_id, status, execution_mode, session_id)
+                   VALUES (?, ?, 'idle', ?, ?)""",
+                (
+                    self.config.worker_type,
+                    self.container_id,
+                    self.config.execution_mode,
+                    self.config.session_id,
+                ),
             )
             self._db_worker_id = cursor.lastrowid
             conn.commit()
@@ -175,13 +192,18 @@ class MockWorker:
 
         self._registered_event.set()
 
-        # Main loop
-        while not self._stop_event.is_set():
-            job = self._poll_job()
-            if job:
-                self._process_job(job)
-            else:
-                self._stop_event.wait(self.config.poll_interval)
+        # One JobQueue for the worker thread. JobQueue keeps a thread-local
+        # connection, so it must be created and closed on this thread.
+        job_queue = JobQueue(self.db_path)
+        try:
+            while not self._stop_event.is_set():
+                job = self._poll_job(job_queue)
+                if job:
+                    self._process_job(job, job_queue)
+                else:
+                    self._stop_event.wait(self.config.poll_interval)
+        finally:
+            job_queue.close()
 
         # Mark worker as dead
         conn = self._get_conn()
@@ -194,48 +216,49 @@ class MockWorker:
         finally:
             conn.close()
 
-    def _poll_job(self) -> dict | None:
-        """Poll for a pending job from the queue.
+    def _poll_job(self, job_queue: "JobQueue") -> Job | None:
+        """Claim the next pending job using the **real** queue implementation.
 
-        Returns:
-            Job dictionary if a job was claimed, None otherwise
+        This used to be a hand-rolled ``UPDATE … RETURNING`` that had drifted
+        badly from ``JobQueue.get_next_job`` (finding T7): it had no
+        ``execution_mode`` filter, no session-ownership filter, no
+        ``attempts < max_attempts`` guard, did not increment ``attempts``, did
+        not set ``started_at``, ignored ``priority``, and wrote the *container
+        id string* into the integer ``jobs.worker_id`` column. The tier meant
+        to exercise real claiming with real workers together was the
+        permanently-skipped file from T1, so nothing caught the divergence.
+
+        Delegating removes the possibility of drifting again: any future change
+        to claiming semantics is picked up here for free.
         """
         conn = self._get_conn()
         try:
-            # Update worker status to idle
             conn.execute(
                 "UPDATE workers SET status = 'idle' WHERE container_id = ?",
                 (self.container_id,),
             )
             conn.commit()
+        finally:
+            conn.close()
 
-            # Try to claim a job
-            cursor = conn.execute(
-                """UPDATE jobs
-                   SET status = 'processing', worker_id = ?
-                   WHERE id = (
-                       SELECT id FROM jobs
-                       WHERE job_type = ? AND status = 'pending'
-                       ORDER BY created_at ASC
-                       LIMIT 1
-                   )
-                   RETURNING *""",
-                (self.container_id, self.config.worker_type),
-            )
-            row = cursor.fetchone()
-            conn.commit()
+        job = job_queue.get_next_job(
+            job_type=self.config.worker_type,
+            worker_id=self._db_worker_id,
+            execution_mode=self.config.execution_mode,
+        )
 
-            if row:
-                # Update worker status to busy
+        if job is not None:
+            conn = self._get_conn()
+            try:
                 conn.execute(
                     "UPDATE workers SET status = 'busy' WHERE container_id = ?",
                     (self.container_id,),
                 )
                 conn.commit()
-                return dict(row)
-            return None
-        finally:
-            conn.close()
+            finally:
+                conn.close()
+
+        return job
 
     def _validate_output_path(self, output_path: str) -> str | None:
         """Validate that output path would work in Docker mode.
@@ -308,22 +331,25 @@ class MockWorker:
 
         return None
 
-    def _process_job(self, job: dict) -> None:
+    def _process_job(self, job: Job, job_queue: "JobQueue") -> None:
         """Process a single job.
 
         Args:
-            job: Job dictionary from the database
+            job: Job claimed from the queue
+            job_queue: The worker thread's queue handle, used to report the
+                terminal status through the real ``update_job_status`` rather
+                than a second hand-rolled UPDATE.
         """
         start_time = time.time()
 
         # Validate paths for Docker compatibility (if enabled)
-        output_error = self._validate_output_path(job["output_file"])
+        output_error = self._validate_output_path(job.output_file)
         if output_error:
             logger.warning(f"Path validation warning: {output_error}")
             # In strict mode, we could fail the job here
             # For now, just log the warning
 
-        input_error = self._validate_input_path(job["input_file"])
+        input_error = self._validate_input_path(job.input_file)
         if input_error:
             logger.warning(f"Path validation warning: {input_error}")
 
@@ -333,18 +359,13 @@ class MockWorker:
         # Determine if job should fail
         should_fail = random.random() < self.config.fail_rate
 
-        conn = self._get_conn()
         try:
             if should_fail:
-                conn.execute(
-                    """UPDATE jobs SET status = 'failed', error = ?, completed_at = datetime('now')
-                       WHERE id = ?""",
-                    ("Mock failure (simulated)", job["id"]),
-                )
+                job_queue.update_job_status(job.id, "failed", error="Mock failure (simulated)")
                 self.stats.jobs_failed += 1
             else:
                 # Create mock output file
-                output_file = Path(job["output_file"])
+                output_file = Path(job.output_file)
                 output_file.parent.mkdir(parents=True, exist_ok=True)
 
                 # Write mock content based on job type
@@ -381,20 +402,12 @@ class MockWorker:
                     # Write placeholder image content
                     output_file.write_bytes(b"MOCK_IMAGE_CONTENT")
                 else:
-                    output_file.write_text(f"Mock output for job {job['id']}")
+                    output_file.write_text(f"Mock output for job {job.id}")
 
-                conn.execute(
-                    """UPDATE jobs SET status = 'completed', completed_at = datetime('now')
-                       WHERE id = ?""",
-                    (job["id"],),
-                )
+                job_queue.update_job_status(job.id, "completed")
                 self.stats.jobs_processed += 1
-
-            conn.commit()
         finally:
-            conn.close()
-
-        self.stats.total_processing_time += time.time() - start_time
+            self.stats.total_processing_time += time.time() - start_time
 
 
 class MockWorkerPool:
@@ -434,6 +447,8 @@ class MockWorkerPool:
         workspace_path: Path | None = None,
         data_dir: Path | None = None,
         validate_paths: bool = False,
+        execution_mode: str = "mock",
+        session_id: str | None = None,
     ) -> list[MockWorker]:
         """Start multiple mock workers.
 
@@ -446,6 +461,8 @@ class MockWorkerPool:
             workspace_path: Workspace path for Docker path validation
             data_dir: Data directory path for input path validation
             validate_paths: Whether to validate paths for Docker compatibility
+            execution_mode: Execution mode the workers register and claim under
+            session_id: Build session the workers belong to (None = unstamped)
 
         Returns:
             List of started MockWorker instances
@@ -458,6 +475,8 @@ class MockWorkerPool:
             workspace_path=workspace_path,
             data_dir=data_dir,
             validate_paths=validate_paths,
+            execution_mode=execution_mode,
+            session_id=session_id,
         )
 
         workers = []

--- a/tests/infrastructure/workers/test_mock_worker_claiming_parity.py
+++ b/tests/infrastructure/workers/test_mock_worker_claiming_parity.py
@@ -1,0 +1,225 @@
+"""Pin the properties ``MockWorker`` inherits from the real claim path.
+
+``MockWorker._poll_job`` used to be a hand-rolled ``UPDATE … RETURNING`` that
+had drifted from ``JobQueue.get_next_job`` in six ways (finding T7 of the
+2026-07-24 adversarial review):
+
+* no ``execution_mode`` filter (PR #564's cross-mode job-theft guard)
+* no session-ownership filter (issue #620)
+* no ``attempts < max_attempts`` guard
+* no ``attempts`` increment
+* no ``started_at`` stamp
+* no ``priority`` ordering
+
+and, on top of that, it wrote the container-id *string* into the integer
+``jobs.worker_id`` column. The tier meant to exercise real claiming with real
+workers together was the permanently-skipped file from finding T1, so nothing
+caught the divergence.
+
+``_poll_job`` now delegates to the real implementation. These tests fail if
+that delegation is ever unpicked.
+"""
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from tests.fixtures.mock_workers import MockWorker, MockWorkerConfig
+
+# Same rationale as ``test_lifecycle_mock.py``: worker threads polling
+# committed SQLite state are CPU-starvation-sensitive under xdist load.
+# ``AssertionError`` is deliberately absent from ``only_rerun`` (finding T6) —
+# an intermittent claiming race is exactly what these tests exist to surface.
+pytestmark = [
+    pytest.mark.serial("workerpool"),
+    pytest.mark.flaky(
+        reruns=2,
+        reruns_delay=1,
+        only_rerun=["OSError", "PermissionError", "OperationalError", "TimeoutError"],
+    ),
+]
+
+# How long to keep watching after the control job finishes, to give a
+# mis-implemented claim time to happen before we assert it did not.
+SETTLE_SECONDS = 0.3
+
+
+def _insert_job(
+    db_path: Path,
+    *,
+    content_hash: str,
+    output_file: Path,
+    execution_mode: str | None = None,
+    session_id: str | None = None,
+    priority: int = 0,
+) -> int:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        cursor = conn.execute(
+            """INSERT INTO jobs
+               (job_type, input_file, output_file, content_hash, payload, status,
+                execution_mode, session_id, priority)
+               VALUES (?, ?, ?, ?, '{}', 'pending', ?, ?, ?)""",
+            (
+                "notebook",
+                f"{content_hash}.ipynb",
+                str(output_file),
+                content_hash,
+                execution_mode,
+                session_id,
+                priority,
+            ),
+        )
+        conn.commit()
+        assert cursor.lastrowid is not None
+        return cursor.lastrowid
+    finally:
+        conn.close()
+
+
+def _job_row(db_path: Path, job_id: int) -> sqlite3.Row:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        row = conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
+        assert row is not None, f"job {job_id} disappeared"
+        return row
+    finally:
+        conn.close()
+
+
+def _wait_for_status(db_path: Path, job_id: int, status: str, timeout: float = 15.0) -> None:
+    """Poll until *job_id* reaches *status*, or fail with what it reached instead."""
+    deadline = time.monotonic() + timeout
+    last = None
+    while time.monotonic() < deadline:
+        last = _job_row(db_path, job_id)["status"]
+        if last == status:
+            return
+        time.sleep(0.05)
+    raise AssertionError(f"job {job_id} never reached {status!r} (last seen: {last!r})")
+
+
+def test_claim_records_numeric_worker_id_and_bookkeeping(mock_db_path, mock_workspace_path):
+    """A claim sets the integer worker row id, ``started_at`` and ``attempts``."""
+    job_id = _insert_job(
+        mock_db_path,
+        content_hash="parity-basic",
+        output_file=mock_workspace_path / "out" / "parity_basic.ipynb",
+    )
+
+    worker = MockWorker(MockWorkerConfig(worker_type="notebook"), mock_db_path, worker_id=0)
+    try:
+        worker.start()
+        assert worker.wait_for_registration(), "Worker should register"
+        _wait_for_status(mock_db_path, job_id, "completed")
+
+        row = _job_row(mock_db_path, job_id)
+        # The old implementation wrote the string "mock-notebook-0" here.
+        assert row["worker_id"] == worker.db_worker_id
+        assert isinstance(row["worker_id"], int)
+        assert row["started_at"] is not None, "get_next_job stamps started_at"
+        assert row["attempts"] == 1, "get_next_job increments attempts"
+    finally:
+        worker.stop()
+
+
+def test_worker_does_not_claim_a_foreign_execution_mode(mock_db_path, mock_workspace_path):
+    """A job tagged for another execution mode is left alone (PR #564)."""
+    foreign = _insert_job(
+        mock_db_path,
+        content_hash="parity-docker",
+        output_file=mock_workspace_path / "out" / "parity_docker.ipynb",
+        execution_mode="docker",
+    )
+    untagged = _insert_job(
+        mock_db_path,
+        content_hash="parity-untagged",
+        output_file=mock_workspace_path / "out" / "parity_untagged.ipynb",
+    )
+
+    worker = MockWorker(
+        MockWorkerConfig(worker_type="notebook", processing_delay=0.01),
+        mock_db_path,
+        worker_id=0,
+    )
+    try:
+        worker.start()
+        assert worker.wait_for_registration(), "Worker should register"
+        # The untagged job completing proves the worker really is polling —
+        # without that control, "foreign job untouched" would also pass if the
+        # worker had never started.
+        _wait_for_status(mock_db_path, untagged, "completed")
+        time.sleep(SETTLE_SECONDS)
+
+        row = _job_row(mock_db_path, foreign)
+        assert row["status"] == "pending"
+        assert row["worker_id"] is None
+    finally:
+        worker.stop()
+
+
+def test_worker_does_not_claim_another_sessions_job(mock_db_path, mock_workspace_path):
+    """A session-stamped worker leaves another session's jobs alone (issue #620)."""
+    other_session = _insert_job(
+        mock_db_path,
+        content_hash="parity-session-b",
+        output_file=mock_workspace_path / "out" / "parity_session_b.ipynb",
+        session_id="session-b",
+    )
+    own_session = _insert_job(
+        mock_db_path,
+        content_hash="parity-session-a",
+        output_file=mock_workspace_path / "out" / "parity_session_a.ipynb",
+        session_id="session-a",
+    )
+
+    worker = MockWorker(
+        MockWorkerConfig(worker_type="notebook", processing_delay=0.01, session_id="session-a"),
+        mock_db_path,
+        worker_id=0,
+    )
+    try:
+        worker.start()
+        assert worker.wait_for_registration(), "Worker should register"
+        _wait_for_status(mock_db_path, own_session, "completed")
+        time.sleep(SETTLE_SECONDS)
+
+        assert _job_row(mock_db_path, other_session)["status"] == "pending"
+    finally:
+        worker.stop()
+
+
+def test_worker_respects_priority_order(mock_db_path, mock_workspace_path):
+    """Higher-priority jobs are claimed first, regardless of insertion order."""
+    low = _insert_job(
+        mock_db_path,
+        content_hash="parity-low",
+        output_file=mock_workspace_path / "out" / "parity_low.ipynb",
+        priority=0,
+    )
+    high = _insert_job(
+        mock_db_path,
+        content_hash="parity-high",
+        output_file=mock_workspace_path / "out" / "parity_high.ipynb",
+        priority=10,
+    )
+
+    # One worker, with a processing delay long enough that the ordering is
+    # observable: the high-priority job must finish while the low-priority one
+    # — inserted first — is still queued or only just started.
+    worker = MockWorker(
+        MockWorkerConfig(worker_type="notebook", processing_delay=0.5),
+        mock_db_path,
+        worker_id=0,
+    )
+    try:
+        worker.start()
+        assert worker.wait_for_registration(), "Worker should register"
+        _wait_for_status(mock_db_path, high, "completed")
+
+        assert _job_row(mock_db_path, low)["status"] in ("pending", "processing")
+    finally:
+        worker.stop()


### PR DESCRIPTION
Phase 1 of the 2026-07-24 adversarial review remediation plan — finding **T7**.
Test-fixture change only; no production code touched.

## The drift

`MockWorker._poll_job` reimplemented job claiming as a hand-rolled
`UPDATE … RETURNING`. Against `JobQueue.get_next_job` it was missing:

| Missing | Consequence |
|---|---|
| `execution_mode` filter | a mock worker claims a job tagged for Docker or Direct — the cross-build job theft PR #564 fixed |
| session-ownership filter | ignores issue #620 entirely |
| `attempts < max_attempts` | an exhausted job stays claimable forever |
| `attempts + 1` | retry accounting sees nothing |
| `started_at` | orphan detection (`mark_orphaned_jobs_failed`) sees nothing |
| `priority DESC` | priority ordering unexercised |

…and it wrote the container-id **string** (`mock-notebook-0`) into the integer
`jobs.worker_id` column.

The tier meant to exercise real claiming with real workers together is exactly
the file finding T1 showed had been skipped everywhere, so the drift was
uncompensated in both directions.

## The fix

Per the plan's preferred option — *"or better, have MockWorker call the real
`JobQueue.get_next_job` so it cannot drift again"* — `_poll_job` now delegates,
and the terminal transition goes through `JobQueue.update_job_status`. Future
changes to claiming or completion semantics are picked up for free instead of
needing a parallel edit here.

`MockWorkerConfig` gains two fields:

- `execution_mode` (default `"mock"`) — the mode it *already* registered under,
  now also used when claiming. Jobs with a NULL `execution_mode`, which is what
  the mock tests submit, stay claimable.
- `session_id` (default `None`) — an unstamped worker, which the real queue
  leaves unrestricted. That is the legacy behaviour existing mock tests rely on;
  set it to exercise session ownership.

## The guard

New `tests/infrastructure/workers/test_mock_worker_claiming_parity.py` pins each
recovered property:

- claim records the **integer** worker row id, `started_at`, and `attempts == 1`
- a `docker`-tagged job is left `pending`
- another session's job is left `pending`
- a later-inserted higher-priority job is claimed first

Both "left alone" tests submit a **control** job that must complete first, so
they cannot pass by the worker simply never having started.

## Verification

```
pytest tests/infrastructure/workers/test_mock_worker_claiming_parity.py tests/infrastructure/workers/test_lifecycle_mock.py -m ""   16 passed
```

Mutation-checked:

- forcing `execution_mode=None` into the delegated call →
  `test_worker_does_not_claim_a_foreign_execution_mode` fails (`pending` → `completed`)
- forcing `worker_id=None` → the numeric-id test and the session test both fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEAsC4QkeoDw34FEBNdh1K
