### PR TITLE
ci: run the slow tier on every PR; repoint the nightly at flake detection

### DIFF
--- a/.github/actions/report-failure/action.yml
+++ b/.github/actions/report-failure/action.yml
@@ -1,0 +1,96 @@
+name: Report a CI failure as an issue
+description: >-
+  File a GitHub issue for a failed scheduled or post-merge run, or comment on
+  the existing open one so an outage produces one issue rather than one per
+  occurrence. Creates the label if it does not exist, so there is no manual
+  setup step to forget.
+
+inputs:
+  label:
+    description: Label used both to find the existing issue and to tag a new one.
+    required: true
+  title:
+    description: Title for a newly created issue.
+    required: true
+  context:
+    description: >-
+      Extra markdown appended to the body, explaining what this run covers and
+      why its failure matters. Keep it short and specific.
+    required: false
+    default: ''
+  label-color:
+    description: Hex colour (no leading '#') used when the label has to be created.
+    required: false
+    default: 'b60205'
+  label-description:
+    description: Description used when the label has to be created.
+    required: false
+    default: 'An automated run failed'
+  github-token:
+    description: "Token carrying the `issues: write` permission."
+    required: false
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: File or update the failure issue
+      uses: actions/github-script@v8
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const LABEL = ${{ toJSON(inputs.label) }};
+          const TITLE = ${{ toJSON(inputs.title) }};
+          const CONTEXT = ${{ toJSON(inputs.context) }};
+          const LABEL_COLOR = ${{ toJSON(inputs['label-color']) }};
+          const LABEL_DESCRIPTION = ${{ toJSON(inputs['label-description']) }};
+
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const body = [
+            `The **${context.workflow}** workflow failed.`,
+            ``,
+            `- Run: ${runUrl}`,
+            `- Commit: ${context.sha}`,
+            `- Branch/ref: ${context.ref}`,
+            `- Trigger: ${context.eventName}`,
+            ...(CONTEXT ? [``, CONTEXT] : []),
+          ].join('\n');
+
+          // The label must exist before it can be applied.
+          try {
+            await github.rest.issues.getLabel({
+              owner: context.repo.owner, repo: context.repo.repo, name: LABEL,
+            });
+          } catch (e) {
+            await github.rest.issues.createLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: LABEL,
+              color: LABEL_COLOR,
+              description: LABEL_DESCRIPTION,
+            });
+          }
+
+          // One open issue per outage, not one per occurrence.
+          const existing = await github.rest.issues.listForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            labels: LABEL,
+            per_page: 1,
+          });
+
+          if (existing.data.length > 0) {
+            const number = existing.data[0].number;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: number, body,
+            });
+            core.notice(`Commented on existing ${LABEL} issue #${number}`);
+          } else {
+            const created = await github.rest.issues.create({
+              owner: context.repo.owner, repo: context.repo.repo,
+              title: TITLE, body, labels: [LABEL],
+            });
+            core.notice(`Filed ${LABEL} issue #${created.data.number}`);
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   # test/lint/docker pipeline. Docs-only changes (design notes, READMEs,
   # changelog fragments) skip the expensive jobs to save CI minutes.
   #
-  # IMPORTANT: the six "Test on Python 3.1x (suite)" jobs and
+  # IMPORTANT: the eight "Test on Python 3.1x (suite)" jobs and
   # "Lint and type check" are *required* status checks (see the "Require CI
   # green" ruleset). A required check that never reports leaves the PR stuck
   # "Expected — waiting for status". So those jobs must always RUN and report
@@ -22,7 +22,8 @@ jobs:
   #
   # Required checks are matched by job NAME, so renaming a test job (or
   # changing the matrix dimensions) requires updating the ruleset in the same
-  # breath (issue #559 landed the python-version × suite split this way).
+  # breath (issue #559 landed the python-version × suite split this way;
+  # adding the ``slow`` suite widened it from six jobs to eight).
   #
   # The doc-only globs are deliberately narrow: ``src/clm/cli/info_topics/*.md``
   # and other markdown shipped under ``src/`` are covered by tests, so a blanket
@@ -62,6 +63,12 @@ jobs:
     # The suites run as parallel jobs instead of sequential steps (issue #559):
     # per-job setup is ~40 s with warm caches, so the split costs ~3 machine-
     # minutes and cuts the test wall clock from ~7 to ~4 minutes.
+    #
+    # ``slow`` joined the matrix rather than staying nightly-only (finding T2 /
+    # decision D12, revisited): the tier is 37 tests / ~78 s at -n 4, so as a
+    # PARALLEL job it costs machine-minutes but no wall clock — the unit job is
+    # ~4.5 min and the docker job ~6.5 min, both longer. It was never excluded
+    # for cost. The other three suites keep ``not slow``, so nothing runs twice.
     name: Test on Python ${{ matrix.python-version }} (${{ matrix.suite }})
     needs: changes
     runs-on: ubuntu-latest
@@ -70,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.12", "3.13"]
-        suite: [unit, integration, e2e]
+        suite: [unit, integration, e2e, slow]
 
     steps:
     - name: Checkout code
@@ -191,6 +198,21 @@ jobs:
         uv run --no-sync pytest -v -m "e2e and not docker and not slow" --timeout=600 --log-cli-level=INFO --cov=src/clm --cov-report=xml --cov-report=term
       env:
         CLM_E2E_TIMEOUT: 600  # 10 minutes timeout for E2E tests (allows multi-build tests)
+        CLM_ENABLE_TEST_LOGGING: "1"
+        CLM_LOG_LEVEL: INFO
+
+    # The tier the other three exclude. Contains the only proof that a cached
+    # notebook replays byte-identically to a direct execution
+    # (test_cache_equivalence.py), the worker-reuse-across-builds e2e tests
+    # covering the PR #595 bug, all 18 real-subprocess CLI tests, and the
+    # high-concurrency Direct-worker tests. Timeout matches the nightly's
+    # former value; the real-subprocess tests are the long poles.
+    - name: Run slow tests
+      if: needs.changes.outputs.code == 'true' && matrix.suite == 'slow'
+      run: |
+        uv run --no-sync pytest -v -m "slow and not docker" --timeout=900 --log-cli-level=INFO --cov=src/clm --cov-report=xml --cov-report=term
+      env:
+        CLM_E2E_TIMEOUT: 900
         CLM_ENABLE_TEST_LOGGING: "1"
         CLM_LOG_LEVEL: INFO
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,21 +1,28 @@
-name: Nightly slow tests
+name: Nightly full suite
 
-# The ``slow`` marker is a "runs nowhere" tier (finding T2 of the 2026-07-24
-# adversarial review): every non-docker step in ci.yml excludes it, and the
-# local default in pyproject excludes it too. ~37 tests carry it, including
-# the *only* proof that a cached notebook replays byte-identically to a direct
-# execution (test_cache_equivalence.py — the guard against silently wrong
-# output), the worker-reuse-across-builds e2e tests covering the PR #595 bug,
-# and all 18 real-subprocess CLI tests.
+# A FLAKE AND ROT DETECTOR, not a coverage backstop.
 #
-# This runs them once a day instead of lengthening PR CI (decision D12).
+# This started life (finding T2 / decision D12) as the home for the ``slow``
+# marker, which ci.yml excluded from every step — so ~37 tests, including the
+# only proof that a cached notebook replays byte-identically to a direct
+# execution, ran nowhere at all. That tier now runs on every PR as a fourth
+# parallel matrix suite, because it costs machine-minutes but no wall clock.
 #
-# WHERE FAILURES SURFACE: the ``report-failure`` job below files a GitHub
-# issue labelled ``nightly-failure``, or comments on the existing open one.
-# That is deliberate and load-bearing — a nightly job nobody reads is worse
-# than no nightly job, because it manufactures the feeling of coverage. Do not
-# remove that job without replacing it with a route the maintainer actually
-# reads.
+# What survives here is the job PR CI structurally *cannot* do: run the
+# **whole** suite — docker included — against **unchanged** master, repeatedly.
+# A PR run tells you "this change is fine". Thirty runs of identical code tell
+# you "this test is 3% flaky", which is how a contention regression like issue
+# #163 surfaces before it wastes someone's afternoon.
+#
+# (Dependency drift, the other usual nightly justification, barely applies
+# here: CI installs from uv.lock with UV_EXCLUDE_NEWER pinned, so nothing moves
+# underneath us.)
+#
+# WHERE FAILURES SURFACE: the ``report-failure`` job files a GitHub issue
+# labelled ``nightly-failure``, or comments on the existing open one. That is
+# deliberate and load-bearing — a nightly job nobody reads is worse than no
+# nightly job, because it manufactures the feeling of coverage. Do not remove
+# it without replacing it with a route the maintainer actually reads.
 
 on:
   schedule:
@@ -26,20 +33,23 @@ on:
 
 # Never run two nightlies at once (a manual dispatch during a scheduled run).
 concurrency:
-  group: nightly-slow
+  group: nightly-full
   cancel-in-progress: false
 
 jobs:
-  slow:
-    name: Slow tier (Python ${{ matrix.python-version }})
+  full:
+    # Everything except the docker tier, in one process rather than the four
+    # parallel suites PR CI uses: a single run is a truer flake measurement,
+    # and wall clock does not matter at 03:17.
+    name: Full suite, no docker (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        # One interpreter is enough for a regression net that runs daily; the
-        # PR matrix already covers 3.12 + 3.13 for everything else. Widen this
-        # only if a slow-tier failure ever turns out to be version-specific.
+        # One interpreter is enough for a daily flake sweep; the PR matrix
+        # already covers 3.12 + 3.13. Widen only if a flake ever turns out to
+        # be version-specific.
         python-version: ["3.12"]
 
     steps:
@@ -104,78 +114,100 @@ jobs:
         git config --global user.email "ci@github.actions"
         git config --global user.name "GitHub Actions CI"
 
-    - name: Run slow tests
+    - name: Run full suite (no docker)
       run: |
-        uv run --no-sync pytest -v -m "slow and not docker" --timeout=900 --log-cli-level=INFO
+        uv run --no-sync pytest -v -m "not docker" --timeout=900 --log-cli-level=INFO
       env:
         CLM_E2E_TIMEOUT: 900
         CLM_ENABLE_TEST_LOGGING: "1"
         CLM_LOG_LEVEL: INFO
 
+  docker:
+    # The tier that is NOT a required check on PRs, so a regression in it can
+    # reach master (it did — PR #667 was green and broke this job). Running it
+    # nightly means a red docker tier surfaces as an issue within a day even if
+    # nobody looks at the merge commit's CI.
+    name: Docker tier
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+      with:
+        lfs: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
+
+    - name: Build notebook-processor:lite-test Docker image
+      run: |
+        docker build \
+          -f docker/notebook/Dockerfile \
+          --build-arg VARIANT=lite \
+          --build-arg DOCKER_PATH=docker/notebook \
+          -t clm-notebook-processor:lite-test \
+          .
+
+    - name: Build plantuml-converter:test Docker image
+      run: |
+        docker build \
+          -f docker/plantuml/Dockerfile \
+          --build-arg DOCKER_PATH=docker/plantuml \
+          -t clm-plantuml-converter:test \
+          .
+
+    - name: Build drawio-converter:test Docker image
+      run: |
+        docker build \
+          -f docker/drawio/Dockerfile \
+          --build-arg DOCKER_PATH=docker/drawio \
+          -t clm-drawio-converter:test \
+          .
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v7
+      with:
+        version: "latest"
+
+    - name: Install dependencies
+      run: |
+        uv sync --locked --python 3.12 --no-default-groups \
+          --extra all-workers --extra recordings --extra dev --extra tui --extra web
+
+    - name: Run Docker integration tests
+      run: |
+        uv run --no-sync pytest -v -n0 -m "docker" --timeout=600 --log-cli-level=INFO
+      env:
+        CLM_E2E_TIMEOUT: 600
+        CLM_ENABLE_TEST_LOGGING: "1"
+        CLM_LOG_LEVEL: INFO
+
   report-failure:
     name: Report failure
-    needs: slow
+    needs: [full, docker]
     if: failure()
     runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:
-      - name: File or update the nightly-failure issue
-        uses: actions/github-script@v8
+      - name: Checkout code
+        uses: actions/checkout@v7
         with:
-          script: |
-            const LABEL = 'nightly-failure';
-            const TITLE = 'Nightly slow-tier tests are failing';
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = [
-              `The nightly \`pytest -m "slow and not docker"\` run failed.`,
-              ``,
-              `- Run: ${runUrl}`,
-              `- Commit: ${context.sha}`,
-              `- Trigger: ${context.eventName}`,
-              ``,
-              `The slow tier is excluded from PR CI by design (decision D12 of the`,
-              `2026-07-24 adversarial review remediation plan), so nothing else`,
-              `covers these tests — notably \`test_cache_equivalence.py\`, the only`,
-              `proof that a cached notebook replays byte-identically to a direct`,
-              `execution.`,
-            ].join('\n');
+          lfs: false
 
-            // The label must exist before it can be applied.
-            try {
-              await github.rest.issues.getLabel({
-                owner: context.repo.owner, repo: context.repo.repo, name: LABEL,
-              });
-            } catch (e) {
-              await github.rest.issues.createLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: LABEL,
-                color: 'b60205',
-                description: 'A scheduled nightly run failed',
-              });
-            }
-
-            // One open issue per outage, not one per night.
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: LABEL,
-              per_page: 1,
-            });
-
-            if (existing.data.length > 0) {
-              const number = existing.data[0].number;
-              await github.rest.issues.createComment({
-                owner: context.repo.owner, repo: context.repo.repo,
-                issue_number: number, body,
-              });
-              core.notice(`Commented on existing nightly-failure issue #${number}`);
-            } else {
-              const created = await github.rest.issues.create({
-                owner: context.repo.owner, repo: context.repo.repo,
-                title: TITLE, body, labels: [LABEL],
-              });
-              core.notice(`Filed nightly-failure issue #${created.data.number}`);
-            }
+      - uses: ./.github/actions/report-failure
+        with:
+          label: nightly-failure
+          title: Nightly full-suite run is failing
+          label-description: A scheduled nightly run failed
+          context: >-
+            This runs the whole suite, docker tier included, against unchanged
+            master. A failure here with no corresponding change on master means
+            a **flaky test**, not a regression — check whether the same test
+            failed on earlier nights before hunting for a cause in the code.

