### PR TITLE
test: cover C++ execution in CI (no new images, no added build time)

### DIFF
--- a/changelog.d/688-cpp-docker-coverage.fixed.md
+++ b/changelog.d/688-cpp-docker-coverage.fixed.md
@@ -1,0 +1,20 @@
+- **C++ execution is now covered by CI.** Nothing automated checked that a valid
+  C++ deck still compiles and runs: the one Docker test that ran a C++ notebook
+  ran a deliberately *broken* one to check error attribution, and it asked for
+  the `full` notebook image, which no workflow builds — so it skipped in CI and
+  ran only on a machine that had pulled the 23 GB image. Three changes, no new
+  images and no added build time:
+  - The C++ kernels come from the Dockerfile's shared stage, not from the `full`
+    variant, so every notebook image has them. C++ tests now use the image CI
+    already builds.
+  - A new test executes a valid C++ deck through the Docker notebook worker and
+    requires the rendered deck to contain a value the C++ code *computes*, so a
+    kernel that stops running code cannot pass it.
+  - A new test compares the kernel names CLM asks for against the kernels the
+    image installs. A rename in an image bump — the xeus-cling → xeus-cpp move
+    did exactly this — breaks every deck in a language at once, and now fails in
+    seconds with the kernel name in the message.
+- **Known gap now recorded**: CLM configures a `rust` kernel that none of the
+  images install, so a Rust deck in Docker mode fails with `NoSuchKernel`. The
+  new kernel test pins this as the only expected hole, so a second one cannot
+  appear unnoticed.

--- a/docs/claude/handovers/adversarial-review-remediation-handover.md
+++ b/docs/claude/handovers/adversarial-review-remediation-handover.md
@@ -465,15 +465,68 @@ cache path; SSTI proof-of-concept from the review no longer executes.
     `mhoelzl/clm-drawio-converter:latest`, so they ran against Docker Hub rather
     than the working tree. **Fixed**: they now discover the image like the
     notebook tests do, preferring the CI-built `clm-drawio-converter:test`.
-  - `test_notebook_error_context.py::TestCppErrorWithDocker` needs the `:full`
-    image (xeus-cling) and **still fails on any machine whose `:full` predates
-    the token change** — verified failing identically on `master`. It is a stale
-    image, not a code defect; rebuild with
-    `clm docker build notebook --variant full`. Its tag preference also puts
-    floating `:full` ahead of the version-matched `<version>-full`, which is
-    backwards — worth flipping when someone is next in that file.
-  Diagnosing this is one command:
+  - `test_notebook_error_context.py::TestCppErrorWithDocker` asked for the
+    `:full` image, and failed on a machine whose `:full` predates the token
+    change — verified failing identically on `master`. **Fixed, and the fix was
+    not "rebuild `:full`": the `full` variant is not where the C++ kernel comes
+    from.** xeus-cpp is installed in the Dockerfile's shared `common` stage, so
+    **every** notebook image ships `xcpp17/20/23`; `full` differs only by an
+    nvidia/cuda base plus torch/fastai. The test now prefers the CI-built
+    `clm-notebook-processor:lite-test` and passes against it in 30s, with the
+    real compilation error correctly attributed to cell #2 — so **C++ execution
+    is covered by the existing CI docker job at zero extra build time**, where
+    before it was skipped in CI and ran only on a machine that had pulled 23 GB.
+  Diagnosing a stale image is one command:
   `docker run --rm --entrypoint python <image> -c "import inspect; from clm.infrastructure.api import client; print('CLM_API_TOKEN' in inspect.getsource(client))"`.
