### PR TITLE
security(serve): contain the dashboard's hosts, origins and WebSocket (S6, D4)

### DIFF
--- a/changelog.d/692-serve-dashboard-containment.security.md
+++ b/changelog.d/692-serve-dashboard-containment.security.md
@@ -18,7 +18,9 @@
   WebSockets are exempt from CORS — so anyone who could reach the port could
   subscribe and read them, around the bearer token that guards every
   `/api/studio` route. When `--spec` is in play the token is now required
-  *before* the handshake is accepted. Browsers cannot set an `Authorization`
+  *before* the handshake is accepted — for the **whole endpoint**, so a script
+  that polled `/ws` for job status needs the token too once a spec is served.
+  Browsers cannot set an `Authorization`
   header on a WebSocket, so the Studio PWA presents it as the
   `clm-token.<token>` subprotocol (kept out of access logs, unlike a query
   parameter); scripts may still use `Authorization: Bearer`.
@@ -31,7 +33,12 @@
   allowlist only in its `Origin` fallback, which is unreachable whenever
   `Sec-Fetch-Site` is present — i.e. for every current browser. Naming an
   origin therefore bought a successful CORS preflight and a `403` on the
-  request behind it. The allowlist is now checked first.
+  request behind it. The allowlist is now checked first — which makes the flag
+  a full exemption from the origin check, so the docs now say so. A value that
+  is not a valid origin (a missing `https://`, say) is reported at startup
+  instead of being dropped in silence, and an `Origin` carrying userinfo or an
+  embedded tab/newline — forms no browser emits, and which parse to a
+  different host than they read as — is refused rather than normalized.
 - **A non-ASCII bearer token no longer raises from inside the auth check.**
   `secrets.compare_digest` rejects non-ASCII `str`, and headers arrive
   latin-1 decoded, so one byte above `0x7F` turned a bad token into a `500`.

--- a/changelog.d/692-serve-dashboard-containment.security.md
+++ b/changelog.d/692-serve-dashboard-containment.security.md
@@ -1,0 +1,31 @@
+- **`clm serve` gets the same browser containment as the recordings
+  dashboard.** The Monitor API has no login, so any page open in the same
+  browser could read your build state, worker list and job history — and,
+  since nothing validated the `Host` header, a DNS-rebinding page reached the
+  app as a genuinely same-origin caller. Requests must now carry a `Host` that
+  names this server, and mutating requests must come from the dashboard's own
+  origin. `--allowed-host` / `--allowed-origin` opt in to a Tailscale hostname
+  or a reverse proxy; a wildcard bind without one now prints a warning instead
+  of silently answering `400` to every remote request.
+- **`--cors-origin` no longer defaults to `*`.** The default combined `*` with
+  `allow_credentials=True`, which makes Starlette echo whichever origin asked —
+  strictly worse than a literal wildcard, because it legalises credentialed
+  cross-origin reads. A dashboard serving its own frontend needs no CORS at
+  all, so the default is now none. Passing `*` explicitly still works, without
+  credentials.
+- **The `/ws` stream is inside the Studio token gate.** It broadcasts
+  deck-change and sync-progress events for the course being served, and
+  WebSockets are exempt from CORS — so anyone who could reach the port could
+  subscribe and read them, around the bearer token that guards every
+  `/api/studio` route. When `--spec` is in play the token is now required
+  *before* the handshake is accepted. Browsers cannot set an `Authorization`
+  header on a WebSocket, so the Studio PWA presents it as the
+  `clm-token.<token>` subprotocol (kept out of access logs, unlike a query
+  parameter); scripts may still use `Authorization: Bearer`.
+- **Channel subscriptions are restricted to `status`, `workers`, `jobs` and
+  `studio`.** Any name was previously stored verbatim, which also meant a typo
+  looked like a successful subscription and then went quiet forever — the
+  reply now reports what was actually subscribed to.
+- **A non-ASCII bearer token no longer raises from inside the auth check.**
+  `secrets.compare_digest` rejects non-ASCII `str`, and headers arrive
+  latin-1 decoded, so one byte above `0x7F` turned a bad token into a `500`.

--- a/changelog.d/692-serve-dashboard-containment.security.md
+++ b/changelog.d/692-serve-dashboard-containment.security.md
@@ -26,6 +26,12 @@
   `studio`.** Any name was previously stored verbatim, which also meant a typo
   looked like a successful subscription and then went quiet forever — the
   reply now reports what was actually subscribed to.
+- **`--allowed-origin` now actually authorizes a browser** (affects
+  `clm recordings serve` too). The origin guard consulted the operator's
+  allowlist only in its `Origin` fallback, which is unreachable whenever
+  `Sec-Fetch-Site` is present — i.e. for every current browser. Naming an
+  origin therefore bought a successful CORS preflight and a `403` on the
+  request behind it. The allowlist is now checked first.
 - **A non-ASCII bearer token no longer raises from inside the auth check.**
   `secrets.compare_digest` rejects non-ASCII `str`, and headers arrive
   latin-1 decoded, so one byte above `0x7F` turned a bad token into a `500`.

--- a/changelog.d/692-serve-websocket-route.fixed.md
+++ b/changelog.d/692-serve-websocket-route.fixed.md
@@ -1,0 +1,7 @@
+- **`clm serve`'s `/ws` endpoint never worked.** Its route function took an
+  unannotated `websocket` parameter, so FastAPI analysed it as a required
+  *query* parameter and closed every handshake with
+  `{"loc": ["query", "websocket"], "msg": "Field required"}`. The Mobile Deck
+  Studio's "changed on disk — reload" banner and its live sync progress line
+  therefore never fired; the deck simply went stale without saying so. Found
+  while adding the token check to the same endpoint.

--- a/docs/claude/design/mobile-deck-studio.md
+++ b/docs/claude/design/mobile-deck-studio.md
@@ -419,10 +419,17 @@ taken while building, several resolving open calls left by §9.1–§9.5:
   markdown**. `POST /api/studio/deck/render-cell` exists but echoes the body
   with `rendered=false`; wiring the jupytext+Jinja no-exec expansion for
   `is_j2` cells is a focused follow-up (still inside the P0 design scope).
-- **WS auth:** REST is fully token-gated; the shared `/ws` endpoint is not yet
-  token-checked (it carries only low-sensitivity `deck-changed-on-disk`
-  notifications, no deck content). Gating WS without disrupting the Monitor
-  channel is a follow-up.
+- **WS auth:** ~~REST is fully token-gated; the shared `/ws` endpoint is not
+  yet token-checked. Gating WS without disrupting the Monitor channel is a
+  follow-up.~~ **Done** (S6 of the 2026-07-24 adversarial review): `/ws`
+  requires the Studio token before `accept()` whenever a spec is configured,
+  presented as the `clm-token.<token>` subprotocol since a browser cannot set
+  an `Authorization` header on a WebSocket. The Monitor channel is undisrupted
+  because the gate keys off Studio being enabled, not off the channel
+  subscribed to. The same review found the endpoint had in fact never worked —
+  an unannotated route parameter made FastAPI treat it as a required query
+  parameter — so the "low-sensitivity notifications" it was assumed to be
+  carrying were never delivered at all.
 - **Reuse (§9.3):** only `qr.py` was lifted from the closed #394 branch (with
   the `[edit]`→`[web]` adaptation); the byte-exact "untouched cells unchanged"
   test pattern was re-authored against `FileState`. `DeckFile`, routes, and

--- a/docs/claude/design/mobile-deck-studio.md
+++ b/docs/claude/design/mobile-deck-studio.md
@@ -424,9 +424,14 @@ taken while building, several resolving open calls left by §9.1–§9.5:
   follow-up.~~ **Done** (S6 of the 2026-07-24 adversarial review): `/ws`
   requires the Studio token before `accept()` whenever a spec is configured,
   presented as the `clm-token.<token>` subprotocol since a browser cannot set
-  an `Authorization` header on a WebSocket. The Monitor channel is undisrupted
-  because the gate keys off Studio being enabled, not off the channel
-  subscribed to. The same review found the endpoint had in fact never worked —
+  an `Authorization` header on a WebSocket. **The "without disrupting the
+  Monitor channel" part was not achieved and was deliberately dropped**: the
+  gate keys off Studio being *enabled*, so under `--spec` the whole endpoint
+  needs the token, including a client that only wants `status`/`workers`/
+  `jobs`. Per-channel gating was rejected because it moves the check after
+  `accept()`, and no shipped client is affected — `static/` contains only
+  `studio/`. Revisit if a Monitor frontend is ever built.
+  The same review found the endpoint had in fact never worked —
   an unannotated route parameter made FastAPI treat it as a required query
   parameter — so the "low-sensitivity notifications" it was assumed to be
   carrying were never delivered at all.

--- a/docs/user-guide/recordings.md
+++ b/docs/user-guide/recordings.md
@@ -190,7 +190,12 @@ which drops the port. With the port dropped, the dashboard cannot tell that
 `Origin: https://box.example:8443` belongs to the request it received, and
 refuses actions on clients that do not send `Sec-Fetch-Site` (older browsers).
 `--allowed-origin https://box.example:8443` is the escape hatch if you cannot
-change the proxy config.
+change the proxy config. It is a **full exemption**, not a proxy-only tweak:
+any page served from that origin may drive every action route, whatever the
+browser's fetch metadata says. Name only origins you would let act as you, and
+pass a complete `scheme://host[:port]` — a value that is not a valid origin
+(a missing `https://`, say) is ignored with a warning at startup rather than
+silently granting nothing.
 
 Paths are contained too: file processing submitted through the dashboard must
 resolve under the recordings root, and course/section/deck names may not

--- a/src/clm/cli/commands/serve.py
+++ b/src/clm/cli/commands/serve.py
@@ -53,8 +53,9 @@ logger = logging.getLogger(__name__)
     "--allowed-origin",
     multiple=True,
     help="Extra origin allowed to drive the dashboard and open /ws (repeatable), "
-    "e.g. https://host.tailnet.ts.net. Only needed behind a reverse proxy that "
-    "rewrites the Host header.",
+    "e.g. https://host.tailnet.ts.net. A full exemption from the origin check — "
+    "any page on that origin may act as you — typically needed only behind a "
+    "reverse proxy that rewrites the Host header.",
 )
 @click.option(
     "--spec",
@@ -172,6 +173,17 @@ def serve(
             "Note: for phone access over Tailscale, run 'tailscale serve' so the "
             "PWA gets a trusted HTTPS origin."
         )
+        # `remote_access_warning` stays silent here — the bind really is
+        # loopback, which is correct for `tailscale serve`. But the proxy
+        # forwards the tailnet Host, and that is not in the allowlist, so
+        # following the advice above verbatim answers 400 to every request.
+        # Say it where the person about to do it is looking.
+        if not allowed_host:
+            click.echo(
+                "      Add '--allowed-host <your-tailnet-name>' too, or the "
+                "dashboard answers '400 Invalid host header' to the proxied "
+                "requests."
+            )
         click.echo("")
 
     # Open browser

--- a/src/clm/cli/commands/serve.py
+++ b/src/clm/cli/commands/serve.py
@@ -38,7 +38,23 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--cors-origin",
     multiple=True,
-    help="CORS allowed origins (can specify multiple times, default: *)",
+    help="Origin allowed to read responses cross-origin (repeatable). Default: "
+    "none — the dashboard serves its own frontend and needs no CORS. Naming an "
+    "origin here also lets it drive the dashboard, as --allowed-origin would.",
+)
+@click.option(
+    "--allowed-host",
+    multiple=True,
+    help="Extra Host header value to accept (repeatable). Needed when you reach "
+    "the dashboard under a name other than localhost — e.g. a Tailscale "
+    "hostname. Pass '*' to disable the check entirely.",
+)
+@click.option(
+    "--allowed-origin",
+    multiple=True,
+    help="Extra origin allowed to drive the dashboard and open /ws (repeatable), "
+    "e.g. https://host.tailnet.ts.net. Only needed behind a reverse proxy that "
+    "rewrites the Host header.",
 )
 @click.option(
     "--spec",
@@ -52,7 +68,18 @@ logger = logging.getLogger(__name__)
     is_flag=True,
     help="Rotate the persistent Studio pairing token (invalidates old QR codes).",
 )