--- a/changelog.d/676-slow-suite-on-pr-ci.changed.md
+++ b/changelog.d/676-slow-suite-on-pr-ci.changed.md
@@ -1,0 +1,9 @@
+- **The `slow` test tier now runs on every PR instead of nightly.** It joins the
+  CI matrix as a fourth parallel suite, so it costs machine-minutes but no wall
+  clock — the tier is 37 tests in ~78 s at `-n 4`, against a `unit` job of
+  ~4.5 min and a Docker job of ~6.5 min. It was never excluded for cost. The
+  nightly workflow is repointed accordingly: it now runs the **whole** suite,
+  Docker tier included, against unchanged `master`, as a flake and rot detector
+  — the one thing PR CI structurally cannot do. Its issue-filing mechanism moved
+  into a `.github/actions/report-failure` composite action so other workflows
+  can reuse it.

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -315,48 +315,75 @@ CLM uses GitHub Actions for continuous integration. The CI workflow runs on ever
 
 ### What Tests Run on CI?
 
-The CI pipeline runs three test suites in order:
+Every PR runs **four** suites, as parallel jobs on a `python-version × suite`
+matrix (3.12 and 3.13):
 
-1. **Unit Tests**: Fast tests without external dependencies
-   ```bash
-   pytest -m "not slow and not integration and not e2e and not docker"
-   ```
+| Suite | Selector |
+|---|---|
+| `unit` | `-m "not slow and not integration and not e2e and not docker"` |
+| `integration` | `-m "integration and not docker and not slow"` |
+| `e2e` | `-m "e2e and not docker and not slow"` |
+| `slow` | `-m "slow and not docker"` |
 