+
+- **Do not add a `full`-variant build to CI.** The decisive numbers are size,
+  not time: `full` is **22.9 GB** against `lite`'s **6.3 GB** (measured with
+  `docker image inspect`). `load: true` on a 23 GB image does not fit a standard
+  GitHub runner's disk without clearing it first, and its layers alone would
+  exceed the repository's 10 GB Actions-cache budget — evicting the uv caches the
+  other jobs depend on, which the workflow's own comment already worries about at
+  lite's size. And there is nothing to buy: the ML stack is the *only* thing
+  `full` adds, so no language kernel depends on it.
+
+#### Language coverage: what a broken C++ (or C#, or Java) course would hit
+
+Everything about C++ *except execution* was already unit-tested — the
+`cpp:percent` jupytext round-trip, the `// j2` jinja prefix, comment-token
+parsing, code extraction, the CMake export. Execution was the hole, and the one
+Docker test that ran a C++ notebook ran a **deliberately broken** one to check
+error attribution, so "valid C++ compiles and its output reaches the deck" was
+asserted nowhere. Now in the docker tier (`test_cpp_docker_execution.py`, ~13s
+for both, no new image):
+
+- a valid C++ deck through the real Docker worker, asserting the rendered HTML
+  contains a value the C++ code *computes* (`6 * 7`), so a kernel that stops
+  running code cannot pass it. **Note it must be an HTML target**: execution is
+  gated by `evaluate_for_html` (`output_spec.py`), so a `format: notebook` job
+  writes a deck with no outputs and asserts nothing about the kernel — the first
+  version of this test passed that way before the assertion was tightened.
+- the kernel names CLM asks for (`kernelspec_for`) against the kernels the image
+  installs. A rename in an image bump — which the xeus-cling → xeus-cpp move
+  actually did — breaks every deck in a language at once, and this fails in
+  seconds with the name in the message, for every language rather than only C++.
+
+**Still uncovered, in rough value order:**
+1. **C#, Java, TypeScript execute nowhere in CI.** The images ship
+   `.net-csharp`, `java` and `deno`; CLM configures all three; no test runs a
+   deck in any of them. The C++ test is ~40 lines of harness — parameterising it
+   over the four languages is the cheapest large win available here, and
+   CSharpCourses is a live downstream repo.
+2. **`rust` is configured but no image installs a Rust kernel**, so a Rust deck
+   in Docker mode fails `NoSuchKernel`. Pinned as the single expected hole in
+   `KNOWN_MISSING_KERNELS`; decide whether to install it or drop the config.
+3. **No full `clm build` of a non-Python course spec.** Output targets, code
+   extraction, per-language directories and the CMake export are unit-tested but
+   never exercised together for C++. An e2e fixture course with one C++ topic
+   would cover the shape a course repo actually uses.
+4. **`clm kernel-triage` is the real-world signal** (it re-runs `evaluate="no"`
+   decks and telemetry-flagged flakes against the current kernel) but needs the
+   maintainer's CppCourses checkout, so it is the same "private corpus" case as
+   the sync full-corpus gates in Phase 1 — a nightly with a course checkout, not
+   a PR check.
 
 ---
 