-def serve(host, port, jobs_db_path, no_browser, reload, cors_origin, spec_path, rotate_token):
+def serve(
+    host,
+    port,
+    jobs_db_path,
+    no_browser,
+    reload,
+    cors_origin,
+    allowed_host,
+    allowed_origin,
+    spec_path,
+    rotate_token,
+):
     """Start web dashboard server.
 
     Launches FastAPI server with REST API and WebSocket support for
@@ -60,6 +87,13 @@ def serve(host, port, jobs_db_path, no_browser, reload, cors_origin, spec_path, 
     the Mobile Deck Studio — a phone-friendly authoring surface for the given
     course's decks (browse, search, and edit cells with byte-exact write-back
     and optimistic-concurrency guards against concurrent desktop edits).
+
+    The monitoring dashboard has no login: it binds localhost by default, only
+    answers to a Host that names this server, and refuses requests driven from
+    another origin — which is what keeps a web page open in another tab from
+    reading your build state. Use --allowed-host / --allowed-origin when you
+    deliberately reach it under a different name. The Studio surface adds a
+    bearer token on top, required by both its API and the /ws stream.
 
     \b
     Examples:
@@ -108,7 +142,18 @@ def serve(host, port, jobs_db_path, no_browser, reload, cors_origin, spec_path, 
         cors_origins=cors_origins,
         spec_path=spec_path,
         studio_token=studio_token,
+        allowed_hosts=list(allowed_host),
+        allowed_origins=list(allowed_origin),
     )
+
+    # A wildcard bind promises remote access the Host allowlist cannot deliver
+    # on its own; say so here rather than letting the user discover it as a
+    # wall of 400s from another machine.
+    from clm.infrastructure.web_security import remote_access_warning
+
+    reach_warning = remote_access_warning(host, allowed_host)
+    if reach_warning:
+        click.echo(f"Note: {reach_warning}", err=True)
 
     # Mobile Deck Studio pairing: print the URL + a scannable QR code.
     if spec_path is not None and studio_token is not None:

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -4344,9 +4344,33 @@ Start the web dashboard server (jobs/workers Monitor). Requires the
 | `--jobs-db-path PATH` | Job-queue database (auto-detected if omitted). |
 | `--no-browser` | Do not auto-open a browser. |
 | `--reload` | Enable auto-reload for development. |
-| `--cors-origin ORIGIN` | CORS allowed origin (repeatable; default `*`). |
+| `--cors-origin ORIGIN` | Origin allowed to read responses cross-origin (repeatable; default: none). Also lets that origin drive the dashboard, as `--allowed-origin` would. |
+| `--allowed-host HOST` | Extra `Host` header value to accept (repeatable). Needed when you reach the dashboard under a name other than `localhost` — e.g. a Tailscale hostname. `*` disables the check. |
+| `--allowed-origin ORIGIN` | Extra origin allowed to drive the dashboard and open `/ws` (repeatable). Only needed behind a reverse proxy that rewrites `Host`. |
 | `--spec SPEC_FILE` | Also enable the **Mobile Deck Studio** scoped to this course spec. |
 | `--rotate-token` | Rotate the persistent Studio pairing token (invalidates old QR codes). |
+
+**Browser containment.** The Monitor dashboard has no login, so it binds
+loopback, answers only to a `Host` that names this server, and refuses
+mutating requests driven from another origin — the same two guards
+`clm recordings serve` uses. This is what stops a web page open in another tab
+from reading your build state, and what closes DNS rebinding. If you reach the
+dashboard under a Tailscale or LAN name, pass `--allowed-host <name>`; a
+wildcard bind (`--host 0.0.0.0`) without one prints a warning, because every
+remote request would otherwise get `400 Invalid host header`.
+
+`--cors-origin` no longer defaults to `*`. The old default combined `*` with
+credentials, which makes Starlette echo whichever origin asked; a same-origin
+dashboard needs no CORS at all. Passing `*` explicitly still works but serves
+cross-origin responses without credentials.
+
+The `/ws` stream requires the Studio bearer token whenever `--spec` is in
+play, checked **before** the handshake is accepted (WebSockets are exempt from
+CORS, so the check cannot live on the HTTP routes). Browsers cannot set an
+`Authorization` header on a WebSocket, so the PWA presents the token as the
+`clm-token.<token>` subprotocol; scripts may use `Authorization: Bearer`
+instead. Subscriptions are restricted to the known channels `status`,
+`workers`, `jobs` and `studio`.
 
 **Mobile Deck Studio** (`--spec`): a phone-friendly authoring surface for the
 given course's decks, served alongside the Monitor at `/studio/`. Browse the

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -4209,7 +4209,7 @@ clm recordings serve ROOT_DIR [OPTIONS]
 | `--obs-password TEXT` | OBS WebSocket password |
 | `--no-browser` | Do not auto-open browser |
 | `--allowed-host TEXT` | Extra `Host` header value to accept (repeatable); `*` disables the check |
-| `--allowed-origin TEXT` | Extra origin allowed to drive actions (repeatable) |
+| `--allowed-origin TEXT` | Extra origin allowed to drive actions (repeatable). A **full exemption** from the origin check — any page on that origin may act as you |
 
 Examples:
 
@@ -4346,7 +4346,7 @@ Start the web dashboard server (jobs/workers Monitor). Requires the
 | `--reload` | Enable auto-reload for development. |
 | `--cors-origin ORIGIN` | Origin allowed to read responses cross-origin (repeatable; default: none). Also lets that origin drive the dashboard, as `--allowed-origin` would. |
 | `--allowed-host HOST` | Extra `Host` header value to accept (repeatable). Needed when you reach the dashboard under a name other than `localhost` — e.g. a Tailscale hostname. `*` disables the check. |
-| `--allowed-origin ORIGIN` | Extra origin allowed to drive the dashboard and open `/ws` (repeatable). Only needed behind a reverse proxy that rewrites `Host`. |
+| `--allowed-origin ORIGIN` | Extra origin allowed to drive the dashboard and open `/ws` (repeatable). A **full exemption** from the origin check — any page on that origin may act as you — so name only origins you trust. Typically a reverse proxy that rewrites `Host`. |
 | `--spec SPEC_FILE` | Also enable the **Mobile Deck Studio** scoped to this course spec. |
 | `--rotate-token` | Rotate the persistent Studio pairing token (invalidates old QR codes). |
 
@@ -4361,12 +4361,16 @@ remote request would otherwise get `400 Invalid host header`.
 
 `--cors-origin` no longer defaults to `*`. The old default combined `*` with
 credentials, which makes Starlette echo whichever origin asked; a same-origin
-dashboard needs no CORS at all. Passing `*` explicitly still works but serves
-cross-origin responses without credentials.
+dashboard needs no CORS at all. `*` is still accepted but serves cross-origin
+responses without credentials, and — unlike a named origin — does **not**
+exempt anyone from the origin check, so a cross-origin `POST` behind it still
+gets `403`. Name the origins you actually want.
 
 The `/ws` stream requires the Studio bearer token whenever `--spec` is in
 play, checked **before** the handshake is accepted (WebSockets are exempt from
-CORS, so the check cannot live on the HTTP routes). Browsers cannot set an
+CORS, so the check cannot live on the HTTP routes). This covers the whole
+endpoint, not only the `studio` channel: with `--spec`, a client that wants
+`status`/`workers`/`jobs` needs the token too. Browsers cannot set an
 `Authorization` header on a WebSocket, so the PWA presents the token as the
 `clm-token.<token>` subprotocol; scripts may use `Authorization: Bearer`
 instead. Subscriptions are restricted to the known channels `status`,

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -2,6 +2,43 @@
 
 This guide covers breaking changes across major CLM versions.
 
+## `clm serve` only answers to a `Host` that names it, and `--cors-origin` no longer defaults to `*` ({version})
+
+**Breaking only if you reach the dashboard from another machine, or relied on
+the wildcard CORS default.** A local `clm serve` on `localhost:8000` is
+unaffected.
+
+The Monitor dashboard has no login, so it now applies the same two browser
+guards `clm recordings serve` uses: every request must carry a `Host` header
+naming this server (loopback, plus whatever `--host` bound), and a mutating
+request must come from the dashboard's own origin. Without the first, a page
+that points its own DNS name at `127.0.0.1` is a genuinely same-origin caller
+and no origin check can tell.
+
+If you reach the dashboard under a Tailscale or LAN name, every request now
+answers:
+
+```
+400 Invalid host header: 'box.tail1234.ts.net'.
+```
+
+Fix: `clm serve --allowed-host box.tail1234.ts.net` (repeatable; `*` disables
+the check). Behind a reverse proxy that rewrites `Host`, add
+`--allowed-origin https://box.tail1234.ts.net`. Binding `--host 0.0.0.0`
+without either now prints a warning at startup, because the allowlist has no
+way to guess the name remote machines will use.
+
+`--cors-origin` defaults to *no* CORS middleware instead of `["*"]`. The old
+default paired `*` with credentials, which makes Starlette echo whichever
+origin asked; a dashboard serving its own frontend never needed CORS. Name
+your origins explicitly if a separate frontend calls the API — doing so also
+authorizes them to drive it, so `--allowed-origin` is not additionally needed.
+
+One further change needs no action: `/ws` now requires the Studio bearer token
+before accepting the handshake whenever `--spec` is in play. The bundled PWA
+presents it automatically as the `clm-token.<token>` subprotocol. A custom
+WebSocket client must do the same, or send `Authorization: Bearer <token>`.
+
 ## Docker worker images must be rebuilt — the Worker API now requires a token ({version})
 
 **Breaking for Docker mode only. Direct mode is unaffected.**

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -34,10 +34,18 @@ origin asked; a dashboard serving its own frontend never needed CORS. Name
 your origins explicitly if a separate frontend calls the API — doing so also
 authorizes them to drive it, so `--allowed-origin` is not additionally needed.
 
-One further change needs no action: `/ws` now requires the Studio bearer token
-before accepting the handshake whenever `--spec` is in play. The bundled PWA
-presents it automatically as the `clm-token.<token>` subprotocol. A custom
-WebSocket client must do the same, or send `Authorization: Bearer <token>`.
+`--allowed-origin` is a full exemption from the origin check, not a
+proxy-only tweak: a named origin may drive every mutating route and open
+`/ws`, whatever fetch metadata the browser sends. Name only origins you would
+let act as you.
+
+One further change affects custom WebSocket clients: `/ws` now requires the
+Studio bearer token before accepting the handshake whenever `--spec` is in
+play. That covers the **whole endpoint**, including the `status`, `workers`
+and `jobs` channels — so a script that polled `/ws` for job status against a
+plain `clm serve` starts being refused once you add `--spec`. The bundled PWA
+presents the token automatically as the `clm-token.<token>` subprotocol; a
+custom client must do the same, or send `Authorization: Bearer <token>`.
 
 ## Docker worker images must be rebuilt — the Worker API now requires a token ({version})
 

--- a/src/clm/infrastructure/web_security.py
+++ b/src/clm/infrastructure/web_security.py
@@ -216,9 +216,20 @@ def normalize_origin(origin: str) -> str | None:
 
     Returns ``None`` for ``"null"`` and anything unparseable — both of which
     are *not* this app's origin, which is the only question being asked.
+
+    Also refuses two forms a browser never emits but ``urlsplit`` quietly
+    accepts, because both let a string that *reads* as one host parse as
+    another: **userinfo** (``https://evil.example@front.example`` has hostname
+    ``front.example``) and embedded tab/CR/LF, which WHATWG parsing strips
+    before resolution (``https://front.exa<TAB>mple``). Neither is exploitable
+    from a browser — a page cannot set ``Origin`` — but this is a public
+    helper an app-agnostic caller may reach for, and refusing them costs
+    nothing.
     """
     value = origin.strip()
     if not value or value.lower() == "null":
+        return None
+    if any(c in value for c in "\t\r\n"):
         return None
     try:
         parts = urlsplit(value)
@@ -228,6 +239,8 @@ def normalize_origin(origin: str) -> str | None:
         # would turn a 403 into a 500 from inside the security middleware.
         return None
     if not parts.scheme or not parts.hostname:
+        return None
+    if parts.username is not None or parts.password is not None:
         return None
     scheme = parts.scheme.lower()
     host = _strip_trailing_dot(parts.hostname.lower())
@@ -421,8 +434,22 @@ class OriginGuardMiddleware:
         allowed_origins: Sequence[str] = (),
     ) -> None:
         self.app = app
-        normalized = [normalize_origin(o) for o in allowed_origins]
-        self.allowed_origins = [o for o in normalized if o is not None]
+        self.allowed_origins = []
+        for raw in allowed_origins:
+            normalized = normalize_origin(raw)
+            if normalized is None:
+                # Dropping this silently is the worst outcome: the operator
+                # asked for an exemption, the server starts fine, and every
+                # request from that origin still 403s with nothing connecting
+                # the two. A missing scheme is by far the likeliest typo.
+                logger.warning(
+                    "Ignoring --allowed-origin %r: not a valid origin. Expected "
+                    "scheme://host[:port], e.g. https://%s.",
+                    raw,
+                    raw or "host.example",
+                )
+                continue
+            self.allowed_origins.append(normalized)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         scope_type = scope["type"]

