### PR TITLE
security(recordings): contain the dashboard's paths and origins (Phase 2, S3 + D4)

### DIFF
--- a/changelog.d/691-recordings-dashboard-containment.security.md
+++ b/changelog.d/691-recordings-dashboard-containment.security.md
@@ -1,0 +1,22 @@
+- **The recordings dashboard can no longer be driven by another web page.**
+  `clm recordings serve` has no login, and every action route was a plain form
+  post, so any site open in the same browser could auto-submit one — arming a
+  deck, starting a recording, or submitting a file for processing. Mutating
+  requests now have to come from the dashboard's own origin (checked via
+  `Sec-Fetch-Site` and `Origin`), and every request has to carry a `Host` that
+  names this server, which closes the DNS-rebinding path that an origin check
+  alone cannot. Reads are unaffected, and requests with neither header
+  (`curl`, scripts) still work — this guards against other *pages*, not other
+  processes. `--allowed-host` / `--allowed-origin` opt in to a Tailscale
+  hostname or a reverse proxy.
+- **`POST /process` no longer uploads arbitrary local files.** It took a path
+  from the form and checked only that it existed, then handed it to the
+  configured backend — with Auphonic, that streams the file to a third party.
+  Submitted paths must now resolve under the recordings root, the same check
+  its sibling `/open-explorer` already performed.
+- **Course, section and deck names from the dashboard are validated.**
+  `course_slug` reached `get_state_path()` unsanitized, so `../../../evil`
+  wrote a state file outside CLM's config directory; a bare `..` escaped the
+  recordings root, which the existing filename sanitizer strips separators
+  from but otherwise leaves intact. Names containing a separator, a drive
+  letter, a null byte, or a `.`/`..` component are now rejected with `400`.

--- a/docs/claude/handovers/adversarial-review-remediation-handover.md
+++ b/docs/claude/handovers/adversarial-review-remediation-handover.md
@@ -297,7 +297,7 @@ verified by deliberately breaking a test once. — **All met.**
 
 ---
 
-### Phase 2 — Network-facing security  ▸ STATUS: item 1 DONE; items 2–4 open
+### Phase 2 — Network-facing security  ▸ STATUS: items 1–2 DONE; items 3–4 open
 **Depends on**: Phase 1 (you are about to change Docker-mode networking and the
 cache format; the worker tests must be alive first). **Phase 1 is DONE**, so
 this is unblocked.
@@ -356,14 +356,23 @@ been explicitly granted access.
    - **Landmine**: `executed_notebook_cache.py` stores raw bytes; make sure the
      *stored* format changes too, not just the wire format, or you leave a
      pickle-loading path alive behind an auth wall.