--- a/tests/docker_image_helpers.py
+++ b/tests/docker_image_helpers.py
@@ -1,0 +1,99 @@
+"""Finding a worker image a Docker-marked test can actually run against.
+
+Three test modules used to answer this question three ways, and two of them got
+it wrong in the same direction: they named a *published* tag, so they ran
+against whatever was last pulled from Docker Hub instead of the image the
+working tree builds. When the host side of the worker protocol changed, those
+tests failed as "the job was never claimed", with nothing pointing at the image.
+
+So the preference order lives here, once:
+
+1. the tag CI builds from this checkout (`…:lite-test`, `…:test`),
+2. then a published tag, for a dev machine that has pulled one.
+
+A test that finds nothing skips; a test that finds a stale published image may
+still fail, but at least every module agrees on which image that is.
+
+**Any notebook image can run C++.** `xeus-cpp` is installed in the Dockerfile's
+shared ``common`` stage, so `lite` ships the same `xcpp17/20/23` kernels as
+`full` — the variants differ only in the Python ML stack (`full` adds an
+nvidia/cuda base plus torch/fastai, 22.9 GB against lite's 6.3 GB). There is
+therefore no reason for a C++ test to ask for `full`, and good reason not to:
+nothing builds `full` in CI, so such a test only ever ran on a maintainer's
+machine.
+"""
+
+from __future__ import annotations
+
+#: Notebook-processor images, best first. Every entry ships every kernel CLM
+#: configures except Rust (see ``test_cpp_docker_execution.py``), so this list
+#: serves Python, C++, C#, Java and TypeScript tests alike.
+NOTEBOOK_IMAGE_TAGS = [
+    "clm-notebook-processor:lite-test",
+    "docker.io/mhoelzl/clm-notebook-processor:lite",
+    "docker.io/mhoelzl/clm-notebook-processor:latest",
+    "clm-notebook-processor:full",
+    "docker.io/mhoelzl/clm-notebook-processor:full",
+]
+
+#: DrawIO converter images, best first.
+DRAWIO_IMAGE_TAGS = [
+    "clm-drawio-converter:test",
+    "docker.io/mhoelzl/clm-drawio-converter:latest",
+]
+
+#: PlantUML converter images, best first.
+PLANTUML_IMAGE_TAGS = [
+    "clm-plantuml-converter:test",
+    "docker.io/mhoelzl/clm-plantuml-converter:latest",
+]
+
+
+def docker_available() -> bool:
+    """True when a Docker daemon answers."""
+    try:
+        import docker
+
+        client = docker.from_env()
+        client.ping()
+        return True
+    except Exception:
+        return False
+
+
+def find_image(tags: list[str]) -> str | None:
+    """Return the first tag in ``tags`` present locally, or None.
+
+    Only ever consults the local daemon: ``images.get`` does not pull, so a
+    missing image makes a test *skip* rather than silently downloading
+    gigabytes mid-test-run.
+    """
+    try:
+        import docker
+
+        client = docker.from_env()
+    except Exception:
+        return None
+
+    for tag in tags:
+        try:
+            client.images.get(tag)
+            return tag
+        except Exception:  # ImageNotFound, or a daemon that went away
+            continue
+    return None
+
+
+def find_notebook_image() -> str | None:
+    """Return a notebook-processor image tag, or None."""
+    return find_image(NOTEBOOK_IMAGE_TAGS)
+
+
+def find_drawio_image() -> str | None:
+    """Return a DrawIO converter image tag, or None."""
+    return find_image(DRAWIO_IMAGE_TAGS)
+
+
+def find_plantuml_image() -> str | None:
+    """Return a PlantUML converter image tag, or None."""
+    return find_image(PLANTUML_IMAGE_TAGS)

--- a/tests/infrastructure/workers/test_docker_job_execution.py
+++ b/tests/infrastructure/workers/test_docker_job_execution.py
@@ -27,18 +27,19 @@ from clm.infrastructure.database.job_queue import JobQueue
 from clm.infrastructure.database.schema import init_database
 from clm.infrastructure.workers.config_loader import load_worker_config
 from clm.infrastructure.workers.lifecycle_manager import WorkerLifecycleManager
+from tests.docker_image_helpers import (
+    docker_available,
+    find_drawio_image,
+    find_notebook_image,
+)
 
 
+# Image discovery and the daemon probe live in ``tests/docker_image_helpers.py``
+# so every Docker-marked test agrees on which image to use. These tests used to
+# hardcode a *published* DrawIO tag, which meant they ran against Docker Hub
+# rather than against the image this checkout builds.
 def _is_docker_available() -> bool:
-    """Check if Docker daemon is available."""
-    try:
-        import docker
-
-        client = docker.from_env()
-        client.ping()
-        return True
-    except Exception:
-        return False
+    return docker_available()
 
 
 # Skip all tests in this module if Docker is not available
@@ -122,34 +123,7 @@ def docker_test_env(tmp_path):
 
 
 def _find_notebook_docker_image() -> str | None:
-    """Find the best available notebook Docker image for testing.
-
-    Checks for images in order of preference:
-    1. clm-notebook-processor:lite-test (CI-built test image)
-    2. docker.io/mhoelzl/clm-notebook-processor:lite (locally built via clm docker build)
-    3. docker.io/mhoelzl/clm-notebook-processor:latest (locally built via clm docker build)
-    4. clm-notebook-processor:full (CI-built full image)
-    5. docker.io/mhoelzl/clm-notebook-processor:full (locally built full image)
-    """
-    try:
-        import docker
-
-        client = docker.from_env()
-        for tag in [
-            "clm-notebook-processor:lite-test",
-            "docker.io/mhoelzl/clm-notebook-processor:lite",
-            "docker.io/mhoelzl/clm-notebook-processor:latest",
-            "clm-notebook-processor:full",
-            "docker.io/mhoelzl/clm-notebook-processor:full",
-        ]:
-            try:
-                client.images.get(tag)
-                return tag
-            except docker.errors.ImageNotFound:
-                continue
-        return None
-    except Exception:
-        return None
+    return find_notebook_image()
 
 
 @pytest.fixture
@@ -489,35 +463,7 @@ class TestDockerPathConversionIntegration:
 
 
 def _find_drawio_docker_image() -> str | None:
-    """Find the best available DrawIO Docker image for testing.
-
-    Same preference order as ``_find_notebook_docker_image``, and for the same
-    reason: newest-built first. These tests used to *hardcode* the published
-    ``mhoelzl/clm-drawio-converter:latest``, which meant they ran against
-    whatever was last pulled from Docker Hub rather than against the image the
-    working tree builds — so a host-side change to the worker protocol failed
-    here as "job stayed pending" with the real cause (an image predating the
-    change) invisible. The CI-built ``:test`` tag now wins.
-
-    1. clm-drawio-converter:test (CI-built test image)
-    2. docker.io/mhoelzl/clm-drawio-converter:latest (published)
-    """
-    try:
-        import docker
-
-        client = docker.from_env()
-        for tag in [
-            "clm-drawio-converter:test",
-            "docker.io/mhoelzl/clm-drawio-converter:latest",
-        ]:
-            try:
-                client.images.get(tag)
-                return tag
-            except docker.errors.ImageNotFound:
-                continue
-        return None
-    except Exception:
-        return None
+    return find_drawio_image()
 
 
 @pytest.fixture