-2. **Integration Tests**: Tests with workers and full setup (excluding Docker)
-   ```bash
-   pytest -m "integration and not docker"
-   ```
+The four selectors partition cleanly — nothing runs twice. All eight jobs plus
+`Lint and type check` are **required** status checks.
 
-3. **E2E Tests**: Full end-to-end course conversion tests (excluding Docker)
-   ```bash
-   pytest -m "e2e and not docker"
-   ```
+A ninth job builds the Docker images and runs `-m "docker"`. It is **not**
+required: the image builds fetch base images plus deno / ijava / dotnet / the
+DrawIO `.deb` from four external hosts, and that has produced a ~12% infra
+failure rate (Docker Hub timeouts, partial `curl` transfers) unrelated to any
+change. Consequence worth internalising: **a green PR proves nothing about the
+Docker tier**, and a Docker regression can reach `master`. Before merging
+anything that un-skips a test module or touches worker/image wiring, check what
+it does under `-m docker`.
 
-Each of the three runs on Python 3.12 and 3.13 as separate jobs. A fourth,
-non-required job builds the Docker images and runs `-m "docker"`.
+> **Adding or renaming a suite?** Required checks are matched by job *name*, so
+> a matrix change must be paired with an update to the "Require CI green"
+> ruleset in the same breath. A required check that never reports leaves every
+> PR stuck on "Expected — waiting for status".
 
