### PR TITLE
test: give the autouse neutralisers provenance, and cover the cap interaction (Phase 1 / T8)

### DIFF
--- a/changelog.d/672-neutralizer-provenance-and-cap-interaction.added.md
+++ b/changelog.d/672-neutralizer-provenance-and-cap-interaction.added.md
@@ -5,4 +5,8 @@
   neutralisers pin the heartbeat slow-write threshold, the pool-size caps and
   the `CLM_*_DB_PATH` defaults suite-wide — each justified in isolation, but
   together they made the production defaults invisible, and nothing outside the
-  clamp's own unit tests had ever seen it engage.
+  clamp's own unit tests had ever seen it engage. The pool-size neutraliser's
+  self-exemption now matches the module *file* rather than a bare substring; it
+  previously exempted any module whose name merely began the same way, leaving
+  it reading the real host CPU/RAM caps and so passing or failing by runner
+  size.

--- a/changelog.d/672-neutralizer-provenance-and-cap-interaction.added.md
+++ b/changelog.d/672-neutralizer-provenance-and-cap-interaction.added.md
@@ -1,0 +1,8 @@
+- **Every autouse env-neutraliser in `tests/conftest.py` now names the test that
+  still covers the real production value**, and a new
+  `test_pool_size_cap_interaction.py` closes the widest of the gaps they left:
+  the worker pool-size clamp firing during real managed-worker startup. The
+  neutralisers pin the heartbeat slow-write threshold, the pool-size caps and
+  the `CLM_*_DB_PATH` defaults suite-wide — each justified in isolation, but
+  together they made the production defaults invisible, and nothing outside the
+  clamp's own unit tests had ever seen it engage.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -865,7 +865,13 @@ def _neutralise_pool_size_cap(monkeypatch, request):
       suite could not observe what happens when the clamp actually engages on
       the path that uses it.
     """
-    if "test_pool_size_cap" in request.node.nodeid:
+    # Match the module FILE, not a bare substring. The old check was
+    # ``"test_pool_size_cap" in nodeid``, which silently exempted any module
+    # whose name merely started that way — including
+    # ``test_pool_size_cap_interaction.py``, which then saw the *real* host CPU
+    # and RAM caps and became environment-dependent (3 requested workers
+    # resolved to 3 on a 32-core dev box and to 2 on a 2-core CI runner).
+    if "test_pool_size_cap.py" in request.node.nodeid:
         return
 
     monkeypatch.setattr(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,14 @@ import pytest
 # new heartbeat test cannot silently re-acquire the flake. The dedicated
 # disable-path test re-patches the constant to 0.0 in its own scope, preserving
 # that coverage. ``setdefault`` lets an operator override it explicitly.
+#
+# PRODUCTION VALUE COVERED BY (finding T8 — every neutraliser must name the
+# single test that still exercises the real behaviour, or the neutraliser is
+# indistinguishable from deleting the feature's coverage):
+#   tests/infrastructure/database/test_worker_heartbeats.py
+#     ::TestWorkerHeartbeatStore::test_slow_write_disables_further_writes
+# **Never raise the 50ms production default** to make a test pass — relax it
+# here, in the test environment only.
 os.environ.setdefault("CLM_HEARTBEAT_SLOW_WRITE_THRESHOLD_SECONDS", "30")
 
 from clm.core.course_spec import TopicSpec
@@ -180,6 +188,12 @@ def _isolate_db_path_env():
     (test_status_collector's env-var tests, test_sqlite_backend_resilience's
     decoy) — that runs after this fixture, so those are unaffected. Mirrors the
     ``_isolate_http_replay_env`` / ``_neutralise_pool_size_cap`` precedents.
+
+    PRODUCTION VALUE COVERED BY (finding T8):
+      tests/cli/test_status_collector.py::TestStatusCollector
+        ::test_default_db_path_detection — the anchored default; and
+        ::test_default_db_path_prefers_jobs_db_env — the env var winning over
+        it, set inside the test body so this fixture cannot mask it.
     """
     keys = (
         "CLM_CACHE_DB_PATH",
@@ -839,6 +853,17 @@ def _neutralise_pool_size_cap(monkeypatch, request):
     operator's personal cap (set in their shell profile) cannot leak
     into test runs. Tests that want to assert the env-var plumbing
     can ``monkeypatch.setenv`` it back.
+
+    PRODUCTION VALUE COVERED BY (finding T8):
+      tests/infrastructure/workers/test_pool_size_cap.py — the whole module,
+      exempted above by the ``test_pool_size_cap`` nodeid check.
+    INTERACTION COVERED BY:
+      tests/infrastructure/workers/test_pool_size_cap_interaction.py — the
+      clamp firing *during managed-worker startup*, which unit tests of the
+      helper in isolation cannot see. This was the widest gap the review
+      identified: every neutraliser here is individually justified, but the
+      suite could not observe what happens when the clamp actually engages on
+      the path that uses it.
     """
     if "test_pool_size_cap" in request.node.nodeid:
         return

--- a/tests/infrastructure/workers/test_pool_size_cap_interaction.py
+++ b/tests/infrastructure/workers/test_pool_size_cap_interaction.py
@@ -1,0 +1,105 @@
+"""The pool-size clamp firing *during managed-worker startup*.
+
+Finding T8 of the 2026-07-24 adversarial review: the suite's autouse
+env-neutralisers are each individually justified, but together they make the
+production defaults a monoculture — and the *interaction* invisible.
+``_neutralise_pool_size_cap`` in ``tests/conftest.py`` pins
+``_compute_cpu_cap`` / ``_compute_mem_cap`` to 128 and clears
+``CLM_MAX_WORKERS`` for every test, so no test outside
+``test_pool_size_cap.py`` had ever observed the clamp actually engaging. That
+module tests ``compute_pool_size_cap`` in isolation; nothing connected it to
+the path that consumes it.
+
+This module closes that gap: it re-enables the cap inside the test body (which
+runs after the autouse fixture, so ``monkeypatch.setenv`` wins) and asserts the
+clamp reaches ``WorkerLifecycleManager.start_managed_workers`` — i.e. that a
+spec asking for more workers than the operator cap allows starts the capped
+number, loudly.
+"""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from clm.infrastructure.database.schema import init_database
+from clm.infrastructure.workers.config_loader import load_worker_config
+from clm.infrastructure.workers.lifecycle_manager import WorkerLifecycleManager
+
+REQUESTED_WORKERS = 3
+OPERATOR_CAP = 1
+
+
+def _worker_overrides(count: int) -> dict:
+    """CLI overrides for a notebook-only, direct-mode managed pool."""
+    return {
+        "default_execution_mode": "direct",
+        "notebook_count": count,
+        "plantuml_count": 0,
+        "drawio_count": 0,
+        "auto_start": True,
+        "auto_stop": True,
+        "reuse_workers": False,
+    }
+
+
+def test_operator_cap_clamps_the_resolved_worker_config(monkeypatch, caplog):
+    """``CLM_MAX_WORKERS`` clamps the count and says so at WARNING."""
+    monkeypatch.setenv("CLM_MAX_WORKERS", str(OPERATOR_CAP))
+    config = load_worker_config(_worker_overrides(REQUESTED_WORKERS))
+
+    with caplog.at_level(logging.WARNING, logger="clm.infrastructure.config"):
+        counts = {c.worker_type: c.count for c in config.get_all_worker_configs()}
+
+    assert counts["notebook"] == OPERATOR_CAP
+    assert any("capping to" in record.message for record in caplog.records), (
+        f"the clamp must be visible on the operator's terminal; "
+        f"logged: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_no_clamp_without_an_operator_cap(monkeypatch):
+    """Control: with the cap cleared, the requested count survives.
+
+    Without this, the test above would also pass if the resolver had started
+    returning 1 for some unrelated reason.
+    """
+    monkeypatch.delenv("CLM_MAX_WORKERS", raising=False)
+    config = load_worker_config(_worker_overrides(REQUESTED_WORKERS))
+
+    counts = {c.worker_type: c.count for c in config.get_all_worker_configs()}
+    assert counts["notebook"] == REQUESTED_WORKERS
+
+
+@pytest.mark.integration
+def test_operator_cap_clamps_managed_worker_startup(tmp_path, monkeypatch):
+    """The clamp reaches real startup: 3 requested, 1 started.
+
+    This is the interaction the unit tests of ``compute_pool_size_cap`` cannot
+    see. It starts real Direct-mode worker subprocesses, so it is marked
+    ``integration``.
+    """
+    monkeypatch.setenv("CLM_MAX_WORKERS", str(OPERATOR_CAP))
+
+    db_path: Path = tmp_path / "jobs.db"
+    init_database(db_path)
+    workspace_path = tmp_path / "workspace"
+    workspace_path.mkdir()
+
+    config = load_worker_config(_worker_overrides(REQUESTED_WORKERS))
+    manager = WorkerLifecycleManager(
+        config=config,
+        db_path=db_path,
+        workspace_path=workspace_path,
+    )
+
+    workers = []
+    try:
+        workers = manager.start_managed_workers()
+        assert len(workers) == OPERATOR_CAP, (
+            f"requested {REQUESTED_WORKERS} workers under a cap of {OPERATOR_CAP}, "
+            f"but started {len(workers)}"
+        )
+        assert all(w.worker_type == "notebook" for w in workers)
+    finally:
+        manager.stop_managed_workers(workers)

--- a/tests/infrastructure/workers/test_pool_size_cap_interaction.py
+++ b/tests/infrastructure/workers/test_pool_size_cap_interaction.py
@@ -15,6 +15,12 @@ runs after the autouse fixture, so ``monkeypatch.setenv`` wins) and asserts the
 clamp reaches ``WorkerLifecycleManager.start_managed_workers`` — i.e. that a
 spec asking for more workers than the operator cap allows starts the capped
 number, loudly.
+
+Deliberately an *operator* cap (``CLM_MAX_WORKERS``) rather than the CPU/RAM
+caps: those depend on the host, so asserting on them would make the test pass
+on a 32-core dev box and fail on a 2-core CI runner. The neutraliser's
+128-worker pinning stays in force here, which is exactly the regime the rest of
+the suite runs under.
 """
 
 import logging
@@ -64,6 +70,18 @@ def test_no_clamp_without_an_operator_cap(monkeypatch):
     Without this, the test above would also pass if the resolver had started
     returning 1 for some unrelated reason.
     """
+    from clm.infrastructure.workers import pool_size_cap
+
+    # This module relies on the autouse neutraliser pinning the host caps, so
+    # the assertion below is about the *operator* cap and nothing else. Say so
+    # explicitly: if the exemption match in ``_neutralise_pool_size_cap`` ever
+    # swallows this module again, the failure names the cause instead of
+    # reading as a mysterious off-by-one on a small runner.
+    assert pool_size_cap._compute_cpu_cap() >= REQUESTED_WORKERS, (
+        "the autouse pool-size neutraliser is not in force for this module — "
+        "check the exemption match in tests/conftest.py::_neutralise_pool_size_cap"
+    )
+
     monkeypatch.delenv("CLM_MAX_WORKERS", raising=False)
     config = load_worker_config(_worker_overrides(REQUESTED_WORKERS))
 


### PR DESCRIPTION
Phase 1 of the 2026-07-24 adversarial review remediation plan — finding **T8**.
Test-only; no production code touched.

The plan's instruction was explicit: *"leave the autouse neutralizers in place
(they are justified), but document each with a comment naming the single test
that covers the real production value, and add one interaction test where the
gap is widest (the pool-size clamp firing during managed-worker startup)."*

## Provenance

Each neutraliser now names, by nodeid, the test that still exercises the real
behaviour:

| Neutraliser | Real value still covered by |
|---|---|
| `CLM_HEARTBEAT_SLOW_WRITE_THRESHOLD_SECONDS=30` (prod: 50 ms) | `test_worker_heartbeats.py::TestWorkerHeartbeatStore::test_slow_write_disables_further_writes` |
| `_neutralise_pool_size_cap` (caps pinned to 128, `CLM_MAX_WORKERS` cleared) | the whole `test_pool_size_cap.py` module, which the fixture already exempts by nodeid |
| `_isolate_db_path_env` (`CLM_*_DB_PATH` cleared) | `test_status_collector.py::TestStatusCollector::test_default_db_path_detection` and `::test_default_db_path_prefers_jobs_db_env` |

A neutraliser without that pointer is indistinguishable from deleting the
feature's coverage. The pointer is what makes a future edit notice what it is
about to orphan. The heartbeat comment also restates the standing rule: relax it
in the test environment, never raise the 50 ms production default.

## The interaction

`_neutralise_pool_size_cap` means no test outside `test_pool_size_cap.py` had
ever seen the clamp engage — and that module tests `compute_pool_size_cap` in
isolation, with nothing connecting it to the code that consumes it.

New `tests/infrastructure/workers/test_pool_size_cap_interaction.py` re-enables
the cap **inside the test body** (which runs after the autouse fixture, so
`monkeypatch.setenv` wins) and follows it through:

1. `CLM_MAX_WORKERS=1` + a 3-worker request → resolved config says 1, and
   `clm.infrastructure.config` logs `capping to 1` at WARNING.
2. Control: no cap set → the requested 3 survives, so (1) cannot pass for an
   unrelated reason.
3. `integration`-marked: the same setup driven through
   `WorkerLifecycleManager.start_managed_workers()` starts exactly **1** real
   Direct-mode worker, not 3.

## Verification

```
pytest tests/infrastructure/workers/test_pool_size_cap_interaction.py tests/infrastructure/workers/test_pool_size_cap.py -m ""   23 passed
```

Mutation-checked: dropping the `CLM_MAX_WORKERS` setenv from the integration
test fails with `requested 3 workers under a cap of 1, but started 3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEAsC4QkeoDw34FEBNdh1K