--- a/tests/workers/notebook/test_cpp_docker_execution.py
+++ b/tests/workers/notebook/test_cpp_docker_execution.py
@@ -1,0 +1,257 @@
+"""Does C++ still work? — executable coverage for the C++ course pipeline.
+
+Everything about C++ *except execution* is unit-tested elsewhere (the
+`cpp:percent` jupytext round-trip, the ``// j2`` jinja prefix, comment-token
+parsing, code extraction, the CMake export). Execution was the hole: the only
+Docker test that ran a C++ notebook deliberately ran a **broken** one to check
+error attribution, so "valid C++ compiles, runs, and its output reaches the
+deck" was asserted nowhere. A course repository would find that out instead.
+
+The two tests here are the cheap half of that coverage, and both run inside the
+existing Docker job against the image CI already builds — no new image, no added
+build time:
+
+- :func:`test_image_ships_every_kernel_clm_requests` — a kernel *rename* in an
+  image bump breaks every deck in the language at once, silently, and it has
+  happened before (the xeus-cling → xeus-cpp move, still referenced from
+  ``sqlite_backend.py`` and ``process_notebook.py``). Comparing the names CLM
+  asks for against the names the image installs catches that in seconds, for
+  every language rather than only C++.
+- :class:`TestCppExecutionInDocker` — a valid C++ deck goes through the real
+  Docker notebook worker and the executed output has to carry the value the
+  program computed. This is the canary for "C++ courses still build".
+
+What is deliberately *not* here: a full ``clm build`` of a C++ course spec
+(output targets, code extraction, per-language directories), and the other
+kernels the images ship (C#, Java, TypeScript) which are configured by CLM and
+executed by nothing in CI. Those are the same shape of gap one level out; see
+the C++ coverage note in the Phase 2 handover.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from clm.workers.notebook.utils.prog_lang_utils import config as prog_lang_config
+from clm.workers.notebook.utils.prog_lang_utils import kernelspec_for
+from tests.docker_image_helpers import docker_available, find_notebook_image
+
+pytestmark = [
+    pytest.mark.docker,
+    pytest.mark.integration,
+    pytest.mark.skipif(not docker_available(), reason="Docker daemon not available"),
+]
+
+#: Languages CLM configures a kernel for whose kernel the images do **not**
+#: install. Pinned rather than skipped so both directions are visible: a new
+#: hole fails the test, and an image that starts shipping Rust also fails it —
+#: with "tighten this set", which is the right thing to do at that point.
+#:
+#: Rust is configured (``prog_lang_utils`` names an ``evcxr``-style ``rust``
+#: kernel) but no Dockerfile installs it, so a Rust deck in Docker mode would
+#: fail with ``NoSuchKernel``. That is a real limitation, recorded here because
+#: nothing else states it.
+KNOWN_MISSING_KERNELS = {"rust"}
+
+
+def _kernelspecs_in(image: str) -> set[str]:
+    """Kernel names installed in ``image``, via ``jupyter kernelspec list``."""
+    import docker
+
+    client = docker.from_env()
+    output = client.containers.run(
+        image,
+        entrypoint="jupyter",
+        command=["kernelspec", "list", "--json"],
+        remove=True,
+        stdout=True,
+        stderr=False,
+    )
+    return set(json.loads(output)["kernelspecs"])
+
+
+def test_image_ships_every_kernel_clm_requests() -> None:
+    """Every kernel CLM names must exist in the image, or be a known hole.
+
+    ``kernelspec_for(lang)["name"]`` is written into each notebook CLM sends to
+    a worker, and the kernel is looked up by that exact name at execution time.
+    A mismatch is not a graceful degradation: every deck in the language fails
+    with ``NoSuchKernel``, and the build's only clue is the kernel name.
+    """
+    image = find_notebook_image()
+    if image is None:
+        pytest.skip("No notebook Docker image available (run: clm docker build)")
+
+    installed = _kernelspecs_in(image)
+    requested = {lang: kernelspec_for(lang)["name"] for lang in prog_lang_config.prog_lang}
+    missing = {lang for lang, kernel in requested.items() if kernel not in installed}
+
+    assert missing == KNOWN_MISSING_KERNELS, (
+        f"kernels CLM requests but {image} does not install: "
+        f"{ {lang: requested[lang] for lang in sorted(missing)} }\n"
+        f"expected exactly {sorted(KNOWN_MISSING_KERNELS)} to be missing; "
+        f"image installs {sorted(installed)}.\n"
+        f"A kernel that disappeared or was renamed breaks every deck in that "
+        f"language — fix the image or the prog_lang config, do not relax this."
+    )
+
+
+class TestCppExecutionInDocker:
+    """A valid C++ deck must compile, run, and carry its output into the deck."""
+
+    #: Percent-format C++ deck. The computed value is deliberately *not* a
+    #: literal in the source: asserting on ``42`` proves the kernel evaluated
+    #: ``6 * 7``, where asserting on a printed constant would pass even if the
+    #: cell output were copied through without execution.
+    DECK = """// %% [markdown]
+// # C++ execution smoke test
+
+// %%
+#include <iostream>
+
+// %%
+int product(int a, int b) { return a * b; }
+
+// %%
+std::cout << "cpp-smoke-result=" << product(6, 7) << std::endl;
+"""
+
+    @pytest.fixture
+    def cpp_env(self, tmp_path: Path) -> dict[str, Path]:
+        """A jobs DB, a workspace, and a data dir holding one C++ deck.
+
+        ``tmp_path`` rather than a hand-rolled ``mkdtemp``: it is already
+        per-test and per-xdist-worker, and pytest keeps the last runs' copies
+        around for post-mortem, which matters when a container is involved.
+        """
+        from clm.infrastructure.database.schema import init_database
+
+        db_path = tmp_path / "jobs.db"
+        init_database(db_path)
+
+        workspace = tmp_path / "output"
+        workspace.mkdir()
+
+        topic_dir = tmp_path / "data" / "slides" / "test_cpp_smoke"
+        topic_dir.mkdir(parents=True)
+        (topic_dir / "cpp_smoke.cpp").write_text(self.DECK, encoding="utf-8")
+
+        return {
+            "db_path": db_path,
+            "workspace": workspace,
+            "data_dir": tmp_path / "data",
+            "topic_dir": topic_dir,
+        }
+
+    def _await_workers(self, db_path: Path, expected: int, timeout: float = 60.0) -> None:
+        """Poll until ``expected`` workers report idle/busy.
+
+        Polling with a generous deadline, never a fixed sleep: activation is
+        subprocess- and container-gated, so any single sleep is either flaky or
+        wasted time (issue #163).
+        """
+        deadline = time.monotonic() + timeout
+        active = 0
+        while time.monotonic() < deadline:
+            conn = sqlite3.connect(db_path)
+            try:
+                active = conn.execute(
+                    "SELECT COUNT(*) FROM workers WHERE status IN ('idle', 'busy')"
+                ).fetchone()[0]
+            finally:
+                conn.close()
+            if active >= expected:
+                return
+            time.sleep(0.25)
+        raise TimeoutError(f"Expected {expected} active worker(s) within {timeout}s; got {active}")
+
+    def test_cpp_deck_executes_and_html_carries_the_result(self, cpp_env: dict[str, Path]) -> None:
+        """A ``completed`` HTML deck must contain the value the C++ code computed.
+
+        HTML, not notebook output, because that is where execution happens:
+        ``evaluate_for_html`` gates it (``output_spec.py``), so a notebook-format
+        job legitimately writes a deck with no outputs at all and would assert
+        nothing about the kernel.
+        """
+        from clm.infrastructure.database.job_queue import JobQueue
+        from clm.infrastructure.workers.config_loader import load_worker_config
+        from clm.infrastructure.workers.lifecycle_manager import WorkerLifecycleManager
+
+        image = find_notebook_image()
+        if image is None:
+            pytest.skip("No notebook Docker image available (run: clm docker build)")
+
+        worker_config = load_worker_config(
+            {
+                "default_execution_mode": "docker",
+                "notebook_count": 1,
+                "plantuml_count": 0,
+                "drawio_count": 0,
+                "auto_start": True,
+                "auto_stop": True,
+                "reuse_workers": False,
+            }
+        )
+        worker_config.notebook.image = image
+
+        manager = WorkerLifecycleManager(
+            config=worker_config,
+            db_path=cpp_env["db_path"],
+            workspace_path=cpp_env["workspace"],
+            data_dir=cpp_env["data_dir"],
+        )
+
+        workers: list = []
+        try:
+            workers = manager.start_managed_workers()
+            assert workers, "No workers started"
+            self._await_workers(cpp_env["db_path"], len(workers))
+
+            queue = JobQueue(cpp_env["db_path"])
+            output_file = cpp_env["workspace"] / "public" / "cpp_smoke.html"
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+
+            job_id = queue.add_job(
+                job_type="notebook",
+                input_file=str(cpp_env["topic_dir"] / "cpp_smoke.cpp"),
+                output_file=str(output_file),
+                content_hash="cpp-smoke-execution",
+                payload={
+                    "kind": "completed",
+                    "prog_lang": "cpp",
+                    "language": "en",
+                    "format": "html",
+                    "source_topic_dir": str(cpp_env["topic_dir"]),
+                },
+            )
+
+            # C++ cells are compiled, so give this a wider budget than the
+            # Python equivalents; it normally finishes in well under a minute.
+            deadline = time.monotonic() + 180.0
+            job = queue.get_job(job_id)
+            while time.monotonic() < deadline and job.status not in ("completed", "failed"):
+                time.sleep(1)
+                job = queue.get_job(job_id)
+
+            assert job.status == "completed", (
+                f"C++ deck did not build: status {job.status!r}\nError: {job.error}"
+            )
+            assert output_file.is_file(), f"No output written to {output_file}"
+
+            html = output_file.read_text(encoding="utf-8", errors="replace")
+            # ``6 * 7`` is computed by the program, so the rendered value can
+            # only be there if the kernel ran it — a deck copied through without
+            # execution contains the source but not the 42.
+            assert "cpp-smoke-result=42" in html, (
+                "The executed deck does not contain the value the C++ code "
+                "computes, so the C++ kernel did not run it (a compile failure "
+                "absorbed by skip-errors looks like this too — check the worker "
+                f"log).\nOutput written to {output_file}"
+            )
+        finally:
+            manager.stop_managed_workers(workers)

--- a/tests/workers/notebook/test_notebook_error_context.py
+++ b/tests/workers/notebook/test_notebook_error_context.py
@@ -32,6 +32,7 @@ from clm.workers.notebook.notebook_processor import (
     TrackingExecutePreprocessor,
 )
 from clm.workers.notebook.output_spec import create_output_spec
+from tests.docker_image_helpers import docker_available, find_notebook_image
 
 # =============================================================================
 # Test Fixtures - Notebook Creation Helpers
@@ -988,58 +989,20 @@ class TestCellContextTracking:
 # =============================================================================
 
 
+# Image discovery lives in ``tests/docker_image_helpers.py`` so that every
+# Docker-marked test agrees on which image to use — see that module for why this
+# test no longer asks for the `full` variant (short version: the C++ kernels come
+# from the Dockerfile's shared stage, so the image CI builds already has them).
 def _is_docker_available() -> bool:
-    """Check if Docker daemon is available."""
-    try:
-        import docker
+    return docker_available()
 
-        client = docker.from_env()
-        client.ping()
-        return True
-    except Exception:
-        return False
+
+def _get_cpp_image_name() -> str | None:
+    return find_notebook_image()
 
 
 def _is_cpp_image_available() -> bool:
-    """Check if C++ Docker image is available."""
-    try:
-        import docker
-
-        client = docker.from_env()
-        # Try to find the full image with C++ support
-        for tag in [
-            "docker.io/mhoelzl/clm-notebook-processor:full",
-            "docker.io/mhoelzl/clm-notebook-processor:1.22.1-full",
-        ]:
-            try:
-                client.images.get(tag)
-                return True
-            except docker.errors.ImageNotFound:
-                continue
-        return False
-    except Exception:
-        return False
-
-
-def _get_full_image_name() -> str | None:
-    """Get the name of the full Docker image if available."""
-    try:
-        import docker
-
-        client = docker.from_env()
-        # Try to find the full image with C++ support
-        for tag in [
-            "docker.io/mhoelzl/clm-notebook-processor:full",
-            "docker.io/mhoelzl/clm-notebook-processor:1.22.1-full",
-        ]:
-            try:
-                client.images.get(tag)
-                return tag
-            except docker.errors.ImageNotFound:
-                continue
-        return None
-    except Exception:
-        return None
+    return _get_cpp_image_name() is not None
 
 
 @pytest.mark.integration
@@ -1050,14 +1013,16 @@ def _get_full_image_name() -> str | None:
 )
 @pytest.mark.skipif(
     not _is_cpp_image_available(),
-    reason="C++ Docker image not available (need full image)",
+    reason="No notebook Docker image with a C++ kernel available "
+    "(build one with: clm docker build notebook)",
 )
 class TestCppErrorWithDocker:
     """Integration tests that execute real C++ notebooks via Docker.
 
     These tests require:
     - Docker daemon running
-    - docker.io/mhoelzl/clm-notebook-processor:full image (has xeus-cling)
+    - any notebook image (every variant ships the xeus-cpp C++ kernels; see
+      ``_CPP_CAPABLE_IMAGE_TAGS``)
     """
 
     @pytest.fixture
@@ -1142,7 +1107,7 @@ public:
         from clm.infrastructure.workers.lifecycle_manager import WorkerLifecycleManager
 
         env = docker_test_env
-        image_name = _get_full_image_name()
+        image_name = _get_cpp_image_name()
         if not image_name:
             pytest.skip("C++ Docker image not available")
 


### PR DESCRIPTION
## The question this answers

*What do we need, so that breaking C++ courses gives us feedback?* Answer: not a
bigger image — the coverage was asking for the wrong one.

## What C++ had, and what it didn't

Already unit-tested: the `cpp:percent` jupytext round-trip, the `// j2` jinja
prefix, comment-token parsing, code extraction, the CMake export,
`prog_lang_utils`.

Not tested anywhere: **execution**. The one Docker test that ran a C++ notebook
ran a *deliberately broken* one to check error attribution, so "valid C++
compiles, runs, and its output reaches the deck" was asserted nowhere. And it
required the `full` image, which no workflow builds — so it skipped in CI and
ran only on a machine that had pulled 23 GB.

## `full` is not where the C++ kernel comes from

`xeus-cpp` is installed in the Dockerfile's **shared `common` stage**
(`docker/notebook/Dockerfile:208-227`), so every notebook image ships the same
kernels:

```
$ docker run --rm --entrypoint jupyter clm-notebook-processor:lite-test kernelspec list
  xc11 xc17 xc23 xc23-omp  xcpp17 xcpp20 xcpp23 xcpp23-omp
  deno java python3 .net-csharp .net-fsharp .net-powershell
```

`full` adds only the Python ML stack (nvidia/cuda base + torch/fastai):
**22.9 GB vs 6.3 GB**. So C++ coverage costs **zero** extra build time, and
building `full` in CI would be a bad trade regardless of time — 23 GB does not
fit a standard runner's disk with `load: true`, and its layers alone would blow
the repo's 10 GB Actions-cache budget, evicting the uv caches other jobs need.

## What's new

`tests/workers/notebook/test_cpp_docker_execution.py` — both tests inside the
**existing** docker job, ~13s together:

1. **`test_cpp_deck_executes_and_html_carries_the_result`** — a valid C++ deck
   through the real Docker worker. It asserts the rendered deck contains
   `cpp-smoke-result=42`, a value the C++ code *computes* (`product(6, 7)`), so a
   kernel that stopped running code cannot pass. Verified in the artifact: the
   string `cpp-smoke-result=` appears once in the source cell and
   `cpp-smoke-result=42` once in the executed output.

   **It has to be an HTML target.** Execution is gated by `evaluate_for_html`
   (`output_spec.py`), so a `format: notebook` job writes a deck with *no
   outputs* — the first version of this test passed exactly that way, asserting
   nothing, until the assertion was tightened.

2. **`test_image_ships_every_kernel_clm_requests`** — the names CLM asks for
   (`kernelspec_for`) vs the names the image installs. A rename in an image bump
   breaks every deck in a language at once, and the xeus-cling → xeus-cpp move
   did exactly that. Seconds to run, covers every language.

   It also surfaced a real hole: **CLM configures a `rust` kernel no image
   installs**, so a Rust deck in Docker mode fails `NoSuchKernel`. Pinned as the
   only expected gap, so a second one can't appear unnoticed.

Plus `tests/docker_image_helpers.py`: three modules answered "which image can I
use" three ways, two of them naming a *published* tag — so they tested Docker
Hub rather than this checkout. One list now, CI-built tags first.

## Still uncovered (recorded in the handover, in value order)

1. **C#, Java, TypeScript execute nowhere in CI** — images ship the kernels, CLM
   configures them, nothing runs a deck. Parameterising the C++ test over the
   four languages is the cheapest large win left, and CSharpCourses is live.
2. `rust` — install a kernel or drop the config.
3. No full `clm build` of a non-Python course spec (output targets, code
   extraction, per-language dirs, CMake export exercised together).
4. `clm kernel-triage` against CppCourses is the real-world signal but needs the
   maintainer's checkout — a nightly-with-corpus job, not a PR check.

## Verification

- Docker tier (`pytest -n0 -m docker --timeout=600`): **14 passed**, up from 11
  passed + 1 failed. Tier wall-clock 166s.
- Fast suite: 8690 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7dqs96oadVLUCmUW64ep8