-### The nightly `slow` tier
+#### Why `slow` is on PR CI and not nightly-only
 
-`slow` is excluded from every PR-CI step *and* from the local default, so a
-`slow` test would otherwise run nowhere at all. `.github/workflows/nightly.yml`
-runs it once a day:
+It used to be excluded everywhere — from all three CI steps *and* the local
+default — so ~37 tests ran nowhere at all, including the only proof that a
+cached notebook replays byte-identically to a direct execution
+(`tests/workers/notebook/test_cache_equivalence.py`), the
+worker-reuse-across-builds e2e tests, and all 18 real-subprocess CLI tests.
 
-```bash
-pytest -m "slow and not docker"
-```
+It was never excluded for cost: the tier is 37 tests in ~78 s at `-n 4`. As a
+*parallel* job it adds machine-minutes but no wall clock — the `unit` job runs
+~4.5 min and the Docker job ~6.5 min.
 
-~37 tests, including the only proof that a cached notebook replays
-byte-identically to a direct execution (`tests/workers/notebook/test_cache_equivalence.py`),
-the worker-reuse-across-builds e2e tests, and all 18 real-subprocess CLI tests.
+Marker choice, restated: `integration` keeps a test off the per-commit gate but
+on every PR. `slow` now also runs on every PR, so the two differ only in which
+job they land in — pick by what the test *is*, not by where you want it to run.
+
+### The nightly full-suite run
+
+`.github/workflows/nightly.yml` is a **flake and rot detector**, not a coverage
+backstop. It runs the whole suite against *unchanged* `master`: `-m "not docker"`
+in one job, and the Docker tier (images built from scratch) in another.
+
+That is the one thing PR CI structurally cannot do. A PR run tells you "this
+change is fine"; thirty runs of identical code tell you "this test is 3% flaky",
+which is how a contention regression like issue #163 surfaces before it wastes
+someone's afternoon. It also means a red Docker tier — not a required check —
+surfaces within a day even if nobody inspects the merge commit's CI.
+
+(Dependency drift, the other usual nightly justification, barely applies here:
+CI installs from `uv.lock` with `UV_EXCLUDE_NEWER` pinned, so nothing moves
+underneath us.)
 
 **Failures file a GitHub issue** labelled `nightly-failure` — or comment on the
 existing open one, so an outage produces one issue rather than one per night.
 That routing is the point of the job: a nightly nobody reads manufactures the