-2. **S3 + D4 — recordings dashboard.** `src/clm/recordings/web/routes.py:567-602`:
-   apply the containment check its own sibling `/open-explorer` (`:794-804`)
-   already implements — `resolve(strict=True)` + `relative_to(root)` — before
-   `/process` submits anything. Then add origin checking to every mutating route
-   and `TrustedHostMiddleware` to the app.
-   - **Landmine**: `/arm` accepts `course_slug` and reaches `get_state_path`
-     unfiltered (verified: `get_state_path('../../../evil')` escapes). Sanitize
-     it here, not only in the generic path fix in Phase 4.
+2. **S3 + D4 — recordings dashboard.** ▸ **DONE** (PR #691) —
+   `src/clm/recordings/web/routes.py`, new
+   `src/clm/infrastructure/web_security.py`.
+   - `/process` now applies the containment check its own sibling
+     `/open-explorer` already implements, over the **whole batch before
+     submitting any of it** (a mid-loop refusal had already started an
+     Auphonic upload).
+   - Two ASGI guards, installed together by `install_web_security()`: a `Host`
+     allowlist (loopback by default; `--allowed-host` opts in) and an origin
+     check on mutating requests only. The host half is what closes DNS
+     rebinding — an origin check alone cannot, because a rebound page *is*
+     same-origin. Hand-rolled rather than Starlette's, whose host splitter
+     turns `[::1]:8000` into `"["`.
+   - `course_slug` validated strictly (it reaches `get_state_path` unsanitized
+     and becomes `<slug>.json`); `section_name`/`deck_name` validated for
+     containment only. **See the notes below — this distinction is the whole
+     lesson of the item.**
 3. **S6 + D4 — `clm serve`.** `src/clm/web/app.py:127-136`: default
    `cors_origins` to the serve origin (never `["*"]` with
    `allow_credentials=True`). `src/clm/web/api/websocket.py:110-126`: require the
@@ -491,6 +500,48 @@ cache path; SSTI proof-of-concept from the review no longer executes.
   other jobs depend on, which the workflow's own comment already worries about at
   lite's size. And there is nothing to buy: the ML stack is the *only* thing
   `full` adds, so no language kernel depends on it.
+
+**Notes from item 2 (2026-07-25/26) — read before items 3 and 4**
+
+- **The dangerous mistake in this item was not a missed attack; it was an
+  over-strict validator.** One rule was applied to `course_slug`,
+  `section_name` and `deck_name`, and it rejected `:`. Real section names are
+  *titles the user wrote* — "Woche 01: Einführung, LLMs und Python in
+  JupyterLite" — and **33 of the 39 in `machine-learning-azav.xml`, the
+  default recordings spec, contain a colon**. That silently 400'd `/arm`,
+  `/record`, `/advance` and both `/decks/…/takes` routes: the entire Lectures
+  page, dead, for every real course. An adversarial review caught it; the
+  test suite did not, because its only positive case was `"Section 1"`.
+- **Then a second false positive of the same shape survived the fix**:
+  "Woche 12: Datenanalyse mit pandas (+ ML-/Metrik-Kostprobe)" contains a
+  **slash**. It was found only by driving the app with *all 22* section names
+  from the real spec instead of three hand-picked ones.
+  **Generalisable rule: when you add validation to a value that originates as
+  human-written content, test it against the real corpus, not against examples
+  you invented.** Both regressions were invisible to hand-picked cases and
+  obvious within seconds of using real data.
+- **The correct distinction**, now encoded in two validators: only
+  `course_slug` is used as a filename *verbatim* (`get_state_path()` joins it
+  into the config dir and appends `.json`), and it is machine-generated
+  (`project_slug + "-de"`, else a sanitized course name), so it can afford a
+  strict rule. `section_name`/`deck_name` reach disk only through
+  `sanitize_file_name()`, which deletes `; ! ? " ' :` and replaces
+  `/ \ $ # % & < > * = ^ € |` — so containment must be judged on the
+  **sanitized** form. Judging the raw form is a false positive. What the
+  sanitizer does *not* neutralize is **dots**: `":..:"` sanitizes to `..` and
+  escapes, which is why the sanitized form is checked for `.`/`..`.
+- **`clm serve` (items 3–4) can reuse `install_web_security()` as-is**,
+  including for its `/ws` route — the origin guard already covers WebSocket
+  handshakes, which are CORS-exempt. Note `clm.web.create_app` will need an
+  `allowed_hosts` parameter for the same reason the recordings app did:
+  `TestClient` sends `Host: testserver`, so the production default 400s every
+  existing test.
+- **Two Windows-first blind spots worth remembering**: `Path.resolve()` raises
+  `OSError` for an embedded null byte on Windows but `ValueError` on POSIX
+  (so catch both — CI is Linux and the local fast suite is not); and a
+  `git checkout HEAD -- <file>` used to check "does this test fail without the
+  fix" **discards uncommitted work in that file** — commit first, then revert
+  to test.
 
 #### Language coverage: what a broken C++ (or C#, or Java) course would hit
 

--- a/docs/user-guide/recordings.md
+++ b/docs/user-guide/recordings.md
@@ -184,6 +184,14 @@ clm recordings serve ~/Recordings --host 0.0.0.0 \
 against *other web pages*; they do not (and cannot) protect against another
 program running as you on the same machine, which can set any header it likes.
 
+**Behind a reverse proxy**, prefer a config that forwards the original `Host`
+including its port — nginx's `proxy_set_header Host $http_host`, not `$host`,
+which drops the port. With the port dropped, the dashboard cannot tell that
+`Origin: https://box.example:8443` belongs to the request it received, and
+refuses actions on clients that do not send `Sec-Fetch-Site` (older browsers).
+`--allowed-origin https://box.example:8443` is the escape hatch if you cannot
+change the proxy config.
+
 Paths are contained too: file processing submitted through the dashboard must
 resolve under the recordings root, and course/section/deck names may not
 contain path separators or `..`.

--- a/docs/user-guide/recordings.md
+++ b/docs/user-guide/recordings.md
@@ -153,6 +153,41 @@ The recordings dashboard is a browser-based UI for the recording workflow:
 clm recordings serve <recordings-root> --spec-file course.xml
 ```
 
+### Who can reach the dashboard
+
+The dashboard has no login. Anyone who can send it a request can arm a deck,
+start a recording, or submit a file for processing — which, with the Auphonic
+backend, uploads that file to a third-party service. Two guards keep that
+"anyone" down to *you, in this browser, on this machine*:
+
+- **Host allowlist.** Requests must carry a `Host` header naming this server
+  (`localhost`, `127.0.0.1`, `::1`, plus whatever you passed to `--host`).
+  Without this, a site that points its own DNS name at `127.0.0.1` would count
+  as same-origin and every other check would pass.
+- **Origin check on actions.** Any state-changing request (`POST` and friends)
+  must come from the dashboard's own pages. A page on another site can submit
+  a form to `http://127.0.0.1:8008/record` without your involvement; that now
+  gets a `403`. Reading pages is unaffected.
+
+Both are on by default and need no configuration for the normal
+`clm recordings serve ~/Recordings` workflow. If you deliberately reach the
+dashboard under a different name — a Tailscale hostname, a reverse proxy —
+tell it so, or requests arrive as `400 Invalid host header`:
+
+```bash
+clm recordings serve ~/Recordings --host 0.0.0.0 \
+    --allowed-host box.tailnet.ts.net \
+    --allowed-origin https://box.tailnet.ts.net
+```
+
+`--allowed-host '*'` turns the host check off entirely. These guards protect
+against *other web pages*; they do not (and cannot) protect against another
+program running as you on the same machine, which can set any header it likes.
+
+Paths are contained too: file processing submitted through the dashboard must
+resolve under the recordings root, and course/section/deck names may not
+contain path separators or `..`.
+
 ### Lecture Selection
 
 The **Lectures** page lists every slide deck in the course, grouped by

--- a/src/clm/cli/commands/recordings.py
+++ b/src/clm/cli/commands/recordings.py
@@ -764,6 +764,43 @@ def _configure_recordings_event_log(root_dir: Path) -> None:
     console.print(f"[dim]Event log: {log_path}[/dim]")
 
 
+class _StdlibToLoguruHandler(logging.Handler):
+    """Forward stdlib log records to loguru.
+
+    Defined at module scope, not inside the installer: a class created inside
+    a function is a *new* class object per call, so an
+    ``isinstance(h, _ToLoguru)`` guard would never recognise a handler an
+    earlier call installed. Every ``clm recordings serve`` in one process (the
+    test suite does several) would then add another handler and write every
+    refusal to ``events.log`` one more time — corrupting the forensic record
+    the bridge exists to produce.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        from loguru import logger as _loguru
+
+        try:
+            # loguru rejects a level it does not know, and stdlib allows any
+            # name via ``addLevelName`` (plus the synthesized "Level 42").
+            # Mapping by severity keeps a future custom level from raising
+            # inside a middleware and turning a 403 into a 500.
+            try:
+                level = _loguru.level(record.levelname).name
+            except ValueError:
+                level = "INFO" if record.levelno < logging.WARNING else "WARNING"
+            # The sink's ``{name}`` would resolve to *this* module, so the
+            # originating logger goes into the message. Binding it into
+            # ``extra`` instead would need a format placeholder that every
+            # other (unbound) record in the process would then KeyError on.
+            _loguru.opt(exception=record.exc_info).log(
+                level, f"[{record.name}] {record.getMessage()}"
+            )
+        except Exception:  # pragma: no cover - logging must never break a request
+            # ``logging.Handler.handle`` does not wrap ``emit``, so anything
+            # raised here would propagate out of the caller's ``log.warning``.
+            self.handleError(record)
+
+
 def _forward_web_security_logs_to_loguru() -> None:
     """Route :mod:`clm.infrastructure.web_security` refusals into the event log.
 
@@ -776,25 +813,18 @@ def _forward_web_security_logs_to_loguru() -> None:
 
     Scoped to that single logger rather than installed on the root: a global
     intercept would re-route every library's logging as a side effect of
-    starting the dashboard.
+    starting the dashboard. Idempotent — safe to call once per server start.
     """
-    import logging as _logging
-
-    from loguru import logger as _loguru
-
     from clm.infrastructure import web_security
 
-    class _ToLoguru(_logging.Handler):
-        def emit(self, record: _logging.LogRecord) -> None:
-            _loguru.bind(stdlib=record.name).opt(depth=0, exception=record.exc_info).log(
-                record.levelname, record.getMessage()
-            )
-
-    target = _logging.getLogger(web_security.__name__)
-    if any(isinstance(h, _ToLoguru) for h in target.handlers):
+    target = logging.getLogger(web_security.__name__)
+    if any(isinstance(h, _StdlibToLoguruHandler) for h in target.handlers):
         return
-    target.addHandler(_ToLoguru())
-    target.setLevel(_logging.INFO)
+    target.addHandler(_StdlibToLoguruHandler())
+    target.setLevel(logging.INFO)
+    # Records are now delivered to loguru; letting them also climb to the root
+    # logger would double every refusal as soon as anything configures root.
+    target.propagate = False
 
 
 def _get_obs_config() -> tuple[str, int, str]:

--- a/src/clm/cli/commands/recordings.py
+++ b/src/clm/cli/commands/recordings.py
@@ -619,6 +619,20 @@ def assemble(root_dir: Path, raw_suffix: str | None, dry_run: bool):
 )
 @click.option("--obs-password", default=None, help="OBS WebSocket password.")
 @click.option("--no-browser", is_flag=True, help="Do not auto-open browser.")
+@click.option(
+    "--allowed-host",
+    multiple=True,
+    help="Extra Host header value to accept (repeatable). Needed when you reach "
+    "the dashboard under a name other than localhost — e.g. a Tailscale "
+    "hostname. Pass '*' to disable the check entirely.",
+)
+@click.option(
+    "--allowed-origin",
+    multiple=True,
+    help="Extra origin allowed to drive actions (repeatable), e.g. "
+    "https://host.tailnet.ts.net. Only needed behind a reverse proxy that "
+    "rewrites the Host header.",
+)
 def serve_recordings(
     root_dir: Path,
     host: str,
@@ -628,6 +642,8 @@ def serve_recordings(
     obs_port: int | None,
     obs_password: str | None,
     no_browser: bool,
+    allowed_host: tuple[str, ...],
+    allowed_origin: tuple[str, ...],
 ):
     """Start the recordings dashboard web UI.
 
@@ -637,6 +653,13 @@ def serve_recordings(
 
     ROOT_DIR is the recordings root containing to-process/, final/,
     and archive/ subdirectories (created automatically if missing).
+
+    The dashboard has no login: anyone who can reach it can arm decks and
+    start recordings. It therefore binds localhost by default, only accepts
+    requests whose Host names this server, and refuses actions driven from
+    another origin — which is what keeps a web page open in another tab from
+    driving it. Use --allowed-host / --allowed-origin when you deliberately
+    reach it under a different name.
     """
     try:
         import uvicorn
@@ -671,6 +694,9 @@ def serve_recordings(
         stability_check_count=cfg_stab_count,
         auphonic_api_key=cfg_auphonic_key,
         auphonic_preset=cfg_auphonic_preset,
+        bind_host=host,
+        allowed_hosts=list(allowed_host),
+        allowed_origins=list(allowed_origin),
     )
 
     url = f"http://{host if host != '0.0.0.0' else 'localhost'}:{port}"

--- a/src/clm/cli/commands/recordings.py
+++ b/src/clm/cli/commands/recordings.py
@@ -667,6 +667,7 @@ def serve_recordings(
         console.print("[red]uvicorn is required. It should be a core CLM dependency.[/red]")
         raise SystemExit(1) from exc
 
+    from clm.infrastructure.web_security import remote_access_warning
     from clm.recordings.web.app import create_app
 
     # Resolve OBS settings from CLI args or CLM config
@@ -700,6 +701,13 @@ def serve_recordings(
     )
 
     url = f"http://{host if host != '0.0.0.0' else 'localhost'}:{port}"
+
+    # A wildcard bind promises remote access the Host allowlist cannot deliver
+    # on its own; say so here rather than letting the user discover it as a
+    # wall of 400s from another machine.
+    reach_warning = remote_access_warning(host, allowed_host)
+    if reach_warning:
+        console.print(f"[yellow]Note:[/yellow] {reach_warning}")
 
     if not no_browser:
         import webbrowser
@@ -752,7 +760,41 @@ def _configure_recordings_event_log(root_dir: Path) -> None:
             "{thread.name} | {name}:{function}:{line} - {message}"
         ),
     )
+    _forward_web_security_logs_to_loguru()
     console.print(f"[dim]Event log: {log_path}[/dim]")
+
+
+def _forward_web_security_logs_to_loguru() -> None:
+    """Route :mod:`clm.infrastructure.web_security` refusals into the event log.
+
+    That module is app-agnostic and so uses stdlib ``logging``, while the rest
+    of the recordings stack uses loguru — and only loguru has the
+    ``events.log`` sink. Without this bridge, a refused ``Host`` or a refused
+    cross-origin action would be the one class of event missing from the
+    forensic record, which is precisely the class you go looking for after an
+    incident.
+
+    Scoped to that single logger rather than installed on the root: a global
+    intercept would re-route every library's logging as a side effect of
+    starting the dashboard.
+    """
+    import logging as _logging
+
+    from loguru import logger as _loguru
+
+    from clm.infrastructure import web_security
+
+    class _ToLoguru(_logging.Handler):
+        def emit(self, record: _logging.LogRecord) -> None:
+            _loguru.bind(stdlib=record.name).opt(depth=0, exception=record.exc_info).log(
+                record.levelname, record.getMessage()
+            )
+
+    target = _logging.getLogger(web_security.__name__)
+    if any(isinstance(h, _ToLoguru) for h in target.handlers):
+        return
+    target.addHandler(_ToLoguru())
+    target.setLevel(_logging.INFO)
 
 
 def _get_obs_config() -> tuple[str, int, str]:

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -4208,6 +4208,8 @@ clm recordings serve ROOT_DIR [OPTIONS]
 | `--obs-port INT` | OBS WebSocket port (default: from config) |
 | `--obs-password TEXT` | OBS WebSocket password |
 | `--no-browser` | Do not auto-open browser |
+| `--allowed-host TEXT` | Extra `Host` header value to accept (repeatable); `*` disables the check |
+| `--allowed-origin TEXT` | Extra origin allowed to drive actions (repeatable) |
 
 Examples:
 
@@ -4216,6 +4218,25 @@ clm recordings serve ~/Recordings
 clm recordings serve ~/Recordings --spec-file course.xml
 clm recordings serve ~/Recordings --obs-host 192.168.1.5 --port 9000
 ```
+
+**Access control.** The dashboard has no login — anyone who can reach it can
+arm decks, start recordings and submit files for processing. Since {version}
+it therefore:
+
+- binds `127.0.0.1` by default (unchanged);
+- answers only requests whose `Host` header names this server (`localhost`,
+  `127.0.0.1`, `::1`, plus whatever `--host` and `--allowed-host` name), which
+  is what stops a DNS-rebinding page from reaching it; and
+- refuses any state-changing request (`POST`/`PUT`/`PATCH`/`DELETE`) that a
+  *different* origin drove, judged by `Sec-Fetch-Site` and `Origin`. Reads are
+  unaffected.
+
+Nothing changes for normal use. If you reach the dashboard under another name
+— a Tailscale hostname, a reverse proxy — name it with `--allowed-host` (and
+`--allowed-origin` if the proxy rewrites `Host`), otherwise you get
+`400 Invalid host header` or `403`. Requests carrying neither `Origin` nor
+`Sec-Fetch-Site` (`curl`, scripts) are still accepted: this guards against
+*other web pages*, not against other processes on your machine.
 
 #### `clm recordings backends`
 

--- a/src/clm/infrastructure/web_security.py
+++ b/src/clm/infrastructure/web_security.py
@@ -1,0 +1,392 @@
+"""Browser-facing containment for CLM's local web apps.
+
+CLM ships two HTTP apps that a user runs on their own machine — the
+recordings dashboard (``clm recordings serve``) and the dashboard/Studio
+(``clm serve``). Both bind loopback by default, and both used to treat "the
+request arrived on the socket" as "the user asked for this". A web page open
+in the same browser can send a request to ``http://127.0.0.1:8008`` without
+any cooperation from the app, so that assumption is wrong twice over:
+
+**CSRF.** A page on ``https://evil.example`` can auto-submit a form at any of
+the dashboard's ``POST`` routes. No token, no cookie, no user interaction —
+form posts are not subject to the same-origin *response* restriction, and the
+attacker does not need to read the response to cause the side effect.
+
+**DNS rebinding.** The origin check alone is not enough: an attacker who
+controls DNS for ``evil.example`` can point it at ``127.0.0.1``, at which
+point their page's requests to ``http://evil.example:8008`` are *genuinely
+same-origin* and pass every origin check. What they cannot fake is the
+``Host`` header, which still reads ``evil.example`` — so the host allowlist
+is what closes this door.
+
+Hence the two middlewares here, which are meant to be installed together:
+
+- :class:`TrustedHostMiddleware` — the request's ``Host`` must name this
+  server (loopback by default, plus whatever the operator bound or allowed).
+- :class:`OriginGuardMiddleware` — a *mutating* request must come from this
+  app's own origin, judged by ``Sec-Fetch-Site`` first and ``Origin`` second.
+
+Both are deliberately zero-friction: no token, no per-form nonce, nothing for
+the user to configure in the common case. That is the point — a protection
+that costs the single-user local workflow something would be turned off.
+
+**What this does not do.** It does not protect against another process, or
+another local user, on the same machine: they can set any header they like.
+That is an accepted limit (decision D4 of the 2026-07-24 adversarial review),
+not an oversight. Requests carrying *neither* ``Origin`` nor
+``Sec-Fetch-Site`` are allowed through for the same reason — that is what
+``curl``, a script, or a test client looks like, and none of them are the
+threat model. Every browser CLM's dashboards support sends ``Origin`` on a
+cross-origin form post.
+
+Why hand-rolled rather than Starlette's ``TrustedHostMiddleware``: that one
+derives the host as ``header.split(":")[0]``, which turns ``[::1]:8000`` into
+``"["`` and rejects anyone browsing over IPv6 loopback. Since the whole point
+here is a *default-on* check, a default that breaks a legitimate local URL is
+not acceptable.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Sequence
+from urllib.parse import urlsplit
+
+from starlette.datastructures import Headers
+from starlette.responses import PlainTextResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+#: HTTP methods that cannot change server state, and so are exempt from the
+#: origin check. ``OPTIONS`` is included because a CORS preflight must be
+#: answerable — a rejected preflight tells the browser nothing useful, and the
+#: actual request behind it is still checked.
+SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
+
+#: Host names that always name this machine.
+LOOPBACK_HOSTS: tuple[str, ...] = ("localhost", "127.0.0.1", "::1")
+
+#: Default scheme ports, stripped when comparing an ``Origin`` to a ``Host``.
+_DEFAULT_PORTS = {"http": "80", "https": "443", "ws": "80", "wss": "443"}
+
+
+def extract_host(host_header: str) -> str:
+    """Return the lower-cased host from a ``Host`` header, without the port.
+
+    Handles the bracketed IPv6 form (``[::1]:8000`` → ``::1``) that Starlette's
+    own splitter mangles, and tolerates a missing port.
+
+    Args:
+        host_header: Raw ``Host`` header value (may be empty).
+
+    Returns:
+        The bare host, lower-cased. Empty when the header was empty.
+    """
+    value = host_header.strip()
+    if not value:
+        return ""
+    if value.startswith("["):
+        end = value.find("]")
+        if end != -1:
+            return value[1:end].lower()
+        return value.lower()
+    if value.count(":") == 1:
+        return value.rsplit(":", 1)[0].lower()
+    # No port, or a bare (invalid) IPv6 literal — either way, use it verbatim.
+    return value.lower()
+
+
+def normalize_host_pattern(pattern: str) -> str:
+    """Return ``pattern`` in the form :func:`extract_host` produces.
+
+    Lets an operator write ``[::1]``, ``::1``, or ``localhost:8008`` and have
+    all of them mean what they obviously mean.
+    """
+    return extract_host(pattern)
+
+
+def default_allowed_hosts(bind_host: str | None = None, extra: Iterable[str] = ()) -> list[str]:
+    """Return the host allowlist for a server bound at ``bind_host``.
+
+    Args:
+        bind_host: The address passed to ``--host``. A wildcard bind
+            (``0.0.0.0`` / ``::``) contributes nothing by itself — it names
+            every interface, not a host somebody types — so an operator who
+            binds wide and reaches the app under a LAN name or Tailscale
+            hostname has to name that host via ``extra``.
+        extra: Additional allowed hosts (``--allowed-host``). A single ``"*"``
+            disables the check entirely.
+
+    Returns:
+        De-duplicated, normalized host patterns, loopback first.
+    """
+    hosts: list[str] = list(LOOPBACK_HOSTS)
+    candidates = [bind_host] if bind_host else []
+    candidates.extend(extra)
+    for candidate in candidates:
+        if not candidate:
+            continue
+        if candidate == "*":
+            return ["*"]
+        normalized = normalize_host_pattern(candidate)
+        if normalized in ("0.0.0.0", "::", ""):
+            continue
+        if normalized not in hosts:
+            hosts.append(normalized)
+    return hosts
+
+
+def host_is_allowed(host: str, allowed: Sequence[str]) -> bool:
+    """True when ``host`` matches one of the ``allowed`` patterns.
+
+    Supports a leading-``*.`` wildcard (``*.ts.net``) and the bare ``*``
+    escape hatch, matching the vocabulary Starlette established.
+    """
+    if "*" in allowed:
+        return True
+    for pattern in allowed:
+        if pattern.startswith("*.") and host.endswith(pattern[1:]):
+            return True
+        if host == pattern:
+            return True
+    return False
+
+
+def normalize_origin(origin: str) -> str | None:
+    """Return ``origin`` as ``scheme://host[:port]`` with default ports dropped.
+
+    Returns ``None`` for ``"null"`` and anything unparseable — both of which
+    are *not* this app's origin, which is the only question being asked.
+    """
+    value = origin.strip()
+    if not value or value.lower() == "null":
+        return None
+    parts = urlsplit(value)
+    if not parts.scheme or not parts.hostname:
+        return None
+    scheme = parts.scheme.lower()
+    host = parts.hostname.lower()
+    try:
+        port = parts.port
+    except ValueError:
+        return None
+    if port is None or str(port) == _DEFAULT_PORTS.get(scheme):
+        return f"{scheme}://{host}"
+    return f"{scheme}://{host}:{port}"
+
+
+def _origin_matches_host(origin: str, host_header: str) -> bool:
+    """True when ``origin``'s authority is the one the request was sent to.
+
+    Compares host and port, deliberately ignoring the scheme: a reverse proxy
+    terminating TLS (``tailscale serve``) forwards ``Origin: https://…`` to a
+    plain-HTTP upstream, and rejecting that would break the documented remote
+    access path for no security gain — the check that matters is *which
+    authority the browser thinks it is talking to*.
+    """
+    parts = urlsplit(origin.strip())
+    if not parts.hostname:
+        return False
+    try:
+        origin_port = parts.port
+    except ValueError:
+        return False
+    origin_host = parts.hostname.lower()
+    if origin_port is None:
+        origin_port_str = _DEFAULT_PORTS.get(parts.scheme.lower(), "")
+    else:
+        origin_port_str = str(origin_port)
+
+    target = host_header.strip()
+    target_host = extract_host(target)
+    if target.startswith("["):
+        end = target.find("]")
+        rest = target[end + 1 :] if end != -1 else ""
+        target_port_str = rest[1:] if rest.startswith(":") else ""
+    elif target.count(":") == 1:
+        target_port_str = target.rsplit(":", 1)[1]
+    else:
+        target_port_str = ""
+
+    if origin_host != target_host:
+        return False
+    if not target_port_str:
+        # No port in Host means the default port for the scheme the client
+        # used; we cannot know it, so host equality is as far as we can go.
+        return True
+    return origin_port_str == target_port_str
+
+
+def check_request_origin(
+    headers: Headers,
+    *,
+    allowed_origins: Sequence[str] = (),
+) -> str | None:
+    """Decide whether a mutating request may proceed.
+
+    Args:
+        headers: The request headers.
+        allowed_origins: Extra origins to accept verbatim (``--allowed-origin``),
+            already normalized by :func:`normalize_origin`.
+
+    Returns:
+        ``None`` when the request may proceed, or a short human-readable reason
+        it was refused (safe to log and to return in the 403 body — it echoes
+        only what the *client* sent).
+    """
+    fetch_site = headers.get("sec-fetch-site")
+    if fetch_site:
+        site = fetch_site.strip().lower()
+        # "none" means a user-initiated navigation (typed URL, bookmark);
+        # "same-origin" is the app's own fetch/HTMX traffic. Everything else —
+        # "same-site" included, since a different port is a different app —
+        # is somebody else's page driving this one.
+        if site in ("same-origin", "none"):
+            return None
+        return f"cross-origin request (Sec-Fetch-Site: {site})"
+
+    origin = headers.get("origin")
+    if not origin:
+        # No Origin and no Sec-Fetch-Site: not a browser. See module docstring.
+        return None
+
+    normalized = normalize_origin(origin)
+    if normalized is not None and normalized in allowed_origins:
+        return None
+    if _origin_matches_host(origin, headers.get("host", "")):
+        return None
+    return f"cross-origin request (Origin: {origin})"
+
+
+class TrustedHostMiddleware:
+    """Reject requests whose ``Host`` header does not name this server.
+
+    Closes the DNS-rebinding path described in the module docstring. Applies
+    to WebSocket handshakes as well as HTTP, because a rebound page can open a
+    WebSocket just as easily as it can POST.
+    """
+
+    def __init__(self, app: ASGIApp, *, allowed_hosts: Sequence[str]) -> None:
+        self.app = app
+        self.allowed_hosts = [normalize_host_pattern(h) if h != "*" else "*" for h in allowed_hosts]
+        self.allow_any = "*" in self.allowed_hosts
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if self.allow_any or scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        host = extract_host(headers.get("host", ""))
+        if host_is_allowed(host, self.allowed_hosts):
+            await self.app(scope, receive, send)
+            return
+
+        logger.warning(
+            "Refused a request with Host %r: not in the allowed hosts %s. "
+            "If you reach this server under that name on purpose, pass it with "
+            "--allowed-host.",
+            host,
+            self.allowed_hosts,
+        )
+        await _reject(scope, receive, send, status_code=400, detail="Invalid host header")
+
+
+class OriginGuardMiddleware:
+    """Reject mutating requests that come from another origin.
+
+    Read-only requests (:data:`SAFE_METHODS`) pass untouched — the browser's
+    own same-origin policy already keeps their *responses* away from an
+    attacker page, and blocking them would break ordinary navigation.
+
+    Implemented as raw ASGI rather than ``BaseHTTPMiddleware`` on purpose: the
+    recordings dashboard streams Server-Sent Events, and wrapping a long-lived
+    streaming response in ``BaseHTTPMiddleware`` is exactly the case that
+    middleware handles badly.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        allowed_origins: Sequence[str] = (),
+    ) -> None:
+        self.app = app
+        normalized = [normalize_origin(o) for o in allowed_origins]
+        self.allowed_origins = [o for o in normalized if o is not None]
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        scope_type = scope["type"]
+        if scope_type == "http":
+            if scope.get("method", "GET").upper() in SAFE_METHODS:
+                await self.app(scope, receive, send)
+                return
+        elif scope_type != "websocket":
+            await self.app(scope, receive, send)
+            return
+
+        reason = check_request_origin(Headers(scope=scope), allowed_origins=self.allowed_origins)
+        if reason is None:
+            await self.app(scope, receive, send)
+            return
+
+        logger.warning(
+            "Refused %s %s: %s. Only this app's own pages may drive it; "
+            "pass --allowed-origin if another origin should be trusted.",
+            scope.get("method", scope_type),
+            scope.get("path", ""),
+            reason,
+        )
+        await _reject(scope, receive, send, status_code=403, detail=f"Refused {reason}")
+
+
+async def _reject(
+    scope: Scope,
+    receive: Receive,
+    send: Send,
+    *,
+    status_code: int,
+    detail: str,
+) -> None:
+    """Answer ``scope`` with a refusal, in whichever protocol it speaks."""
+    if scope["type"] == "websocket":
+        # ASGI lets a handshake be refused by closing before accepting; uvicorn
+        # turns that into an HTTP 403. The connect message has to be consumed
+        # first or the server has nothing to close.
+        try:
+            await receive()
+        except Exception:  # pragma: no cover - client vanished mid-handshake
+            return
+        await send({"type": "websocket.close", "code": 1008})
+        return
+    response = PlainTextResponse(detail, status_code=status_code)
+    await response(scope, receive, send)
+
+
+def install_web_security(
+    app,
+    *,
+    bind_host: str | None = None,
+    allowed_hosts: Iterable[str] | None = None,
+    allowed_origins: Iterable[str] = (),
+) -> list[str]:
+    """Install both guards on ``app`` and return the effective host allowlist.
+
+    Args:
+        app: The FastAPI/Starlette application.
+        bind_host: The address the server binds, folded into the allowlist.
+        allowed_hosts: Operator-supplied additions (``--allowed-host``). ``["*"]``
+            disables the host check.
+        allowed_origins: Operator-supplied additional origins
+            (``--allowed-origin``).
+
+    Returns:
+        The host allowlist actually installed, for logging.
+    """
+    hosts = default_allowed_hosts(bind_host, allowed_hosts or ())
+    # add_middleware prepends, so the host check ends up outermost: a rebound
+    # request is refused before anything else looks at it.
+    app.add_middleware(OriginGuardMiddleware, allowed_origins=list(allowed_origins))
+    app.add_middleware(TrustedHostMiddleware, allowed_hosts=hosts)
+    return hosts

--- a/src/clm/infrastructure/web_security.py
+++ b/src/clm/infrastructure/web_security.py
@@ -101,9 +101,17 @@ def extract_host(host_header: str) -> str:
     else:
         # No port, or a bare (invalid) IPv6 literal — either way, use it verbatim.
         host = value.lower()
-    # ``http://localhost./`` is a legal URL (an explicitly-absolute FQDN) and
-    # the browser sends the dot through. Treat it as the same host rather than
-    # 400-ing somebody who typed a legitimate address.
+    return _strip_trailing_dot(host)
+
+
+def _strip_trailing_dot(host: str) -> str:
+    """Drop one trailing dot from ``host``.
+
+    ``http://localhost./`` is a legal URL (an explicitly-absolute FQDN) and the
+    browser sends the dot through, so treating it as a different host would
+    400 somebody who typed a legitimate address. Exactly one dot is stripped,
+    so ``localhost..`` — which names nothing — stays refused.
+    """
     return host[:-1] if host.endswith(".") and len(host) > 1 else host
 
 
@@ -212,11 +220,17 @@ def normalize_origin(origin: str) -> str | None:
     value = origin.strip()
     if not value or value.lower() == "null":
         return None
-    parts = urlsplit(value)
+    try:
+        parts = urlsplit(value)
+    except ValueError:
+        # ``http://[::1`` and friends. An unparseable Origin is not this app's
+        # origin, which is the only question — but letting the ValueError out
+        # would turn a 403 into a 500 from inside the security middleware.
+        return None
     if not parts.scheme or not parts.hostname:
         return None
     scheme = parts.scheme.lower()
-    host = parts.hostname.lower()
+    host = _strip_trailing_dot(parts.hostname.lower())
     if ":" in host:
         # ``urlsplit`` strips the brackets off an IPv6 literal; putting them
         # back keeps the result a parseable authority rather than the
@@ -240,14 +254,20 @@ def _origin_matches_host(origin: str, host_header: str) -> bool:
     access path for no security gain — the check that matters is *which
     authority the browser thinks it is talking to*.
     """
-    parts = urlsplit(origin.strip())
+    try:
+        parts = urlsplit(origin.strip())
+    except ValueError:
+        return False
     if not parts.hostname:
         return False
     try:
         origin_port = parts.port
     except ValueError:
         return False
-    origin_host = parts.hostname.lower()
+    # Same trailing-dot normalization the host side does, so a request made
+    # through the legal FQDN form ``http://localhost./`` is not refused by one
+    # guard after being accepted by the other.
+    origin_host = _strip_trailing_dot(parts.hostname.lower())
     if origin_port is None:
         origin_port_str = _DEFAULT_PORTS.get(parts.scheme.lower(), "")
     else:
@@ -350,7 +370,10 @@ class TrustedHostMiddleware:
             self.allowed_hosts,
         )
         # The remediation belongs in the *body*: the person hitting this is
-        # looking at a browser, not at the server's log.
+        # looking at a browser, not at the server's log. The allowlist itself
+        # stays in the log — under DNS rebinding, the page reading this body is
+        # the attacker's, and the operator's Tailscale or LAN names are not
+        # something to hand it.
         await _reject(
             scope,
             receive,
@@ -358,8 +381,8 @@ class TrustedHostMiddleware:
             status_code=400,
             detail=(
                 f"Invalid host header: {host!r}.\n"
-                f"This server only answers to: {', '.join(self.allowed_hosts)}.\n"
-                f"Restart it with --allowed-host {host or '<name>'} to accept this name."
+                f"Restart the server with --allowed-host {host or '<name>'} "
+                f"to accept this name."
             ),
         )
 

--- a/src/clm/infrastructure/web_security.py
+++ b/src/clm/infrastructure/web_security.py
@@ -1,11 +1,10 @@
 """Browser-facing containment for CLM's local web apps.
 
-CLM ships two HTTP apps that a user runs on their own machine — the
-recordings dashboard (``clm recordings serve``) and the dashboard/Studio
-(``clm serve``). Both bind loopback by default, and both used to treat "the
-request arrived on the socket" as "the user asked for this". A web page open
-in the same browser can send a request to ``http://127.0.0.1:8008`` without
-any cooperation from the app, so that assumption is wrong twice over:
+Its one caller today is the **recordings dashboard** (``clm recordings
+serve``), which has no login at all: it treated "the request arrived on the
+socket" as "the user asked for this". A web page open in the same browser can
+send a request to ``http://127.0.0.1:8008`` without any cooperation from the
+app, so that assumption is wrong twice over:
 
 **CSRF.** A page on ``https://evil.example`` can auto-submit a form at any of
 the dashboard's ``POST`` routes. No token, no cookie, no user interaction —
@@ -38,6 +37,12 @@ not an oversight. Requests carrying *neither* ``Origin`` nor
 ``curl``, a script, or a test client looks like, and none of them are the
 threat model. Every browser CLM's dashboards support sends ``Origin`` on a
 cross-origin form post.
+
+Written to be app-agnostic because ``clm serve`` needs the same two guards
+(its dashboard API is unauthenticated, and its WebSocket accepts anyone) — but
+until that is wired, nothing here should be read as a claim about it. CLM's
+third HTTP app, the Worker API in :mod:`clm.infrastructure.api`, protects
+itself differently: a per-build bearer token on every route.
 
 Why hand-rolled rather than Starlette's ``TrustedHostMiddleware``: that one
 derives the host as ``header.split(":")[0]``, which turns ``[::1]:8000`` into
@@ -92,9 +97,14 @@ def extract_host(host_header: str) -> str:
             return value[1:end].lower()
         return value.lower()
     if value.count(":") == 1:
-        return value.rsplit(":", 1)[0].lower()
-    # No port, or a bare (invalid) IPv6 literal — either way, use it verbatim.
-    return value.lower()
+        host = value.rsplit(":", 1)[0].lower()
+    else:
+        # No port, or a bare (invalid) IPv6 literal — either way, use it verbatim.
+        host = value.lower()
+    # ``http://localhost./`` is a legal URL (an explicitly-absolute FQDN) and
+    # the browser sends the dot through. Treat it as the same host rather than
+    # 400-ing somebody who typed a legitimate address.
+    return host[:-1] if host.endswith(".") and len(host) > 1 else host
 
 
 def normalize_host_pattern(pattern: str) -> str:
@@ -137,6 +147,46 @@ def default_allowed_hosts(bind_host: str | None = None, extra: Iterable[str] = (
     return hosts
 
 
+def remote_access_warning(bind_host: str | None, extra: Iterable[str] = ()) -> str | None:
+    """Return a warning when the bind address promises more reach than the allowlist.
+
+    Binding ``0.0.0.0`` says "I want other machines to reach this", but the
+    host allowlist has no way to learn the *name* those machines will use, so
+    every one of their requests gets ``400 Invalid host header``. Without this
+    warning the symptom is a dashboard that appears to start normally and then
+    refuses everything remote, with the explanation only in a server log the
+    user is not watching.
+
+    Args:
+        bind_host: The address about to be bound.
+        extra: Operator-supplied allowed hosts.
+
+    Returns:
+        A message to print, or ``None`` when the configuration is coherent.
+    """
+    extras = [e for e in extra if e]
+    if extras:
+        return None
+    if not bind_host:
+        return None
+    host = normalize_host_pattern(bind_host)
+    if host in LOOPBACK_HOSTS:
+        return None
+    if host in ("0.0.0.0", "::"):
+        return (
+            f"Binding {bind_host} exposes this server to the network, but it will "
+            f"only answer to {', '.join(LOOPBACK_HOSTS)} — every request from "
+            f"another machine gets '400 Invalid host header'. Add "
+            f"--allowed-host <name-or-ip> for each address you will use to reach it "
+            f"(or --allowed-host '*' to accept any)."
+        )
+    return (
+        f"This server will answer to {host} and loopback only. If you reach it "
+        f"under a different name (a hostname rather than the bare address), add "
+        f"--allowed-host <name>."
+    )
+
+
 def host_is_allowed(host: str, allowed: Sequence[str]) -> bool:
     """True when ``host`` matches one of the ``allowed`` patterns.
 
@@ -167,6 +217,11 @@ def normalize_origin(origin: str) -> str | None:
         return None
     scheme = parts.scheme.lower()
     host = parts.hostname.lower()
+    if ":" in host:
+        # ``urlsplit`` strips the brackets off an IPv6 literal; putting them
+        # back keeps the result a parseable authority rather than the
+        # ambiguous ``http://::1:8008``.
+        host = f"[{host}]"
     try:
         port = parts.port
     except ValueError:
@@ -212,9 +267,13 @@ def _origin_matches_host(origin: str, host_header: str) -> bool:
     if origin_host != target_host:
         return False
     if not target_port_str:
-        # No port in Host means the default port for the scheme the client
-        # used; we cannot know it, so host equality is as far as we can go.
-        return True
+        # No port in Host means the client used the default port for whatever
+        # scheme it spoke, and we cannot see the scheme through a proxy. Accept
+        # only an origin that is *itself* on a default port: that keeps the
+        # ``tailscale serve`` case (Origin https://box.ts.net / Host box.ts.net)
+        # working, while refusing a dev server on localhost:3000 driving a
+        # dashboard reached as plain ``localhost``.
+        return origin_port is None
     return origin_port_str == target_port_str
 
 
@@ -290,7 +349,19 @@ class TrustedHostMiddleware:
             host,
             self.allowed_hosts,
         )
