### PR TITLE
ci: cache Docker layers and retry the two un-retried fetches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,9 +277,22 @@ jobs:
     needs: changes
     # Not a required status check, so it is safe to skip the whole job for
     # docs-only changes.
+    #
+    # It is not required because its image builds reach four external hosts
+    # (Docker Hub, dot.net, astral.sh, the pinned GitHub release assets) and
+    # flaked ~12% of recent runs on registry timeouts and partial transfers —
+    # failures unrelated to the change under test. The layer cache below plus
+    # the retry loops in docker/notebook/Dockerfile exist to drive that toward
+    # zero, so this job can eventually join the ruleset. Until it does,
+    # remember: a green PR proves nothing about this job, and
+    # ``report-master-failure`` is what surfaces a breakage that slips through.
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      # The type=gha buildx cache backend writes through the Actions cache API.
+      actions: write
 
     steps:
     # The notebook/plantuml/drawio build inputs (deno, ijava, drawio .deb) are
@@ -298,30 +311,59 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
+    # Built through build-push-action rather than plain `docker build` purely
+    # to get `cache-from`/`cache-to`. On a cache hit BuildKit replays the
+    # layers instead of re-running them, so the external fetches inside the
+    # Dockerfiles (dotnet, uv, deno, ijava, the drawio .deb, apt, pip) do not
+    # happen at all — which is the point: those fetches are the flake.
+    #
+    # `load: true` puts the image into the local daemon, which the tests need;
+    # without it buildx keeps the result in its own cache and
+    # `docker.images.get()` finds nothing.
+    #
+    # `mode=min` on purpose. These Dockerfiles are linear multi-stage chains
+    # (base → common → packages-<variant> → final), so the final image's layer
+    # set already covers every stage on the build path; `mode=max` would add
+    # the off-path stages (notably the CUDA-based `base-full-amd64`, which CI
+    # never builds) and could crowd the repository's 10 GB Actions-cache budget,
+    # evicting the uv caches other jobs depend on. Scoped per image so the
+    # three builds cannot evict each other.
     - name: Build notebook-processor:lite-test Docker image
-      run: |
-        docker build \
-          -f docker/notebook/Dockerfile \
-          --build-arg VARIANT=lite \
-          --build-arg DOCKER_PATH=docker/notebook \
-          -t clm-notebook-processor:lite-test \
-          .
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/notebook/Dockerfile
+        build-args: |
+          VARIANT=lite
+          DOCKER_PATH=docker/notebook
+        tags: clm-notebook-processor:lite-test
+        load: true
+        cache-from: type=gha,scope=notebook-lite
+        cache-to: type=gha,mode=min,scope=notebook-lite
 
     - name: Build plantuml-converter:test Docker image
-      run: |
-        docker build \
-          -f docker/plantuml/Dockerfile \
-          --build-arg DOCKER_PATH=docker/plantuml \
-          -t clm-plantuml-converter:test \
-          .
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/plantuml/Dockerfile
+        build-args: |
+          DOCKER_PATH=docker/plantuml
+        tags: clm-plantuml-converter:test
+        load: true
+        cache-from: type=gha,scope=plantuml
+        cache-to: type=gha,mode=min,scope=plantuml
 
     - name: Build drawio-converter:test Docker image
-      run: |
-        docker build \
-          -f docker/drawio/Dockerfile \
-          --build-arg DOCKER_PATH=docker/drawio \
-          -t clm-drawio-converter:test \
-          .
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/drawio/Dockerfile
+        build-args: |
+          DOCKER_PATH=docker/drawio
+        tags: clm-drawio-converter:test
+        load: true
+        cache-from: type=gha,scope=drawio
+        cache-to: type=gha,mode=min,scope=drawio
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -145,30 +145,51 @@ jobs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4
 
+    # ``cache-from`` but NOT ``cache-to``: this job reads the layer cache the
+    # PR workflow populates, and does not write to it.
+    #
+    # Reading matters because a nightly that rebuilds cold every night would
+    # keep hitting the ~12% external-fetch flake and file a spurious
+    # ``nightly-failure`` issue roughly weekly — which poisons the alert
+    # channel and turns this into the nightly-nobody-reads it was designed not
+    # to be. This job exists to detect flaky *tests*, not flaky image builds;
+    # the PR workflow already builds these images on every code change.
+    #
+    # Not writing matters because two workflows writing the same scopes would
+    # thrash the repository's Actions-cache budget.
     - name: Build notebook-processor:lite-test Docker image
-      run: |
-        docker build \
-          -f docker/notebook/Dockerfile \
-          --build-arg VARIANT=lite \
-          --build-arg DOCKER_PATH=docker/notebook \
-          -t clm-notebook-processor:lite-test \
-          .
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/notebook/Dockerfile
+        build-args: |
+          VARIANT=lite
+          DOCKER_PATH=docker/notebook
+        tags: clm-notebook-processor:lite-test
+        load: true
+        cache-from: type=gha,scope=notebook-lite
 
     - name: Build plantuml-converter:test Docker image
