### PR TITLE
ci: surface a red master, and guard image tags in the fast suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,3 +342,42 @@ jobs:
         CLM_E2E_TIMEOUT: 600
         CLM_ENABLE_TEST_LOGGING: "1"
         CLM_LOG_LEVEL: INFO
+
+  # ------------------------------------------------------------------
+  # A red master must be impossible to miss.
+  #
+  # "Docker Integration Tests" is deliberately NOT a required status check
+  # (its image builds fetch from four external hosts and flake ~12% of the
+  # time on registry timeouts and partial transfers). That is a reasonable
+  # trade, but it has a sharp edge: a PR can be green and still break master,
+  # which is exactly what happened when PR #667 un-skipped a module containing
+  # docker-marked tests. Nothing surfaced it until someone happened to look.
+  #
+  # This job closes that gap for EVERY job in the workflow, not just docker:
+  # any failure on a push to the default branch files (or comments on) an
+  # issue within minutes. It never runs for pull requests — a red PR is
+  # already visible to the person who opened it.
+  # ------------------------------------------------------------------
+  report-master-failure:
+    name: Report master failure
+    needs: [changes, test, lint, docker-test]
+    if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          lfs: false
+
+      - uses: ./.github/actions/report-failure
+        with:
+          label: master-red
+          title: CI is failing on master
+          label-description: A post-merge CI run on master failed
+          context: >-
+            At least one job failed on `master` after a merge. Note that the
+            **Docker Integration Tests** job is not a required status check, so
+            a failure there can reach `master` through a fully green PR — check
+            it explicitly before assuming the required suites are at fault.

--- a/changelog.d/677-red-master-visibility.added.md
+++ b/changelog.d/677-red-master-visibility.added.md
@@ -1,0 +1,15 @@
+- **A red `master` now files an issue within minutes.** The "Docker Integration
+  Tests" job is deliberately not a required status check, so a fully green PR
+  can still break `master` — which is exactly what happened when a PR un-skipped
+  a module containing docker-marked tests. A `report-master-failure` job now
+  fires on any post-merge CI failure (not just Docker) and files, or comments
+  on, a `master-red` issue.
+- **`tests/infrastructure/workers/test_docker_image_tags.py`** rejects any test
+  naming a Docker image CLM does not build — the sibling of the module-probe
+  guard, one layer down. Repository names must carry the `clm-` prefix,
+  registry-qualified references must sit under `docker.io/mhoelzl`, and bare
+  tags must be built by a workflow or be a published variant. The CI-built tags
+  are parsed out of the workflow files rather than duplicated, so a renamed tag
+  fails the fast suite instead of only the non-required Docker job. Six
+  references to a pre-rename image name in `test_worker_executor.py` are
+  corrected in passing.