-        await _reject(scope, receive, send, status_code=400, detail="Invalid host header")
+        # The remediation belongs in the *body*: the person hitting this is
+        # looking at a browser, not at the server's log.
+        await _reject(
+            scope,
+            receive,
+            send,
+            status_code=400,
+            detail=(
+                f"Invalid host header: {host!r}.\n"
+                f"This server only answers to: {', '.join(self.allowed_hosts)}.\n"
+                f"Restart it with --allowed-host {host or '<name>'} to accept this name."
+            ),
+        )
 
 
 class OriginGuardMiddleware:
@@ -349,7 +420,14 @@ async def _reject(
     status_code: int,
     detail: str,
 ) -> None:
-    """Answer ``scope`` with a refusal, in whichever protocol it speaks."""
+    """Answer ``scope`` with a refusal, in whichever protocol it speaks.
+
+    ``status_code`` and ``detail`` apply to HTTP only. A refused handshake has
+    no equivalent: both refusals close with 1008 (policy violation), so a
+    WebSocket client cannot tell a bad ``Host`` from a bad ``Origin``. That is
+    deliberate — the distinction is in the server log, and the client is by
+    definition one we are refusing to talk to.
+    """
     if scope["type"] == "websocket":
         # ASGI lets a handshake be refused by closing before accepting; uvicorn
         # turns that into an HTTP 403. The connect message has to be consumed

--- a/src/clm/recordings/web/app.py
+++ b/src/clm/recordings/web/app.py
@@ -21,6 +21,7 @@ from fastapi.templating import Jinja2Templates
 from loguru import logger
 
 from clm.__version__ import __version__
+from clm.infrastructure.web_security import install_web_security
 
 from .routes import router
 