-feeling of coverage without providing any. `workflow_dispatch` is enabled, so
-the run (and its failure route) can be exercised on demand.
+feeling of coverage without providing any. The mechanism lives in the
+`.github/actions/report-failure` composite action. `workflow_dispatch` is
+enabled, so the run and its failure route can be exercised on demand.
 
-Marker choice, restated: if you want a test kept off the per-commit gate but
-still run on every PR, mark it `integration`, **not** `slow`.
+When triaging a nightly failure, check first whether the same test failed on
+earlier nights. `master` did not change between runs, so a first-time failure
+with no corresponding merge is a **flake**, not a regression.
 
 ### CI Environment Setup
 


### PR DESCRIPTION
Acts on your call that the slow tier should gate every PR, and follows the
consequence through to what the nightly is then *for*.

## Slow joins the PR matrix

Fourth parallel suite on the existing `python-version × suite` matrix. Measured
on a green master run, the jobs are:

| Job | Duration |
|---|---|
| unit | 4m27s |
| integration | 3m13s |
| e2e | 3m03s |
| Docker | 6m19s |

The slow tier is 37 tests / ~78 s at `-n 4`; with runner setup it lands ~3–4 min,
under `unit` and well under Docker. **Wall clock does not move**; the cost is
~8 machine-minutes per PR. It was never excluded for cost.