-      run: |
-        docker build \
-          -f docker/plantuml/Dockerfile \
-          --build-arg DOCKER_PATH=docker/plantuml \
-          -t clm-plantuml-converter:test \
-          .
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/plantuml/Dockerfile
+        build-args: |
+          DOCKER_PATH=docker/plantuml
+        tags: clm-plantuml-converter:test
+        load: true
+        cache-from: type=gha,scope=plantuml
 
     - name: Build drawio-converter:test Docker image
-      run: |
-        docker build \
-          -f docker/drawio/Dockerfile \
-          --build-arg DOCKER_PATH=docker/drawio \
-          -t clm-drawio-converter:test \
-          .
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: docker/drawio/Dockerfile
+        build-args: |
+          DOCKER_PATH=docker/drawio
+        tags: clm-drawio-converter:test
+        load: true
+        cache-from: type=gha,scope=drawio
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7

--- a/changelog.d/678-docker-ci-cache-retries.fixed.md
+++ b/changelog.d/678-docker-ci-cache-retries.fixed.md
@@ -1,0 +1,12 @@
+- **The Docker CI job no longer re-fetches the world on every run.** Its three
+  image builds now use a scoped BuildKit layer cache (`type=gha`), so on a cache
+  hit the external fetches inside the Dockerfiles do not run at all — and those
+  fetches were the entire source of the job's ~12% infra failure rate (Docker
+  Hub timeouts, partial transfers). The two remaining un-retried downloads in
+  the notebook image are fixed too: the .NET installer is wrapped in a retry
+  loop, because the script does its *own* downloads and was failing with
+  `curl` exit 18 (partial file), and the `uv` installer is downloaded to a file
+  before execution instead of piped into `sh`, where a truncated download would
+  have executed a truncated script and still reported success. The nightly reads
+  the same cache but does not write it, so a cold-build flake cannot file a
+  spurious `nightly-failure` issue.

--- a/docker/notebook/Dockerfile
+++ b/docker/notebook/Dockerfile
@@ -136,13 +136,47 @@ ARG TARGETARCH
 # See: https://github.com/dotnet/interactive/issues/3951
 # This works across different Linux distributions without libicu version conflicts
 # Note: DOTNET_ROOT and PATH are set in the base images
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh && \
-    chmod +x dotnet-install.sh && \
-    ./dotnet-install.sh --channel 10.0 --install-dir /root/.dotnet && \
-    rm dotnet-install.sh
+#
+# Retried at two levels. ``curl --retry-all-errors`` covers the fetch of the
+# installer itself; the surrounding loop covers ``dotnet-install.sh``, which
+# does its OWN downloads and has no retry flag of its own. That inner download
+# is the one that actually failed in CI:
+#
+#   #13 ERROR: process "/bin/sh -c curl -sSL https://dot.net/... &&
+#       ./dotnet-install.sh ..." did not complete successfully: exit code: 18
+#
+# Exit 18 is CURLE_PARTIAL_FILE — a truncated transfer, not a bad URL. It is
+# the single largest source of the Docker job's infra flake, which is why that
+# job is not a required status check.
+RUN set -eu; \
+    ok=0; \
+    for attempt in 1 2 3; do \
+        if curl --fail --location --silent --show-error \
+                --retry 5 --retry-delay 5 --retry-all-errors \
+                https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh \
+           && chmod +x dotnet-install.sh \
+           && ./dotnet-install.sh --channel 10.0 --install-dir /root/.dotnet; then \
+            ok=1; \
+            break; \
+        fi; \
+        echo "dotnet install attempt ${attempt}/3 failed; retrying in 15s" >&2; \
+        rm -f dotnet-install.sh; \
+        sleep 15; \
+    done; \
+    rm -f dotnet-install.sh; \
+    [ "${ok}" -eq 1 ]
 
-# Install uv (modern Python package installer)
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+# Install uv (modern Python package installer).
+#
+# Downloaded to a file and then executed, rather than piped straight into
+# ``sh``. In a ``curl | sh`` pipeline the exit status is the shell's, so a
+# truncated download runs a truncated script and can still succeed — the same
+# partial-transfer failure mode as the dotnet installer above, but silent.
+RUN curl --fail --location --silent --show-error \
+        --retry 5 --retry-delay 5 --retry-all-errors \
+        https://astral.sh/uv/install.sh -o /tmp/uv-install.sh \
+    && sh /tmp/uv-install.sh \
+    && rm -f /tmp/uv-install.sh
 
 # Install micromamba for Python environment management.
 # This provides a clean Python installation without PEP 668 restrictions.

--- a/tests/infrastructure/workers/test_docker_image_tags.py
+++ b/tests/infrastructure/workers/test_docker_image_tags.py
@@ -84,8 +84,19 @@ def _split_reference(reference: str) -> tuple[str, str, str]:
     return "/".join(prefix), name, tag
 
 
+# Both spellings of "this workflow builds this tag": the ``-t`` flag of a plain
+# ``docker build``, and the ``tags:`` input of ``docker/build-push-action``.
+# Both are matched so the guard survives a workflow switching between them — it
+# already had to once, when the builds moved to build-push-action for layer
+# caching, and the anchor test below is what caught it.
+WORKFLOW_TAG = re.compile(
+    r"(?:-t\s+|^\s*tags:\s*)([A-Za-z0-9._/-]+:[A-Za-z0-9._-]+)\s*$",
+    re.MULTILINE,
+)
+
+
 def _ci_built_tags() -> set[str]:
-    """Locally-built image tags, read out of the workflow ``-t`` arguments.
+    """Locally-built image tags, read out of the workflow files.
 
     Parsed from the workflows rather than hard-coded, so a rename of a CI tag
     changes both sides at once and this test cannot drift into agreeing with
@@ -93,9 +104,7 @@ def _ci_built_tags() -> set[str]:
     """
     tags: set[str] = set()
     for workflow in WORKFLOWS:
-        for match in re.finditer(
-            r"-t\s+([A-Za-z0-9._/-]+:[A-Za-z0-9._-]+)", workflow.read_text(encoding="utf-8")
-        ):
+        for match in WORKFLOW_TAG.finditer(workflow.read_text(encoding="utf-8")):
             tags.add(match.group(1))
     return tags
 
@@ -104,10 +113,11 @@ def test_workflows_build_the_expected_local_tags() -> None:
     """The workflows must build one local tag per worker image.
 
     Anchors the other tests: if this set ever empties (a workflow rename, a
-    parsing change), they would silently stop checking anything.
+    change of build action, a parsing change), they would silently stop
+    checking anything.
     """
     tags = _ci_built_tags()
-    assert tags, f"no `docker build -t` tags found in {[w.name for w in WORKFLOWS]}"
+    assert tags, f"no locally-built image tags found in {[w.name for w in WORKFLOWS]}"
 
     repositories = {_split_reference(tag)[1] for tag in tags}
     assert repositories == CLM_REPOSITORIES, (


### PR DESCRIPTION
Item (c) of the red-master plan: drive the Docker job's infra flake toward zero
so it can eventually become a required check.

## The measurement

Last 20 CI runs: 13 success, 4 failure, 3 skipped. Of the four failures, **two
were a genuine regression** (correctly caught) and **two were infrastructure**:

```
ERROR: Error response from daemon:
  Get "https://registry-1.docker.io/v2/": context deadline exceeded

#13 ERROR: process "/bin/sh -c curl -sSL https://dot.net/... &&
  ./dotnet-install.sh ..." did not complete successfully: exit code: 18
```

Exit 18 is `CURLE_PARTIAL_FILE` — a truncated transfer, not a bad URL. So the
flake is *entirely* network fetches during image build. Nothing about Docker,
nothing about the tests.

## Cache the layers

The three builds move from plain `docker build` to `docker/build-push-action`,
purely to gain `cache-from`/`cache-to` (`type=gha`, scoped per image so they
cannot evict each other). On a cache hit BuildKit replays the layers rather than
re-running them, so the fetches do not happen at all.

`mode=min` is deliberate. These Dockerfiles are linear multi-stage chains
(`base → common → packages-<variant> → final`), so the final image's layer set
already covers every stage on the build path. `mode=max` would additionally
export the off-path stages — notably the CUDA-based `base-full-amd64`, which CI
never builds — and could crowd the repository's 10 GB Actions-cache budget,
evicting the `uv` caches other jobs depend on.

`load: true` is required so the built image lands in the local daemon; without
it buildx keeps the result in its own cache and `docker.images.get()` finds
nothing.

## Retry what still has to be fetched

#239 already added `--retry 5 --retry-all-errors` to the pinned deno / ijava /
drawio fetches. Two were missed:

- **The .NET installer** — retried at *two* levels, because `curl --retry` only
  covers fetching the script; the script then does its own downloads with no
  retry flag of its own, and that inner download is what actually failed.
- **The uv installer** — was `curl … | sh`. In a pipeline the exit status is the
  shell's, so a truncated download runs a truncated script **and can still
  report success**. Now downloaded to a file and executed separately, which
  turns a silent failure into a loud one.

## The nightly reads the cache but does not write it

A nightly that rebuilt cold every night would keep hitting the fetch flake and
file a spurious `nightly-failure` issue roughly weekly — poisoning the alert
channel the whole design depends on. It exists to detect flaky *tests*; the PR
workflow already builds these images on every code change. Not writing also
stops two workflows thrashing the same cache scopes.

## Verification

- `docker buildx build --check` on the modified Dockerfile: *"Check complete, no
  warnings found."*
- The retry loop's control flow was run in a real container against scripted
  outcomes — both branches confirmed: `CASE1 pass (recovered after 3 attempts)`,
  `CASE2 pass (exhausted retries, non-zero)`.
- Moving to `build-push-action` changed how the workflows spell "builds this
  tag", which broke `_ci_built_tags()` in the image-tag guard from #677 — and
  was **caught by that module's own anchor test** (`no locally-built image tags
  found`), which is precisely what it is there for. The parser now matches both
  spellings.

## Not done here

Making the job a required check. That needs evidence, not hope: I'd let it run
~20 times and confirm the infra flake is actually gone before proposing the
ruleset change. The first run after this merges will also be a cold cache, so
it proves nothing by itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEAsC4QkeoDw34FEBNdh1K