@@ -97,6 +98,9 @@ def create_app(
     stability_check_count: int = 3,
     auphonic_api_key: str = "",
     auphonic_preset: str = "",
+    bind_host: str | None = None,
+    allowed_hosts: list[str] | None = None,
+    allowed_origins: list[str] | None = None,
 ) -> FastAPI:
     """Create the recordings dashboard FastAPI application.
 
@@ -114,6 +118,18 @@ def create_app(
             ``processing_backend == "auphonic"``; ignored otherwise).
         auphonic_preset: Optional managed preset name to reference on
             every Auphonic production. Empty means inline algorithms.
+        bind_host: Address the server will bind, folded into the ``Host``
+            allowlist so a non-loopback bind keeps working.
+        allowed_hosts: Extra ``Host`` values to accept (``--allowed-host``).
+        allowed_origins: Extra origins allowed to drive mutating routes
+            (``--allowed-origin``).
+
+    Notes:
+        Every mutating route is guarded against cross-origin drivers and the
+        app rejects a ``Host`` it does not recognise — see
+        :mod:`clm.infrastructure.web_security`. The dashboard has no login, so
+        without these a page open in another tab could arm decks, start
+        recordings, and upload local files to the processing backend.
     """
     from clm.infrastructure.config import AuphonicConfig, RecordingsConfig
     from clm.recordings.state import CourseRecordingState, load_or_create, save_state
@@ -132,6 +148,14 @@ def create_app(
         version=__version__,
         lifespan=lifespan,
     )
+
+    effective_hosts = install_web_security(
+        app,
+        bind_host=bind_host,
+        allowed_hosts=allowed_hosts,
+        allowed_origins=allowed_origins or (),
+    )
+    logger.debug("Recordings dashboard accepts Host values: {}", effective_hosts)
 
     # Ensure directory structure
     ensure_root(recordings_root)

--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -90,6 +90,18 @@ def _lectures_refresh_response() -> HTMLResponse:
     return HTMLResponse("", headers={"HX-Location": _LECTURES_REFRESH_LOCATION})
 
 
+def _validate_deck_identity(course_slug: str, section_name: str, deck_name: str) -> None:
+    """Validate the ``(course, section, deck)`` triple a request names.
+
+    All three become path components under the recordings root via
+    :func:`~clm.recordings.workflow.naming.recording_relative_dir`. See
+    :func:`_validate_name` for why rejecting beats rewriting.
+    """
+    _validate_name(course_slug, field="course_slug")
+    _validate_name(section_name, field="section_name")
+    _validate_name(deck_name, field="deck_name")
+
+
 def _resolve_lecture_id(section_name: str, deck_name: str) -> str:
     """Derive a stable ``lecture_id`` for *(section_name, deck_name)*.
 
@@ -206,6 +218,44 @@ def _build_deck_provenance(request: Request, section_name: str, deck_name: str, 
         return None
 
 
+#: Characters that must never appear in a request-supplied name that ends up
+#: as a path component. ``/`` and ``\`` are separators; ``:`` carries a drive
+#: letter or an NTFS alternate data stream; the null byte truncates a path in
+#: the C layer beneath ``open()``.
+_PATH_UNSAFE_CHARS = ("/", "\\", ":", "\x00")
+
+
+def _validate_name(value: str, *, field: str) -> str:
+    """Return ``value`` if it is safe to use as a single path component.
+
+    ``course_slug``, ``section_name`` and ``deck_name`` arrive from a form or
+    a URL and reach the filesystem twice over: through
+    :func:`~clm.recordings.workflow.naming.recording_relative_dir` (under the
+    recordings root) and — for ``course_slug`` — through
+    :func:`~clm.recordings.state.get_state_path`, which joins it into CLM's
+    config directory with **no** sanitizing at all. ``get_state_path(
+    "../../../evil")`` writes outside the config dir; ``..`` alone escapes the
+    recordings root, because the existing sanitizer strips separators but
+    leaves a lone ``..`` intact.
+
+    Rejecting is the right answer rather than rewriting: these values name
+    something the UI already knows exists, so anything containing a separator
+    is a bug or an attack, not a user with an unusual course name.
+
+    Raises:
+        HTTPException: 400 when ``value`` is empty, is a relative-path
+            component (``.`` / ``..``), or contains a separator.
+    """
+    if not value or not value.strip():
+        raise HTTPException(status_code=400, detail=f"{field} must not be empty")
+    if value.strip(". ") == "":
+        raise HTTPException(status_code=400, detail=f"Invalid {field}: {value!r}")
+    for char in _PATH_UNSAFE_CHARS:
+        if char in value:
+            raise HTTPException(status_code=400, detail=f"Invalid {field}: {value!r}")
+    return value
+
+
 def _get_or_load_course_state(request: Request, course_slug: str) -> CourseRecordingState:
     """Return the cached :class:`CourseRecordingState` for *course_slug*.
 
@@ -213,7 +263,12 @@ def _get_or_load_course_state(request: Request, course_slug: str) -> CourseRecor
     fresh empty state if no file exists yet. Subsequent calls return
     the cached in-memory instance so mutations from the session thread
     and the request thread share the same object.
+
+    ``course_slug`` is validated here rather than only at the call sites:
+    every path into this function ends in ``get_state_path(course_slug)``,
+    which joins the value into CLM's config directory unsanitized.
     """
+    _validate_name(course_slug, field="course_slug")
     cache = cast(dict[str, CourseRecordingState], request.app.state.recording_states)
     cached = cache.get(course_slug)
     if cached is not None:
@@ -370,6 +425,7 @@ async def arm_deck(
     part_number: int = Form(0),
 ):
     """Arm a slide deck for the next recording."""
+    _validate_deck_identity(course_slug, section_name, deck_name)
     session = _get_session(request)
     lang = _get_lang(request)
     if not request.app.state.obs.connected:
@@ -425,6 +481,7 @@ async def record_deck(
     OBS error. The user can retry via the lower-level ``/arm`` route or
     start OBS manually.
     """
+    _validate_deck_identity(course_slug, section_name, deck_name)
     session = _get_session(request)
     lang = _get_lang(request)
     if not request.app.state.obs.connected:
@@ -471,6 +528,7 @@ async def advance_take(
     history (e.g. because they noticed a mistake mid-session) without
     having to record a throwaway just to trigger the demote.
     """
+    _validate_deck_identity(course_slug, section_name, deck_name)
     session = _get_session(request)
     lang = _get_lang(request)
     lecture_id = _resolve_lecture_id(section_name, deck_name)
@@ -566,7 +624,19 @@ async def resume_recording(request: Request):
 
 @router.post("/process", response_class=HTMLResponse)
 async def process_file(request: Request):
-    """Manually submit one or more files for backend processing."""
+    """Manually submit one or more files for backend processing.
+
+    Every submitted path must resolve **under the recordings root**. Without
+    that check this route was an arbitrary-file exfiltration primitive: it
+    took a path from a form, checked only that it existed, and handed it to
+    the configured backend — which for Auphonic means uploading the file to a
+    third-party service. Its sibling ``/open-explorer`` already did exactly
+    this check; the omission here was inconsistent, not deliberate.
+
+    Status codes:
+    - 400: no path given, or a path outside the recordings root.
+    - 200: submitted (missing files are skipped with a notice, as before).
+    """
     from pathlib import Path as _Path
 
     from clm.recordings.workflow.jobs import ProcessingOptions
@@ -577,6 +647,7 @@ async def process_file(request: Request):
         raise HTTPException(status_code=400, detail="No raw_path provided")
 
     job_manager = _get_job_manager(request)
+    root = _Path(request.app.state.recordings_root).resolve()
     submitted = 0
     for raw_path in raw_paths:
         path = _Path(str(raw_path))
@@ -584,6 +655,23 @@ async def process_file(request: Request):
             logger.warning("Skipping missing file: {}", raw_path)
             _push_notice(request, "warning", f"Skipped missing file: {path.name}")
             continue
+        # resolve() after the existence check so a missing file keeps its
+        # friendlier "skipped" path rather than turning into a hard 400.
+        try:
+            resolved = path.resolve(strict=True)
+        except OSError as exc:  # pragma: no cover - raced deletion
+            logger.warning("Skipping unresolvable file {}: {}", raw_path, exc)
+            _push_notice(request, "warning", f"Skipped missing file: {path.name}")
+            continue
+        try:
+            resolved.relative_to(root)
+        except ValueError as exc:
+            logger.warning("Refused to process {} — outside the recordings root", resolved)
+            raise HTTPException(
+                status_code=400,
+                detail="Path is outside the recordings root",
+            ) from exc
+        path = resolved
         try:
             # submit_async returns immediately; the actual blocking
             # backend.submit (Auphonic upload, etc.) runs on a worker
@@ -639,6 +727,7 @@ async def deck_takes(
     """
     from clm.recordings.workflow.deck_status import TakeFileInfo, scan_take_files
 
+    _validate_deck_identity(course_slug, section_name, deck_name)
     templates = _get_templates(request)
     root = request.app.state.recordings_root
     raw_suffix = request.app.state.raw_suffix
@@ -737,6 +826,7 @@ async def restore_take(
       state record.
     - 409: Session is busy (recording, paused, or renaming).
     """
+    _validate_deck_identity(course_slug, section_name, deck_name)
     session = _get_session(request)
     lang = _get_lang(request)
     lecture_id = _resolve_lecture_id(section_name, deck_name)

--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -224,6 +224,16 @@ def _build_deck_provenance(request: Request, section_name: str, deck_name: str, 
 #: the C layer beneath ``open()``.
 _PATH_UNSAFE_CHARS = ("/", "\\", ":", "\x00")
 
+#: Windows device names, which resolve to the device rather than to a file
+#: **whatever extension follows** — ``NUL.json`` is the null device, so a state
+#: write against it is silently discarded rather than stored. Matching is
+#: case-insensitive and ignores the extension, exactly as Windows does.
+_WINDOWS_RESERVED_NAMES = frozenset(
+    {"CON", "PRN", "AUX", "NUL"}
+    | {f"COM{i}" for i in range(1, 10)}
+    | {f"LPT{i}" for i in range(1, 10)}
+)
+
 
 def _validate_name(value: str, *, field: str) -> str:
     """Return ``value`` if it is safe to use as a single path component.
@@ -239,20 +249,40 @@ def _validate_name(value: str, *, field: str) -> str:
     leaves a lone ``..`` intact.
 
     Rejecting is the right answer rather than rewriting: these values name
-    something the UI already knows exists, so anything containing a separator
-    is a bug or an attack, not a user with an unusual course name.
+    something the UI already knows exists, so anything unusable as a filename
+    is a bug or an attack, not a user with an eccentric course name.
+
+    Beyond containment, this also refuses names that would produce a *silently
+    broken* file rather than an escape — control characters (which make the
+    write raise, and the raise is swallowed by design in
+    ``_on_state_mutation``) and Windows device names (which make the write go
+    to the device and vanish). Failing the request is the honest answer.
 
     Raises:
         HTTPException: 400 when ``value`` is empty, is a relative-path
-            component (``.`` / ``..``), or contains a separator.
+            component (``.`` / ``..``), contains a separator or a control
+            character, or names a Windows device.
     """
     if not value or not value.strip():
         raise HTTPException(status_code=400, detail=f"{field} must not be empty")
-    if value.strip(". ") == "":
+
+    def _reject() -> None:
         raise HTTPException(status_code=400, detail=f"Invalid {field}: {value!r}")
+
+    if value.strip(". ") == "":
+        _reject()
     for char in _PATH_UNSAFE_CHARS:
         if char in value:
-            raise HTTPException(status_code=400, detail=f"Invalid {field}: {value!r}")
+            _reject()
+    if any(ord(char) < 0x20 or ord(char) == 0x7F for char in value):
+        _reject()
+    # Windows also strips trailing dots and spaces, so "deck." and "deck "
+    # both open "deck" — two different requests writing one file.
+    if value != value.rstrip(". "):
+        _reject()
+    stem = value.split(".", 1)[0].strip().upper()
+    if stem in _WINDOWS_RESERVED_NAMES:
+        _reject()
     return value
 
 
@@ -633,6 +663,12 @@ async def process_file(request: Request):
     third-party service. Its sibling ``/open-explorer`` already did exactly
     this check; the omission here was inconsistent, not deliberate.
 
+    Validation runs over the **whole** batch before anything is submitted. A
+    one-pass loop that refused mid-way would already have started an Auphonic
+    upload for the earlier entries, and then abandon the response — leaving a
+    job running that the user was never told about and the lectures panel
+    never refreshed to show.
+
     Status codes:
     - 400: no path given, or a path outside the recordings root.
     - 200: submitted (missing files are skipped with a notice, as before).
@@ -648,19 +684,19 @@ async def process_file(request: Request):
 
     job_manager = _get_job_manager(request)
     root = _Path(request.app.state.recordings_root).resolve()
-    submitted = 0
+
+    # Pass 1 — resolve and contain. Nothing is submitted until every path in
+    # the batch has been judged.
+    accepted: list[_Path] = []
     for raw_path in raw_paths:
         path = _Path(str(raw_path))
-        if not path.exists():
-            logger.warning("Skipping missing file: {}", raw_path)
-            _push_notice(request, "warning", f"Skipped missing file: {path.name}")
-            continue
-        # resolve() after the existence check so a missing file keeps its
-        # friendlier "skipped" path rather than turning into a hard 400.
         try:
             resolved = path.resolve(strict=True)
-        except OSError as exc:  # pragma: no cover - raced deletion
-            logger.warning("Skipping unresolvable file {}: {}", raw_path, exc)
+        except OSError:
+            # Missing (or unresolvable) stays a skip-with-notice rather than a
+            # hard failure: a file can vanish between the page render and the
+            # click, and that is not the user's mistake.
+            logger.warning("Skipping missing file: {}", raw_path)
             _push_notice(request, "warning", f"Skipped missing file: {path.name}")
             continue
         try:
@@ -671,7 +707,14 @@ async def process_file(request: Request):
                 status_code=400,
                 detail="Path is outside the recordings root",
             ) from exc
-        path = resolved
+        if not resolved.is_file():
+            logger.warning("Refused to process {} — not a file", resolved)
+            raise HTTPException(status_code=400, detail="Path is not a file")
+        accepted.append(resolved)
+
+    # Pass 2 — submit.
+    submitted = 0
+    for path in accepted:
         try:
             # submit_async returns immediately; the actual blocking
             # backend.submit (Auphonic upload, etc.) runs on a worker
@@ -679,7 +722,7 @@ async def process_file(request: Request):
             job_manager.submit_async(path, options=ProcessingOptions())
             submitted += 1
         except Exception as exc:
-            logger.warning("Failed to submit {}: {}", raw_path, exc)
+            logger.warning("Failed to submit {}: {}", path, exc)
             _push_notice(request, "error", f"Failed to submit {path.name}: {exc}")
     if submitted:
         _push_notice(

--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -266,36 +266,42 @@ def _validate_component(value: str, *, field: str) -> str:
     For ``section_name`` and ``deck_name``, which are titles the user wrote.
     They reach the filesystem only through
     :func:`~clm.core.utils.text_utils.sanitize_file_name`, which deletes
-    ``; ! ? " ' :`` and replaces ``/ \\ $ # % & < > * = ^ € |`` — so the only
-    question left is containment, and the answer must not depend on the value
-    reading like a tidy filename. "Woche 01: Einführung, LLMs und Python in
-    JupyterLite" is a real section name.
+    ``; ! ? " ' :`` and replaces ``/ \\ $ # % & < > * = ^ € |`` with ``_``.
 
-    Both forms are checked. The raw value must not carry a separator (some
-    scanners join it before sanitizing), and the *sanitized* value must not
-    come out as ``.``/``..`` — ``":..:"`` sanitizes to ``..``, which would
-    escape the recordings root even though the raw value looks harmless.
+    So the question is **not** whether the value looks like a tidy filename —
+    it is whether its *sanitized* form can escape. Judging the raw value is a
+    false positive, and an expensive one: real section names are
+    "Woche 01: Einführung, LLMs und Python in JupyterLite" and "Woche 12:
+    Datenanalyse mit pandas (+ ML-/Metrik-Kostprobe)". The first carries a
+    colon, the second a slash, and both are perfectly safe by the time they
+    reach disk.
+
+    What the sanitizer does *not* neutralize is dots: ``":..:"`` sanitizes to
+    ``..``, which escapes the recordings root while looking harmless raw. Nor
+    does it strip null bytes or control characters, which produce an
+    unusable path rather than a wrong one.
 
     Raises:
-        HTTPException: 400 when ``value`` is blank, is a relative-path
-            component before or after sanitizing, or contains a separator,
-            a null byte or a control character.
+        HTTPException: 400 when ``value`` is blank, contains a null byte or a
+            control character, or sanitizes to nothing, to ``.``/``..``, or to
+            anything still carrying a separator.
     """
     from clm.core.utils.text_utils import sanitize_file_name
 
     if not value or not value.strip():
         raise HTTPException(status_code=400, detail=f"{field} must not be empty")
-    if _is_relative_component(value):
-        _reject_name(value, field)
-    for char in _CONTAINMENT_UNSAFE_CHARS:
-        if char in value:
-            _reject_name(value, field)
     if any(ord(char) < 0x20 or ord(char) == 0x7F for char in value):
         _reject_name(value, field)
 
     sanitized = sanitize_file_name(value)
     if not sanitized.strip() or _is_relative_component(sanitized):
         _reject_name(value, field)
+    # Belt and braces: the sanitizer replaces both separators today, and this
+    # holds it to that. If it ever stops, this fails closed instead of quietly
+    # letting a component become a path.
+    for char in _CONTAINMENT_UNSAFE_CHARS:
+        if char in sanitized:
+            _reject_name(value, field)
     return value
 
 

--- a/src/clm/recordings/web/routes.py
+++ b/src/clm/recordings/web/routes.py
@@ -93,13 +93,25 @@ def _lectures_refresh_response() -> HTMLResponse:
 def _validate_deck_identity(course_slug: str, section_name: str, deck_name: str) -> None:
     """Validate the ``(course, section, deck)`` triple a request names.
 
-    All three become path components under the recordings root via
-    :func:`~clm.recordings.workflow.naming.recording_relative_dir`. See
-    :func:`_validate_name` for why rejecting beats rewriting.
+    The three are **not** interchangeable, and applying one rule to all of
+    them is a bug rather than caution:
+
+    - ``course_slug`` reaches :func:`~clm.recordings.state.get_state_path`
+      **unsanitized**, where it becomes the filename ``<slug>.json``. It has
+      to survive as a literal filename, so :func:`_validate_slug` is strict.
+      It can afford to be: the value is machine-generated
+      (``project_slug + "-de"``, else a sanitized course name), never a title.
+    - ``section_name`` and ``deck_name`` are *titles the user wrote* — "Woche
+      01: Einführung, LLMs und Python" is a real section name, and 33 of the
+      39 in the default recordings spec contain a colon. They only ever reach
+      disk through :func:`~clm.core.utils.text_utils.sanitize_file_name`,
+      which deletes exactly those characters. Judging them as filenames would
+      reject the entire Lectures page for every real course, so
+      :func:`_validate_component` checks containment and nothing else.
     """
-    _validate_name(course_slug, field="course_slug")
-    _validate_name(section_name, field="section_name")
-    _validate_name(deck_name, field="deck_name")
+    _validate_slug(course_slug, field="course_slug")
+    _validate_component(section_name, field="section_name")
+    _validate_component(deck_name, field="deck_name")
 
 
 def _resolve_lecture_id(section_name: str, deck_name: str) -> str:
@@ -218,11 +230,14 @@ def _build_deck_provenance(request: Request, section_name: str, deck_name: str, 
         return None
 
 
-#: Characters that must never appear in a request-supplied name that ends up
-#: as a path component. ``/`` and ``\`` are separators; ``:`` carries a drive
-#: letter or an NTFS alternate data stream; the null byte truncates a path in
-#: the C layer beneath ``open()``.
-_PATH_UNSAFE_CHARS = ("/", "\\", ":", "\x00")
+#: Characters that can never appear in a request-supplied value that becomes a
+#: path component, whatever else is done to it. ``/`` and ``\`` are separators;
+#: the null byte truncates a path in the C layer beneath ``open()``.
+_CONTAINMENT_UNSAFE_CHARS = ("/", "\\", "\x00")
+
+#: Additionally forbidden in a value used as a filename *verbatim*: ``:``
+#: carries a drive letter or an NTFS alternate data stream.
+_FILENAME_UNSAFE_CHARS = (*_CONTAINMENT_UNSAFE_CHARS, ":")
 
 #: Windows device names, which resolve to the device rather than to a file
 #: **whatever extension follows** — ``NUL.json`` is the null device, so a state
@@ -235,54 +250,93 @@ _WINDOWS_RESERVED_NAMES = frozenset(
 )
 
 
-def _validate_name(value: str, *, field: str) -> str:
-    """Return ``value`` if it is safe to use as a single path component.
+def _reject_name(value: str, field: str) -> None:
+    """Raise the 400 both validators use."""
+    raise HTTPException(status_code=400, detail=f"Invalid {field}: {value!r}")
 
-    ``course_slug``, ``section_name`` and ``deck_name`` arrive from a form or
-    a URL and reach the filesystem twice over: through
-    :func:`~clm.recordings.workflow.naming.recording_relative_dir` (under the
-    recordings root) and — for ``course_slug`` — through
-    :func:`~clm.recordings.state.get_state_path`, which joins it into CLM's
-    config directory with **no** sanitizing at all. ``get_state_path(
-    "../../../evil")`` writes outside the config dir; ``..`` alone escapes the
-    recordings root, because the existing sanitizer strips separators but
-    leaves a lone ``..`` intact.
 
-    Rejecting is the right answer rather than rewriting: these values name
-    something the UI already knows exists, so anything unusable as a filename
-    is a bug or an attack, not a user with an eccentric course name.
+def _is_relative_component(value: str) -> bool:
+    """True when ``value`` is ``.``/``..`` (or only dots and spaces)."""
+    return value.strip(". ") == ""
 
-    Beyond containment, this also refuses names that would produce a *silently
-    broken* file rather than an escape — control characters (which make the
-    write raise, and the raise is swallowed by design in
-    ``_on_state_mutation``) and Windows device names (which make the write go
-    to the device and vanish). Failing the request is the honest answer.
+
+def _validate_component(value: str, *, field: str) -> str:
+    """Return ``value`` if it can safely *become* a path component.
+
+    For ``section_name`` and ``deck_name``, which are titles the user wrote.
+    They reach the filesystem only through
+    :func:`~clm.core.utils.text_utils.sanitize_file_name`, which deletes
+    ``; ! ? " ' :`` and replaces ``/ \\ $ # % & < > * = ^ € |`` — so the only
+    question left is containment, and the answer must not depend on the value
+    reading like a tidy filename. "Woche 01: Einführung, LLMs und Python in
+    JupyterLite" is a real section name.
+
+    Both forms are checked. The raw value must not carry a separator (some
+    scanners join it before sanitizing), and the *sanitized* value must not
+    come out as ``.``/``..`` — ``":..:"`` sanitizes to ``..``, which would
+    escape the recordings root even though the raw value looks harmless.
 
     Raises:
-        HTTPException: 400 when ``value`` is empty, is a relative-path
-            component (``.`` / ``..``), contains a separator or a control
-            character, or names a Windows device.
+        HTTPException: 400 when ``value`` is blank, is a relative-path
+            component before or after sanitizing, or contains a separator,
+            a null byte or a control character.
+    """
+    from clm.core.utils.text_utils import sanitize_file_name
+
+    if not value or not value.strip():
+        raise HTTPException(status_code=400, detail=f"{field} must not be empty")
+    if _is_relative_component(value):
+        _reject_name(value, field)
+    for char in _CONTAINMENT_UNSAFE_CHARS:
+        if char in value:
+            _reject_name(value, field)
+    if any(ord(char) < 0x20 or ord(char) == 0x7F for char in value):
+        _reject_name(value, field)
+
+    sanitized = sanitize_file_name(value)
+    if not sanitized.strip() or _is_relative_component(sanitized):
+        _reject_name(value, field)
+    return value
+
+
+def _validate_slug(value: str, *, field: str) -> str:
+    """Return ``value`` if it is safe to use as a filename **verbatim**.
+
+    For ``course_slug`` alone. It reaches
+    :func:`~clm.recordings.state.get_state_path`, which joins it into CLM's
+    config directory with no sanitizing at all and appends ``.json`` —
+    ``get_state_path("../../../evil")`` writes outside the config dir.
+
+    Strictness is affordable here in a way it is not for a title: the value is
+    machine-generated (``project_slug + "-de"``, or a *sanitized* course name
+    plus that suffix), so it never legitimately contains a colon, a control
+    character or a trailing dot.
+
+    Beyond containment this also refuses names that would produce a *silently
+    broken* file rather than an escape — control characters (the write raises,
+    and the raise is swallowed by design in ``_on_state_mutation``) and Windows
+    device names (the write goes to the device and vanishes).
+
+    Raises:
+        HTTPException: 400 when ``value`` is blank, is a relative-path
+            component, contains a separator, colon or control character, ends
+            in a dot or space, or names a Windows device.
     """
     if not value or not value.strip():
         raise HTTPException(status_code=400, detail=f"{field} must not be empty")
-
-    def _reject() -> None:
-        raise HTTPException(status_code=400, detail=f"Invalid {field}: {value!r}")
-
-    if value.strip(". ") == "":
-        _reject()
-    for char in _PATH_UNSAFE_CHARS:
+    if _is_relative_component(value):
+        _reject_name(value, field)
+    for char in _FILENAME_UNSAFE_CHARS:
         if char in value:
-            _reject()
+            _reject_name(value, field)
     if any(ord(char) < 0x20 or ord(char) == 0x7F for char in value):
-        _reject()
-    # Windows also strips trailing dots and spaces, so "deck." and "deck "
-    # both open "deck" — two different requests writing one file.
+        _reject_name(value, field)
+    # Windows also strips trailing dots and spaces, so "course." and "course "
+    # both open "course" — two different requests writing one file.
     if value != value.rstrip(". "):
-        _reject()
-    stem = value.split(".", 1)[0].strip().upper()
-    if stem in _WINDOWS_RESERVED_NAMES:
-        _reject()
+        _reject_name(value, field)
+    if value.split(".", 1)[0].strip().upper() in _WINDOWS_RESERVED_NAMES:
+        _reject_name(value, field)
     return value
 
 
@@ -298,7 +352,7 @@ def _get_or_load_course_state(request: Request, course_slug: str) -> CourseRecor
     every path into this function ends in ``get_state_path(course_slug)``,
     which joins the value into CLM's config directory unsanitized.
     """
-    _validate_name(course_slug, field="course_slug")
+    _validate_slug(course_slug, field="course_slug")
     cache = cast(dict[str, CourseRecordingState], request.app.state.recording_states)
     cached = cache.get(course_slug)
     if cached is not None:
@@ -692,10 +746,15 @@ async def process_file(request: Request):
         path = _Path(str(raw_path))
         try:
             resolved = path.resolve(strict=True)
-        except OSError:
+        except (OSError, ValueError):
             # Missing (or unresolvable) stays a skip-with-notice rather than a
             # hard failure: a file can vanish between the page render and the
             # click, and that is not the user's mistake.
+            #
+            # ValueError is not redundant with OSError: an embedded null byte
+            # raises OSError on Windows but ValueError on POSIX, where
+            # ``posixpath.realpath`` guards ``os.lstat`` for OSError only. A
+            # Windows-only run of the suite cannot see that, and CI is Linux.
             logger.warning("Skipping missing file: {}", raw_path)
             _push_notice(request, "warning", f"Skipped missing file: {path.name}")
             continue

--- a/tests/infrastructure/test_web_security.py
+++ b/tests/infrastructure/test_web_security.py
@@ -124,8 +124,11 @@ class TestNormalizeOrigin:
     def test_default_ports_are_dropped(self, origin: str, expected: str):
         assert normalize_origin(origin) == expected
 
-    @pytest.mark.parametrize("origin", ["null", "", "   ", "not-a-url", "http://"])
+    @pytest.mark.parametrize(
+        "origin", ["null", "", "   ", "not-a-url", "http://", "http://[::1", "http://a]b"]
+    )
     def test_unusable_origins_are_none(self, origin: str):
+        """Includes the forms ``urlsplit`` raises ValueError on."""
         assert normalize_origin(origin) is None
 
     def test_ipv6_keeps_its_brackets(self):
@@ -192,6 +195,22 @@ class TestCheckRequestOrigin:
         """
         headers = self._headers(origin="http://localhost:3000", host="localhost")
         assert check_request_origin(headers) is not None
+
+    @pytest.mark.parametrize("origin", ["http://[::1", "http://[oops", "http://a]b"])
+    def test_a_malformed_origin_is_refused_not_raised(self, origin: str):
+        """``urlsplit`` raises ValueError on these; a raise here would be a 500.
+
+        Not a bypass — the handler is never reached either way — but a refusal
+        turning into a traceback from inside the security middleware is its own
+        defect.
+        """
+        headers = self._headers(origin=origin, host="127.0.0.1:8008")
+        assert check_request_origin(headers) is not None
+
+    def test_trailing_dot_origin_matches_trailing_dot_host(self):
+        """The two guards must agree about the FQDN form."""
+        headers = self._headers(origin="http://localhost.:8008", host="localhost.:8008")
+        assert check_request_origin(headers) is None
 
     def test_explicitly_allowed_origin_passes(self):
         headers = self._headers(origin="https://studio.example", host="127.0.0.1:8008")

--- a/tests/infrastructure/test_web_security.py
+++ b/tests/infrastructure/test_web_security.py
@@ -1,0 +1,277 @@
+"""Tests for the browser-facing guards in :mod:`clm.infrastructure.web_security`.
+
+The properties under test are the ones an attacker's page probes: can it send
+a mutating request that the app acts on, and can it reach the app under a name
+the app should not answer to (DNS rebinding). The negative cases matter as
+much as the positive ones — a guard that also blocks ``curl``, the app's own
+HTMX traffic, or IPv6 loopback would be turned off, and then it protects
+nothing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route, WebSocketRoute
+from starlette.testclient import TestClient
+
+from clm.infrastructure.web_security import (
+    OriginGuardMiddleware,
+    TrustedHostMiddleware,
+    check_request_origin,
+    default_allowed_hosts,
+    extract_host,
+    host_is_allowed,
+    install_web_security,
+    normalize_origin,
+)
+
+
+class TestExtractHost:
+    @pytest.mark.parametrize(
+        ("header", "expected"),
+        [
+            ("localhost:8008", "localhost"),
+            ("localhost", "localhost"),
+            ("127.0.0.1:8008", "127.0.0.1"),
+            ("EXAMPLE.COM", "example.com"),
+            ("  example.com:80  ", "example.com"),
+            ("", ""),
+        ],
+    )
+    def test_strips_port_and_case(self, header: str, expected: str):
+        assert extract_host(header) == expected
+
+    def test_bracketed_ipv6_keeps_the_address(self):
+        """Starlette's own splitter yields ``"["`` here, locking out IPv6 loopback."""
+        assert extract_host("[::1]:8000") == "::1"
+        assert extract_host("[fe80::1]") == "fe80::1"
+
+
+class TestDefaultAllowedHosts:
+    def test_loopback_is_always_allowed(self):
+        hosts = default_allowed_hosts(None)
+        assert "localhost" in hosts
+        assert "127.0.0.1" in hosts
+        assert "::1" in hosts
+
+    def test_bind_host_is_folded_in(self):
+        assert "studio.local" in default_allowed_hosts("studio.local")
+
+    def test_wildcard_bind_contributes_nothing(self):
+        """``0.0.0.0`` names every interface, not a host anybody types."""
+        assert default_allowed_hosts("0.0.0.0") == list(default_allowed_hosts(None))
+        assert default_allowed_hosts("::") == list(default_allowed_hosts(None))
+
+    def test_extra_hosts_are_normalized(self):
+        hosts = default_allowed_hosts("0.0.0.0", ["box.ts.net:8008"])
+        assert "box.ts.net" in hosts
+
+    def test_star_disables_the_check(self):
+        assert default_allowed_hosts("0.0.0.0", ["*"]) == ["*"]
+
+    def test_wildcard_suffix_matches_subdomains(self):
+        assert host_is_allowed("box.ts.net", ["*.ts.net"])
+        assert not host_is_allowed("boxts.net", ["*.ts.net"])
+
+
+class TestNormalizeOrigin:
+    @pytest.mark.parametrize(
+        ("origin", "expected"),
+        [
+            ("http://localhost:80", "http://localhost"),
+            ("https://example.com:443", "https://example.com"),
+            ("http://example.com:8000", "http://example.com:8000"),
+            ("HTTP://Example.COM", "http://example.com"),
+        ],
+    )
+    def test_default_ports_are_dropped(self, origin: str, expected: str):
+        assert normalize_origin(origin) == expected
+
+    @pytest.mark.parametrize("origin", ["null", "", "   ", "not-a-url", "http://"])
+    def test_unusable_origins_are_none(self, origin: str):
+        assert normalize_origin(origin) is None
+
+
+class TestCheckRequestOrigin:
+    @staticmethod
+    def _headers(**kwargs: str):
+        from starlette.datastructures import Headers
+
+        return Headers({k.replace("_", "-"): v for k, v in kwargs.items()})
+
+    def test_no_browser_headers_at_all_is_allowed(self):
+        """``curl`` and the test client send neither header; they are not the threat."""
+        assert check_request_origin(self._headers(host="127.0.0.1:8008")) is None
+
+    @pytest.mark.parametrize("site", ["same-origin", "none"])
+    def test_same_origin_and_user_initiated_pass(self, site: str):
+        assert check_request_origin(self._headers(sec_fetch_site=site)) is None
+
+    @pytest.mark.parametrize("site", ["cross-site", "same-site"])
+    def test_other_sites_are_refused(self, site: str):
+        reason = check_request_origin(self._headers(sec_fetch_site=site))
+        assert reason is not None
+        assert site in reason
+
+    def test_fetch_metadata_wins_over_a_matching_origin(self):
+        """A forged ``Origin`` cannot talk its way past ``Sec-Fetch-Site``."""
+        headers = self._headers(
+            sec_fetch_site="cross-site",
+            origin="http://127.0.0.1:8008",
+            host="127.0.0.1:8008",
+        )
+        assert check_request_origin(headers) is not None
+
+    def test_origin_matching_the_host_passes(self):
+        headers = self._headers(origin="http://127.0.0.1:8008", host="127.0.0.1:8008")
+        assert check_request_origin(headers) is None
+
+    def test_foreign_origin_is_refused(self):
+        headers = self._headers(origin="https://evil.example", host="127.0.0.1:8008")
+        reason = check_request_origin(headers)
+        assert reason is not None
+        assert "evil.example" in reason
+
+    def test_same_host_different_port_is_refused(self):
+        """A different port is a different app, even on the same machine."""
+        headers = self._headers(origin="http://127.0.0.1:3000", host="127.0.0.1:8008")
+        assert check_request_origin(headers) is not None
+
+    def test_https_origin_from_a_tls_terminating_proxy_passes(self):
+        """``tailscale serve`` forwards ``https://…`` to a plain-HTTP upstream."""
+        headers = self._headers(origin="https://box.ts.net", host="box.ts.net")
+        assert check_request_origin(headers) is None
+
+    def test_explicitly_allowed_origin_passes(self):
+        headers = self._headers(origin="https://studio.example", host="127.0.0.1:8008")
+        assert check_request_origin(headers, allowed_origins=["https://studio.example"]) is None
+
+
+def _guarded_app(**kwargs) -> Starlette:
+    """A two-route app carrying both guards, for end-to-end middleware tests."""
+
+    async def read(request):
+        return PlainTextResponse("read ok")
+
+    async def write(request):
+        return PlainTextResponse("write ok")
+
+    async def socket(websocket):
+        await websocket.accept()
+        await websocket.send_text("ws ok")
+        await websocket.close()
+
+    app = Starlette(
+        routes=[
+            Route("/read", read, methods=["GET"]),
+            Route("/write", write, methods=["POST"]),
+            WebSocketRoute("/ws", socket),
+        ]
+    )
+    install_web_security(app, **kwargs)
+    return app
+
+
+class TestMiddlewareEndToEnd:
+    def test_loopback_host_is_served(self):
+        client = TestClient(_guarded_app(), base_url="http://127.0.0.1:8008")
+        assert client.get("/read").status_code == 200
+
+    def test_ipv6_loopback_host_is_served(self):
+        """Browsing to ``http://[::1]:8008/`` must not 400.
+
+        The header is set by hand because Starlette's own test client cannot
+        parse an IPv6 ``base_url`` — which is beside the point here, since the
+        header is the only thing the guard looks at.
+        """
+        client = TestClient(_guarded_app(), base_url="http://127.0.0.1:8008")
+        assert client.get("/read", headers={"Host": "[::1]:8008"}).status_code == 200
+
+    def test_rebound_host_is_refused(self):
+        """DNS rebinding: the page's origin *is* the app's, but Host is not."""
+        client = TestClient(_guarded_app(), base_url="http://evil.example:8008")
+        response = client.post("/write", headers={"Origin": "http://evil.example:8008"})
+        assert response.status_code == 400
+        assert "host" in response.text.lower()
+
+    def test_allowed_host_opt_in_is_honoured(self):
+        app = _guarded_app(allowed_hosts=["box.ts.net"])
+        client = TestClient(app, base_url="http://box.ts.net")
+        assert client.get("/read").status_code == 200
+
+    def test_cross_site_post_is_refused(self):
+        client = TestClient(_guarded_app(), base_url="http://127.0.0.1:8008")
+        response = client.post("/write", headers={"Sec-Fetch-Site": "cross-site"})
+        assert response.status_code == 403
+
+    def test_cross_origin_post_is_refused(self):
+        client = TestClient(_guarded_app(), base_url="http://127.0.0.1:8008")
+        response = client.post("/write", headers={"Origin": "https://evil.example"})
+        assert response.status_code == 403
+
+    def test_same_origin_post_is_served(self):
+        client = TestClient(_guarded_app(), base_url="http://127.0.0.1:8008")
+        response = client.post(
+            "/write",
+            headers={"Origin": "http://127.0.0.1:8008", "Sec-Fetch-Site": "same-origin"},
+        )
+        assert response.status_code == 200
+
+    def test_get_is_never_origin_checked(self):
+        """Blocking cross-origin reads would break ordinary navigation."""
+        client = TestClient(_guarded_app(), base_url="http://127.0.0.1:8008")
+        response = client.get("/read", headers={"Sec-Fetch-Site": "cross-site"})
+        assert response.status_code == 200
+
+    def test_websocket_from_a_foreign_origin_is_refused(self):
+        """WebSockets are CORS-exempt, so the guard has to cover the handshake."""
+        from starlette.websockets import WebSocketDisconnect
+
+        # The test client always sends ``Host: testserver`` on a WS handshake
+        # regardless of base_url, so the host check is opted out of here to
+        # leave the origin check as the only thing under test.
+        client = TestClient(_guarded_app(allowed_hosts=["testserver"]))
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect("/ws", headers={"Origin": "https://evil.example"}):
+                pass
+
+    def test_websocket_from_the_same_origin_is_served(self):
+        client = TestClient(_guarded_app(allowed_hosts=["testserver"]))
+        with client.websocket_connect("/ws", headers={"Origin": "http://testserver"}) as ws:
+            assert ws.receive_text() == "ws ok"
+
+    def test_websocket_with_a_rebound_host_is_refused(self):
+        from starlette.websockets import WebSocketDisconnect
+
+        client = TestClient(_guarded_app())
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect("/ws"):
+                pass
+
+    def test_middlewares_can_be_disabled_wholesale(self):
+        app = _guarded_app(allowed_hosts=["*"])
+        client = TestClient(app, base_url="http://anything.example")
+        assert client.get("/read").status_code == 200
+
+
+class TestGuardsAreIndependentlyUsable:
+    def test_trusted_host_alone(self):
+        async def read(request):
+            return PlainTextResponse("ok")
+
+        app = Starlette(routes=[Route("/read", read)])
+        app.add_middleware(TrustedHostMiddleware, allowed_hosts=["good.example"])
+        assert TestClient(app, base_url="http://good.example").get("/read").status_code == 200
+        assert TestClient(app, base_url="http://bad.example").get("/read").status_code == 400
+
+    def test_origin_guard_alone(self):
+        async def write(request):
+            return PlainTextResponse("ok")
+
+        app = Starlette(routes=[Route("/write", write, methods=["POST"])])
+        app.add_middleware(OriginGuardMiddleware, allowed_origins=[])
+        client = TestClient(app, base_url="http://127.0.0.1:8008")
+        assert client.post("/write").status_code == 200
+        assert client.post("/write", headers={"Origin": "https://evil.example"}).status_code == 403

--- a/tests/infrastructure/test_web_security.py
+++ b/tests/infrastructure/test_web_security.py
@@ -25,6 +25,7 @@ from clm.infrastructure.web_security import (
     host_is_allowed,
     install_web_security,
     normalize_origin,
+    remote_access_warning,
 )
 
 
@@ -47,6 +48,11 @@ class TestExtractHost:
         """Starlette's own splitter yields ``"["`` here, locking out IPv6 loopback."""
         assert extract_host("[::1]:8000") == "::1"
         assert extract_host("[fe80::1]") == "fe80::1"
+
+    def test_trailing_dot_fqdn_is_the_same_host(self):
+        """``http://localhost./`` is a legal URL and the dot reaches the header."""
+        assert extract_host("localhost.:8008") == "localhost"
+        assert extract_host("box.ts.net.") == "box.ts.net"
 
 
 class TestDefaultAllowedHosts:
@@ -71,9 +77,38 @@ class TestDefaultAllowedHosts:
     def test_star_disables_the_check(self):
         assert default_allowed_hosts("0.0.0.0", ["*"]) == ["*"]
 
+
+class TestHostIsAllowed:
     def test_wildcard_suffix_matches_subdomains(self):
         assert host_is_allowed("box.ts.net", ["*.ts.net"])
         assert not host_is_allowed("boxts.net", ["*.ts.net"])
+        assert not host_is_allowed("ts.net", ["*.ts.net"])
+
+    def test_exact_match(self):
+        assert host_is_allowed("localhost", ["localhost"])
+        assert not host_is_allowed("localhost.evil.example", ["localhost"])
+
+
+class TestRemoteAccessWarning:
+    """A bind address that promises more reach than the allowlist can deliver."""
+
+    def test_loopback_bind_is_silent(self):
+        assert remote_access_warning("127.0.0.1") is None
+        assert remote_access_warning("localhost") is None
+
+    @pytest.mark.parametrize("host", ["0.0.0.0", "::"])
+    def test_wildcard_bind_warns(self, host: str):
+        message = remote_access_warning(host)
+        assert message is not None
+        assert "--allowed-host" in message
+
+    def test_explicit_allowed_host_silences_it(self):
+        assert remote_access_warning("0.0.0.0", ["box.ts.net"]) is None
+
+    def test_specific_non_loopback_bind_warns_about_names(self):
+        message = remote_access_warning("192.168.1.5")
+        assert message is not None
+        assert "192.168.1.5" in message
 
 
 class TestNormalizeOrigin:
@@ -92,6 +127,11 @@ class TestNormalizeOrigin:
     @pytest.mark.parametrize("origin", ["null", "", "   ", "not-a-url", "http://"])
     def test_unusable_origins_are_none(self, origin: str):
         assert normalize_origin(origin) is None
+
+    def test_ipv6_keeps_its_brackets(self):
+        """Otherwise the result is the ambiguous ``http://::1:8008``."""
+        assert normalize_origin("http://[::1]:8008") == "http://[::1]:8008"
+        assert normalize_origin("http://[::1]") == "http://[::1]"
 
 
 class TestCheckRequestOrigin:
@@ -143,6 +183,15 @@ class TestCheckRequestOrigin:
         """``tailscale serve`` forwards ``https://…`` to a plain-HTTP upstream."""
         headers = self._headers(origin="https://box.ts.net", host="box.ts.net")
         assert check_request_origin(headers) is None
+
+    def test_portless_host_still_refuses_an_origin_on_another_port(self):
+        """A dev server on :3000 must not drive a dashboard reached as bare ``localhost``.
+
+        The portless-``Host`` branch exists for the TLS-proxy case above; it
+        must not degrade into "any port on this hostname".
+        """
+        headers = self._headers(origin="http://localhost:3000", host="localhost")
+        assert check_request_origin(headers) is not None
 
     def test_explicitly_allowed_origin_passes(self):
         headers = self._headers(origin="https://studio.example", host="127.0.0.1:8008")

--- a/tests/recordings/test_recordings_command.py
+++ b/tests/recordings/test_recordings_command.py
@@ -910,6 +910,119 @@ class TestServeRecordingsCommand:
         assert result.exit_code == 1
         assert "Server error" in result.output
 
+    def test_wildcard_bind_warns_about_the_host_allowlist(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A wildcard bind promises reach the Host allowlist cannot deliver.
+
+        Without this the symptom is a dashboard that starts normally and then
+        400s every remote request, explained only in a log nobody watches.
+        """
+        self._install_stubs(monkeypatch)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            recordings_group,
+            ["serve", str(tmp_path), "--no-browser", "--host", "0.0.0.0"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "--allowed-host" in result.output
+
+    def test_loopback_bind_does_not_warn(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        self._install_stubs(monkeypatch)
+
+        runner = CliRunner()
+        result = runner.invoke(recordings_group, ["serve", str(tmp_path), "--no-browser"])
+
+        assert result.exit_code == 0, result.output
+        assert "--allowed-host" not in result.output
+
+    def test_allowed_hosts_reach_the_app(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        _, fake_app_module, _ = self._install_stubs(monkeypatch)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            recordings_group,
+            [
+                "serve",
+                str(tmp_path),
+                "--no-browser",
+                "--allowed-host",
+                "box.ts.net",
+                "--allowed-origin",
+                "https://box.ts.net",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        kwargs = fake_app_module.create_app.call_args.kwargs
+        assert kwargs["allowed_hosts"] == ["box.ts.net"]
+        assert kwargs["allowed_origins"] == ["https://box.ts.net"]
+        assert kwargs["bind_host"] == "127.0.0.1"
+
+
+class TestWebSecurityLogBridge:
+    """The bridge that puts refusals into the recordings forensic log."""
+
+    def test_installing_twice_leaves_one_handler(self):
+        """A guard that cannot fire leaks handlers and duplicates every line.
+
+        Defining the handler class inside the installer made
+        ``isinstance(h, _ToLoguru)`` false for handlers a previous call had
+        installed, so each ``clm recordings serve`` in a process added another
+        one — and the test suite starts several.
+        """
+        import logging
+
+        from clm.infrastructure import web_security
+
+        target = logging.getLogger(web_security.__name__)
+        original = list(target.handlers)
+        original_propagate = target.propagate
+        try:
+            for handler in list(target.handlers):
+                target.removeHandler(handler)
+
+            recordings_module._forward_web_security_logs_to_loguru()
+            recordings_module._forward_web_security_logs_to_loguru()
+            recordings_module._forward_web_security_logs_to_loguru()
+
+            bridges = [
+                h
+                for h in target.handlers
+                if isinstance(h, recordings_module._StdlibToLoguruHandler)
+            ]
+            assert len(bridges) == 1
+        finally:
+            for handler in list(target.handlers):
+                target.removeHandler(handler)
+            for handler in original:
+                target.addHandler(handler)
+            target.propagate = original_propagate
+
+    def test_an_unknown_level_does_not_raise_through_the_caller(self):
+        """``logging.Handler.handle`` does not wrap ``emit``.
+
+        A level loguru does not know would otherwise propagate out of the
+        middleware's ``log.warning`` and turn a 403 into a 500.
+        """
+        import logging
+
+        handler = recordings_module._StdlibToLoguruHandler()
+        record = logging.LogRecord(
+            name="clm.infrastructure.web_security",
+            level=42,
+            pathname=__file__,
+            lineno=1,
+            msg="refused something",
+            args=(),
+            exc_info=None,
+        )
+        record.levelname = "Level 42"
+
+        handler.emit(record)  # must not raise
+
 
 # ---------------------------------------------------------------------------
 # backends command (list_backends)

--- a/tests/recordings/test_web.py
+++ b/tests/recordings/test_web.py
@@ -46,6 +46,11 @@ def app(recording_root: Path):
             recordings_root=recording_root,
             obs_host="localhost",
             obs_port=4455,
+            # TestClient sends ``Host: testserver``; the production default
+            # (loopback only) would 400 every request here. The default policy
+            # itself is covered by tests/recordings/test_web_security.py, which
+            # builds an app *without* this override.
+            allowed_hosts=["testserver"],
         )
         # Prevent lifespan from trying to connect
         mock_obs.connect.side_effect = ConnectionError("OBS not running")

--- a/tests/recordings/test_web.py
+++ b/tests/recordings/test_web.py
@@ -47,9 +47,13 @@ def app(recording_root: Path):
             obs_host="localhost",
             obs_port=4455,
             # TestClient sends ``Host: testserver``; the production default
-            # (loopback only) would 400 every request here. The default policy
-            # itself is covered by tests/recordings/test_web_security.py, which
-            # builds an app *without* this override.
+            # (loopback only) would 400 every request here. This override
+            # reaches the *host* guard only. The origin guard is also inert
+            # across this suite, but for a different reason: TestClient sends
+            # neither Origin nor Sec-Fetch-Site, which is deliberately allowed
+            # (non-browser clients are not the threat model — decision D4).
+            # Both defaults are exercised in tests/recordings/test_web_security.py,
+            # which builds an app without this override.
             allowed_hosts=["testserver"],
         )
         # Prevent lifespan from trying to connect

--- a/tests/recordings/test_web_security.py
+++ b/tests/recordings/test_web_security.py
@@ -1,0 +1,244 @@
+"""Containment tests for the recordings dashboard (finding S3, decision D4).
+
+The dashboard has no login, so "the request reached the socket" used to be the
+whole authorization story. Three separate holes followed from that, and each
+gets a test here:
+
+1. ``POST /process`` took a path from a form, checked only ``exists()``, and
+   handed it to the processing backend — which for Auphonic uploads the file
+   to a third party. Any local file, chosen by any page in the browser.
+2. ``course_slug`` reached :func:`clm.recordings.state.get_state_path`
+   unsanitized, so ``../../../evil`` wrote outside CLM's config directory.
+3. Every mutating route was reachable from a cross-origin auto-submitting
+   form, and from a rebound DNS name.
+
+Unlike ``test_web.py``, the app here is built **without** a host override, so
+these exercise the production default.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from clm.recordings.workflow.directories import ensure_root
+
+#: The dashboard's real default bind; used as the test client's base URL so
+#: requests carry a Host the production allowlist accepts.
+LOCAL_URL = "http://127.0.0.1:8008"
+
+
+@pytest.fixture()
+def recording_root(tmp_path: Path) -> Path:
+    root = tmp_path / "recordings"
+    ensure_root(root)
+    return root
+
+
+@pytest.fixture()
+def app(recording_root: Path):
+    """A dashboard app with the **default** security posture and a mock OBS."""
+    with patch("clm.recordings.workflow.obs.ObsClient") as MockObs:
+        mock_obs = MagicMock()
+        mock_obs.connected = True
+        mock_obs.connection_state = "connected"
+        mock_obs._record_callbacks = []
+        mock_obs.on_record_state_changed.side_effect = lambda cb: mock_obs._record_callbacks.append(
+            cb
+        )
+        MockObs.return_value = mock_obs
+
+        from clm.recordings.web.app import create_app
+
+        application = create_app(
+            recordings_root=recording_root,
+            obs_host="localhost",
+            obs_port=4455,
+        )
+        mock_obs.connect.side_effect = ConnectionError("OBS not running")
+        yield application
+
+
+@pytest.fixture()
+def client(app) -> TestClient:
+    return TestClient(app, base_url=LOCAL_URL)
+
+
+class TestProcessPathContainment:
+    """S3 — ``/process`` must refuse a path outside the recordings root."""
+
+    def test_file_outside_the_root_is_refused(self, client: TestClient, tmp_path: Path):
+        secret = tmp_path / "id_rsa"
+        secret.write_text("PRIVATE KEY", encoding="utf-8")
+
+        with patch("clm.recordings.workflow.job_manager.JobManager.submit_async") as submit:
+            response = client.post("/process", data={"raw_path": str(secret)})
+
+        assert response.status_code == 400
+        assert "outside the recordings root" in response.text
+        submit.assert_not_called()
+
+    def test_traversal_out_of_the_root_is_refused(
+        self, client: TestClient, recording_root: Path, tmp_path: Path
+    ):
+        """The escape is spelled relative to a legitimate directory."""
+        secret = tmp_path / "id_rsa"
+        secret.write_text("PRIVATE KEY", encoding="utf-8")
+        traversal = recording_root / "to-process" / ".." / ".." / "id_rsa"
+
+        with patch("clm.recordings.workflow.job_manager.JobManager.submit_async") as submit:
+            response = client.post("/process", data={"raw_path": str(traversal)})
+
+        assert response.status_code == 400
+        submit.assert_not_called()
+
+    def test_a_batch_is_refused_whole_if_any_path_escapes(
+        self, client: TestClient, recording_root: Path, tmp_path: Path
+    ):
+        """A good path alongside a bad one must not smuggle the bad one through."""
+        good = recording_root / "to-process" / "lecture--RAW.mkv"
+        good.write_bytes(b"video")
+        secret = tmp_path / "id_rsa"
+        secret.write_text("PRIVATE KEY", encoding="utf-8")
+
+        with patch("clm.recordings.workflow.job_manager.JobManager.submit_async") as submit:
+            response = client.post("/process", data={"raw_path": [str(good), str(secret)]})
+
+        assert response.status_code == 400
+        # The good file may or may not have been submitted before the bad one
+        # was reached, but the secret never is.
+        for call in submit.call_args_list:
+            assert Path(call.args[0]) != secret.resolve()
+
+    def test_a_file_under_the_root_is_still_submitted(
+        self, client: TestClient, recording_root: Path
+    ):
+        """The guard must not break the feature it protects."""
+        raw = recording_root / "to-process" / "lecture--RAW.mkv"
+        raw.write_bytes(b"video")
+
+        with patch("clm.recordings.workflow.job_manager.JobManager.submit_async") as submit:
+            response = client.post("/process", data={"raw_path": str(raw)})
+
+        assert response.status_code == 200
+        submit.assert_called_once()
+        assert Path(submit.call_args.args[0]) == raw.resolve()
+
+    def test_a_missing_file_is_still_skipped_not_refused(self, client: TestClient):
+        """Pre-existing behaviour: a vanished file is a notice, not a 400."""
+        with patch("clm.recordings.workflow.job_manager.JobManager.submit_async") as submit:
+            response = client.post("/process", data={"raw_path": "no-such-file.mkv"})
+
+        assert response.status_code == 200
+        submit.assert_not_called()
+
+
+class TestDeckIdentityValidation:
+    """The ``(course, section, deck)`` triple names path components."""
+
+    @pytest.mark.parametrize(
+        "course_slug",
+        ["../../../evil", "..", ".", "a/b", "a\\b", "C:evil", "nul\x00byte"],
+    )
+    def test_arm_refuses_an_unsafe_course_slug(self, client: TestClient, course_slug: str):
+        response = client.post(
+            "/arm",
+            data={
+                "course_slug": course_slug,
+                "section_name": "section",
+                "deck_name": "deck",
+            },
+        )
+        assert response.status_code == 400
+
+    def test_arm_refuses_a_blank_course_slug(self, client: TestClient):
+        """422 is FastAPI's own answer for a blank required field — also a refusal."""
+        response = client.post(
+            "/arm",
+            data={"course_slug": "  ", "section_name": "section", "deck_name": "deck"},
+        )
+        assert response.status_code in (400, 422)
+
+    def test_state_file_is_never_written_outside_the_config_dir(self, client: TestClient):
+        """The concrete escape: ``get_state_path`` joins the slug unsanitized."""
+        with patch("clm.recordings.state.save_state") as save:
+            response = client.post(
+                "/arm",
+                data={
+                    "course_slug": "../../../evil",
+                    "section_name": "section",
+                    "deck_name": "deck",
+                },
+            )
+        assert response.status_code == 400
+        save.assert_not_called()
+
+    @pytest.mark.parametrize("field", ["section_name", "deck_name"])
+    def test_record_refuses_traversal_in_any_component(self, client: TestClient, field: str):
+        data = {"course_slug": "course", "section_name": "section", "deck_name": "deck"}
+        data[field] = ".."
+        response = client.post("/record", data=data)
+        assert response.status_code == 400
+
+    def test_take_panel_refuses_traversal(self, client: TestClient):
+        response = client.get("/decks/course/section/../takes")
+        # Either the router does not match the traversed path, or the handler
+        # rejects it — both are containment; what must not happen is a 200.
+        assert response.status_code in (400, 404, 405)
+
+    def test_a_normal_deck_name_still_works(self, client: TestClient):
+        """Names with spaces, dots and parentheses are ordinary here."""
+        response = client.post(
+            "/arm",
+            data={
+                "course_slug": "python-course",
+                "section_name": "Section 1",
+                "deck_name": "topic_100_intro (part 1).py",
+            },
+        )
+        assert response.status_code != 400
+
+
+class TestCrossOriginContainment:
+    """D4 — no other page may drive the dashboard."""
+
+    def test_cross_site_form_post_is_refused(self, client: TestClient):
+        response = client.post(
+            "/disarm",
+            headers={"Origin": "https://evil.example", "Sec-Fetch-Site": "cross-site"},
+        )
+        assert response.status_code == 403
+
+    def test_cross_origin_post_without_fetch_metadata_is_refused(self, client: TestClient):
+        response = client.post("/disarm", headers={"Origin": "https://evil.example"})
+        assert response.status_code == 403
+
+    def test_the_dashboards_own_htmx_post_is_served(self, client: TestClient):
+        response = client.post(
+            "/disarm",
+            headers={"Origin": LOCAL_URL, "Sec-Fetch-Site": "same-origin"},
+        )
+        assert response.status_code != 403
+
+    def test_reading_the_dashboard_is_never_blocked(self, client: TestClient):
+        assert client.get("/").status_code == 200
+
+    def test_a_rebound_dns_name_is_refused(self, app):
+        """Origin and Host agree — only the host allowlist catches this."""
+        rebound = TestClient(app, base_url="http://evil.example:8008")
+        response = rebound.post("/disarm", headers={"Origin": "http://evil.example:8008"})
+        assert response.status_code == 400
+
+    def test_an_opted_in_host_is_served(self, recording_root: Path):
+        from clm.recordings.web.app import create_app
+
+        with patch("clm.recordings.workflow.obs.ObsClient"):
+            application = create_app(
+                recordings_root=recording_root,
+                allowed_hosts=["box.ts.net"],
+            )
+        client = TestClient(application, base_url="http://box.ts.net")
+        assert client.get("/").status_code == 200

--- a/tests/recordings/test_web_security.py
+++ b/tests/recordings/test_web_security.py
@@ -269,6 +269,11 @@ class TestDeckIdentityValidation:
             # spec: 33 of its 39 section names contain a colon. Validating
             # these as if they were filenames took out the whole Lectures page.
             "Woche 01: Einführung, LLMs und Python in JupyterLite",
+            # And this one carries a *slash* — sanitize_file_name replaces it
+            # with "_", so it never becomes a separator. Found by driving the
+            # dashboard with all 22 section names from the real spec after the
+            # colon fix; three hand-picked examples had missed it.
+            "Woche 12: Datenanalyse mit pandas (+ ML-/Metrik-Kostprobe)",
             "Week 04: Chatbots in Practice -- CLI, Gradio, Streaming",
             "Woche 02: Python-Setup, Webservices und erste LLM-API",
         ],

--- a/tests/recordings/test_web_security.py
+++ b/tests/recordings/test_web_security.py
@@ -246,6 +246,9 @@ class TestDeckIdentityValidation:
     def test_restore_refuses_traversal(self, client: TestClient):
         response = client.post("/decks/course/section/%2e%2e/takes/1/restore")
         assert response.status_code == 400
+        # Pin the *source* of the 400: without this the session's own "no such
+        # take" 404 would look like containment.
+        assert "deck_name" in response.text
 
     def test_a_normal_deck_name_still_works(self, client: TestClient):
         """Names with spaces, dots and parentheses are ordinary here."""
@@ -258,6 +261,65 @@ class TestDeckIdentityValidation:
             },
         )
         assert response.status_code == 200
+
+    @pytest.mark.parametrize(
+        "section_name",
+        [
+            # Verbatim from machine-learning-azav.xml, the default recordings
+            # spec: 33 of its 39 section names contain a colon. Validating
+            # these as if they were filenames took out the whole Lectures page.
+            "Woche 01: Einführung, LLMs und Python in JupyterLite",
+            "Week 04: Chatbots in Practice -- CLI, Gradio, Streaming",
+            "Woche 02: Python-Setup, Webservices und erste LLM-API",
+        ],
+    )
+    def test_a_real_course_section_name_is_accepted(self, client: TestClient, section_name: str):
+        """Section names are titles the user wrote, not slugs.
+
+        They reach disk only through ``sanitize_file_name``, which deletes the
+        very characters (``:`` ``?`` ``!`` ``"`` ``'``) that make them look
+        unsafe — so judging them as filenames is a false positive, and an
+        expensive one.
+        """
+        response = client.post(
+            "/arm",
+            data={
+                "course_slug": "ml-course-de",
+                "section_name": section_name,
+                "deck_name": "01 Einführung.py",
+            },
+        )
+        assert response.status_code == 200
+
+    def test_a_colon_is_still_refused_in_the_course_slug(self, client: TestClient):
+        """The slug is used as a filename verbatim, so it keeps the strict rule."""
+        response = client.post(
+            "/arm",
+            data={
+                "course_slug": "ml:course",
+                "section_name": "Woche 01: Einführung",
+                "deck_name": "deck",
+            },
+        )
+        assert response.status_code == 400
+        assert "course_slug" in response.text
+
+    def test_a_component_that_sanitizes_to_dotdot_is_refused(self, client: TestClient):
+        """``":..:"`` looks harmless raw and sanitizes to ``..``.
+
+        The sanitizer deletes colons, so containment has to be judged on the
+        sanitized form as well as the raw one.
+        """
+        response = client.post(
+            "/arm",
+            data={
+                "course_slug": "ml-course-de",
+                "section_name": ":..:",
+                "deck_name": "deck",
+            },
+        )
+        assert response.status_code == 400
+        assert "section_name" in response.text
 
 
 class TestCrossOriginContainment:
@@ -334,7 +396,9 @@ class TestCrossOriginContainment:
         client = TestClient(application, base_url="http://box.ts.net")
 
         allowed = client.post("/disarm", headers={"Origin": "https://proxy.example"})
-        assert allowed.status_code != 403
+        # 409 is the session's own "nothing armed" answer; either way the
+        # request reached the handler, which is what is under test.
+        assert allowed.status_code in (200, 409)
 
         refused = client.post("/disarm", headers={"Origin": "https://other.example"})
         assert refused.status_code == 403

--- a/tests/recordings/test_web_security.py
+++ b/tests/recordings/test_web_security.py
@@ -98,7 +98,12 @@ class TestProcessPathContainment:
     def test_a_batch_is_refused_whole_if_any_path_escapes(
         self, client: TestClient, recording_root: Path, tmp_path: Path
     ):
-        """A good path alongside a bad one must not smuggle the bad one through."""
+        """Nothing at all is submitted when any entry in the batch escapes.
+
+        Validation runs as its own pass for exactly this reason: refusing
+        mid-loop would already have started an upload for the entries before
+        the bad one, while returning an error that says nothing about it.
+        """
         good = recording_root / "to-process" / "lecture--RAW.mkv"
         good.write_bytes(b"video")
         secret = tmp_path / "id_rsa"
@@ -108,10 +113,36 @@ class TestProcessPathContainment:
             response = client.post("/process", data={"raw_path": [str(good), str(secret)]})
 
         assert response.status_code == 400
-        # The good file may or may not have been submitted before the bad one
-        # was reached, but the secret never is.
-        for call in submit.call_args_list:
-            assert Path(call.args[0]) != secret.resolve()
+        submit.assert_not_called()
+
+    def test_a_directory_is_refused(self, client: TestClient, recording_root: Path):
+        """A directory resolves and is contained, but is not something to upload."""
+        with patch("clm.recordings.workflow.job_manager.JobManager.submit_async") as submit:
+            response = client.post(
+                "/process", data={"raw_path": str(recording_root / "to-process")}
+            )
+
+        assert response.status_code == 400
+        assert "not a file" in response.text
+        submit.assert_not_called()
+
+    def test_a_symlink_out_of_the_root_is_refused(
+        self, client: TestClient, recording_root: Path, tmp_path: Path
+    ):
+        """Containment is judged after resolution, not on the literal path."""
+        secret = tmp_path / "id_rsa"
+        secret.write_text("PRIVATE KEY", encoding="utf-8")
+        link = recording_root / "to-process" / "innocent--RAW.mkv"
+        try:
+            link.symlink_to(secret)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks unavailable (Windows without developer mode)")
+
+        with patch("clm.recordings.workflow.job_manager.JobManager.submit_async") as submit:
+            response = client.post("/process", data={"raw_path": str(link)})
+
+        assert response.status_code == 400
+        submit.assert_not_called()
 
     def test_a_file_under_the_root_is_still_submitted(
         self, client: TestClient, recording_root: Path
@@ -141,7 +172,23 @@ class TestDeckIdentityValidation:
 
     @pytest.mark.parametrize(
         "course_slug",
-        ["../../../evil", "..", ".", "a/b", "a\\b", "C:evil", "nul\x00byte"],
+        [
+            "../../../evil",
+            "..",
+            ".",
+            "a/b",
+            "a\\b",
+            "C:evil",
+            "nul\x00byte",
+            "ctrl\x01char",
+            "trailing.",
+            "trailing ",
+            # Windows device names ignore the extension, so ``NUL.json`` is the
+            # null device: the state write succeeds and the data disappears.
+            "NUL",
+            "nul",
+            "COM1",
+        ],
     )
     def test_arm_refuses_an_unsafe_course_slug(self, client: TestClient, course_slug: str):
         response = client.post(
@@ -155,12 +202,12 @@ class TestDeckIdentityValidation:
         assert response.status_code == 400
 
     def test_arm_refuses_a_blank_course_slug(self, client: TestClient):
-        """422 is FastAPI's own answer for a blank required field — also a refusal."""
         response = client.post(
             "/arm",
             data={"course_slug": "  ", "section_name": "section", "deck_name": "deck"},
         )
-        assert response.status_code in (400, 422)
+        assert response.status_code == 400
+        assert "must not be empty" in response.text
 
     def test_state_file_is_never_written_outside_the_config_dir(self, client: TestClient):
         """The concrete escape: ``get_state_path`` joins the slug unsanitized."""
@@ -176,18 +223,29 @@ class TestDeckIdentityValidation:
         assert response.status_code == 400
         save.assert_not_called()
 
-    @pytest.mark.parametrize("field", ["section_name", "deck_name"])
-    def test_record_refuses_traversal_in_any_component(self, client: TestClient, field: str):
+    @pytest.mark.parametrize("route", ["/record", "/advance"])
+    @pytest.mark.parametrize("field", ["course_slug", "section_name", "deck_name"])
+    def test_action_routes_refuse_traversal_in_any_component(
+        self, client: TestClient, route: str, field: str
+    ):
         data = {"course_slug": "course", "section_name": "section", "deck_name": "deck"}
         data[field] = ".."
-        response = client.post("/record", data=data)
+        response = client.post(route, data=data)
         assert response.status_code == 400
 
     def test_take_panel_refuses_traversal(self, client: TestClient):
-        response = client.get("/decks/course/section/../takes")
-        # Either the router does not match the traversed path, or the handler
-        # rejects it — both are containment; what must not happen is a 200.
-        assert response.status_code in (400, 404, 405)
+        """Percent-encoded, so the traversal survives client-side normalization.
+
+        A literal ``..`` segment is collapsed by httpx before the request is
+        sent, which would make this test pass with the validation deleted.
+        """
+        response = client.get("/decks/course/section/%2e%2e/takes")
+        assert response.status_code == 400
+        assert "deck_name" in response.text
+
+    def test_restore_refuses_traversal(self, client: TestClient):
+        response = client.post("/decks/course/section/%2e%2e/takes/1/restore")
+        assert response.status_code == 400
 
     def test_a_normal_deck_name_still_works(self, client: TestClient):
         """Names with spaces, dots and parentheses are ordinary here."""
@@ -199,7 +257,7 @@ class TestDeckIdentityValidation:
                 "deck_name": "topic_100_intro (part 1).py",
             },
         )
-        assert response.status_code != 400
+        assert response.status_code == 200
 
 
 class TestCrossOriginContainment:
@@ -216,12 +274,20 @@ class TestCrossOriginContainment:
         response = client.post("/disarm", headers={"Origin": "https://evil.example"})
         assert response.status_code == 403
 
+    @pytest.mark.parametrize("method", ["put", "patch", "delete"])
+    def test_every_unsafe_method_is_guarded(self, client: TestClient, method: str):
+        """Pins the SAFE_METHODS complement — not just POST."""
+        response = getattr(client, method)("/disarm", headers={"Origin": "https://evil.example"})
+        assert response.status_code == 403
+
     def test_the_dashboards_own_htmx_post_is_served(self, client: TestClient):
         response = client.post(
             "/disarm",
             headers={"Origin": LOCAL_URL, "Sec-Fetch-Site": "same-origin"},
         )
-        assert response.status_code != 403
+        # 409 is the session's own "nothing armed" answer — the point is that
+        # the request reached the handler at all.
+        assert response.status_code in (200, 409)
 
     def test_reading_the_dashboard_is_never_blocked(self, client: TestClient):
         assert client.get("/").status_code == 200
@@ -242,3 +308,40 @@ class TestCrossOriginContainment:
             )
         client = TestClient(application, base_url="http://box.ts.net")
         assert client.get("/").status_code == 200