The four selectors partition cleanly — the other three keep `not slow` — so
nothing runs twice.

## The nightly becomes a flake detector

Once slow gates every PR, the *coverage* justification for a nightly slow tier is
gone. What does not go away is the job PR CI structurally cannot do: run the
whole suite against **unchanged** master, repeatedly. A PR run says "this change
is fine". Thirty runs of identical code say "this test is 3% flaky" — which is
how a contention regression like issue #163 surfaces before it costs someone an
afternoon.

So it is repointed, not deleted: `-m "not docker"` in one job, the Docker tier
(images built from scratch) in another.

**That second job also closes a real hole.** The Docker job is not a required
check, so a regression in it reaches master unnoticed — exactly what happened
when #667 was green on its own PR and broke master's Docker job. A nightly run
surfaces that within a day even if nobody inspects the merge commit's CI.

Dependency drift, the other usual nightly justification, barely applies here:
CI installs from `uv.lock` with `UV_EXCLUDE_NEWER` pinned, so nothing moves
underneath us. Worth stating so nobody re-derives it.

## Refactor

The issue-filing block moves into `.github/actions/report-failure`, a composite
action, so the CI workflow can reuse it for post-merge master failures without a
second copy of the `github-script` body. Behaviour is unchanged: create the
label if missing, comment on the existing open issue if there is one, otherwise
file a new one.

## ⚠️ Needs a ruleset change right after this merges

Required checks are matched by job **name**. These two are new:

- `Test on Python 3.12 (slow)`
- `Test on Python 3.13 (slow)`

Until they are added to "Require CI green" they will run and be visible but will
not gate. Adding them *before* this merges would block this very PR on checks
that do not exist yet, so the sequencing is forced. You approved this; I will
apply it once this lands and confirm the resulting context list.

## Verification

All three YAML files parse, and the matrix expands to exactly the eight expected
job names. The slow tier itself is already proven green on master — the previous
nightly ran it end to end (`Slow tier: success`) before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEAsC4QkeoDw34FEBNdh1K