--- a/src/clm/infrastructure/web_security.py
+++ b/src/clm/infrastructure/web_security.py
@@ -307,13 +307,25 @@ def check_request_origin(
     Args:
         headers: The request headers.
         allowed_origins: Extra origins to accept verbatim (``--allowed-origin``),
-            already normalized by :func:`normalize_origin`.
+            already normalized by :func:`normalize_origin`. Consulted before
+            the fetch-metadata check, so naming an origin actually authorizes
+            a browser on it — see the comment in the body.
 
     Returns:
         ``None`` when the request may proceed, or a short human-readable reason
         it was refused (safe to log and to return in the 403 body — it echoes
         only what the *client* sent).
     """
+    origin = headers.get("origin")
+
+    # An operator-named origin is trusted whatever the fetch metadata says.
+    # This has to come *first*: every current browser sends Sec-Fetch-Site, so
+    # checking it before the allowlist made ``--allowed-origin`` unreachable
+    # for the only clients it exists to serve — the flag would let a
+    # cross-origin preflight succeed and then 403 the request behind it.
+    if origin and _origin_is_allowed(origin, allowed_origins):
+        return None
+
     fetch_site = headers.get("sec-fetch-site")
     if fetch_site:
         site = fetch_site.strip().lower()
@@ -325,17 +337,19 @@ def check_request_origin(
             return None
         return f"cross-origin request (Sec-Fetch-Site: {site})"
 
-    origin = headers.get("origin")
     if not origin:
         # No Origin and no Sec-Fetch-Site: not a browser. See module docstring.
         return None
 
-    normalized = normalize_origin(origin)
-    if normalized is not None and normalized in allowed_origins:
-        return None
     if _origin_matches_host(origin, headers.get("host", "")):
         return None
     return f"cross-origin request (Origin: {origin})"
+
+
+def _origin_is_allowed(origin: str, allowed_origins: Sequence[str]) -> bool:
+    """True when ``origin`` is one the operator named explicitly."""
+    normalized = normalize_origin(origin)
+    return normalized is not None and normalized in allowed_origins
 
 
 class TrustedHostMiddleware:

--- a/src/clm/web/api/websocket.py
+++ b/src/clm/web/api/websocket.py
@@ -171,30 +171,37 @@ def offered_subprotocols(websocket: WebSocket) -> list[str]:
     return [part.strip() for part in raw.split(",") if part.strip()]
 
 
-def _token_subprotocol(websocket: WebSocket) -> str | None:
-    """Return the offered ``clm-token.*`` subprotocol, if the client sent one.
+def _token_subprotocols(websocket: WebSocket) -> list[str]:
+    """Return every offered ``clm-token.*`` subprotocol, in the order offered."""
+    return [o for o in offered_subprotocols(websocket) if o.startswith(TOKEN_SUBPROTOCOL_PREFIX)]
 
-    Echoed back on accept even when no token is required: RFC 6455 says a
-    client that offered protocols and got none selected must fail the
-    connection, so a Studio PWA pointed at a plain ``clm serve`` would
-    otherwise reconnect forever against a server that kept "accepting" it.
+
+def _echo_subprotocol(websocket: WebSocket) -> str | None:
+    """Return the subprotocol to select on accept, or ``None`` to select none.
+
+    Echoed even when no token is required: RFC 6455 says a client that offered
+    protocols and got none selected must fail the connection, so a Studio PWA
+    pointed at a plain ``clm serve`` would otherwise reconnect forever against
+    a server that kept "accepting" it.
+
+    Only ``clm-token.*`` is ever echoed. Selecting an arbitrary protocol the
+    server does not actually speak would be a worse lie than selecting none —
+    this covers CLM's own client, which offers exactly that one.
     """
-    for offered in offered_subprotocols(websocket):
-        if offered.startswith(TOKEN_SUBPROTOCOL_PREFIX):
-            return offered
-    return None
+    offered = _token_subprotocols(websocket)
+    return offered[0] if offered else None
 
 
 def _presented_tokens(websocket: WebSocket) -> list[str]:
-    """Return every credential the handshake carries, best-first.
+    """Return every credential the handshake carries, in the order offered.
 
-    Both are returned rather than the first one found: a debugging client that
-    copies the PWA's subprotocol list *and* sets ``Authorization`` should not
-    be refused because the stale half was checked and the valid half ignored.
+    All of them, rather than the first found: a client that offers a stale
+    subprotocol alongside a fresh one — or copies the PWA's subprotocol list
+    *and* sets ``Authorization`` — should authenticate on the valid credential
+    rather than be refused because a dead one was checked first.
     """
     candidates: list[str] = []
-    subprotocol = _token_subprotocol(websocket)
-    if subprotocol:
+    for subprotocol in _token_subprotocols(websocket):
         token = subprotocol[len(TOKEN_SUBPROTOCOL_PREFIX) :]
         if token:
             candidates.append(token)
@@ -219,16 +226,23 @@ async def websocket_endpoint(websocket: WebSocket):
     # alone would fail open in the one state that matters: a Studio app built
     # without a token, whose disk watcher is broadcasting on `studio` anyway.
     studio_enabled = getattr(state, "studio_service", None) is not None
-    subprotocol = _token_subprotocol(websocket)
+    subprotocol = _echo_subprotocol(websocket)
 
     if studio_enabled:
         expected = getattr(state, "studio_token", None)
         presented = _presented_tokens(websocket)
         if not expected or not any(tokens_match(token, expected) for token in presented):
-            logger.warning(
-                "Refused a /ws handshake with %s Studio token.",
-                "an invalid" if presented else "no",
-            )
+            # Name the *server's* fault separately: with the Studio enabled but
+            # no token configured, nothing the client sends can ever work, and
+            # blaming the client is the one message that would send an operator
+            # looking in the wrong place.
+            if not expected:
+                reason = "no Studio token is configured on this server"
+            elif presented:
+                reason = "an invalid Studio token"
+            else:
+                reason = "no Studio token"
+            logger.warning("Refused a /ws handshake: %s.", reason)
             # Close without accepting: the connection never exists, so the
             # client cannot send on it. uvicorn turns this into an HTTP 403.
             await websocket.close(code=WS_POLICY_VIOLATION)

--- a/src/clm/web/api/websocket.py
+++ b/src/clm/web/api/websocket.py
@@ -1,4 +1,31 @@
-"""WebSocket endpoint for real-time updates."""
+"""WebSocket endpoint for real-time updates.
+
+**Why this file has an auth check at all.** WebSockets are exempt from CORS,
+so a cross-origin page can open one where it could not have made the
+equivalent ``fetch``. Two things stop that here:
+
+- the origin and Host guards in :mod:`clm.infrastructure.web_security`, which
+  apply to the handshake as ASGI middleware — this is the containment the
+  whole dashboard gets; and
+- the Studio bearer token, required *before* :meth:`WebSocket.accept` whenever
+  ``clm serve --spec`` configured one.
+
+The second exists because ``/ws`` carries the ``studio`` channel, which
+broadcasts deck-change and sync-progress events for the course being served.
+Without a check here, anyone who can reach the port could subscribe and
+receive them, walking straight around the bearer token that
+:mod:`clm.web.studio.auth` calls "the real access gate". Checking after
+``accept()`` would be too late in the sense that matters: the connection would
+already exist and the client would already be able to send.
+
+**How the browser presents the token.** The ``WebSocket`` constructor cannot
+set an ``Authorization`` header, so the Studio PWA passes it as a
+subprotocol — ``clm-token.<token>`` — which is the standard workaround and,
+unlike ``?token=``, keeps the secret out of the server's access log. A
+non-browser client may use ``Authorization: Bearer`` instead. The accepted
+subprotocol is echoed back, because a browser fails the connection if the
+server accepts without selecting one of the offered protocols.
+"""
 
 import asyncio
 import json
@@ -7,8 +34,23 @@ import logging
 from fastapi import WebSocket, WebSocketDisconnect
 
 from clm.web.services.monitor_service import MonitorService
+from clm.web.studio.auth import tokens_match
 
 logger = logging.getLogger(__name__)
+
+#: Channels a client may subscribe to. An unknown name used to be accepted
+#: verbatim, which made the subscription set attacker-controlled and unbounded;
+#: worse, it hid typos, since a client subscribed to ``"jobss"`` simply never
+#: heard anything. ``studio`` is only ever broadcast on when ``--spec`` is set.
+KNOWN_CHANNELS = frozenset({"status", "workers", "jobs", "studio"})
+
+#: Prefix of the ``Sec-WebSocket-Protocol`` value carrying the Studio token.
+TOKEN_SUBPROTOCOL_PREFIX = "clm-token."
+
+#: Close code for a refused handshake (RFC 6455 policy violation), matching
+#: what the origin/Host guards use so an unauthorized client learns no more
+#: from one refusal than from the other.
+WS_POLICY_VIOLATION = 1008
 
 
 class WebSocketManager:
@@ -19,13 +61,16 @@ class WebSocketManager:
         self.active_connections: set[WebSocket] = set()
         self.subscriptions: dict[WebSocket, set[str]] = {}
 
-    async def connect(self, websocket: WebSocket):
+    async def connect(self, websocket: WebSocket, subprotocol: str | None = None):
         """Accept new WebSocket connection.
 
         Args:
             websocket: WebSocket connection
+            subprotocol: Subprotocol to select in the handshake response. Must
+                echo one the client offered, or the browser drops the
+                connection immediately after the server accepts it.
         """
-        await websocket.accept()
+        await websocket.accept(subprotocol=subprotocol)
         self.active_connections.add(websocket)
         self.subscriptions[websocket] = set()
         logger.info(f"WebSocket client connected. Total: {len(self.active_connections)}")
@@ -40,16 +85,25 @@ class WebSocketManager:
         self.subscriptions.pop(websocket, None)
         logger.info(f"WebSocket client disconnected. Total: {len(self.active_connections)}")
 
-    async def subscribe(self, websocket: WebSocket, channels: list[str]):
-        """Subscribe connection to channels.
+    async def subscribe(self, websocket: WebSocket, channels: list[str]) -> list[str]:
+        """Subscribe connection to the known channels among ``channels``.
 
         Args:
             websocket: WebSocket connection
-            channels: List of channel names (workers, jobs, status)
+            channels: Requested channel names. Anything outside
+                :data:`KNOWN_CHANNELS` is dropped rather than stored.
+
+        Returns:
+            The channel names actually subscribed to, in the order requested.
         """
+        accepted = [c for c in channels if c in KNOWN_CHANNELS]
+        rejected = [c for c in channels if c not in KNOWN_CHANNELS]
+        if rejected:
+            logger.warning("Ignoring subscription to unknown channel(s): %s", rejected)
         if websocket in self.subscriptions:
-            self.subscriptions[websocket].update(channels)
-            logger.debug(f"Client subscribed to: {channels}")
+            self.subscriptions[websocket].update(accepted)
+            logger.debug(f"Client subscribed to: {accepted}")
+        return accepted
 
     async def broadcast(self, message: dict, channel: str | None = None):
         """Broadcast message to subscribed clients.
@@ -107,12 +161,57 @@ class WebSocketManager:
 ws_manager = WebSocketManager()
 
 
+def offered_subprotocols(websocket: WebSocket) -> list[str]:
+    """Return the subprotocols the client offered, in order.
+
+    Starlette exposes the raw header rather than a parsed list, and the header
+    is comma-separated with optional whitespace.
+    """
+    raw = websocket.headers.get("sec-websocket-protocol", "")
+    return [part.strip() for part in raw.split(",") if part.strip()]
+
+
+def _presented_token(websocket: WebSocket) -> tuple[str | None, str | None]:
+    """Return ``(token, subprotocol_to_echo)`` from the handshake.
+
+    The subprotocol is returned alongside the token because accepting without
+    echoing an offered protocol makes a browser close the connection, so the
+    two decisions cannot be made independently.
+    """
+    for offered in offered_subprotocols(websocket):
+        if offered.startswith(TOKEN_SUBPROTOCOL_PREFIX):
+            token = offered[len(TOKEN_SUBPROTOCOL_PREFIX) :]
+            return (token or None), offered
+
+    auth = websocket.headers.get("authorization", "")
+    scheme, _, param = auth.partition(" ")
+    if scheme.lower() == "bearer" and param.strip():
+        return param.strip(), None
+    return None, None
+
+
 async def websocket_endpoint(websocket: WebSocket):
     """WebSocket endpoint for real-time updates.
 
-    Clients can subscribe to channels: status, workers, jobs
+    Clients can subscribe to the channels in :data:`KNOWN_CHANNELS`. When the
+    server was started with ``--spec``, the handshake must carry the Studio
+    token (see the module docstring) or it is closed without being accepted.
     """
-    await ws_manager.connect(websocket)
+    expected = getattr(websocket.app.state, "studio_token", None)
+    subprotocol: str | None = None
+    if expected:
+        presented, subprotocol = _presented_token(websocket)
+        if not tokens_match(presented, expected):
+            logger.warning(
+                "Refused a /ws handshake with %s Studio token.",
+                "an invalid" if presented else "no",
+            )
+            # Close without accepting: the connection never exists, so the
+            # client cannot send on it. uvicorn turns this into an HTTP 403.
+            await websocket.close(code=WS_POLICY_VIOLATION)
+            return
+
+    await ws_manager.connect(websocket, subprotocol=subprotocol)
 
     try:
         while True:
@@ -122,8 +221,11 @@ async def websocket_endpoint(websocket: WebSocket):
             # Handle subscription
             if data.get("action") == "subscribe":
                 channels = data.get("channels", [])
-                await ws_manager.subscribe(websocket, channels)
-                await websocket.send_json({"type": "subscribed", "channels": channels})
+                accepted = await ws_manager.subscribe(websocket, channels)
+                # Report what was actually subscribed to, not what was asked
+                # for: echoing the request back made a typo look like a
+                # success and then go quiet forever.
+                await websocket.send_json({"type": "subscribed", "channels": accepted})
 
             # Handle ping
             elif data.get("type") == "ping":

--- a/src/clm/web/api/websocket.py
+++ b/src/clm/web/api/websocket.py
@@ -171,23 +171,39 @@ def offered_subprotocols(websocket: WebSocket) -> list[str]:
     return [part.strip() for part in raw.split(",") if part.strip()]
 
 
-def _presented_token(websocket: WebSocket) -> tuple[str | None, str | None]:
-    """Return ``(token, subprotocol_to_echo)`` from the handshake.
+def _token_subprotocol(websocket: WebSocket) -> str | None:
+    """Return the offered ``clm-token.*`` subprotocol, if the client sent one.
 
-    The subprotocol is returned alongside the token because accepting without
-    echoing an offered protocol makes a browser close the connection, so the
-    two decisions cannot be made independently.
+    Echoed back on accept even when no token is required: RFC 6455 says a
+    client that offered protocols and got none selected must fail the
+    connection, so a Studio PWA pointed at a plain ``clm serve`` would
+    otherwise reconnect forever against a server that kept "accepting" it.
     """
     for offered in offered_subprotocols(websocket):
         if offered.startswith(TOKEN_SUBPROTOCOL_PREFIX):
-            token = offered[len(TOKEN_SUBPROTOCOL_PREFIX) :]
-            return (token or None), offered
+            return offered
+    return None
+
+
+def _presented_tokens(websocket: WebSocket) -> list[str]:
+    """Return every credential the handshake carries, best-first.
+
+    Both are returned rather than the first one found: a debugging client that
+    copies the PWA's subprotocol list *and* sets ``Authorization`` should not
+    be refused because the stale half was checked and the valid half ignored.
+    """
+    candidates: list[str] = []
+    subprotocol = _token_subprotocol(websocket)
+    if subprotocol:
+        token = subprotocol[len(TOKEN_SUBPROTOCOL_PREFIX) :]
+        if token:
+            candidates.append(token)
 
     auth = websocket.headers.get("authorization", "")
     scheme, _, param = auth.partition(" ")
     if scheme.lower() == "bearer" and param.strip():
-        return param.strip(), None
-    return None, None
+        candidates.append(param.strip())
+    return candidates
 
 
 async def websocket_endpoint(websocket: WebSocket):
@@ -197,11 +213,18 @@ async def websocket_endpoint(websocket: WebSocket):
     server was started with ``--spec``, the handshake must carry the Studio
     token (see the module docstring) or it is closed without being accepted.
     """
-    expected = getattr(websocket.app.state, "studio_token", None)
-    subprotocol: str | None = None
-    if expected:
-        presented, subprotocol = _presented_token(websocket)
-        if not tokens_match(presented, expected):
+    state = websocket.app.state
+    # Gate on Studio being *enabled*, not on a token being configured — the
+    # same condition `studio.routes.require_token` uses. Keying off the token
+    # alone would fail open in the one state that matters: a Studio app built
+    # without a token, whose disk watcher is broadcasting on `studio` anyway.
+    studio_enabled = getattr(state, "studio_service", None) is not None
+    subprotocol = _token_subprotocol(websocket)
+
+    if studio_enabled:
+        expected = getattr(state, "studio_token", None)
+        presented = _presented_tokens(websocket)
+        if not expected or not any(tokens_match(token, expected) for token in presented):
             logger.warning(
                 "Refused a /ws handshake with %s Studio token.",
                 "an invalid" if presented else "no",

--- a/src/clm/web/app.py
+++ b/src/clm/web/app.py
@@ -1,16 +1,29 @@
-"""FastAPI application for CLM web dashboard."""
+"""FastAPI application for CLM web dashboard.
+
+The dashboard API (``/api/*``) has no login: like the recordings dashboard, it
+treats "the request arrived on the socket" as "the user asked for this", and
+binds loopback so that stays true. What it therefore needs is containment
+against the two things a *browser* can do without the user's cooperation —
+cross-origin drives and DNS rebinding — which is
+:func:`clm.infrastructure.web_security.install_web_security`.
+
+Mobile Deck Studio (``--spec``) sits on top of that with a real access gate: a
+bearer token on every ``/api/studio`` route. ``/ws`` is part of that gate, not
+outside it — see :mod:`clm.web.api.websocket`.
+"""
 
 import logging
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Iterable
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
 from clm.__version__ import __version__
+from clm.infrastructure.web_security import install_web_security
 from clm.web.api.routes import router as api_router
 from clm.web.api.websocket import websocket_endpoint
 from clm.web.services.monitor_service import MonitorService
@@ -60,18 +73,29 @@ def create_app(
     cors_origins: list[str] | None = None,
     spec_path: Path | None = None,
     studio_token: str | None = None,
+    allowed_hosts: Iterable[str] | None = None,
+    allowed_origins: Iterable[str] = (),
 ) -> FastAPI:
     """Create and configure FastAPI application.
 
     Args:
         db_path: Path to SQLite database
-        host: Host to bind to
+        host: Host to bind to. Folded into the ``Host`` allowlist, so a
+            deliberate non-loopback bind keeps working.
         port: Port to bind to
-        cors_origins: CORS allowed origins
+        cors_origins: Origins allowed to read responses cross-origin
+            (``--cors-origin``). ``None`` — the default — installs no CORS
+            middleware at all, which is what a same-origin app needs. Named
+            origins are *also* added to the origin guard's allowlist, since
+            "let this origin talk to me" is the only reason to pass the flag.
         spec_path: When given, enable the Mobile Deck Studio view scoped to this
             course spec (one course per server instance).
         studio_token: Bearer token required by the Studio API/WS (ignored when
             ``spec_path`` is None).
+        allowed_hosts: Extra ``Host`` values to accept (``--allowed-host``).
+            ``["*"]`` disables the host check.
+        allowed_origins: Extra origins allowed to drive mutating requests and
+            open ``/ws`` (``--allowed-origin``).
 
     Returns:
         Configured FastAPI application
@@ -123,24 +147,60 @@ def create_app(
                 name="studio",
             )
 
-    # Configure CORS
-    if cors_origins is None:
-        cors_origins = ["*"]
+    # Configure CORS. The default is *no* CORS middleware: this app serves its
+    # own frontend, and same-origin traffic never needs one. The previous
+    # default — `allow_origins=["*"]` together with `allow_credentials=True` —
+    # made Starlette echo whichever Origin asked, which is strictly worse than
+    # a literal `*` because it makes credentialed cross-origin reads legal.
+    guard_origins = list(allowed_origins)
+    if cors_origins:
+        wildcard = "*" in cors_origins
+        if wildcard:
+            # A credentialed wildcard is not a thing the CORS spec allows; the
+            # only reason it "worked" is Starlette's echo. Honour the wildcard
+            # and drop credentials rather than silently reinstating the bug.
+            logger.warning(
+                "CORS origin '*' cannot be combined with credentials; serving "
+                "cross-origin responses without credentials. Name the origins "
+                "explicitly with --cors-origin to keep credentials."
+            )
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=cors_origins,
+            allow_credentials=not wildcard,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+        # CORS governs who may *read* a response; the origin guard governs who
+        # may *cause* one. Naming an origin for the first without the second
+        # leaves a caller with a working preflight and a 403 behind it, so an
+        # explicit --cors-origin implies --allowed-origin.
+        guard_origins.extend(o for o in cors_origins if o != "*")
 
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=cors_origins,
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+    # Browser containment (D4): a Host allowlist closes DNS rebinding, and an
+    # origin check on mutating requests closes CSRF. Installed last so both
+    # guards sit outside CORS — a rebound request is refused before any other
+    # middleware looks at it. Covers the /ws handshake too, which is why the
+    # WebSocket is not exposed by CORS being off.
+    effective_hosts = install_web_security(
+        app,
+        bind_host=host,
+        allowed_hosts=allowed_hosts,
+        allowed_origins=guard_origins,
     )
+    logger.debug("Dashboard accepts Host values: %s", effective_hosts)
+    app.state.allowed_hosts = effective_hosts
 
     # Include API router
     app.include_router(api_router)
 
-    # WebSocket endpoint
+    # WebSocket endpoint. The annotation is load-bearing: FastAPI resolves a
+    # route's parameters from its signature, and an *unannotated* `websocket`
+    # was analysed as a required query parameter — so every handshake was
+    # closed with "Field required" and the Studio's disk-change banner never
+    # fired. Found while adding the token check below.
     @app.websocket("/ws")
-    async def websocket_route(websocket):
+    async def websocket_route(websocket: WebSocket) -> None:
         """WebSocket endpoint."""
         await websocket_endpoint(websocket)
 

--- a/src/clm/web/app.py
+++ b/src/clm/web/app.py
@@ -23,7 +23,7 @@ from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
 from clm.__version__ import __version__
-from clm.infrastructure.web_security import install_web_security
+from clm.infrastructure.web_security import install_web_security, normalize_origin
 from clm.web.api.routes import router as api_router
 from clm.web.api.websocket import websocket_endpoint
 from clm.web.services.monitor_service import MonitorService
@@ -64,6 +64,42 @@ async def lifespan(app: FastAPI) -> AsyncGenerator:
             await watcher_task
         except (asyncio.CancelledError, Exception):  # noqa: BLE001 - best-effort stop
             pass
+
+
+def _checked_cors_origins(cors_origins: list[str]) -> list[str]:
+    """Return the ``--cors-origin`` values, warning about ones that won't work.
+
+    ``CORSMiddleware`` compares the ``Origin`` header verbatim while the origin
+    guard compares a normalized form, so a value the two read differently is
+    half-applied in silence:
+
+    - ``localhost:3000`` (no scheme) matches neither — no browser ever sends
+      an ``Origin`` without one — and is simply inert.
+    - ``https://x.example/`` (trailing slash) normalizes for the guard but
+      never matches ``CORSMiddleware``, so the flag widens what may *drive*
+      the app without granting what the operator actually asked for.
+
+    Both are operator typos, and both are invisible without this. The values
+    are still returned: refusing to start over a mistyped origin would be
+    worse than saying so.
+    """
+    for origin in cors_origins:
+        if origin == "*":
+            continue
+        normalized = normalize_origin(origin)
+        if normalized is None:
+            logger.warning(
+                "CORS origin %r is not a valid origin (expected scheme://host[:port]) "
+                "and will match nothing.",
+                origin,
+            )
+        elif normalized != origin:
+            logger.warning(
+                "CORS origin %r does not match what a browser sends; use %r.",
+                origin,
+                normalized,
+            )
+    return [o for o in cors_origins if o != "*"]
 
 
 def create_app(
@@ -175,7 +211,7 @@ def create_app(
         # may *cause* one. Naming an origin for the first without the second
         # leaves a caller with a working preflight and a 403 behind it, so an
         # explicit --cors-origin implies --allowed-origin.
-        guard_origins.extend(o for o in cors_origins if o != "*")
+        guard_origins.extend(_checked_cors_origins(cors_origins))
 
     # Browser containment (D4): a Host allowlist closes DNS rebinding, and an
     # origin check on mutating requests closes CSRF. Installed last so both

--- a/src/clm/web/static/studio/app.js
+++ b/src/clm/web/static/studio/app.js
@@ -529,7 +529,19 @@ function editCell(cell, idx) {
 }
 
 // --- WebSocket: disk-change notifications -------------------------------------
+// Reconnect backs off from 3s to 60s and resets on a successful open. A flat
+// 3s retry hammers the server forever after --rotate-token invalidates a phone
+// that still has a tab open, and each refused handshake writes a server-side
+// WARNING — which would bury the diagnostics the Host/Origin guards emit.
+const WS_RETRY_MIN_MS = 3000;
+const WS_RETRY_MAX_MS = 60000;
+let wsRetryMs = WS_RETRY_MIN_MS;
+
 function connectWs() {
+  // Without a token the handshake is refused, so an unpaired tab would spin on
+  // the retry loop instead of showing the "not paired" banner resolveToken()
+  // already drives.
+  if (!TOKEN) return;
   const proto = location.protocol === "https:" ? "wss" : "ws";
   let ws;
   // The WebSocket constructor cannot set an Authorization header, so the token
@@ -538,7 +550,10 @@ function connectWs() {
   // server's access log on every reconnect.
   try { ws = new WebSocket(`${proto}://${location.host}/ws`, ["clm-token." + TOKEN]); }
   catch { return; }
-  ws.addEventListener("open", () => ws.send(JSON.stringify({ action: "subscribe", channels: ["studio"] })));
+  ws.addEventListener("open", () => {
+    wsRetryMs = WS_RETRY_MIN_MS;
+    ws.send(JSON.stringify({ action: "subscribe", channels: ["studio"] }));
+  });
   ws.addEventListener("message", (ev) => {
     let msg; try { msg = JSON.parse(ev.data); } catch { return; }
     if (!currentDeck || msg.deck_id !== currentDeck.deck_id) return;
@@ -556,7 +571,11 @@ function connectWs() {
       openDeck(currentDeck.deck_id); // refresh content + lock state
     }
   });
-  ws.addEventListener("close", () => setTimeout(connectWs, 3000));
+  ws.addEventListener("close", () => {
+    const delay = wsRetryMs;
+    wsRetryMs = Math.min(wsRetryMs * 2, WS_RETRY_MAX_MS);
+    setTimeout(connectWs, delay);
+  });
 }
 
 // --- service worker (P4): installable PWA + offline read-only cache -----------

--- a/src/clm/web/static/studio/app.js
+++ b/src/clm/web/static/studio/app.js
@@ -532,7 +532,11 @@ function editCell(cell, idx) {
 function connectWs() {
   const proto = location.protocol === "https:" ? "wss" : "ws";
   let ws;
-  try { ws = new WebSocket(`${proto}://${location.host}/ws`); }
+  // The WebSocket constructor cannot set an Authorization header, so the token
+  // travels as a subprotocol (the server matches on the "clm-token." prefix and
+  // echoes it back). A query parameter would work too but would land in the
+  // server's access log on every reconnect.
+  try { ws = new WebSocket(`${proto}://${location.host}/ws`, ["clm-token." + TOKEN]); }
   catch { return; }
   ws.addEventListener("open", () => ws.send(JSON.stringify({ action: "subscribe", channels: ["studio"] })));
   ws.addEventListener("message", (ev) => {

--- a/src/clm/web/studio/auth.py
+++ b/src/clm/web/studio/auth.py
@@ -81,9 +81,20 @@ def extract_token(request: Request) -> str | None:
     return None
 
 
-def token_matches(request: Request, expected: str) -> bool:
-    """Constant-time check that the request presents ``expected``."""
-    presented = extract_token(request)
+def tokens_match(presented: str | None, expected: str) -> bool:
+    """Constant-time comparison of a client-supplied token against ``expected``.
+
+    ``secrets.compare_digest`` raises ``TypeError`` when either ``str`` holds a
+    non-ASCII character, and the presented value comes straight off the wire —
+    Starlette decodes headers as latin-1, so a byte above 0x7F is enough. That
+    would turn a bad token into a 500 from inside the auth check. Comparing
+    the UTF-8 encodings keeps the comparison constant-time *and* total.
+    """
     if not presented:
         return False
-    return secrets.compare_digest(presented, expected)
+    return secrets.compare_digest(presented.encode("utf-8"), expected.encode("utf-8"))
+
+
+def token_matches(request: Request, expected: str) -> bool:
+    """Constant-time check that the request presents ``expected``."""
+    return tokens_match(extract_token(request), expected)

--- a/tests/cli/test_monitoring_command.py
+++ b/tests/cli/test_monitoring_command.py
@@ -251,6 +251,91 @@ class TestServeCommand:
         kwargs = fake_create_app.call_args.kwargs
         assert kwargs["cors_origins"] == ["https://a.example", "https://b.example"]
 
+    def test_containment_flags_reach_create_app(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The Host/origin allowlists are only as good as their plumbing.
+
+        A typo in either keyword name would leave the guards at their
+        loopback-only default with the CLI still reporting success, and every
+        remote request answering 400 with no clue why.
+        """
+        db_path = tmp_path / "jobs.db"
+        db_path.touch()
+
+        fake_create_app = MagicMock(return_value="app")
+        fake_web_app_module = MagicMock()
+        fake_web_app_module.create_app = fake_create_app
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "uvicorn", MagicMock())
+        monkeypatch.setitem(sys.modules, "clm.web.app", fake_web_app_module)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            serve,
+            [
+                "--jobs-db-path",
+                str(db_path),
+                "--no-browser",
+                "--allowed-host",
+                "box.tail1234.ts.net",
+                "--allowed-origin",
+                "https://box.tail1234.ts.net",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        kwargs = fake_create_app.call_args.kwargs
+        assert kwargs["allowed_hosts"] == ["box.tail1234.ts.net"]
+        assert kwargs["allowed_origins"] == ["https://box.tail1234.ts.net"]
+
+    def test_wildcard_bind_without_an_allowed_host_warns(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Otherwise the symptom is a wall of 400s from another machine."""
+        db_path = tmp_path / "jobs.db"
+        db_path.touch()
+
+        fake_web_app_module = MagicMock()
+        fake_web_app_module.create_app = MagicMock(return_value="app")
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "uvicorn", MagicMock())
+        monkeypatch.setitem(sys.modules, "clm.web.app", fake_web_app_module)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            serve,
+            ["--jobs-db-path", str(db_path), "--no-browser", "--host", "0.0.0.0"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "--allowed-host" in result.output
+
+    def test_no_warning_when_the_configuration_is_coherent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A plain loopback serve must not nag."""
+        db_path = tmp_path / "jobs.db"
+        db_path.touch()
+
+        fake_web_app_module = MagicMock()
+        fake_web_app_module.create_app = MagicMock(return_value="app")
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "uvicorn", MagicMock())
+        monkeypatch.setitem(sys.modules, "clm.web.app", fake_web_app_module)
+
+        runner = CliRunner()
+        result = runner.invoke(serve, ["--jobs-db-path", str(db_path), "--no-browser"])
+
+        assert result.exit_code == 0, result.output
+        assert "--allowed-host" not in result.output
+
     def test_opens_browser_by_default(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         db_path = tmp_path / "jobs.db"
         db_path.touch()

--- a/tests/infrastructure/test_web_security.py
+++ b/tests/infrastructure/test_web_security.py
@@ -187,6 +187,36 @@ class TestCheckRequestOrigin:
         headers = self._headers(origin="https://box.ts.net", host="box.ts.net")
         assert check_request_origin(headers) is None
 
+    def test_allowlisted_origin_beats_cross_site_fetch_metadata(self):
+        """``--allowed-origin`` has to outrank ``Sec-Fetch-Site`` to mean anything.
+
+        Every current browser sends fetch metadata, so consulting the
+        allowlist only in the ``Origin`` fallback made the flag unreachable
+        for exactly the clients it exists to authorize: a named front-end got
+        a successful CORS preflight and a 403 on the request behind it.
+        """
+        headers = self._headers(
+            sec_fetch_site="cross-site",
+            origin="https://front.example",
+            host="127.0.0.1:8008",
+        )
+        assert check_request_origin(headers, allowed_origins=["https://front.example"]) is None
+
+    def test_unlisted_origin_is_still_refused_with_an_allowlist_present(self):
+        """Widening for one origin must not widen for its neighbours."""
+        headers = self._headers(
+            sec_fetch_site="cross-site",
+            origin="https://evil.example",
+            host="127.0.0.1:8008",
+        )
+        reason = check_request_origin(headers, allowed_origins=["https://front.example"])
+        assert reason is not None
+
+    def test_allowlist_matching_is_normalized_not_textual(self):
+        """A default port is not part of an origin a browser sends."""
+        headers = self._headers(sec_fetch_site="cross-site", origin="https://front.example:443")
+        assert check_request_origin(headers, allowed_origins=["https://front.example"]) is None
+
     def test_portless_host_still_refuses_an_origin_on_another_port(self):
         """A dev server on :3000 must not drive a dashboard reached as bare ``localhost``.
 

--- a/tests/infrastructure/test_web_security.py
+++ b/tests/infrastructure/test_web_security.py
@@ -158,8 +158,14 @@ class TestCheckRequestOrigin:
         assert reason is not None
         assert site in reason
 
-    def test_fetch_metadata_wins_over_a_matching_origin(self):
-        """A forged ``Origin`` cannot talk its way past ``Sec-Fetch-Site``."""
+    def test_fetch_metadata_wins_over_an_origin_matching_the_host(self):
+        """Matching the ``Host`` is not enough to beat ``Sec-Fetch-Site``.
+
+        Only an origin the *operator* named can do that — see
+        ``test_allowlisted_origin_beats_cross_site_fetch_metadata`` below. This
+        case passes the default empty allowlist, so a forged ``Origin`` echoing
+        the host buys nothing.
+        """
         headers = self._headers(
             sec_fetch_site="cross-site",
             origin="http://127.0.0.1:8008",
@@ -217,6 +223,22 @@ class TestCheckRequestOrigin:
         headers = self._headers(sec_fetch_site="cross-site", origin="https://front.example:443")
         assert check_request_origin(headers, allowed_origins=["https://front.example"]) is None
 
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "https://evil.example@front.example",  # userinfo: hostname is front.example
+            "https://front.exa\tmple",  # WHATWG strips the tab before resolving
+        ],
+    )
+    def test_origins_that_read_as_one_host_and_parse_as_another_are_refused(self, origin: str):
+        """No browser emits these; a hand-rolled client should not benefit from them."""
+        from starlette.datastructures import Headers
+
+        headers = Headers(
+            {"sec-fetch-site": "cross-site", "host": "127.0.0.1:8008", "origin": origin}
+        )
+        assert check_request_origin(headers, allowed_origins=["https://front.example"]) is not None
+
     def test_portless_host_still_refuses_an_origin_on_another_port(self):
         """A dev server on :3000 must not drive a dashboard reached as bare ``localhost``.
 
@@ -270,6 +292,32 @@ def _guarded_app(**kwargs) -> Starlette:
     )
     install_web_security(app, **kwargs)
     return app
+
+
+class TestUnusableAllowedOriginIsReported:
+    """An exemption the operator asked for and did not get must not be silent."""
+
+    def test_scheme_less_allowed_origin_warns(self, caplog):
+        import logging
+
+        from clm.infrastructure.web_security import OriginGuardMiddleware
+
+        with caplog.at_level(logging.WARNING, logger="clm.infrastructure.web_security"):
+            guard = OriginGuardMiddleware(None, allowed_origins=["box.tail1234.ts.net"])
+
+        assert guard.allowed_origins == []
+        assert "Ignoring --allowed-origin" in caplog.text
+
+    def test_usable_allowed_origin_is_kept_quietly(self, caplog):
+        import logging
+
+        from clm.infrastructure.web_security import OriginGuardMiddleware
+
+        with caplog.at_level(logging.WARNING, logger="clm.infrastructure.web_security"):
+            guard = OriginGuardMiddleware(None, allowed_origins=["https://box.tail1234.ts.net"])
+
+        assert guard.allowed_origins == ["https://box.tail1234.ts.net"]
+        assert "Ignoring" not in caplog.text
 
 
 class TestMiddlewareEndToEnd:

--- a/tests/web/studio/conftest.py
+++ b/tests/web/studio/conftest.py
@@ -10,10 +10,33 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
+from typing import TYPE_CHECKING
 
 import pytest
 
 from clm.web.studio.service import StudioService
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+
+def make_app(spec_path: Path, db_path: Path, token: str) -> FastAPI:
+    """Build the ``clm serve`` app wired for Studio, ready for ``TestClient``.
+
+    Exists so one place knows about ``allowed_hosts``: ``TestClient`` sends
+    ``Host: testserver``, and the production allowlist is loopback-only (the
+    DNS-rebinding guard from the 2026-07-24 review, D4), so a plain
+    ``create_app`` here answers every request with ``400 Invalid host header``.
+    """
+    from clm.web.app import create_app
+
+    return create_app(
+        db_path=db_path,
+        spec_path=spec_path,
+        studio_token=token,
+        allowed_hosts=["testserver"],
+    )
+
 
 # A single-language deck with two id'd markdown cells (distinct roles → distinct
 # keys) and one shared, id-less code cell (not per-cell addressable → read-only).

--- a/tests/web/studio/test_lock.py
+++ b/tests/web/studio/test_lock.py
@@ -14,10 +14,9 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
-from clm.web.app import create_app
 from clm.web.studio.service import LanguageLockedError, StudioService
 
-from .conftest import Bilingual, Course, record_pair
+from .conftest import Bilingual, Course, make_app, record_pair
 
 TOKEN = "test-studio-token"
 AUTH = {"Authorization": f"Bearer {TOKEN}"}
@@ -183,11 +182,7 @@ class TestLockOverHttp:
     def test_locked_write_is_423_with_reason(self, bilingual: Bilingual):
         record_pair(bilingual.de_path, bilingual.en_path)
         _dirty_de(bilingual)
-        app = create_app(
-            db_path=bilingual.slides_dir.parent / "jobs.db",
-            spec_path=bilingual.spec_path,
-            studio_token=TOKEN,
-        )
+        app = make_app(bilingual.spec_path, bilingual.slides_dir.parent / "jobs.db", TOKEN)
         client = TestClient(app)
         body = client.get(f"/api/studio/deck?id={bilingual.en_id}", headers=AUTH).json()
         assert body["lock"]["editable"] is False  # EN locked, surfaced on open

--- a/tests/web/studio/test_render_pwa.py
+++ b/tests/web/studio/test_render_pwa.py
@@ -7,11 +7,10 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from clm.web.app import create_app
 from clm.web.studio.render import render_j2_cell
 from clm.web.studio.service import StudioService
 
-from .conftest import Course
+from .conftest import Course, make_app
 
 TOKEN = "test-studio-token"
 AUTH = {"Authorization": f"Bearer {TOKEN}"}
@@ -42,11 +41,7 @@ class TestTier2Render:
 class TestRenderEndpoint:
     @pytest.fixture()
     def client(self, course: Course) -> TestClient:
-        app = create_app(
-            db_path=course.slides_dir.parent / "jobs.db",
-            spec_path=course.spec_path,
-            studio_token=TOKEN,
-        )
+        app = make_app(course.spec_path, course.slides_dir.parent / "jobs.db", TOKEN)
         return TestClient(app)
 
     def test_render_cell_expands_j2(self, client: TestClient, course: Course):
@@ -79,11 +74,7 @@ class TestRenderEndpoint:
 class TestPwaAssets:
     @pytest.fixture()
     def client(self, course: Course) -> TestClient:
-        app = create_app(
-            db_path=course.slides_dir.parent / "jobs.db",
-            spec_path=course.spec_path,
-            studio_token=TOKEN,
-        )
+        app = make_app(course.spec_path, course.slides_dir.parent / "jobs.db", TOKEN)
         return TestClient(app)
 
     def test_manifest_served(self, client: TestClient):

--- a/tests/web/studio/test_routes.py
+++ b/tests/web/studio/test_routes.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
-from clm.web.app import create_app
-
-from .conftest import Course
+from .conftest import Course, make_app
 
 TOKEN = "test-studio-token"
 AUTH = {"Authorization": f"Bearer {TOKEN}"}
@@ -15,11 +13,7 @@ AUTH = {"Authorization": f"Bearer {TOKEN}"}
 
 @pytest.fixture()
 def client(course: Course) -> TestClient:
-    app = create_app(
-        db_path=course.slides_dir.parent / "jobs.db",
-        spec_path=course.spec_path,
-        studio_token=TOKEN,
-    )
+    app = make_app(course.spec_path, course.slides_dir.parent / "jobs.db", TOKEN)
     # No `with` → lifespan (and the filesystem watcher) is not started; routes
     # work because StudioService is wired in create_app, not the lifespan.
     return TestClient(app)

--- a/tests/web/studio/test_sync.py
+++ b/tests/web/studio/test_sync.py
@@ -14,11 +14,10 @@ import sys
 import pytest
 from fastapi.testclient import TestClient
 
-from clm.web.app import create_app
 from clm.web.studio import sync_runner
 from clm.web.studio.service import InvalidStructuralOpError, StudioService
 
-from .conftest import Bilingual, Course
+from .conftest import Bilingual, Course, make_app
 
 TOKEN = "test-studio-token"
 AUTH = {"Authorization": f"Bearer {TOKEN}"}
@@ -116,11 +115,7 @@ async def _collect(bucket: list[dict], message: dict) -> None:
 class TestSyncEndpoint:
     @pytest.fixture()
     def bilingual_client(self, bilingual: Bilingual) -> TestClient:
-        app = create_app(
-            db_path=bilingual.slides_dir.parent / "jobs.db",
-            spec_path=bilingual.spec_path,
-            studio_token=TOKEN,
-        )
+        app = make_app(bilingual.spec_path, bilingual.slides_dir.parent / "jobs.db", TOKEN)
         return TestClient(app)
 
     def test_sync_starts(self, bilingual_client: TestClient, bilingual: Bilingual, monkeypatch):
@@ -148,11 +143,7 @@ class TestSyncEndpoint:
         service.end_sync(de_id)
 
     def test_sync_no_twin_is_400(self, course: Course):
-        app = create_app(
-            db_path=course.slides_dir.parent / "jobs.db",
-            spec_path=course.spec_path,
-            studio_token=TOKEN,
-        )
+        app = make_app(course.spec_path, course.slides_dir.parent / "jobs.db", TOKEN)
         client = TestClient(app)
         r = client.post("/api/studio/deck/sync", headers=AUTH, json={"deck_id": course.deck_id})
         assert r.status_code == 400

--- a/tests/web/studio/test_ws_auth.py
+++ b/tests/web/studio/test_ws_auth.py
@@ -149,6 +149,18 @@ class TestHandshakeIsAccepted:
             ws.send_json({"type": "ping"})
             assert ws.receive_json() == {"type": "pong"}
 
+    def test_a_valid_subprotocol_wins_over_a_stale_one(self, client: TestClient):
+        """Every offered ``clm-token.*`` is checked, not just the first.
+
+        A phone that re-pairs without dropping its old value offers both.
+        """
+        with client.websocket_connect(
+            "/ws",
+            subprotocols=[f"{TOKEN_SUBPROTOCOL_PREFIX}stale", f"{TOKEN_SUBPROTOCOL_PREFIX}{TOKEN}"],
+        ) as ws:
+            ws.send_json({"type": "ping"})
+            assert ws.receive_json() == {"type": "pong"}
+
     def test_a_valid_header_wins_over_a_stale_subprotocol(self, client: TestClient):
         """Checking only the first credential found would refuse a valid one.
 

--- a/tests/web/studio/test_ws_auth.py
+++ b/tests/web/studio/test_ws_auth.py
@@ -1,0 +1,149 @@
+"""``/ws`` is inside the Studio token gate, not outside it.
+
+The hole S6 named: ``/ws`` carries the ``studio`` channel, which broadcasts
+deck-change and sync-progress events for the course being served. WebSockets
+are CORS-exempt, so before this change anyone who could reach the port could
+open one, subscribe to ``studio``, and read those events — walking around the
+bearer token that :mod:`clm.web.studio.auth` calls "the real access gate".
+
+The assertions here are all of the form "the server never accepted", not "the
+server closed afterwards": once a connection is accepted it exists, and the
+client can send on it. ``ws_manager.active_connections`` is the sentinel —
+:meth:`WebSocketManager.connect` is the only caller of ``accept()``, so an
+empty set proves the refusal preceded it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from clm.web.api.websocket import TOKEN_SUBPROTOCOL_PREFIX, WS_POLICY_VIOLATION, ws_manager
+
+from .conftest import Course, make_app
+
+TOKEN = "test-studio-token"
+
+
+@pytest.fixture()
+def client(course: Course) -> TestClient:
+    app = make_app(course.spec_path, course.slides_dir.parent / "jobs.db", TOKEN)
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _no_leaked_connections():
+    ws_manager.active_connections.clear()
+    ws_manager.subscriptions.clear()
+    yield
+    ws_manager.active_connections.clear()
+    ws_manager.subscriptions.clear()
+
+
+def _refused(client: TestClient, **kwargs) -> None:
+    """Assert ``/ws`` refuses this handshake without ever accepting it."""
+    with pytest.raises(WebSocketDisconnect) as exc:
+        with client.websocket_connect("/ws", **kwargs):
+            pass
+    assert exc.value.code == WS_POLICY_VIOLATION
+    assert ws_manager.active_connections == set()
+
+
+class TestHandshakeIsGated:
+    def test_no_token_is_refused(self, client: TestClient):
+        _refused(client)
+
+    def test_wrong_token_in_subprotocol_is_refused(self, client: TestClient):
+        _refused(client, subprotocols=[f"{TOKEN_SUBPROTOCOL_PREFIX}nope"])
+
+    def test_wrong_token_in_authorization_header_is_refused(self, client: TestClient):
+        _refused(client, headers={"Authorization": "Bearer nope"})
+
+    def test_empty_subprotocol_token_is_refused(self, client: TestClient):
+        """``clm-token.`` with nothing after it must not read as "no check"."""
+        _refused(client, subprotocols=[TOKEN_SUBPROTOCOL_PREFIX])
+
+    def test_token_prefix_of_the_real_one_is_refused(self, client: TestClient):
+        """A length-truncated guess must not pass a constant-time compare."""
+        _refused(client, subprotocols=[f"{TOKEN_SUBPROTOCOL_PREFIX}{TOKEN[:-1]}"])
+
+    def test_non_ascii_token_is_refused_not_crashed(self, client: TestClient):
+        """``secrets.compare_digest`` raises TypeError on non-ASCII ``str``.
+
+        Sent as raw bytes because that is what a hostile client does and what
+        httpx will let us express: the header arrives latin-1 decoded, so a
+        byte above 0x7F would otherwise turn a bad token into a 500 raised
+        from inside the auth check itself.
+        """
+        _refused(client, headers={b"Authorization": b"Bearer p\xe4ssword"})
+
+    def test_query_parameter_token_is_refused(self, client: TestClient):
+        """``?token=`` is deliberately not honoured on the handshake.
+
+        It works for the REST routes because the QR deep link needs it, but a
+        WebSocket reconnects on a timer — putting the token in the URL would
+        write it into the access log over and over. The PWA uses a subprotocol.
+        """
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with client.websocket_connect(f"/ws?token={TOKEN}"):
+                pass
+        assert exc.value.code == WS_POLICY_VIOLATION
+        assert ws_manager.active_connections == set()
+
+
+class TestHandshakeIsAccepted:
+    def test_token_via_subprotocol_connects(self, client: TestClient):
+        offered = f"{TOKEN_SUBPROTOCOL_PREFIX}{TOKEN}"
+        with client.websocket_connect("/ws", subprotocols=[offered]) as ws:
+            ws.send_json({"type": "ping"})
+            assert ws.receive_json() == {"type": "pong"}
+
+    def test_accepted_subprotocol_is_echoed(self, client: TestClient):
+        """A browser drops the connection if the server selects nothing.
+
+        The PWA offers exactly one subprotocol, so failing to echo it would
+        make every Studio connection close immediately after opening.
+        """
+        offered = f"{TOKEN_SUBPROTOCOL_PREFIX}{TOKEN}"
+        with client.websocket_connect("/ws", subprotocols=[offered]) as ws:
+            assert ws.accepted_subprotocol == offered
+
+    def test_token_via_authorization_header_connects(self, client: TestClient):
+        """Non-browser clients (scripts, tests) can use the ordinary header."""
+        with client.websocket_connect("/ws", headers={"Authorization": f"Bearer {TOKEN}"}) as ws:
+            ws.send_json({"type": "ping"})
+            assert ws.receive_json() == {"type": "pong"}
+
+    def test_authenticated_client_may_subscribe_to_studio(self, client: TestClient):
+        offered = f"{TOKEN_SUBPROTOCOL_PREFIX}{TOKEN}"
+        with client.websocket_connect("/ws", subprotocols=[offered]) as ws:
+            ws.send_json({"action": "subscribe", "channels": ["studio"]})
+            assert ws.receive_json() == {"type": "subscribed", "channels": ["studio"]}
+
+
+class TestStudioRoutesAreOriginGuarded:
+    """The HTTP half: a cross-origin page must not drive a Studio write."""
+
+    def test_cross_origin_post_is_refused(self, client: TestClient, course: Course):
+        r = client.post(
+            "/api/studio/deck/render-cell",
+            headers={
+                "Authorization": f"Bearer {TOKEN}",
+                "Origin": "https://evil.example",
+            },
+            json={"deck_id": course.deck_id, "body": "# hi", "is_j2": False},
+        )
+        assert r.status_code == 403
+        assert "cross-origin" in r.text
+
+    def test_same_origin_post_still_works(self, client: TestClient, course: Course):
+        r = client.post(
+            "/api/studio/deck/render-cell",
+            headers={
+                "Authorization": f"Bearer {TOKEN}",
+                "Origin": "http://testserver",
+            },
+            json={"deck_id": course.deck_id, "body": "# hi", "is_j2": False},
+        )
+        assert r.status_code == 200

--- a/tests/web/studio/test_ws_auth.py
+++ b/tests/web/studio/test_ws_auth.py
@@ -92,6 +92,40 @@ class TestHandshakeIsGated:
         assert ws_manager.active_connections == set()
 
 
+class TestStudioWithoutATokenFailsClosed:
+    """A Studio app built without a token must not be *more* open than with one.
+
+    ``create_app`` takes ``spec_path`` and ``studio_token`` independently, and
+    the lifespan starts the disk watcher on the spec alone — so in this state
+    the ``studio`` channel is broadcasting while nothing can authenticate. The
+    REST routes already fail closed here (``require_token`` rejects on
+    ``not expected``); ``/ws`` gates on the same condition so the two surfaces
+    cannot disagree. The CLI never produces this state; ``create_app`` is a
+    public constructor that can.
+    """
+
+    @pytest.fixture()
+    def tokenless(self, course: Course) -> TestClient:
+        from clm.web.app import create_app
+
+        app = create_app(
+            db_path=course.slides_dir.parent / "jobs.db",
+            spec_path=course.spec_path,
+            allowed_hosts=["testserver"],
+        )
+        return TestClient(app)
+
+    def test_rest_rejects(self, tokenless: TestClient):
+        assert tokenless.get("/api/studio/decks").status_code == 401
+
+    def test_ws_rejects_too(self, tokenless: TestClient):
+        _refused(tokenless)
+
+    def test_no_token_at_all_does_not_authenticate(self, tokenless: TestClient):
+        """Presenting *some* token must not match an absent expected one."""
+        _refused(tokenless, subprotocols=[f"{TOKEN_SUBPROTOCOL_PREFIX}anything"])
+
+
 class TestHandshakeIsAccepted:
     def test_token_via_subprotocol_connects(self, client: TestClient):
         offered = f"{TOKEN_SUBPROTOCOL_PREFIX}{TOKEN}"
@@ -112,6 +146,20 @@ class TestHandshakeIsAccepted:
     def test_token_via_authorization_header_connects(self, client: TestClient):
         """Non-browser clients (scripts, tests) can use the ordinary header."""
         with client.websocket_connect("/ws", headers={"Authorization": f"Bearer {TOKEN}"}) as ws:
+            ws.send_json({"type": "ping"})
+            assert ws.receive_json() == {"type": "pong"}
+
+    def test_a_valid_header_wins_over_a_stale_subprotocol(self, client: TestClient):
+        """Checking only the first credential found would refuse a valid one.
+
+        A debugging client that copies the PWA's subprotocol list and *also*
+        sets ``Authorization`` should authenticate on the good half.
+        """
+        with client.websocket_connect(
+            "/ws",
+            subprotocols=[f"{TOKEN_SUBPROTOCOL_PREFIX}stale"],
+            headers={"Authorization": f"Bearer {TOKEN}"},
+        ) as ws:
             ws.send_json({"type": "ping"})
             assert ws.receive_json() == {"type": "pong"}
 

--- a/tests/web/test_api_integration.py
+++ b/tests/web/test_api_integration.py
@@ -28,6 +28,9 @@ class TestAPIEndpoints:
             db_path=test_db,
             host="127.0.0.1",
             port=8000,
+            # TestClient sends ``Host: testserver``; the production default
+            # allowlist is loopback-only, so without this every request 400s.
+            allowed_hosts=["testserver"],
         )
 
         return TestClient(app)

--- a/tests/web/test_app.py
+++ b/tests/web/test_app.py
@@ -12,6 +12,18 @@ from fastapi.testclient import TestClient
 from clm.__version__ import __version__
 
 
+def _middleware_names(app) -> list[str]:
+    """Names of the middleware classes installed on ``app``."""
+    return [m.cls.__name__ for m in app.user_middleware]
+
+
+def _middleware_named(app, name: str):
+    """Return the single installed middleware whose class is ``name``."""
+    matches = [m for m in app.user_middleware if m.cls.__name__ == name]
+    assert len(matches) == 1, f"expected exactly one {name}, got {_middleware_names(app)}"
+    return matches[0]
+
+
 class TestCreateApp:
     """Test create_app function."""
 
@@ -58,27 +70,45 @@ class TestCreateApp:
         assert hasattr(app.state, "monitor_service")
         assert isinstance(app.state.monitor_service, MonitorService)
 
-    def test_create_app_default_cors(self, tmp_path):
-        """Should add CORS middleware with default origins."""
+    def test_create_app_installs_no_cors_by_default(self, tmp_path):
+        """Default is *no* CORS middleware — a same-origin app needs none.
+
+        The old default was ``allow_origins=["*"]`` with
+        ``allow_credentials=True``, which makes Starlette echo whichever Origin
+        asked (S6 of the 2026-07-24 review).
+        """
         from clm.web.app import create_app
 
         db_path = tmp_path / "test.db"
         app = create_app(db_path)
 
-        # Check that CORS middleware was added
-        middleware_classes = [type(m).__name__ for m in app.user_middleware]
-        # Note: CORS middleware is wrapped, so we check it exists via routes
-        assert app is not None
+        assert "CORSMiddleware" not in _middleware_names(app)
 
     def test_create_app_custom_cors(self, tmp_path):
-        """Should accept custom CORS origins."""
+        """A named origin installs CORS, with credentials allowed."""
         from clm.web.app import create_app
 
         db_path = tmp_path / "test.db"
         app = create_app(db_path, cors_origins=["http://localhost:3000"])
 
-        # App should be created without error
-        assert app is not None
+        cors = _middleware_named(app, "CORSMiddleware")
+        assert cors.kwargs["allow_origins"] == ["http://localhost:3000"]
+        assert cors.kwargs["allow_credentials"] is True
+
+    def test_wildcard_cors_drops_credentials(self, tmp_path):
+        """``*`` and credentials cannot be combined — credentials lose.
+
+        Honouring both is what made the wildcard dangerous: Starlette echoes
+        the requesting Origin, which legalises credentialed cross-origin reads.
+        """
+        from clm.web.app import create_app
+
+        db_path = tmp_path / "test.db"
+        app = create_app(db_path, cors_origins=["*"])
+
+        cors = _middleware_named(app, "CORSMiddleware")
+        assert cors.kwargs["allow_origins"] == ["*"]
+        assert cors.kwargs["allow_credentials"] is False
 
     def test_create_app_includes_api_router(self, tmp_path):
         """Should include API router with endpoints."""
@@ -100,7 +130,7 @@ class TestDefaultFrontend:
         from clm.web.app import create_app
 
         db_path = tmp_path / "test.db"
-        app = create_app(db_path)
+        app = create_app(db_path, allowed_hosts=["testserver"])
 
         client = TestClient(app, raise_server_exceptions=False)
 

--- a/tests/web/test_serve_security.py
+++ b/tests/web/test_serve_security.py
@@ -152,13 +152,19 @@ class TestChannelAllowlist:
             ws.send_json({"action": "subscribe", "channels": ["jobss"]})
             assert ws.receive_json() == {"type": "subscribed", "channels": []}
 
+    def test_known_channels_are_pinned(self):
+        """``KNOWN_CHANNELS`` is the subscription control — pin it both ways.
+
+        Widening it is what would let a client subscribe to something new, so
+        the set should not change without a test changing with it.
+        """
+        assert KNOWN_CHANNELS == {"status", "workers", "jobs", "studio"}
+
     def test_every_broadcast_channel_is_subscribable(self):
         """A channel nothing can subscribe to is a broadcast into the void.
 
-        Derived from the source rather than restated as a constant: the
-        allowlist and the ``broadcast(..., channel=...)`` call sites are two
-        lists that must agree, and a test that only re-asserts the constant
-        would not notice a new call site at all.
+        Complements the pin above by reading the *call sites*: the two lists
+        must agree, and the pin alone would not notice a new broadcast.
         """
         import re
         from pathlib import Path
@@ -167,13 +173,19 @@ class TestChannelAllowlist:
 
         broadcast = set()
         for path in Path(web_pkg.__file__).parent.rglob("*.py"):
+            # Skip the module that defines KNOWN_CHANNELS: its own
+            # `channel="status"` would keep the non-empty guard below satisfied
+            # even if the pattern stopped matching everywhere else, quietly
+            # turning this test vacuous.
+            if path.name == "websocket.py":
+                continue
             source = path.read_text(encoding="utf-8")
             broadcast.update(re.findall(r"""channel=["']([a-z_]+)["']""", source))
             # The studio sites go through a module constant rather than a
             # literal, so pick that up too.
             broadcast.update(re.findall(r"""^[A-Z_]*CHANNEL = ["']([a-z_]+)["']""", source, re.M))
 
-        assert broadcast, "found no broadcast channels — did the regex stop matching?"
+        assert broadcast, "found no broadcast channels — did the pattern stop matching?"
         assert broadcast <= KNOWN_CHANNELS, (
             f"not subscribable: {sorted(broadcast - KNOWN_CHANNELS)}"
         )

--- a/tests/web/test_serve_security.py
+++ b/tests/web/test_serve_security.py
@@ -152,16 +152,112 @@ class TestChannelAllowlist:
             ws.send_json({"action": "subscribe", "channels": ["jobss"]})
             assert ws.receive_json() == {"type": "subscribed", "channels": []}
 
-    def test_known_channels_cover_every_broadcast_channel(self):
-        """Guard against a new broadcast channel that no client can subscribe to.
+    def test_every_broadcast_channel_is_subscribable(self):
+        """A channel nothing can subscribe to is a broadcast into the void.
 
-        The allowlist and the broadcast sites are two lists that must agree;
-        this fails when someone adds to one and not the other.
+        Derived from the source rather than restated as a constant: the
+        allowlist and the ``broadcast(..., channel=...)`` call sites are two
+        lists that must agree, and a test that only re-asserts the constant
+        would not notice a new call site at all.
         """
-        from clm.web.studio.sync_runner import SYNC_CHANNEL
+        import re
+        from pathlib import Path
 
-        assert SYNC_CHANNEL in KNOWN_CHANNELS
-        assert KNOWN_CHANNELS == {"status", "workers", "jobs", "studio"}
+        import clm.web as web_pkg
+
+        broadcast = set()
+        for path in Path(web_pkg.__file__).parent.rglob("*.py"):
+            source = path.read_text(encoding="utf-8")
+            broadcast.update(re.findall(r"""channel=["']([a-z_]+)["']""", source))
+            # The studio sites go through a module constant rather than a
+            # literal, so pick that up too.
+            broadcast.update(re.findall(r"""^[A-Z_]*CHANNEL = ["']([a-z_]+)["']""", source, re.M))
+
+        assert broadcast, "found no broadcast channels — did the regex stop matching?"
+        assert broadcast <= KNOWN_CHANNELS, (
+            f"not subscribable: {sorted(broadcast - KNOWN_CHANNELS)}"
+        )
+
+
+class TestAllowedOrigins:
+    """``--allowed-origin`` must actually authorize a browser on that origin."""
+
+    def test_allowlisted_origin_may_open_ws_cross_site(self, tmp_path):
+        from clm.web.app import create_app
+
+        app = create_app(
+            tmp_path / "jobs.db",
+            allowed_hosts=["testserver"],
+            allowed_origins=["https://front.example"],
+        )
+        client = TestClient(app)
+        with client.websocket_connect(
+            "/ws",
+            headers={"Origin": "https://front.example", "Sec-Fetch-Site": "cross-site"},
+        ) as ws:
+            ws.send_json({"type": "ping"})
+            assert ws.receive_json() == {"type": "pong"}
+
+    def test_cors_origin_also_authorizes_driving(self, tmp_path):
+        """The folding `--cors-origin` performs is not decorative.
+
+        Without it the operator gets a successful preflight and a 403 on the
+        request behind it, which is the confusing dead end the flag exists to
+        avoid.
+        """
+        from clm.web.app import create_app
+
+        app = create_app(
+            tmp_path / "jobs.db",
+            allowed_hosts=["testserver"],
+            cors_origins=["https://front.example"],
+        )
+        client = TestClient(app)
+        with client.websocket_connect(
+            "/ws",
+            headers={"Origin": "https://front.example", "Sec-Fetch-Site": "cross-site"},
+        ) as ws:
+            ws.send_json({"type": "ping"})
+            assert ws.receive_json() == {"type": "pong"}
+
+    def test_unlisted_origin_is_still_refused(self, tmp_path):
+        from clm.web.app import create_app
+
+        app = create_app(
+            tmp_path / "jobs.db",
+            allowed_hosts=["testserver"],
+            allowed_origins=["https://front.example"],
+        )
+        client = TestClient(app)
+        with pytest.raises(WebSocketDisconnect):
+            with client.websocket_connect(
+                "/ws",
+                headers={"Origin": "https://evil.example", "Sec-Fetch-Site": "cross-site"},
+            ):
+                pass
+        assert ws_manager.active_connections == set()
+
+    def test_unusable_cors_origin_is_warned_about(self, tmp_path, caplog):
+        """A scheme-less origin matches nothing in either consumer."""
+        import logging
+
+        from clm.web.app import create_app
+
+        with caplog.at_level(logging.WARNING, logger="clm.web.app"):
+            create_app(tmp_path / "jobs.db", cors_origins=["localhost:3000"])
+
+        assert "not a valid origin" in caplog.text
+
+    def test_trailing_slash_cors_origin_is_warned_about(self, tmp_path, caplog):
+        """It widens the guard but never matches what a browser sends."""
+        import logging
+
+        from clm.web.app import create_app
+
+        with caplog.at_level(logging.WARNING, logger="clm.web.app"):
+            create_app(tmp_path / "jobs.db", cors_origins=["https://x.example/"])
+
+        assert "does not match what a browser sends" in caplog.text
 
 
 class TestNoStudioNoToken:
@@ -178,3 +274,16 @@ class TestNoStudioNoToken:
         with client.websocket_connect("/ws") as ws:
             ws.send_json({"type": "ping"})
             assert ws.receive_json() == {"type": "pong"}
+
+    def test_an_offered_token_subprotocol_is_still_echoed(self, app):
+        """RFC 6455: a client that offered protocols and got none selected fails.
+
+        A Studio PWA cached on a phone keeps offering ``clm-token.<stale>``. If
+        a plain ``clm serve`` accepts it while selecting nothing, the browser
+        closes the connection the instant it opens — and the client's reconnect
+        loop makes that permanent, with no diagnostic on either side.
+        """
+        offered = "clm-token.whatever"
+        client = TestClient(app)
+        with client.websocket_connect("/ws", subprotocols=[offered]) as ws:
+            assert ws.accepted_subprotocol == offered

--- a/tests/web/test_serve_security.py
+++ b/tests/web/test_serve_security.py
@@ -1,0 +1,180 @@
+"""Browser containment for ``clm serve`` (S6 + D4 of the 2026-07-24 review).
+
+Three separate holes are pinned here, because closing any one of them alone
+leaves the dashboard reachable:
+
+- **CORS**: the default was ``allow_origins=["*"]`` *with*
+  ``allow_credentials=True``, which makes Starlette echo whichever ``Origin``
+  asked — strictly worse than a literal ``*``, since it legalises credentialed
+  cross-origin reads.
+- **Host**: no ``TrustedHostMiddleware``, so a DNS-rebinding page reached the
+  app as a genuinely same-origin caller.
+- **WebSocket**: ``/ws`` is CORS-exempt by protocol, so a cross-origin page
+  could open it where the equivalent ``fetch`` was impossible, and then
+  subscribe to any channel name it liked.
+
+The Studio token half of ``/ws`` lives in ``studio/test_ws_auth.py``, which has
+the fixtures to build a Studio-enabled app.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from clm.web.api.websocket import KNOWN_CHANNELS, WS_POLICY_VIOLATION, ws_manager
+
+
+@pytest.fixture()
+def app(tmp_path):
+    from clm.web.app import create_app
+
+    return create_app(tmp_path / "jobs.db", allowed_hosts=["testserver"])
+
+
+@pytest.fixture(autouse=True)
+def _no_leaked_connections():
+    """Fail loudly if a test leaves a connection on the module-global manager.
+
+    ``ws_manager`` is a module global, so a refused handshake that nonetheless
+    registered would otherwise leak into the next test instead of failing this
+    one — and "did the server accept?" is exactly what these tests assert.
+    """
+    ws_manager.active_connections.clear()
+    ws_manager.subscriptions.clear()
+    yield
+    ws_manager.active_connections.clear()
+    ws_manager.subscriptions.clear()
+
+
+class TestHostAllowlist:
+    """The Host header must name this server — this is the anti-rebinding guard."""
+
+    def test_unknown_host_is_refused(self, app):
+        client = TestClient(app, base_url="http://evil.example")
+        r = client.get("/api/health")
+        assert r.status_code == 400
+        assert "Invalid host header" in r.text
+
+    # ``[::1]`` is deliberately absent: Starlette's own TestClient splits the
+    # netloc as ``netloc.split(":", 1)`` and dies on a bracketed IPv6 literal,
+    # so it cannot express the request. The server side of that case is
+    # covered directly in ``tests/infrastructure/test_web_security.py``.
+    @pytest.mark.parametrize("host", ["localhost", "127.0.0.1"])
+    def test_loopback_hosts_are_accepted(self, tmp_path, host):
+        from clm.web.app import create_app
+
+        client = TestClient(create_app(tmp_path / "jobs.db"), base_url=f"http://{host}:8000")
+        assert client.get("/api/health").status_code == 200
+
+    def test_operator_named_host_is_accepted(self, tmp_path):
+        from clm.web.app import create_app
+
+        app = create_app(tmp_path / "jobs.db", allowed_hosts=["box.tail1234.ts.net"])
+        client = TestClient(app, base_url="http://box.tail1234.ts.net")
+        assert client.get("/api/health").status_code == 200
+
+    def test_bind_host_is_folded_into_the_allowlist(self, tmp_path):
+        """A deliberate ``--host 192.168.1.5`` must not 400 its own address."""
+        from clm.web.app import create_app
+
+        app = create_app(tmp_path / "jobs.db", host="192.168.1.5")
+        client = TestClient(app, base_url="http://192.168.1.5:8000")
+        assert client.get("/api/health").status_code == 200
+
+    def test_wildcard_disables_the_check(self, tmp_path):
+        from clm.web.app import create_app
+
+        app = create_app(tmp_path / "jobs.db", allowed_hosts=["*"])
+        client = TestClient(app, base_url="http://anything.example")
+        assert client.get("/api/health").status_code == 200
+
+
+class TestWebSocketOriginGuard:
+    """WebSockets bypass CORS, so the guard has to sit on the handshake."""
+
+    def test_cross_origin_handshake_is_refused(self, app):
+        client = TestClient(app)
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with client.websocket_connect("/ws", headers={"Origin": "https://evil.example"}):
+                pass
+        assert exc.value.code == WS_POLICY_VIOLATION
+        # The refusal must precede accept(): if the server had accepted, the
+        # connection would be registered even though it was closed after.
+        assert ws_manager.active_connections == set()
+
+    def test_cross_site_fetch_metadata_is_refused(self, app):
+        client = TestClient(app)
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with client.websocket_connect("/ws", headers={"Sec-Fetch-Site": "cross-site"}):
+                pass
+        assert exc.value.code == WS_POLICY_VIOLATION
+        assert ws_manager.active_connections == set()
+
+    def test_rebound_host_is_refused_even_though_same_origin(self, app):
+        """The rebinding case: Origin and Host agree, and both are the attacker's.
+
+        An origin check alone cannot catch this — the page genuinely *is*
+        same-origin once DNS points ``evil.example`` at 127.0.0.1. Only the
+        host allowlist closes it.
+        """
+        client = TestClient(app, base_url="http://evil.example")
+        with pytest.raises(WebSocketDisconnect) as exc:
+            with client.websocket_connect("/ws", headers={"Origin": "http://evil.example"}):
+                pass
+        assert exc.value.code == WS_POLICY_VIOLATION
+        assert ws_manager.active_connections == set()
+
+    def test_same_origin_handshake_is_accepted(self, app):
+        client = TestClient(app)
+        with client.websocket_connect(
+            "/ws",
+            headers={"Origin": "http://testserver", "Sec-Fetch-Site": "same-origin"},
+        ) as ws:
+            ws.send_json({"type": "ping"})
+            assert ws.receive_json() == {"type": "pong"}
+
+
+class TestChannelAllowlist:
+    """``subscribe`` used to store whatever name it was handed."""
+
+    def test_unknown_channel_is_not_subscribed(self, app):
+        client = TestClient(app)
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json({"action": "subscribe", "channels": ["jobs", "../../etc/passwd"]})
+            assert ws.receive_json() == {"type": "subscribed", "channels": ["jobs"]}
+
+    def test_reply_reports_what_was_subscribed_not_what_was_asked(self, app):
+        """A typo must not read as success and then go silent forever."""
+        client = TestClient(app)
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json({"action": "subscribe", "channels": ["jobss"]})
+            assert ws.receive_json() == {"type": "subscribed", "channels": []}
+
+    def test_known_channels_cover_every_broadcast_channel(self):
+        """Guard against a new broadcast channel that no client can subscribe to.
+
+        The allowlist and the broadcast sites are two lists that must agree;
+        this fails when someone adds to one and not the other.
+        """
+        from clm.web.studio.sync_runner import SYNC_CHANNEL
+
+        assert SYNC_CHANNEL in KNOWN_CHANNELS
+        assert KNOWN_CHANNELS == {"status", "workers", "jobs", "studio"}
+
+
+class TestNoStudioNoToken:
+    def test_ws_is_open_when_no_studio_token_is_configured(self, app):
+        """Without ``--spec`` there is no token concept — the guards are the gate.
+
+        This mirrors ``clm recordings serve``: the monitoring surface is
+        entirely unauthenticated (every ``/api`` route is a plain GET), so
+        token-gating only the WebSocket would be theatre. Pinned so the
+        asymmetry is a decision rather than an accident.
+        """
+        assert app.state.__dict__.get("studio_token") is None
+        client = TestClient(app)
+        with client.websocket_connect("/ws") as ws:
+            ws.send_json({"type": "ping"})
+            assert ws.receive_json() == {"type": "pong"}


### PR DESCRIPTION
Phase 2, item 3 of the adversarial-review remediation plan
(`docs/claude/handovers/adversarial-review-remediation-handover.md`).
Closes finding **S6** under decision **D4**.

## What was wrong

Three independent holes, none of which is closed by fixing another:

1. **CORS.** `web/app.py` defaulted `cors_origins` to `["*"]` *with*
   `allow_credentials=True`. Starlette resolves that combination by echoing
   whichever `Origin` asked — strictly worse than a literal wildcard, because
   it makes credentialed cross-origin reads legal.
2. **Host.** No `TrustedHostMiddleware`. An origin check alone cannot catch
   DNS rebinding: once `evil.example` resolves to `127.0.0.1`, the attacker's
   page *is* same-origin. What it cannot fake is `Host`.
3. **WebSocket.** `/ws` broadcasts the `studio` channel — deck-change and
   sync-progress events for the served course — and WebSockets are exempt from
   CORS by protocol. So the bearer token that `studio/auth.py` calls "the real
   access gate" guarded every `/api/studio` route but not the stream those
   routes drive. `subscribe` also stored whatever channel name it was handed.

## What changed

Reuses `install_web_security()` unchanged; it was written app-agnostic for
exactly this case, and its `OriginGuardMiddleware` already covers WebSocket
handshakes. New `--allowed-host` / `--allowed-origin` flags mirror
`clm recordings serve`, including the `remote_access_warning` on a wildcard
bind.

CORS now installs no middleware by default. An explicit `--cors-origin` is
honoured and also authorizes that origin in the guard — naming an origin for
one and not the other would leave a caller with a working preflight and a 403
behind it.

`/ws` requires the Studio token before `accept()` when `--spec` configured
one. Browsers cannot set an `Authorization` header on a WebSocket, so the PWA
presents it as the `clm-token.<token>` subprotocol; unlike `?token=`, that
keeps the secret out of the access log across the client's 3-second reconnect
loop. Scripts may still use `Authorization: Bearer`. Subscriptions are
restricted to `status`/`workers`/`jobs`/`studio`, and the reply now reports
what was *subscribed to* rather than what was asked for.

## Two bugs found on the way

- **`/ws` has never worked.** Its route function took an unannotated
  `websocket` parameter, so FastAPI analysed it as a required *query*
  parameter and closed every handshake with
  `{"loc": ["query", "websocket"], "msg": "Field required"}`. The Studio's
  "changed on disk — reload" banner and its live sync line therefore never
  fired. Worth stating precisely: this means S6's WebSocket hole was real in
  code but unreachable through the mounted route — and fixing the route is
  what makes the token check load-bearing rather than theoretical.
- **`secrets.compare_digest` raises `TypeError` on non-ASCII `str`.** Headers
  arrive latin-1 decoded, so one byte above `0x7F` turned a bad token into a
  500 raised from inside `token_matches`. Now compares encoded bytes, still
  constant-time.

## Decision made in flight (please object if you disagree)

**Without `--spec`, `/ws` stays open** — the host and origin guards are the
gate, exactly as for `clm recordings serve`. There is no token concept for the
plain Monitor at all (every `/api` route is an unauthenticated GET), so
token-gating only the WebSocket would be friction without a gain.
`TestNoStudioNoToken` pins this so it reads as a decision, not an oversight.

## Checks

- `pytest -q -n 8` — **8834 passed**, 7 skipped, 1 xfailed (94s)
- `ruff check src/ tests/` — clean; `ruff format` — clean
- `mypy src/clm/web/ src/clm/cli/commands/serve.py` — clean
- `clm serve --help` renders the new flags

27 new tests across `tests/web/test_serve_security.py` (host allowlist,
rebinding, WS origin guard, channel allowlist) and
`tests/web/studio/test_ws_auth.py` (token gate, subprotocol echo, cross-origin
studio POST). Every refusal asserts `ws_manager.active_connections == set()`,
not merely that an exception was raised — `connect()` is the only caller of
`accept()`, so an empty set is what proves the refusal *preceded* the accept.

## Docs

Per the info-topic maintenance rule: `commands.md` (new flags + a browser
containment section) and `migration.md` (the `Host` allowlist and the
`--cors-origin` default are breaking for remote users). Changelog fragments in
`changelog.d/`, not `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG954qREDhNpPSFnHhVeQ8