+
+    def test_a_wildcard_host_pattern_is_served(self, recording_root: Path):
+        """``*.ts.net`` has to survive the middleware's own normalization."""
+        from clm.recordings.web.app import create_app
+
+        with patch("clm.recordings.workflow.obs.ObsClient"):
+            application = create_app(
+                recordings_root=recording_root,
+                allowed_hosts=["*.ts.net"],
+            )
+        assert TestClient(application, base_url="http://box.ts.net").get("/").status_code == 200
+        assert TestClient(application, base_url="http://evilts.net").get("/").status_code == 400
+
+    def test_an_opted_in_origin_can_drive_actions(self, recording_root: Path):
+        """``--allowed-origin`` end-to-end, not just through the unit helper."""
+        from clm.recordings.web.app import create_app
+
+        with patch("clm.recordings.workflow.obs.ObsClient"):
+            application = create_app(
+                recordings_root=recording_root,
+                allowed_hosts=["box.ts.net"],
+                allowed_origins=["https://proxy.example"],
+            )
+        client = TestClient(application, base_url="http://box.ts.net")
+
+        allowed = client.post("/disarm", headers={"Origin": "https://proxy.example"})
+        assert allowed.status_code != 403
+
+        refused = client.post("/disarm", headers={"Origin": "https://other.example"})
+        assert refused.status_code == 403
+
+    def test_the_400_body_says_how_to_fix_it(self, app):
+        """The user hitting this is looking at a browser, not at the server log."""
+        rebound = TestClient(app, base_url="http://evil.example:8008")
+        response = rebound.get("/")
+        assert response.status_code == 400
+        assert "--allowed-host" in response.text