--- a/tests/infrastructure/workers/test_docker_image_tags.py
+++ b/tests/infrastructure/workers/test_docker_image_tags.py
@@ -1,0 +1,182 @@
+"""Guard against tests naming a Docker image CLM does not build.
+
+The sibling of ``test_worker_module_probes.py``, for image tags instead of
+module names — and it exists for the same reason, one layer down.
+
+``test_direct_integration.py`` hard-coded an image whose repository had lost
+its ``clm-`` prefix. CLM has not published under that name since the images
+were renamed, so the Docker client treated it as a registry reference and
+tried to *pull* it:
+
+    docker.errors.ImageNotFound: 404 ... pull access denied for
+    drawio-converter, repository does not exist or may require 'docker login'
+
+Nothing caught it, for two compounding reasons: the module was permanently
+skipped (finding T1), and the **Docker Integration Tests** job is not a
+required status check — so even after the skip was lifted, the PR was green
+and `master` broke.
+
+These tests are fast and unmarked, so they run on every commit. A rename of a
+CI image tag, or a test reaching for a tag nobody builds, now fails in the
+72-second gate rather than in a job that does not block anything.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from clm.cli.commands.docker import AVAILABLE_SERVICES, HUB_NAMESPACE, REGISTRY
+from clm.infrastructure.config import DEFAULT_WORKER_IMAGES
+
+REPO_ROOT = Path(__file__).parents[3]
+TESTS_ROOT = REPO_ROOT / "tests"
+WORKFLOWS = sorted((REPO_ROOT / ".github" / "workflows").glob("*.yml"))
+
+# ``clm docker build`` composes image names as ``clm-<service>`` where the
+# notebook service is published as ``clm-notebook-processor`` and the
+# converters as ``clm-<name>-converter`` (docker.py:184).
+CLM_REPOSITORIES = {
+    "clm-notebook-processor",
+    "clm-plantuml-converter",
+    "clm-drawio-converter",
+}
+
+# Any string literal in the test tree that *looks* like a CLM worker image
+# reference. Deliberately matches the un-prefixed form too — catching those is
+# the whole point.
+IMAGE_LITERAL = re.compile(
+    r"""["']((?:[A-Za-z0-9._-]+/)*[A-Za-z0-9._-]*(?:converter|processor)[A-Za-z0-9._-]*:[A-Za-z0-9._-]+)["']"""
+)
+
+# Tags that exist without any workflow building them: the variants
+# ``clm docker build`` publishes, plus version tags like ``1.22.1-full``.
+# A bare reference to one of these is legitimate in an ``images.get()`` probe
+# list (which never pulls) — several tests search local-then-published tags
+# that way.
+PUBLISHED_TAGS = {"latest", "lite", "full"}
+VERSION_TAG = re.compile(r"^\d+\.\d+\.\d+(?:-[A-Za-z0-9._-]+)?$")
+
+
+def _iter_image_literals() -> list[tuple[Path, int, str]]:
+    """Every image-shaped literal in the test tree, with its location.
+
+    This module is skipped: its own prose necessarily quotes the malformed
+    references it exists to reject.
+    """
+    found: list[tuple[Path, int, str]] = []
+    for path in sorted(TESTS_ROOT.rglob("*.py")):
+        if path.resolve() == Path(__file__).resolve():
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for match in IMAGE_LITERAL.finditer(line):
+                found.append((path, lineno, match.group(1)))
+    return found
+
+
+def _split_reference(reference: str) -> tuple[str, str, str]:
+    """Split ``[registry/][namespace/]repository:tag`` into its parts."""
+    repository, _, tag = reference.rpartition(":")
+    *prefix, name = repository.split("/")
+    return "/".join(prefix), name, tag
+
+
+def _ci_built_tags() -> set[str]:
+    """Locally-built image tags, read out of the workflow ``-t`` arguments.
+
+    Parsed from the workflows rather than hard-coded, so a rename of a CI tag
+    changes both sides at once and this test cannot drift into agreeing with
+    itself.
+    """
+    tags: set[str] = set()
+    for workflow in WORKFLOWS:
+        for match in re.finditer(
+            r"-t\s+([A-Za-z0-9._/-]+:[A-Za-z0-9._-]+)", workflow.read_text(encoding="utf-8")
+        ):
+            tags.add(match.group(1))
+    return tags
+
+
+def test_workflows_build_the_expected_local_tags() -> None:
+    """The workflows must build one local tag per worker image.
+
+    Anchors the other tests: if this set ever empties (a workflow rename, a
+    parsing change), they would silently stop checking anything.
+    """
+    tags = _ci_built_tags()
+    assert tags, f"no `docker build -t` tags found in {[w.name for w in WORKFLOWS]}"
+
+    repositories = {_split_reference(tag)[1] for tag in tags}
+    assert repositories == CLM_REPOSITORIES, (
+        f"workflows build {sorted(repositories)}, expected {sorted(CLM_REPOSITORIES)}"
+    )
+
+
+def test_default_worker_images_match_the_published_naming() -> None:
+    """``DEFAULT_WORKER_IMAGES`` must agree with what ``clm docker`` publishes."""
+    assert set(DEFAULT_WORKER_IMAGES) == set(AVAILABLE_SERVICES)
+    for service, reference in DEFAULT_WORKER_IMAGES.items():
+        prefix, repository, tag = _split_reference(reference)
+        assert prefix == f"{REGISTRY}/{HUB_NAMESPACE}", (
+            f"{service}: {reference} is not under {REGISTRY}/{HUB_NAMESPACE}"
+        )
+        assert repository in CLM_REPOSITORIES, f"{service}: unknown repository {repository!r}"
+        assert tag, f"{service}: {reference} has no tag"
+
+
+def test_every_image_literal_in_tests_is_one_clm_builds() -> None:
+    """No test may name an image outside the set CLM builds or publishes.
+
+    Three rules, in order of how likely each is to rot:
+
+    1. The **repository** must be one CLM builds. This is the rule that would
+       have caught the real bug — the failing reference had lost its ``clm-``
+       prefix — and it is the part a rename breaks.
+    2. A registry-qualified reference must sit under ``docker.io/mhoelzl``.
+    3. A bare tag must be one a workflow builds, or a published variant
+       (``latest``/``lite``/``full``/a version). Bare published tags are
+       legitimate inside ``images.get()`` probe lists, which never pull; a
+       typo'd tag still fails.
+    """
+    ci_tags = _ci_built_tags()
+    problems: list[str] = []
+
+    for path, lineno, reference in _iter_image_literals():
+        location = f"{path.relative_to(REPO_ROOT).as_posix()}:{lineno}"
+        prefix, repository, tag = _split_reference(reference)
+
+        if repository not in CLM_REPOSITORIES:
+            problems.append(
+                f"{location}: {reference!r} — repository {repository!r} is not one CLM builds "
+                f"({sorted(CLM_REPOSITORIES)}). Did the `clm-` prefix get dropped?"
+            )
+            continue
+
+        if prefix:
+            if prefix != f"{REGISTRY}/{HUB_NAMESPACE}":
+                problems.append(
+                    f"{location}: {reference!r} — published images live under "
+                    f"{REGISTRY}/{HUB_NAMESPACE}, not {prefix!r}"
+                )
+            continue
+
+        known = reference in ci_tags or tag in PUBLISHED_TAGS or VERSION_TAG.match(tag)
+        if not known:
+            problems.append(
+                f"{location}: {reference!r} — tag {tag!r} is neither built by a workflow "
+                f"({sorted(ci_tags)}) nor a published variant ({sorted(PUBLISHED_TAGS)} "
+                f"or a version). A Docker client will try to PULL this."
+            )
+
+    assert not problems, "Docker image references that cannot resolve:\n  " + "\n  ".join(problems)
+
+
+@pytest.mark.parametrize("workflow", WORKFLOWS, ids=lambda p: p.name)
+def test_workflow_is_parseable(workflow: Path) -> None:
+    """A malformed workflow silently stops running — parse it here, cheaply."""
+    parsed = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+    assert isinstance(parsed, dict), f"{workflow.name} did not parse to a mapping"
+    assert parsed.get("jobs"), f"{workflow.name} declares no jobs"

--- a/tests/infrastructure/workers/test_worker_executor.py
+++ b/tests/infrastructure/workers/test_worker_executor.py
@@ -80,14 +80,14 @@ class TestWorkerConfig:
             worker_type="notebook",
             count=2,
             execution_mode="docker",
-            image="notebook-processor:latest",
+            image="clm-notebook-processor:latest",
             memory_limit="1g",
         )
 
         assert config.worker_type == "notebook"
         assert config.count == 2
         assert config.execution_mode == "docker"
-        assert config.image == "notebook-processor:latest"
+        assert config.image == "clm-notebook-processor:latest"
         assert config.memory_limit == "1g"
         assert config.max_job_time == 600  # default
 
@@ -519,7 +519,7 @@ class TestDockerWorkerExecutor:
             worker_type="notebook",
             count=1,
             execution_mode="docker",
-            image="notebook-processor:latest",
+            image="clm-notebook-processor:latest",
             memory_limit="1g",
         )
 
@@ -533,7 +533,7 @@ class TestDockerWorkerExecutor:
         call_args = mock_client.containers.run.call_args
 
         # Check image (now passed as kwargs since we use **run_kwargs)
-        assert call_args.kwargs["image"] == "notebook-processor:latest"
+        assert call_args.kwargs["image"] == "clm-notebook-processor:latest"
 
         # Check environment
         env = call_args.kwargs["environment"]