### PR DESCRIPTION
Phase 2 item 2 of the adversarial-review remediation plan
(`docs/claude/handovers/adversarial-review-remediation-handover.md`), closing
finding **S3** under decision **D4**.

## The problem

`clm recordings serve` has no login, so "the request reached the socket" was
the entire authorization story. Three separate consequences:

1. **`POST /process` was an arbitrary-file upload primitive.** It took
   `raw_path` from a form, checked only `exists()`, and handed it to the
   configured backend — with Auphonic that streams the file to auphonic.com.
   Its sibling `/open-explorer` already did `resolve(strict=True)` +
   `relative_to(root)`; the omission was inconsistent, not deliberate.
2. **`course_slug` reached `get_state_path()` unsanitized**, which joins it
   into CLM's config directory with no normalization at all. A bare `..` also
   escapes the recordings root: the existing filename sanitizer replaces
   separators but leaves a lone `..` intact.
3. **Every mutating route was reachable cross-origin.** All `Form(...)`-based,
   no CSRF protection — an auto-submitting form on any page open in the same
   browser could arm a deck, start a recording, or submit a file.

## What changed

**New `src/clm/infrastructure/web_security.py`** — two ASGI guards, installed
together by `install_web_security()`:

- `TrustedHostMiddleware`: the `Host` must name this server (loopback plus
  whatever `--host`/`--allowed-host` name). This is what closes DNS rebinding,
  which an origin check alone cannot: a rebound page's requests are *genuinely*
  same-origin.
- `OriginGuardMiddleware`: mutating requests (`POST`/`PUT`/`PATCH`/`DELETE`)
  must come from this app's own origin, judged by `Sec-Fetch-Site` first and
  `Origin` second. Reads are untouched. Covers WebSocket handshakes too, which
  are CORS-exempt — `clm serve` (item 3) inherits that.

Deliberately **not** Starlette's `TrustedHostMiddleware`: it derives the host
as `header.split(":")[0]`, turning `[::1]:8000` into `"["` and rejecting anyone
browsing IPv6 loopback. A default-on check that breaks a legitimate local URL
is a check that gets turned off.

Requests carrying *neither* `Origin` nor `Sec-Fetch-Site` still pass — that is
`curl`, scripts and the test client, and per D4 same-machine actors are
explicitly out of scope. Raw ASGI rather than `BaseHTTPMiddleware` because the
dashboard streams SSE.

**Route fixes**: `/process` containment; `_validate_name` on `course_slug`,
`section_name`, `deck_name` across `/arm`, `/record`, `/advance` and both
`/decks/…/takes` routes, plus inside `_get_or_load_course_state` so no path
into `get_state_path` is left unguarded.

**CLI**: `--allowed-host` / `--allowed-origin` on `clm recordings serve`
(repeatable; `--allowed-host '*'` disables the host check) for Tailscale /
reverse-proxy access.

## Assumptions (flagged per the plan)

- `same-site` is refused alongside `cross-site`: a different port is a
  different app. Nothing legitimate sends that here — the dashboard's own HTMX
  traffic is `same-origin`.
- The origin check ignores the *scheme* when comparing to `Host`, because
  `tailscale serve` terminates TLS and forwards `https://…` to a plain-HTTP
  upstream. Rejecting that would break the documented remote path for no gain;
  the authority is what matters.
- `/process` refuses the **whole** batch when any path escapes, rather than
  skipping the bad entry. A mixed batch is not a user mistake.
- S11's `sanitize_file_name` hardening (rejecting `.`/`..` globally) stays in
  Phase 4; this PR validates at the route boundary only.

## Checks

- `pytest tests/recordings tests/infrastructure/test_web_security.py -n 4` →
  **936 passed**
- Pre-push hook (ruff lint + format, mypy, fast suite) → **passed**
- **Teeth verified**: with the two route/app files reverted to their pre-fix
  content, `tests/recordings/test_web_security.py` is **18 failed / 6 passed** —
  the 6 that pass are the "the guard must not break the feature" cases
  (legitimate file submitted, missing file still skipped, normal deck names,
  reads not blocked).

## Docs checklist (AGENTS.md)

| Row | Applied |
|---|---|
| CLI commands, flags, options | **yes** — `src/clm/cli/info_topics/commands.md`: the two new flags plus an "Access control" section |
| Spec file format | no |
| Breaking changes / migration | no — no existing invocation changes; only new refusals for requests that were never legitimate |
| User guide | **yes** — `docs/user-guide/recordings.md` gains "Who can reach the dashboard" |
| Changelog | **yes** — `changelog.d/691-recordings-dashboard-containment.security.md` |

Refs #  — Phase 2 item 2 of the adversarial-review remediation plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG954qREDhNpPSFnHhVeQ8