@@ -569,7 +569,7 @@ class TestDockerWorkerExecutor:
             worker_type="notebook",
             count=1,
             execution_mode="docker",
-            image="notebook-processor:latest",
+            image="clm-notebook-processor:latest",
         )
 
         # Start worker
@@ -606,7 +606,7 @@ class TestDockerWorkerExecutor:
             worker_type="notebook",
             count=1,
             execution_mode="docker",
-            image="notebook-processor:latest",
+            image="clm-notebook-processor:latest",
         )
 
         # Start worker


### PR DESCRIPTION
Two halves of the same hole, per your go-ahead on (a) and (b).

## The hole

"Docker Integration Tests" is deliberately not a required status check — its
image builds fetch from four external hosts and flake ~12% of the time on
registry timeouts and partial transfers. Reasonable trade, sharp edge: **a fully
green PR can still break master**. That is what happened when #667 un-skipped a
module containing docker-marked tests, and nothing surfaced it until someone
happened to inspect the merge commit's CI.

## (a) Report it

`report-master-failure` fires on any failure of a push to the default branch and
files — or comments on — a `master-red` issue, through the composite action the
nightly already uses. It covers **every** job in the workflow, not just Docker,
and never runs for pull requests: a red PR is already visible to whoever opened
it.

## (b) Catch it earlier

`tests/infrastructure/workers/test_docker_image_tags.py` is the sibling of
`test_worker_module_probes.py`, for image tags instead of module names. Three
rules, ordered by how likely each is to rot:

1. **Repository must be one CLM builds.** This is the rule that would have caught
   the actual bug — the failing reference had lost its `clm-` prefix — and it is
   the part a rename breaks.
2. Registry-qualified references must sit under `docker.io/mhoelzl`.
3. A bare tag must be built by a workflow, or be a published variant
   (`latest`/`lite`/`full`/a version).

The CI-built tags are **parsed out of the workflow files**, not duplicated, so
the test cannot drift into agreeing with itself — rename a `-t` argument and it
fails. It is unmarked and fast, so a renamed tag now breaks the 72-second gate
instead of a job that blocks nothing.

Rule 3 is deliberately not "must be built by a workflow": several tests probe
local-then-published tags through `images.get()`, which never pulls, and
flagging those would be a false positive. A *typo'd* tag still fails.

## What writing it turned up

Six references to a pre-rename image name in `test_worker_executor.py`. They are
harmless — the docker client there is a `Mock`, so nothing is ever pulled — but
they are precisely the misleading example that produced the outage, so they are
corrected rather than allowlisted.

## Verification

```
pytest tests/infrastructure/workers/test_docker_image_tags.py tests/infrastructure/workers/test_worker_executor.py -n0   42 passed
```

Mutation-checked — restoring the un-prefixed repository name at one call site
reproduces the original failure, with file, line and reason:

```
tests/infrastructure/workers/test_pool_manager.py:105: 'drawio-converter:latest'
  — repository 'drawio-converter' is not one CLM builds
    (['clm-drawio-converter', 'clm-notebook-processor', 'clm-plantuml-converter']).
    Did the `clm-` prefix get dropped?
```

Note the `report-master-failure` job cannot be exercised from a PR by
construction (it is gated on `push` + `refs/heads/master`). Its mechanism is the
same composite action whose issue-filing and dedup paths were both verified end
to end during Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEAsC4QkeoDw34FEBNdh1K
