### PR TITLE
security(studio): sandbox the cell render, escape quotes, drop ?token= (S7)

### DIFF
--- a/changelog.d/696-studio-render-sandbox.fixed.md
+++ b/changelog.d/696-studio-render-sandbox.fixed.md
@@ -1,0 +1,8 @@
+- **Removed the Studio's dead tier-2 preview path.** `renderJ2()` was gated on
+  `cell.cell_type === "markdown"`, but the API types a Jinja cell as
+  `cell_type: "j2"` (a `markdown` cell always has `is_j2 === false`), so the
+  branch had been unreachable since it was written — and what it contained was
+  an unescaped `innerHTML` assignment of a server response. The server-side
+  endpoint is live, sandboxed and tested; only the in-page consumer is gone.
+  Wiring it up needs a decision about sanitizing macro-emitted HTML, so it is
+  tracked as issue #697 rather than fixed in passing.

--- a/changelog.d/696-studio-render-sandbox.security.md
+++ b/changelog.d/696-studio-render-sandbox.security.md
@@ -2,7 +2,8 @@
   `POST /api/studio/deck/render-cell` rendered its request body through a plain
   `jinja2.Environment`, so a template could read `__class__` and walk out of
   the template namespace from there — server-side template injection, verified
-  against the real function. It now renders in a `SandboxedEnvironment`. The
+  against the real function. It now renders in an
+  `ImmutableSandboxedEnvironment`. The
   module advertised itself as the "no-execution" render tier while doing this;
   the claim is now accurate about what it means (no *kernel*, not no code).
   Legitimate previews are unaffected — the bundled header macros for all five
@@ -26,12 +27,20 @@
   and relative URLs, with control characters stripped before the scheme is
   judged (browsers strip them when resolving, so `java&#9;script:` would
   otherwise slip past and then execute).
-- **The cell preview can no longer be used to exhaust memory or stall the
-  server.** Blocking attribute traversal says nothing about size:
-  `{{ "A" * 200000000 }}` allocated 200 MB in about a second, and the route
-  rendered inline on the event loop, so one request from any token holder
-  stalled every other request and the disk watcher. Sequence repetition is now
-  bounded, the output has a cap, and the render runs in a worker thread.
+- **The cell preview is bounded in size and no longer runs on the event
+  loop.** Blocking attribute traversal says nothing about how big a render
+  gets: `{{ "A" * 200000000 }}` allocated 200 MB in about a second, and the
+  route rendered inline, so one request from any token holder stalled every
+  other request and the disk watcher. Sequence repetition and `+` are now
+  refused before they allocate, the rendered output is bounded *as it
+  accumulates* (a 500-iteration loop of individually-legal emits went from a
+  100 MB peak to 1.1 MB), and the render runs in a worker thread. **This is
+  not a claim that the preview is DoS-proof**: `~` cannot be intercepted
+  without a process-wide monkeypatch of `jinja2.runtime` that would also
+  change how the build renders decks, and nested loops burn CPU without
+  allocating. A client holding the Studio token can still exhaust the process
+  — accepted, because the token is the trust boundary and that client can
+  already rewrite any deck.
 - **The Studio service worker cached the app shell forever.** `sw.js` only
   re-installs when its own bytes change and `activate` only drops caches whose
   *name* differs, but the shell handler was pure cache-first — so `app.js`,

--- a/changelog.d/696-studio-render-sandbox.security.md
+++ b/changelog.d/696-studio-render-sandbox.security.md
@@ -34,13 +34,15 @@
   other request and the disk watcher. Sequence repetition and `+` are now
   refused before they allocate, the rendered output is bounded *as it
   accumulates* (a 500-iteration loop of individually-legal emits went from a
-  100 MB peak to 1.1 MB), and the render runs in a worker thread. **This is
-  not a claim that the preview is DoS-proof**: `~` cannot be intercepted
-  without a process-wide monkeypatch of `jinja2.runtime` that would also
-  change how the build renders decks, and nested loops burn CPU without
-  allocating. A client holding the Studio token can still exhaust the process
-  — accepted, because the token is the trust boundary and that client can
-  already rewrite any deck.
+  100 MB peak to 1.1 MB), `~` is redirected at compile time via
+  `code_generator_class` (a doubling payload went from ~1.2 GB to 5.2 MB), and
+  the render runs in a worker thread. Each needs a different hook because
+  Jinja routes the three differently — in particular `~` compiles to a
+  `Concat` node that neither `intercepted_binops` nor `environment.concat` can
+  see. **This is not a claim that the preview is DoS-proof**: nothing bounds
+  *iteration*, so nested loops still burn CPU without allocating. A client
+  holding the Studio token can still stall the process — accepted, because the
+  token is the trust boundary and that client can already rewrite any deck.
 - **The Studio service worker cached the app shell forever.** `sw.js` only
   re-installs when its own bytes change and `activate` only drops caches whose
   *name* differs, but the shell handler was pure cache-first — so `app.js`,

--- a/changelog.d/696-studio-render-sandbox.security.md
+++ b/changelog.d/696-studio-render-sandbox.security.md
@@ -1,0 +1,26 @@
+- **The Studio cell preview no longer runs arbitrary Python.**
+  `POST /api/studio/deck/render-cell` rendered its request body through a plain
+  `jinja2.Environment`, so a template could read `__class__` and walk out of
+  the template namespace from there — server-side template injection, verified
+  against the real function. It now renders in a `SandboxedEnvironment`. The
+  module advertised itself as the "no-execution" render tier while doing this;
+  the claim is now accurate about what it means (no *kernel*, not no code).
+  Legitimate previews are unaffected — the bundled header macros for all five
+  shipped languages render unchanged.
+- **The Studio API no longer accepts `?token=`.** A URL is the worst place for
+  a credential that does not expire: it reaches uvicorn's access log, any
+  proxy's, browser history, and the `Referer` of outbound links. Only
+  `Authorization: Bearer` is accepted now (and, on `/ws`, the `clm-token.…`
+  subprotocol). Nothing needed the query form — the pairing deep link targets
+  the unauthenticated `/studio/` static mount and is read by the frontend.
+- **The QR pairing URL moved the token into the fragment**
+  (`/studio/#token=…`). Browsers never send a fragment to the server, so
+  pairing itself no longer writes the token into a log. The QR is reprinted on
+  every launch, so there is nothing to migrate.
+- **The Studio frontend escapes quotes.** `esc()` handled `&`, `<` and `>` but
+  not `"`, and its output is interpolated into `<a href="…">` before reaching
+  `innerHTML` — so a markdown link target could close the attribute and add an
+  event handler. Link targets are also restricted to `http`, `https`, `mailto`
+  and relative URLs, with control characters stripped before the scheme is
+  judged (browsers strip them when resolving, so `java&#9;script:` would
+  otherwise slip past and then execute).

--- a/changelog.d/696-studio-render-sandbox.security.md
+++ b/changelog.d/696-studio-render-sandbox.security.md
@@ -15,8 +15,10 @@
   the unauthenticated `/studio/` static mount and is read by the frontend.
 - **The QR pairing URL moved the token into the fragment**
   (`/studio/#token=…`). Browsers never send a fragment to the server, so
-  pairing itself no longer writes the token into a log. The QR is reprinted on
-  every launch, so there is nothing to migrate.
+  pairing no longer writes the token into uvicorn's access log, a proxy's, or
+  an outbound `Referer`. Browser *history* still records it — a fragment is
+  stored there like a query string — so that half is unchanged. The QR is
+  reprinted on every launch, so there is nothing to migrate.
 - **The Studio frontend escapes quotes.** `esc()` handled `&`, `<` and `>` but
   not `"`, and its output is interpolated into `<a href="…">` before reaching
   `innerHTML` — so a markdown link target could close the attribute and add an
@@ -24,3 +26,18 @@
   and relative URLs, with control characters stripped before the scheme is
   judged (browsers strip them when resolving, so `java&#9;script:` would
   otherwise slip past and then execute).
+- **The cell preview can no longer be used to exhaust memory or stall the
+  server.** Blocking attribute traversal says nothing about size:
+  `{{ "A" * 200000000 }}` allocated 200 MB in about a second, and the route
+  rendered inline on the event loop, so one request from any token holder
+  stalled every other request and the disk watcher. Sequence repetition is now
+  bounded, the output has a cap, and the render runs in a worker thread.
+- **The Studio service worker cached the app shell forever.** `sw.js` only
+  re-installs when its own bytes change and `activate` only drops caches whose
+  *name* differs, but the shell handler was pure cache-first — so `app.js`,
+  which had changed three times under `clm-studio-shell-v1`, was served from
+  cache indefinitely. Any already-installed PWA would have kept running the
+  pre-fix frontend and, because the pairing URL moved, would have been unable
+  to re-pair. The cache name is bumped and the shell now uses
+  stale-while-revalidate, so a future missed bump costs one stale load rather
+  than permanent staleness.

--- a/docs/claude/design/mobile-deck-studio.md
+++ b/docs/claude/design/mobile-deck-studio.md
@@ -110,6 +110,13 @@ Each of these was an explicit fork resolved during design.
   already authenticated; the app stores the token (localStorage) and sends it on
   every API/WS call. One token, full access — anyone on the tailnet could reach
   the URL, so the token is the real gate.
+  **Amended (S7, 2026-07-26):** the QR URL carries the token in the URL
+  *fragment* (`/studio/#token=…`), not a query string, because a fragment is
+  never sent to the server and so cannot reach an access log; and the server no
+  longer accepts `?token=` as an API credential at all — only
+  `Authorization: Bearer`, plus the `clm-token.<token>` subprotocol on `/ws`.
+  Nothing needed the query form: the deep link targets the unauthenticated
+  `/studio/` static mount, where the token is read by the frontend.
 
 ### 3.3 Scope & navigation
 

--- a/docs/claude/design/mobile-deck-studio.md
+++ b/docs/claude/design/mobile-deck-studio.md
@@ -227,7 +227,7 @@ structural op. No naïve whole-file re-emit.
    initial phase plan.
 
 - **Inline toggle = hybrid:** tier 1 for plain markdown, tier 2 for `is_j2` cells.
-- **"Build preview" button = tier 2 (fast no-exec) only, for now.** The full
+- **"Build preview" button = tier 2 (fast, kernel-free) only, for now.** The full
   executed build (tier 3) is left for a later phase.
 
 ---
@@ -241,7 +241,7 @@ structural op. No naïve whole-file re-emit.
 | **P2** ✅ | **Structural ops** (`insert` / `delete` / `move` / mint-id) via the byte-exact serializer; reorder mode in the UI; byte-exact untouched-cell tests. *(Implemented — see §9.7.)* |
 | **P3a** ✅ | **Bilingual lock core**: language toggle (switch to the split twin) + watermark-derived lock (read-only `build_sync_plan`) + stale badges + **423** enforcement on every write. *(Implemented — see §9.8.)* |
 | **P3b** ✅ | **Sync-to-other-language**: a streamed server-side `clm slides sync` subprocess (LLM reconciliation) over WS; the lock releases when it completes. *(Implemented — see §9.9. **Discard & unlock deferred** by decision: its revert is git-coupled and risky — use the desktop.)* |
-| **P4** ✅ | **Tier-2 preview** (no-exec Jinja macro/header expansion per cell) + tier-1 comment-prefix fix + **installable PWA** + **read-only offline cache** of opened decks. *(Implemented — see §9.10. Editor de-prefix ergonomics deferred.)* |
+| **P4** ✅ | **Tier-2 preview** (kernel-free Jinja macro/header expansion per cell) + tier-1 comment-prefix fix + **installable PWA** + **read-only offline cache** of opened decks. *(Implemented — see §9.10. Editor de-prefix ergonomics deferred.)* |
 | **Later / optional** | **Full executed single-deck build** (tier 3) for code outputs and rendered diagrams. |
 
 ---
@@ -276,14 +276,14 @@ REST under `/api/decks` (course pre-scoped per server instance):
 | `GET /api/decks` | Tree + recents + "not in spec"; status/coverage badges. |
 | `GET /api/decks/search?q=` | Full-text search (reuses `slides search`). |
 | `GET /api/decks/{id}?lang=` | Cells (with `content_hash`), `deck_version`, lock state. |
-| `POST /api/decks/{id}/render-cell` | Tier-2 no-exec render of one `is_j2` cell. |
+| `POST /api/decks/{id}/render-cell` | Tier-2 kernel-free (sandboxed Jinja) render of one `is_j2` cell. |
 | `PATCH /api/decks/{id}/cells/{slide_id}` | `edit-body` / `edit-tags` (optimistic). |
 | `POST /api/decks/{id}/cells` | `insert` (mints id). |
 | `DELETE /api/decks/{id}/cells/{slide_id}` | `delete`. |
 | `POST /api/decks/{id}/reorder` | `move`. |
 | `POST /api/decks/{id}/sync` | Propagate source → other language (streamed via WS). |
 | `POST /api/decks/{id}/discard` | Discard in-session edits, unlock. |
-| `POST /api/decks/{id}/preview` | Tier-2 no-exec deck render (P4). |
+| `POST /api/decks/{id}/preview` | Tier-2 kernel-free deck render (P4). |
 
 WS `/ws` events: `deck-updated` (after any write, for other tabs),
 `deck-changed-on-disk` (watcher), `sync-progress` / `preview-progress`.
@@ -424,7 +424,7 @@ taken while building, several resolving open calls left by §9.1–§9.5:
   app's *own* save back to the phone as an external "changed on disk" event.
 - **Tier-2 render scaffolded:** the working preview is **tier-1 client-side
   markdown**. `POST /api/studio/deck/render-cell` exists but echoes the body
-  with `rendered=false`; wiring the jupytext+Jinja no-exec expansion for
+  with `rendered=false`; wiring the jupytext+Jinja kernel-free expansion for
   `is_j2` cells is a focused follow-up (still inside the P0 design scope).
 - **WS auth:** ~~REST is fully token-gated; the shared `/ws` endpoint is not
   yet token-checked. Gating WS without disrupting the Monitor channel is a

--- a/src/clm/cli/commands/serve.py
+++ b/src/clm/cli/commands/serve.py
@@ -161,7 +161,12 @@ def serve(
         from clm.web.studio import qr
 
         display_host = host if host != "0.0.0.0" else "localhost"
-        studio_url = f"http://{display_host}:{port}/studio/?token={studio_token}"
+        # The token rides in the URL *fragment*: browsers never send a fragment
+        # to the server, so pairing cannot write the token into uvicorn's
+        # access log, a proxy's, or an outbound Referer. `/studio/` itself is
+        # an unauthenticated static mount — the frontend reads the token from
+        # the fragment and stores it, then uses the Authorization header.
+        studio_url = f"http://{display_host}:{port}/studio/#token={studio_token}"
         click.echo("")
         click.echo(f"Mobile Deck Studio: {studio_url}")
         if qr.is_available():

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -4398,10 +4398,11 @@ authenticate with `Authorization: Bearer` only; `?token=` is **not** accepted
 a Jinja sandbox: it expands the bundled header macros without a kernel, and a
 template cannot walk Python attributes (`__class__` and friends) out of the
 template namespace, nor repeat a sequence into a memory bomb. The sandbox does
-not restrict the template *loader*, so `{% include %}` can still read a file
-sitting next to the deck — path traversal out of the deck's directory is
-refused, but a secret parked beside a slide is readable by anyone holding the
-Studio token.
+not restrict the template *loader*, so `{% include %}` can still read files.
+Traversal out of the deck's directory is refused, but the reach is that
+directory **and its whole subtree, dotfiles included** — so anything parked
+beside a deck (a `.env`, a sidecar subdir, a `.clm/` ledger) is readable by
+anyone holding the Studio token.
 
 This is the P0/P1 slice (read-only browse + the cell-editing concurrency core).
 Structural insert/delete/move, the bilingual language lock + sync-to-other-

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -4387,7 +4387,16 @@ rather than a silent clobber. A filesystem watcher also pushes a
 "changed on disk — reload" signal over the WebSocket. On startup the command
 prints the Studio URL and a scannable QR code carrying a persistent bearer
 token; for phone access over Tailscale, run `tailscale serve` so the PWA gets a
-trusted HTTPS origin.
+trusted HTTPS origin, and pass `--allowed-host <your-tailnet-name>` so the
+dashboard accepts the proxied `Host`.
+
+The QR URL carries the token in the URL **fragment** (`/studio/#token=…`),
+which browsers never transmit — so pairing cannot write the token into
+uvicorn's access log, a proxy's, or an outbound `Referer`. API calls
+authenticate with `Authorization: Bearer` only; `?token=` is **not** accepted
+(it was, until CLM {version}). The server-side `is_j2` cell preview renders in
+a Jinja sandbox: it expands the bundled header macros without a kernel, and
+templates cannot reach out of the template namespace.
 
 This is the P0/P1 slice (read-only browse + the cell-editing concurrency core).
 Structural insert/delete/move, the bilingual language lock + sync-to-other-

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -4395,8 +4395,13 @@ which browsers never transmit — so pairing cannot write the token into
 uvicorn's access log, a proxy's, or an outbound `Referer`. API calls
 authenticate with `Authorization: Bearer` only; `?token=` is **not** accepted
 (it was, until CLM {version}). The server-side `is_j2` cell preview renders in
-a Jinja sandbox: it expands the bundled header macros without a kernel, and
-templates cannot reach out of the template namespace.
+a Jinja sandbox: it expands the bundled header macros without a kernel, and a
+template cannot walk Python attributes (`__class__` and friends) out of the
+template namespace, nor repeat a sequence into a memory bomb. The sandbox does
+not restrict the template *loader*, so `{% include %}` can still read a file
+sitting next to the deck — path traversal out of the deck's directory is
+refused, but a secret parked beside a slide is readable by anyone holding the
+Studio token.
 
 This is the P0/P1 slice (read-only browse + the cell-editing concurrency core).
 Structural insert/delete/move, the bilingual language lock + sync-to-other-

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -2,6 +2,31 @@
 
 This guide covers breaking changes across major CLM versions.
 
+## Mobile Deck Studio no longer accepts `?token=` ({version})
+
+**Breaking only for a custom client.** The bundled PWA is unaffected — it has
+always sent `Authorization: Bearer` on every API call, and it reads the pairing
+token out of the URL itself.
+
+`GET /api/studio/…?token=<token>` now answers `401`. A URL is the worst place
+for a credential that never expires: it lands in uvicorn's access log, in any
+proxy's, in browser history, and in the `Referer` of anything the page links
+out to. Send the header instead:
+
+```
+Authorization: Bearer <token>
+```
+
+On `/ws`, where a browser cannot set a header, use the `clm-token.<token>`
+subprotocol.
+
+Relatedly, the QR pairing URL changed from `/studio/?token=…` to
+`/studio/#token=…`. A fragment is never transmitted to the server, so pairing
+now leaks nothing into the logs. The QR is reprinted on every `clm serve
+--spec`, so there is nothing to migrate — rescan if a phone ever loses its
+pairing. The frontend still reads a `?token=` it finds in the URL, so an old
+bookmark keeps working for pairing purposes.
+
 ## `clm serve` only answers to a `Host` that names it, and `--cors-origin` no longer defaults to `*` ({version})
 
 **Breaking only if you reach the dashboard from another machine, or relied on

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -22,7 +22,10 @@ subprotocol.
 
 Relatedly, the QR pairing URL changed from `/studio/?token=…` to
 `/studio/#token=…`. A fragment is never transmitted to the server, so pairing
-now leaks nothing into the logs. The QR is reprinted on every `clm serve
+no longer writes the token into uvicorn's access log, a proxy's, or an
+outbound `Referer`. It does **not** hide the token from *browser* history —
+fragments are recorded (and synced) there just as query strings are — so a
+shared phone still warrants `--rotate-token`. The QR is reprinted on every `clm serve
 --spec`, so there is nothing to migrate — rescan if a phone ever loses its
 pairing. The frontend still reads a `?token=` it finds in the URL, so an old
 bookmark keeps working for pairing purposes.

--- a/src/clm/web/static/studio/app.js
+++ b/src/clm/web/static/studio/app.js
@@ -67,7 +67,8 @@ function esc(s) {
     .replace(/'/g, "&#39;");
 }
 
-// A markdown link target may not smuggle in a scripting scheme.
+// A markdown link target may not smuggle in a scripting scheme, nor point
+// off-origin without one.
 //
 // The cleaning mirrors how a browser parses a URL, deliberately and no more
 // than that: tab/CR/LF are removed *anywhere*, and C0 controls or spaces are
@@ -83,10 +84,13 @@ function safeUrl(u) {
   if (/^[a-z][a-z0-9+.\-]*:/i.test(cleaned)) {
     return /^(https?|mailto):/i.test(cleaned) ? cleaned : "#";
   }
-  // `//host` carries no scheme, but the browser supplies the page's — so it
-  // is a live off-origin navigation from a deck's link target, on a page
-  // holding a non-expiring bearer token. Relative paths and fragments are fine.
-  if (cleaned.startsWith("//")) return "#";
+  // No scheme in the string, but the browser supplies the page's — so an
+  // authority-relative target is a live off-origin navigation from a deck's
+  // link, on a page holding a non-expiring bearer token. WHATWG parsing
+  // treats `\` as `/` for http(s), so `/\evil.example` and `\\evil.example`
+  // reach evil.example just as `//evil.example` does; all four leading-pair
+  // combinations have to go. Ordinary relative paths and fragments are fine.
+  if (/^[/\\]{2}/.test(cleaned)) return "#";
   return cleaned;
 }
 function renderMarkdown(src) {

--- a/src/clm/web/static/studio/app.js
+++ b/src/clm/web/static/studio/app.js
@@ -11,15 +11,24 @@
 
 const TOKEN_KEY = "clm_studio_token";
 
-// --- token: from ?token= (QR deep link) then localStorage ---------------------
+// --- token: from #token= (QR deep link) then localStorage ---------------------
+// The QR code carries the token in the URL *fragment*, not the query string: a
+// fragment is never sent to the server, so it cannot land in uvicorn's access
+// log or in a proxy's. `?token=` is still read here for a link somebody
+// bookmarked or typed before the switch — that costs nothing on the client,
+// and the server no longer accepts it as an API credential either way.
 function resolveToken() {
   const url = new URL(window.location.href);
+  const fromHash = new URLSearchParams(url.hash.replace(/^#/, "")).get("token");
   const fromQuery = url.searchParams.get("token");
-  if (fromQuery) {
-    localStorage.setItem(TOKEN_KEY, fromQuery);
+  const paired = fromHash || fromQuery;
+  if (paired) {
+    localStorage.setItem(TOKEN_KEY, paired);
     url.searchParams.delete("token");
-    window.history.replaceState({}, "", url.pathname + url.hash);
-    return fromQuery;
+    // Drop the fragment as well as the query: leaving it would keep the token
+    // on screen in the address bar and in this history entry.
+    window.history.replaceState({}, "", url.pathname + url.search);
+    return paired;
   }
   return localStorage.getItem(TOKEN_KEY) || "";
 }
@@ -43,8 +52,31 @@ async function api(path, opts = {}) {
 }
 
 // --- tiny markdown renderer (tier-1 client preview) ---------------------------
+// Quotes are escaped too. Every caller interpolates the result into an HTML
+// string that reaches innerHTML, and inline() puts it inside href="…" — so
+// leaving `"` intact let a link target close the attribute and add its own
+// (S7 of the 2026-07-24 review). Deck text is not attacker-controlled in the
+// usual sense, but it is the one thing this app renders, and a cell body is
+// exactly what a compromised or shared course repo would carry.
 function esc(s) {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// A markdown link target may not smuggle in a scripting scheme. Control
+// characters are stripped *before* the scheme test because browsers strip them
+// when resolving a URL, so `java\tscript:` would otherwise pass a naive check
+// and then execute.
+function safeUrl(u) {
+  const cleaned = u.replace(/[\u0000-\u0020\u007f]/g, "").trim();
+  if (/^[a-z][a-z0-9+.\-]*:/i.test(cleaned)) {
+    return /^(https?|mailto):/i.test(cleaned) ? cleaned : "#";
+  }
+  return cleaned; // relative, fragment, or protocol-relative — no scheme to abuse
 }
 function renderMarkdown(src) {
   const lines = src.split("\n");
@@ -74,7 +106,10 @@ function inline(s) {
   return esc(s)
     .replace(/`([^`]+)`/g, "<code>$1</code>")
     .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
-    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>');
+    .replace(
+      /\[([^\]]+)\]\(([^)]+)\)/g,
+      (_m, text, url) => `<a href="${safeUrl(url)}" target="_blank" rel="noopener">${text}</a>`
+    );
 }
 
 // --- comment-prefix handling (CLM markdown is `# `/`// ` prefixed in the .py) --

--- a/src/clm/web/static/studio/app.js
+++ b/src/clm/web/static/studio/app.js
@@ -67,16 +67,27 @@ function esc(s) {
     .replace(/'/g, "&#39;");
 }
 
-// A markdown link target may not smuggle in a scripting scheme. Control
-// characters are stripped *before* the scheme test because browsers strip them
-// when resolving a URL, so `java\tscript:` would otherwise pass a naive check
-// and then execute.
+// A markdown link target may not smuggle in a scripting scheme.
+//
+// The cleaning mirrors how a browser parses a URL, deliberately and no more
+// than that: tab/CR/LF are removed *anywhere*, and C0 controls or spaces are
+// trimmed from both ends. Doing less lets `java<TAB>script:` through, because
+// the browser strips the tab when it resolves the URL. Doing more is wrong
+// too: JS `.trim()` also eats U+00A0/U+2028/U+FEFF, which browsers do *not*
+// strip, so trimming those could promote a string the browser reads as a
+// relative path into one it reads as a scheme.
 function safeUrl(u) {
-  const cleaned = u.replace(/[\u0000-\u0020\u007f]/g, "").trim();
+  const cleaned = u
+    .replace(/[\u0009\u000a\u000d]/g, "")
+    .replace(/^[\u0000-\u0020]+|[\u0000-\u0020]+$/g, "");
   if (/^[a-z][a-z0-9+.\-]*:/i.test(cleaned)) {
     return /^(https?|mailto):/i.test(cleaned) ? cleaned : "#";
   }
-  return cleaned; // relative, fragment, or protocol-relative — no scheme to abuse
+  // `//host` carries no scheme, but the browser supplies the page's — so it
+  // is a live off-origin navigation from a deck's link target, on a page
+  // holding a non-expiring bearer token. Relative paths and fragments are fine.
+  if (cleaned.startsWith("//")) return "#";
+  return cleaned;
 }
 function renderMarkdown(src) {
   const lines = src.split("\n");
@@ -125,22 +136,22 @@ function stripCommentPrefix(text, token) {
   }).join("\n");
 }
 
-// Tier-2 (P4): ask the server to expand an is_j2 cell's Jinja, then inject the
-// expanded HTML (header macros emit trusted HTML from our own desktop). Falls
-// back silently to the tier-1 markdown already shown.
-function renderJ2(cell, bodyEl, token) {
-  api("/deck/render-cell", {
-    method: "POST",
-    body: JSON.stringify({ deck_id: currentDeck.deck_id, body: cell.body, is_j2: true, lang: cell.lang }),
-  }).then((res) => {
-    if (!res.rendered) return;
-    const html = stripCommentPrefix(res.body, token)
-      .split("\n")
-      .filter((l) => !l.trimStart().startsWith("%%")) // drop cell-boundary remnants
-      .join("\n");
-    bodyEl.innerHTML = html;
-  }).catch(() => {});
-}
+// Tier-2 in-page preview (P4) is NOT wired up, and the code that used to sit
+// here has been removed rather than left dormant.
+//
+// It could never run: it was gated on `cell.cell_type === "markdown"`, but the
+// API gives an is_j2 cell `cell_type === "j2"` (a `markdown` cell always has
+// `is_j2 === false`), so the branch was unreachable from the day it was
+// written. What it *did* contain was `bodyEl.innerHTML = <server response>`
+// with no escaping — the one raw-HTML sink in this file, and the exact sink
+// the S7 hardening of esc()/safeUrl() above exists to close. Keeping a latent
+// one behind a broken gate is the worst of the options.
+//
+// Wiring it up properly is a real design question, not a one-line fix: the
+// header macros legitimately emit HTML, so the answer cannot just be "escape
+// it" — it needs a decision about sanitizing macro output. Tracked as issue
+// #697. The server side (`POST /api/studio/deck/render-cell`) is
+// live, sandboxed and tested; only the in-page consumer is absent.
 
 // --- UI helpers ---------------------------------------------------------------
 const appEl = document.getElementById("app");
@@ -348,7 +359,9 @@ function cellCard(cell, idx, locked) {
     // are comment-prefixed, so strip the token for the tier-1 preview.
     const md = cell.body_format === "clean" ? cell.body : stripCommentPrefix(cell.body, token);
     body.innerHTML = renderMarkdown(md);
-    if (cell.is_j2) renderJ2(cell, body, token); // tier-2: expand macros server-side
+    // No tier-2 call here: a `markdown` cell always has is_j2 === false (the
+    // API types a j2 cell as `cell_type: "j2"`), so the condition that used to
+    // sit here was dead. See the note where renderJ2 was removed.
   } else {
     body.innerHTML = `<pre><code>${esc(cell.body)}</code></pre>`;
   }

--- a/src/clm/web/static/studio/sw.js
+++ b/src/clm/web/static/studio/sw.js
@@ -57,19 +57,40 @@ self.addEventListener("fetch", (event) => {
   // updated app.js is picked up on the next load even if SHELL_CACHE was not
   // bumped. Pure cache-first made a shell asset permanently immutable, which
   // is how a security fix ends up undeliverable.
+  //
+  // Only `resp.ok` responses are cached: storing a 404 or a 5xx from a restart
+  // would pin the error in place, which is the same failure in a new costume.
   if (url.pathname.startsWith("/studio/")) {
     event.respondWith(
       caches.match(req).then((hit) => {
-        const fresh = fetch(req)
-          .then((resp) => {
-            if (resp && resp.ok) {
-              const copy = resp.clone();
-              caches.open(SHELL_CACHE).then((cache) => cache.put(req, copy));
-            }
-            return resp;
-          })
-          .catch(() => hit); // offline: the cached copy is the answer
-        return hit || fresh;
+        const fresh = fetch(req).then((resp) => {
+          if (resp && resp.ok && resp.type !== "opaque") {
+            const copy = resp.clone();
+            return caches
+              .open(SHELL_CACHE)
+              .then((cache) => cache.put(req, copy))
+              .catch(() => {}) // quota / partial response — not worth failing over
+              .then(() => resp);
+          }
+          return resp;
+        });
+
+        if (hit) {
+          // Answer from cache *now* — that is the "stale" half, and returning
+          // `fresh` here instead would silently make this network-first and
+          // cost the offline guarantee. The revalidation continues in the
+          // background, held open by waitUntil: respondWith settles
+          // immediately, and the browser may kill the worker once every
+          // extendable event has settled, which would abort the refetch and
+          // restore the permanent staleness this handler exists to prevent.
+          event.waitUntil(fresh.catch(() => {}));
+          return hit;
+        }
+        // Cache miss: the network is the only answer, so let a failure
+        // propagate as a failed fetch rather than resolving to `undefined`
+        // (respondWith rejects on a non-Response, which surfaces as a
+        // confusing console error instead of a network error).
+        return fresh;
       })
     );
     return;

--- a/src/clm/web/static/studio/sw.js
+++ b/src/clm/web/static/studio/sw.js
@@ -14,7 +14,14 @@
  */
 "use strict";
 
-const SHELL_CACHE = "clm-studio-shell-v1";
+// Bump SHELL_CACHE whenever a shell asset changes. Changing this file's bytes
+// is what makes the browser re-run `install`, and the new cache name is what
+// makes `activate` drop the old contents — a shell asset edited without a bump
+// is served from cache forever. That is not hypothetical: app.js changed three
+// times under `-v1`, so the S7 XSS fix would have reached no installed PWA at
+// all. The stale-while-revalidate handler below is the belt to this braces —
+// it means a missed bump costs one stale load rather than permanent staleness.
+const SHELL_CACHE = "clm-studio-shell-v2";
 const API_CACHE = "clm-studio-api-v1";
 const SHELL = [
   "/studio/",
@@ -45,9 +52,26 @@ self.addEventListener("fetch", (event) => {
   if (req.method !== "GET") return; // writes pass through, never cached
   const url = new URL(req.url);
 
-  // App shell: cache-first.
+  // App shell: stale-while-revalidate. Answer from cache (instant, works
+  // offline) but always refetch in the background and store the result, so an
+  // updated app.js is picked up on the next load even if SHELL_CACHE was not
+  // bumped. Pure cache-first made a shell asset permanently immutable, which
+  // is how a security fix ends up undeliverable.
   if (url.pathname.startsWith("/studio/")) {
-    event.respondWith(caches.match(req).then((hit) => hit || fetch(req)));
+    event.respondWith(
+      caches.match(req).then((hit) => {
+        const fresh = fetch(req)
+          .then((resp) => {
+            if (resp && resp.ok) {
+              const copy = resp.clone();
+              caches.open(SHELL_CACHE).then((cache) => cache.put(req, copy));
+            }
+            return resp;
+          })
+          .catch(() => hit); // offline: the cached copy is the answer
+        return hit || fresh;
+      })
+    );
     return;
   }
 

--- a/src/clm/web/studio/auth.py
+++ b/src/clm/web/studio/auth.py
@@ -64,20 +64,25 @@ def get_or_create_token(*, rotate: bool = False) -> str:
 
 
 def extract_token(request: Request) -> str | None:
-    """Pull the presented token from a request.
+    """Pull the presented token from a request's ``Authorization`` header.
 
-    Accepts either an ``Authorization: Bearer <token>`` header (used by the
-    PWA for REST/WS calls once paired) or a ``?token=`` query parameter (used
-    by the initial QR-code deep link, which the frontend then stores).
+    **Only** the header. A ``?token=`` query parameter used to be accepted as
+    well, for the QR-code deep link — but a URL is the worst place to keep a
+    credential that never expires: it lands in uvicorn's access log, in any
+    proxy's, in browser history, and in the ``Referer`` of anything the page
+    links out to (S7 of the 2026-07-24 review).
+
+    Nothing needed it. The deep link targets ``/studio/``, which is a static
+    mount with no auth at all — the token in that URL is read by the frontend,
+    not by this function — and the PWA has always sent the header on every API
+    call. The QR now carries the token in the URL *fragment*, which is never
+    transmitted to the server, so the pairing flow leaks nothing.
     """
     auth = request.headers.get("Authorization")
     if auth:
         scheme, param = get_authorization_scheme_param(auth)
         if scheme.lower() == "bearer" and param:
             return param
-    query_token = request.query_params.get("token")
-    if query_token:
-        return query_token
     return None
 
 

--- a/src/clm/web/studio/models.py
+++ b/src/clm/web/studio/models.py
@@ -239,7 +239,7 @@ class SyncStartResult(BaseModel):
 
 
 class RenderCellRequest(BaseModel):
-    """Tier-2 (no-exec) render request for one ``is_j2`` cell (P4)."""
+    """Tier-2 (kernel-free) render request for one ``is_j2`` cell (P4)."""
 
     deck_id: str = Field(description="Slides-dir-relative deck path (for prog-lang + includes).")
     body: str = Field(description="Raw cell body (comment-prefixed, with the j2 lines).")

--- a/src/clm/web/studio/render.py
+++ b/src/clm/web/studio/render.py
@@ -21,24 +21,32 @@ Two things the sandbox does *not* give you, and what this module does about
 each. Both are stated precisely because the first attempt at them overclaimed.
 
 **Size.** A sandbox bounds attribute access and nothing else, so
-``{{ "A" * 200000000 }}`` was a one-expression memory bomb. Now bounded:
-``*`` and ``+`` are intercepted before they allocate (:data:`MAX_REPEAT`,
-:data:`MAX_OUTPUT_CHARS`), and :meth:`concat` accumulates the rendered output
-with a running check — which matters because a post-render ``len()`` bounds
-only what is *returned*: a 500-iteration loop emitting a legal 100 000
-characters each peaked at 100 MB before such a check could run. It is now
-1.1 MB. **Not** bounded: ``~``. Jinja compiles it to a ``Concat`` node, which
-is not a ``BinExpr`` (so ``intercepted_binops`` cannot see it) and which emits
-a call to ``str_join`` resolved from the compiled template's own namespace
-(so ``environment.concat`` does not see it either); the only hook left is a
-process-wide monkeypatch of ``jinja2.runtime``, which would also change how
-the *build* renders decks. So
-``{% set s = "A" * 100000 %}{% set s = s ~ s %}…`` still reaches ~1.2 GB, and
-nested ``{% for %}`` over ``range()`` still burns CPU without allocating.
-**A client holding the Studio token can therefore still exhaust this
-process.** That is accepted rather than fixed: the token is the trust boundary
-(decision D4), the same client can already rewrite any deck, and closing it
-properly means rendering in a subprocess under an rlimit — issue #698.
+``{{ "A" * 200000000 }}`` was a one-expression memory bomb. Every way of
+growing a *value* is now bounded, each needing a different hook because Jinja
+routes them differently:
+
+- ``*`` and ``+`` — ``intercepted_binops``, refused before they allocate
+  (:data:`MAX_REPEAT`, :data:`MAX_OUTPUT_CHARS`).
+- the rendered output — :meth:`concat`, accumulating with a running check.
+  This matters because a post-render ``len()`` bounds only what is *returned*:
+  a 500-iteration loop emitting an individually-legal 100 000 characters each
+  peaked at 100 MB before such a check could run, and 1.1 MB after it.
+- ``~`` — neither of the above can see it. It compiles to a ``Concat`` node,
+  which is not a ``BinExpr`` (invisible to ``intercepted_binops``) and which
+  emits ``str_join`` resolved from the compiled template's own namespace
+  (invisible to ``environment.concat``). It is redirected at compile time
+  instead, via ``code_generator_class`` — a documented per-environment
+  extension point, so the build pipeline's environments are untouched.
+  ``{% set s = "A" * 100000 %}{% set s = s ~ s %}…`` went from ~1.2 GB to
+  5.2 MB.
+
+**Still unbounded: CPU.** Nothing limits iteration, so nested ``{% for %}``
+over ``range()`` burns time without allocating, and ``run_in_threadpool``
+gives a client 40 shared threads to occupy. A token holder can still stall
+this process. That is accepted rather than fixed — the token is the trust
+boundary (decision D4) and the same client can already rewrite any deck —
+and doing it properly means rendering under a wall-clock limit in a
+subprocess, which is issue #698.
 
 **The loader.** The sandbox constrains the *template*, not the
 ``FileSystemLoader`` under it, so ``{% include %}`` still reads files. Jinja
@@ -95,18 +103,51 @@ def _preview_environment_class():
     without these a single expression is a memory bomb. See the module
     docstring for what remains unbounded and why.
     """
+    from jinja2.compiler import CodeGenerator
     from jinja2.sandbox import ImmutableSandboxedEnvironment
     from jinja2.sandbox import SecurityError as _SecurityError
 
+    def _bounded_join(iterable) -> str:  # noqa: ANN001
+        """Join ``iterable``, refusing once the running total exceeds the cap.
+
+        The point is *running*: a check after ``"".join(...)`` bounds only what
+        is returned, so a 500-iteration loop emitting an individually-legal
+        100 000 characters each peaked at 100 MB before anything looked at it.
+        """
+        parts: list[str] = []
+        total = 0
+        for part in iterable:
+            text = str(part)
+            total += len(text)
+            if total > MAX_OUTPUT_CHARS:
+                raise _SecurityError(f"preview output exceeded {MAX_OUTPUT_CHARS} characters")
+            parts.append(text)
+        return "".join(parts)
+
+    class _BoundedCodeGenerator(CodeGenerator):
+        """Route ``~`` through the environment so it can be bounded.
+
+        Stock Jinja compiles ``~`` to ``str_join((a, b))``, resolved from the
+        compiled template's own module namespace — which is why neither
+        ``intercepted_binops`` (``Concat`` is not a ``BinExpr``) nor
+        ``environment.concat`` can see it. ``code_generator_class`` is a
+        documented per-environment extension point, so redirecting the emitted
+        call is enough; the build pipeline's own environments are untouched.
+        """
+
+        def visit_Concat(self, node, frame) -> None:  # noqa: ANN001
+            self.write("environment.concat_operands((")
+            for arg in node.nodes:
+                self.visit(arg, frame)
+                self.write(", ")
+            self.write("))")
+
     class _PreviewEnvironment(ImmutableSandboxedEnvironment):
-        # `*` and `+` go through the sandbox's binop interception. `~` does
-        # NOT, and cannot: Jinja compiles it to a `Concat` node, which is not a
-        # `BinExpr` (invisible to `intercepted_binops`) and which calls
-        # `str_join` from the compiled template's own namespace (invisible to
-        # `environment.concat` too). That gap is documented in the module
-        # docstring and pinned by a test; do not add "~" here expecting it to
-        # work — it is silently inert.
+        # `*` and `+` go through the sandbox's binop interception; `~` cannot
+        # (see _BoundedCodeGenerator), so it is redirected at compile time
+        # instead. Adding "~" to this set is silently inert — don't.
         intercepted_binops = frozenset({"*", "+"})
+        code_generator_class = _BoundedCodeGenerator
 
         def call_binop(self, context, operator, left, right):  # noqa: ANN001
             if operator == "*":
@@ -117,25 +158,24 @@ def _preview_environment_class():
             return super().call_binop(context, operator, left, right)
 
         def concat(self, iterable) -> str:  # noqa: ANN001
-            """Join with a running bound, refusing before the total is built.
+            """Bound the rendered output as it accumulates.
 
-            Jinja calls this once per render, over the root render function's
-            generator, so it is the one place that sees output growth
-            incrementally. Checking ``len()`` after ``"".join(...)`` — which is
-            what this replaced — bounds only what is *returned*: a
-            500-iteration loop each emitting a legal 100 000 characters peaked
-            at 100 MB before the check ran, and 1.1 MB after this.
-
-            (It does **not** see ``~``; that goes to ``str_join``. See above.)
+            Jinja emits ``concat = environment.concat`` into the root render
+            function *and* every block, macro, ``{% filter %}`` and ``{% call %}``
+            body — so this runs once per output buffer, not once per render.
+            Each call bounds its own buffer and the root call still sees the
+            grand total, so the effect is a stricter bound, not a leaky one.
             """
-            parts: list[str] = []
-            total = 0
-            for part in iterable:
-                total += len(part)
-                if total > MAX_OUTPUT_CHARS:
-                    raise _SecurityError(f"preview output exceeded {MAX_OUTPUT_CHARS} characters")
-                parts.append(part)
-            return "".join(parts)
+            return _bounded_join(iterable)
+
+        def concat_operands(self, iterable) -> str:  # noqa: ANN001
+            """Bound a ``~`` expression. Emitted by :class:`_BoundedCodeGenerator`.
+
+            Separate from :meth:`concat` only because this one receives
+            arbitrary operands rather than already-rendered strings; both
+            stringify, so the shared join handles it.
+            """
+            return _bounded_join(iterable)
 
     def _size_of(value) -> int | None:  # noqa: ANN001
         """Length of a sequence whose growth is worth bounding, else ``None``.

--- a/src/clm/web/studio/render.py
+++ b/src/clm/web/studio/render.py
@@ -17,20 +17,39 @@ in the server. It now renders in an
 :class:`~jinja2.sandbox.ImmutableSandboxedEnvironment`, which blocks the
 attribute traversal those escapes depend on.
 
-Two limits that the sandbox does *not* give you, and this module adds:
+Two things the sandbox does *not* give you, and what this module does about
+each. Both are stated precisely because the first attempt at them overclaimed.
 
-- **Size.** A sandbox bounds attribute access and nothing else, so
-  ``{{ "A" * 200000000 }}`` was a one-expression memory bomb. Repetition is
-  intercepted (:data:`MAX_REPEAT`) and the output is capped
-  (:data:`MAX_OUTPUT_CHARS`). The caller runs this off the event loop.
-- **The loader.** ``SandboxedEnvironment`` constrains the *template*, not the
-  ``FileSystemLoader`` under it, so ``{% include %}`` still reads files next to
-  the deck. Jinja refuses traversal out of that directory (``..`` and absolute
-  paths), and ``_resolve_deck_id`` pins the deck under the slides dir, so the
-  reach is "a file sitting beside a slide" — not nothing, but bounded.
+**Size.** A sandbox bounds attribute access and nothing else, so
+``{{ "A" * 200000000 }}`` was a one-expression memory bomb. Now bounded:
+``*`` and ``+`` are intercepted before they allocate (:data:`MAX_REPEAT`,
+:data:`MAX_OUTPUT_CHARS`), and :meth:`concat` accumulates the rendered output
+with a running check — which matters because a post-render ``len()`` bounds
+only what is *returned*: a 500-iteration loop emitting a legal 100 000
+characters each peaked at 100 MB before such a check could run. It is now
+1.1 MB. **Not** bounded: ``~``. Jinja compiles it to a ``Concat`` node, which
+is not a ``BinExpr`` (so ``intercepted_binops`` cannot see it) and which emits
+a call to ``str_join`` resolved from the compiled template's own namespace
+(so ``environment.concat`` does not see it either); the only hook left is a
+process-wide monkeypatch of ``jinja2.runtime``, which would also change how
+the *build* renders decks. So
+``{% set s = "A" * 100000 %}{% set s = s ~ s %}…`` still reaches ~1.2 GB, and
+nested ``{% for %}`` over ``range()`` still burns CPU without allocating.
+**A client holding the Studio token can therefore still exhaust this
+process.** That is accepted rather than fixed: the token is the trust boundary
+(decision D4), the same client can already rewrite any deck, and closing it
+properly means rendering in a subprocess under an rlimit — issue #698.
 
-And the boundary is not unlimited in the usual sense either: a sandbox escape
-is a sandbox escape, and the token remains the access gate.
+**The loader.** The sandbox constrains the *template*, not the
+``FileSystemLoader`` under it, so ``{% include %}`` still reads files. Jinja
+refuses traversal out of the loader's root (``..``, absolute paths, and the
+backslash forms), and ``_resolve_deck_id`` pins the deck under the slides dir
+— but the root is the deck's directory *and its whole subtree*, dotfiles
+included. Anything parked beside a deck (a ``.env``, a sidecar subdir) is
+readable by a token holder.
+
+And the sandbox boundary is not unlimited in the usual sense either: a sandbox
+escape is a sandbox escape, and the token remains the access gate.
 
 This is best-effort preview: any Jinja error (a macro that needs build-only
 context, a missing include, a sandbox refusal) is caught and returned as
@@ -71,32 +90,86 @@ def _preview_environment_class():
 
     ``ImmutableSandboxedEnvironment`` rather than the mutable one — Jinja's own
     recommendation for untrusted template text, and nothing here needs to call
-    a mutating method. On top of that it intercepts ``*``: the sandbox bounds
-    *attribute access* and nothing else, so sequence repetition is left as a
-    one-expression memory bomb.
+    a mutating method. On top of that it adds the size bounds the sandbox does
+    not provide: a sandbox constrains *attribute access* and nothing else, so
+    without these a single expression is a memory bomb. See the module
+    docstring for what remains unbounded and why.
     """
     from jinja2.sandbox import ImmutableSandboxedEnvironment
     from jinja2.sandbox import SecurityError as _SecurityError
 
     class _PreviewEnvironment(ImmutableSandboxedEnvironment):
-        intercepted_binops = frozenset({"*"})
+        # `*` and `+` go through the sandbox's binop interception. `~` does
+        # NOT, and cannot: Jinja compiles it to a `Concat` node, which is not a
+        # `BinExpr` (invisible to `intercepted_binops`) and which calls
+        # `str_join` from the compiled template's own namespace (invisible to
+        # `environment.concat` too). That gap is documented in the module
+        # docstring and pinned by a test; do not add "~" here expecting it to
+        # work — it is silently inert.
+        intercepted_binops = frozenset({"*", "+"})
 
         def call_binop(self, context, operator, left, right):  # noqa: ANN001
             if operator == "*":
                 _refuse_oversized_repeat(left, right)
                 _refuse_oversized_repeat(right, left)
+            else:
+                _refuse_oversized_concat(left, right)
             return super().call_binop(context, operator, left, right)
+
+        def concat(self, iterable) -> str:  # noqa: ANN001
+            """Join with a running bound, refusing before the total is built.
+
+            Jinja calls this once per render, over the root render function's
+            generator, so it is the one place that sees output growth
+            incrementally. Checking ``len()`` after ``"".join(...)`` — which is
+            what this replaced — bounds only what is *returned*: a
+            500-iteration loop each emitting a legal 100 000 characters peaked
+            at 100 MB before the check ran, and 1.1 MB after this.
+
+            (It does **not** see ``~``; that goes to ``str_join``. See above.)
+            """
+            parts: list[str] = []
+            total = 0
+            for part in iterable:
+                total += len(part)
+                if total > MAX_OUTPUT_CHARS:
+                    raise _SecurityError(f"preview output exceeded {MAX_OUTPUT_CHARS} characters")
+                parts.append(part)
+            return "".join(parts)
+
+    def _size_of(value) -> int | None:  # noqa: ANN001
+        """Length of a sequence whose growth is worth bounding, else ``None``.
+
+        Numbers and ``None`` return ``None``: they cannot grow, and treating
+        them as sized would make ordinary arithmetic pay for this check.
+        """
+        if isinstance(value, str | bytes | list | tuple):
+            return len(value)
+        return None
 
     def _refuse_oversized_repeat(sequence, count) -> None:  # noqa: ANN001
         """Raise before ``sequence * count`` allocates, not after."""
-        if not isinstance(sequence, str | bytes | list | tuple):
+        size = _size_of(sequence)
+        if size is None:
             return
         if isinstance(count, bool) or not isinstance(count, int):
             return
-        if count > MAX_REPEAT or len(sequence) * max(count, 0) > MAX_OUTPUT_CHARS:
+        if count > MAX_REPEAT or size * max(count, 0) > MAX_OUTPUT_CHARS:
             raise _SecurityError(
-                f"refusing to repeat a {len(sequence)}-item sequence {count} times "
+                f"refusing to repeat a {size}-item sequence {count} times "
                 f"(preview limit: {MAX_REPEAT} repeats / {MAX_OUTPUT_CHARS} characters)"
+            )
+
+    def _refuse_oversized_concat(left, right) -> None:  # noqa: ANN001
+        """Raise before ``left ~ right`` / ``left + right`` allocates."""
+        left_size, right_size = _size_of(left), _size_of(right)
+        if left_size is None and right_size is None:
+            return  # numeric addition — nothing to bound
+        total = (left_size or 0) + (right_size or 0)
+        if total > MAX_OUTPUT_CHARS:
+            raise _SecurityError(
+                f"refusing to build a {total}-item value "
+                f"(preview limit: {MAX_OUTPUT_CHARS} characters)"
             )
 
     return _PreviewEnvironment

--- a/src/clm/web/studio/render.py
+++ b/src/clm/web/studio/render.py
@@ -1,4 +1,4 @@
-"""Tier-2 (no-execution) cell render — design §3.8.
+"""Tier-2 cell render — design §3.8.
 
 Expands the Jinja in an ``is_j2`` cell (header macros, ``{{ … }}`` expressions)
 server-side using the **same** bundled ``macros.j2`` and line-statement prefix as
@@ -6,11 +6,24 @@ the build pipeline, but **without a kernel** — so the phone sees an expanded
 header instead of raw ``{{ header_de("…") }}``. Plain (non-j2) cells need no
 round-trip; the client renders their markdown directly (tier 1).
 
+**"No-execution" means no kernel, not no code.** This tier used to be described
+as the no-execution one, which was wrong in the way that matters: Jinja
+rendering *is* execution, and on a plain ``Environment`` a template can walk
+``__class__``/``__mro__`` out of the template namespace and reach anything the
+process can. The 2026-07-24 adversarial review (S7) reproduced that against
+this function — the body being rendered is a **request body**, not a file from
+the course repo, so a client with the Studio token could run arbitrary Python
+in the server. It now renders in a :class:`~jinja2.sandbox.SandboxedEnvironment`,
+which blocks the attribute traversal those escapes depend on. That is a real
+boundary but not an unlimited one: a sandbox escape is a sandbox escape, and
+the token remains the access gate.
+
 This is best-effort preview: any Jinja error (a macro that needs build-only
-context, a missing include) is caught and returned as ``ok=False`` with the body
-unchanged, so the preview degrades to tier-1 rather than failing. It also runs
-with a **lenient** ``Undefined`` (not the build's ``StrictUndefined``) so a
-missing course variable renders empty instead of raising — preview, not parity.
+context, a missing include, a sandbox refusal) is caught and returned as
+``ok=False`` with the body unchanged, so the preview degrades to tier-1 rather
+than failing. It also runs with a **lenient** ``Undefined`` (not the build's
+``StrictUndefined``) so a missing course variable renders empty instead of
+raising — preview, not parity.
 """
 
 from __future__ import annotations
@@ -34,7 +47,8 @@ def render_j2_cell(deck_path: Path, body: str, lang: str | None) -> tuple[bool, 
     raises — a preview must not crash the request.
     """
     try:
-        from jinja2 import ChoiceLoader, Environment, FileSystemLoader, PackageLoader
+        from jinja2 import ChoiceLoader, FileSystemLoader, PackageLoader
+        from jinja2.sandbox import SandboxedEnvironment
 
         from clm.infrastructure.utils.path_utils import path_to_prog_lang
         from clm.workers.notebook.utils.prog_lang_utils import jinja_prefix_for
@@ -52,7 +66,10 @@ def render_j2_cell(deck_path: Path, body: str, lang: str | None) -> tuple[bool, 
         if deck_dir.exists():
             # Lets the cell `{% include %}` a sibling file shown in a slide.
             loaders.append(FileSystemLoader(str(deck_dir)))
-        env = Environment(
+        # Sandboxed, not plain: `body` is a request body. See the module
+        # docstring — a plain Environment lets a template reach `__class__` and
+        # walk out of the template namespace.
+        env = SandboxedEnvironment(
             loader=ChoiceLoader(loaders) if len(loaders) > 1 else loaders[0],
             autoescape=False,
             line_statement_prefix=jinja_prefix_for(prog_lang),

--- a/src/clm/web/studio/render.py
+++ b/src/clm/web/studio/render.py
@@ -13,10 +13,24 @@ rendering *is* execution, and on a plain ``Environment`` a template can walk
 process can. The 2026-07-24 adversarial review (S7) reproduced that against
 this function — the body being rendered is a **request body**, not a file from
 the course repo, so a client with the Studio token could run arbitrary Python
-in the server. It now renders in a :class:`~jinja2.sandbox.SandboxedEnvironment`,
-which blocks the attribute traversal those escapes depend on. That is a real
-boundary but not an unlimited one: a sandbox escape is a sandbox escape, and
-the token remains the access gate.
+in the server. It now renders in an
+:class:`~jinja2.sandbox.ImmutableSandboxedEnvironment`, which blocks the
+attribute traversal those escapes depend on.
+
+Two limits that the sandbox does *not* give you, and this module adds:
+
+- **Size.** A sandbox bounds attribute access and nothing else, so
+  ``{{ "A" * 200000000 }}`` was a one-expression memory bomb. Repetition is
+  intercepted (:data:`MAX_REPEAT`) and the output is capped
+  (:data:`MAX_OUTPUT_CHARS`). The caller runs this off the event loop.
+- **The loader.** ``SandboxedEnvironment`` constrains the *template*, not the
+  ``FileSystemLoader`` under it, so ``{% include %}`` still reads files next to
+  the deck. Jinja refuses traversal out of that directory (``..`` and absolute
+  paths), and ``_resolve_deck_id`` pins the deck under the slides dir, so the
+  reach is "a file sitting beside a slide" — not nothing, but bounded.
+
+And the boundary is not unlimited in the usual sense either: a sandbox escape
+is a sandbox escape, and the token remains the access gate.
 
 This is best-effort preview: any Jinja error (a macro that needs build-only
 context, a missing include, a sandbox refusal) is caught and returned as
@@ -38,6 +52,55 @@ logger = logging.getLogger(__name__)
 _PREVIEW_AUTHOR = "Preview"
 _PREVIEW_ORG = ""
 
+#: Largest sequence repetition a preview template may ask for. Blocking
+#: attribute traversal does nothing about ``{{ "A" * 200000000 }}``, which
+#: allocates 200 MB in about a second — measured — and then again for the JSON
+#: response. The body is client-supplied, so this is the cheapest denial of
+#: service in the app and needs its own bound.
+MAX_REPEAT = 100_000
+
+#: Largest render output returned. Backstop for any other way of growing the
+#: output (nested loops, a macro over a long list) that the repeat cap misses.
+MAX_OUTPUT_CHARS = 1_000_000
+
+
+def _preview_environment_class():
+    """Return the sandboxed Environment subclass used for previews.
+
+    Built lazily so this module keeps importing without jinja2 installed.
+
+    ``ImmutableSandboxedEnvironment`` rather than the mutable one — Jinja's own
+    recommendation for untrusted template text, and nothing here needs to call
+    a mutating method. On top of that it intercepts ``*``: the sandbox bounds
+    *attribute access* and nothing else, so sequence repetition is left as a
+    one-expression memory bomb.
+    """
+    from jinja2.sandbox import ImmutableSandboxedEnvironment
+    from jinja2.sandbox import SecurityError as _SecurityError
+
+    class _PreviewEnvironment(ImmutableSandboxedEnvironment):
+        intercepted_binops = frozenset({"*"})
+
+        def call_binop(self, context, operator, left, right):  # noqa: ANN001
+            if operator == "*":
+                _refuse_oversized_repeat(left, right)
+                _refuse_oversized_repeat(right, left)
+            return super().call_binop(context, operator, left, right)
+
+    def _refuse_oversized_repeat(sequence, count) -> None:  # noqa: ANN001
+        """Raise before ``sequence * count`` allocates, not after."""
+        if not isinstance(sequence, str | bytes | list | tuple):
+            return
+        if isinstance(count, bool) or not isinstance(count, int):
+            return
+        if count > MAX_REPEAT or len(sequence) * max(count, 0) > MAX_OUTPUT_CHARS:
+            raise _SecurityError(
+                f"refusing to repeat a {len(sequence)}-item sequence {count} times "
+                f"(preview limit: {MAX_REPEAT} repeats / {MAX_OUTPUT_CHARS} characters)"
+            )
+
+    return _PreviewEnvironment
+
 
 def render_j2_cell(deck_path: Path, body: str, lang: str | None) -> tuple[bool, str | None, str]:
     """Expand the Jinja in ``body`` for ``deck_path``. Returns ``(ok, error, text)``.
@@ -48,7 +111,6 @@ def render_j2_cell(deck_path: Path, body: str, lang: str | None) -> tuple[bool, 
     """
     try:
         from jinja2 import ChoiceLoader, FileSystemLoader, PackageLoader
-        from jinja2.sandbox import SandboxedEnvironment
 
         from clm.infrastructure.utils.path_utils import path_to_prog_lang
         from clm.workers.notebook.utils.prog_lang_utils import jinja_prefix_for
@@ -69,7 +131,7 @@ def render_j2_cell(deck_path: Path, body: str, lang: str | None) -> tuple[bool, 
         # Sandboxed, not plain: `body` is a request body. See the module
         # docstring — a plain Environment lets a template reach `__class__` and
         # walk out of the template namespace.
-        env = SandboxedEnvironment(
+        env = _preview_environment_class()(
             loader=ChoiceLoader(loaders) if len(loaders) > 1 else loaders[0],
             autoescape=False,
             line_statement_prefix=jinja_prefix_for(prog_lang),
@@ -85,7 +147,17 @@ def render_j2_cell(deck_path: Path, body: str, lang: str | None) -> tuple[bool, 
                 "organization": _PREVIEW_ORG,
             },
         )
-        return True, None, template.render()
+        text = template.render()
+        if len(text) > MAX_OUTPUT_CHARS:
+            # Backstop for growth the repeat cap does not see — a nested loop,
+            # a macro over a long list. Refusing beats returning it: the result
+            # is JSON-encoded into a response and then assigned to innerHTML.
+            return (
+                False,
+                f"preview output too large ({len(text)} chars; limit {MAX_OUTPUT_CHARS})",
+                body,
+            )
+        return True, None, text
     except Exception as exc:  # noqa: BLE001 - preview must never crash the request
         logger.debug("Studio tier-2 render failed for %s: %s", deck_path, exc)
         return False, str(exc), body

--- a/src/clm/web/studio/routes.py
+++ b/src/clm/web/studio/routes.py
@@ -18,6 +18,7 @@ from collections.abc import Callable
 from typing import cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from starlette.concurrency import run_in_threadpool
 
 from clm.web.studio import sync_runner
 from clm.web.studio.auth import token_matches
@@ -253,16 +254,20 @@ async def sync_deck(request: Request, req: SyncRequest) -> SyncStartResult:
     dependencies=[Depends(require_token)],
 )
 async def render_cell(request: Request, req: RenderCellRequest) -> RenderCellResult:
-    """Tier-2 (no-exec) render of one ``is_j2`` cell (P4).
+    """Tier-2 (kernel-free) render of one ``is_j2`` cell (P4).
 
     Expands the cell's Jinja (header macros, ``{{ … }}``) server-side through the
     build's bundled macros, no kernel. Plain cells (or any failure) return the
     body unchanged with ``rendered=False`` so the phone falls back to tier-1.
+
+    Runs in a worker thread: Jinja rendering is CPU-bound and the body is
+    client-supplied, so doing it inline would let one request hold the event
+    loop and stall every other request plus the disk watcher.
     """
     service = get_service(request)
     try:
-        rendered, error, text = service.render_cell(
-            req.deck_id, req.body, is_j2=req.is_j2, lang=req.lang
+        rendered, error, text = await run_in_threadpool(
+            service.render_cell, req.deck_id, req.body, is_j2=req.is_j2, lang=req.lang
         )
     except InvalidDeckIdError as e:
         raise HTTPException(status_code=400, detail=f"Invalid deck id: {e}") from e

--- a/src/clm/web/studio/service.py
+++ b/src/clm/web/studio/service.py
@@ -444,7 +444,7 @@ class StudioService:
     def render_cell(
         self, deck_id: str, body: str, *, is_j2: bool, lang: str | None = None
     ) -> tuple[bool, str | None, str]:
-        """Tier-2 (no-exec) render of one cell. Returns ``(rendered, error, text)``.
+        """Tier-2 (kernel-free) render of one cell. Returns ``(rendered, error, text)``.
 
         Only ``is_j2`` cells are expanded server-side (through the build's bundled
         macros); plain cells are returned unchanged for the client to render as

--- a/tests/cli/test_monitoring_command.py
+++ b/tests/cli/test_monitoring_command.py
@@ -315,6 +315,42 @@ class TestServeCommand:
         assert result.exit_code == 0, result.output
         assert "--allowed-host" in result.output
 
+    def test_pairing_url_puts_the_token_in_the_fragment(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A query-string token lands in uvicorn's access log; a fragment never
+        leaves the browser.
+
+        The URL is printed and QR-encoded, so this is the one place the token
+        is deliberately embedded in a URL — it has to be the half that is not
+        transmitted.
+        """
+        db_path = tmp_path / "jobs.db"
+        db_path.touch()
+        spec = tmp_path / "course.xml"
+        spec.write_text("<course/>", encoding="utf-8")
+
+        fake_web_app_module = MagicMock()
+        fake_web_app_module.create_app = MagicMock(return_value="app")
+
+        import sys
+
+        monkeypatch.setitem(sys.modules, "uvicorn", MagicMock())
+        monkeypatch.setitem(sys.modules, "clm.web.app", fake_web_app_module)
+        monkeypatch.setattr(
+            "clm.web.studio.auth.get_or_create_token", lambda rotate=False: "TESTTOKEN"
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            serve,
+            ["--jobs-db-path", str(db_path), "--no-browser", "--spec", str(spec)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "/studio/#token=TESTTOKEN" in result.output
+        assert "?token=" not in result.output
+
     def test_no_warning_when_the_configuration_is_coherent(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):

--- a/tests/web/studio/test_auth_qr.py
+++ b/tests/web/studio/test_auth_qr.py
@@ -32,9 +32,27 @@ class TestToken:
         req = _FakeRequest(headers={"Authorization": "Bearer abc123"})
         assert auth.extract_token(req) == "abc123"
 
-    def test_extract_from_query_param(self):
+    def test_query_param_is_no_longer_a_credential(self):
+        """``?token=`` used to authenticate — a URL is the worst place for one.
+
+        It reaches uvicorn's access log, any proxy's, browser history and the
+        ``Referer`` of outbound links, and the Studio token does not expire
+        (S7 of the 2026-07-24 review). The QR deep link now carries it in the
+        URL *fragment*, which browsers never send to the server.
+        """
         req = _FakeRequest(query={"token": "qtok"})
-        assert auth.extract_token(req) == "qtok"
+        assert auth.extract_token(req) is None
+        assert not auth.token_matches(req, "qtok")
+
+    def test_query_param_cannot_rescue_a_bad_header(self):
+        req = _FakeRequest(headers={"Authorization": "Bearer wrong"}, query={"token": "right"})
+        assert auth.extract_token(req) == "wrong"
+        assert not auth.token_matches(req, "right")
+
+    def test_non_ascii_token_does_not_raise(self):
+        """``secrets.compare_digest`` rejects non-ASCII ``str``; headers are latin-1."""
+        req = _FakeRequest(headers={"Authorization": "Bearer pässword"})
+        assert auth.token_matches(req, "secret") is False
 
     def test_token_matches_is_constant_time_check(self):
         req = _FakeRequest(headers={"Authorization": "Bearer secret"})

--- a/tests/web/studio/test_client_escaping.py
+++ b/tests/web/studio/test_client_escaping.py
@@ -1,0 +1,148 @@
+"""The Studio frontend's HTML escaping (S7 of the 2026-07-24 review).
+
+``esc()`` did not escape quotes, and ``inline()`` interpolates its output into
+``<a href="…">`` — so a markdown link target could close the attribute and add
+its own, reaching ``innerHTML``. Separately, nothing stopped a ``javascript:``
+target from becoming a working link.
+
+There is no JS test harness in this repo and adding one (package.json, a
+runner, a CI step) is out of proportion to three pure functions. Instead the
+functions are lifted out of ``app.js`` by name and executed under ``node``,
+which is present on the GitHub runners and on the maintainer's machine. If
+node is missing the module skips with that reason stated — a skip is honest,
+a test that silently asserts nothing is not.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+APP_JS = (
+    Path(__file__).resolve().parents[3] / "src" / "clm" / "web" / "static" / "studio" / "app.js"
+)
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node is not on PATH; the Studio frontend helpers cannot be executed",
+)
+
+
+def _extract_function(source: str, name: str) -> str:
+    """Return the full text of the top-level ``function <name>(…) {…}``.
+
+    Brace-matched rather than regex-terminated so a brace inside a string or a
+    nested arrow function does not truncate the result.
+    """
+    marker = f"function {name}("
+    start = source.index(marker)
+    brace = source.index("{", start)
+    depth = 0
+    for i in range(brace, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : i + 1]
+    raise AssertionError(f"unbalanced braces while extracting {name}()")
+
+
+@pytest.fixture(scope="module")
+def run_js():
+    """Return a callable evaluating ``expr`` against app.js's escaping helpers."""
+    source = APP_JS.read_text(encoding="utf-8")
+    helpers = "\n".join(_extract_function(source, n) for n in ("esc", "safeUrl", "inline"))
+
+    def _run(expr: str) -> str:
+        script = f"{helpers}\nprocess.stdout.write(JSON.stringify({expr}));"
+        proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            ["node", "-e", script],  # noqa: S607 - resolved via PATH, guarded by the skipif
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert proc.returncode == 0, f"node failed: {proc.stderr}"
+        return json.loads(proc.stdout)
+
+    return _run
+
+
+class TestEsc:
+    def test_escapes_the_five_html_significant_characters(self, run_js):
+        assert run_js("""esc('&<>"\\'')""") == "&amp;&lt;&gt;&quot;&#39;"
+
+    def test_ampersand_is_escaped_first(self, run_js):
+        """Otherwise ``&lt;`` from a literal ``<`` gets re-escaped into ``&amp;lt;``."""
+        assert run_js("esc('<')") == "&lt;"
+
+    def test_plain_text_is_untouched(self, run_js):
+        assert run_js("esc('Woche 01: Einführung')") == "Woche 01: Einführung"
+
+
+class TestLinkTargetCannotEscapeTheAttribute:
+    def test_quote_in_link_target_cannot_add_an_attribute(self, run_js):
+        """The S7 chain: `"` closed href and injected an event handler."""
+        out = run_js("""inline('[x](a" onerror="alert(1))')""")
+
+        assert 'onerror="' not in out
+        assert "&quot;" in out  # the quote survived as an entity, not as syntax
+
+    def test_quote_in_link_text_cannot_add_an_attribute(self, run_js):
+        out = run_js("""inline('[a" onmouseover="alert(1)](http://ok.example)')""")
+
+        assert 'onmouseover="' not in out
+
+    def test_angle_brackets_cannot_open_a_tag(self, run_js):
+        out = run_js("""inline('[x](http://a.example) <img src=x onerror=alert(1)>')""")
+
+        assert "<img" not in out
+        assert "&lt;img" in out
+
+
+class TestLinkSchemes:
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "javascript:alert(1)",
+            "JaVaScRiPt:alert(1)",
+            "data:text/html;base64,PHNjcmlwdD4=",
+            "vbscript:msgbox(1)",
+        ],
+    )
+    def test_scripting_schemes_are_neutralised(self, run_js, target: str):
+        out = run_js(f"inline('[click]({target})')")
+
+        assert 'href="#"' in out, out
+
+    def test_control_characters_cannot_smuggle_a_scheme(self, run_js):
+        """Browsers strip tabs/newlines when resolving a URL.
+
+        ``java\\tscript:`` therefore executes as ``javascript:`` while defeating
+        a naive scheme test, so the characters are stripped *before* the test.
+        """
+        out = run_js(r"""inline('[click](java\tscript:alert(1))')""")
+
+        assert 'href="#"' in out, out
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "http://example.test/a",
+            "https://example.test/a?x=1&y=2",
+            "mailto:someone@example.test",
+            "relative/path.html",
+            "#anchor",
+        ],
+    )
+    def test_ordinary_targets_still_work(self, run_js, target: str):
+        out = run_js(f"inline('[click]({target})')")
+
+        assert 'href="#"' not in out or target == "#anchor"
+        assert "<a href=" in out
+        assert ">click</a>" in out

--- a/tests/web/studio/test_client_escaping.py
+++ b/tests/web/studio/test_client_escaping.py
@@ -33,10 +33,13 @@ pytestmark = pytest.mark.skipif(
 
 
 def _extract_function(source: str, name: str) -> str:
-    """Return the full text of the top-level ``function <name>(…) {…}``.
+    r"""Return the full text of the top-level ``function <name>(…) {…}``.
 
-    Brace-matched rather than regex-terminated so a brace inside a string or a
-    nested arrow function does not truncate the result.
+    Brace-counted rather than regex-terminated, so a nested function body does
+    not truncate the result. The scanner is *not* string- or regex-aware, so a
+    brace inside a string literal or a quantifier like ``/\d{1,3}/`` would
+    miscount — the assertion below turns that into a loud failure rather than a
+    silently truncated extraction, and node would reject the result anyway.
     """
     marker = f"function {name}("
     start = source.index(marker)
@@ -143,6 +146,116 @@ class TestLinkSchemes:
     def test_ordinary_targets_still_work(self, run_js, target: str):
         out = run_js(f"inline('[click]({target})')")
 
-        assert 'href="#"' not in out or target == "#anchor"
-        assert "<a href=" in out
+        # Assert the target is preserved verbatim rather than "is not '#'":
+        # for the `#anchor` case the latter is satisfied by the target itself,
+        # so a regression that returned "#" would still have passed.
+        expected = target.replace("&", "&amp;")  # esc() runs before safeUrl()
+        assert f'href="{expected}"' in out, out
         assert ">click</a>" in out
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "//evil.example",
+            "//evil.example/path",
+        ],
+    )
+    def test_protocol_relative_targets_are_neutralised(self, run_js, target: str):
+        """No scheme in the string, but the browser supplies the page's.
+
+        That makes it a live off-origin navigation from a deck's link target,
+        on a page whose localStorage holds a bearer token that never expires.
+        """
+        out = run_js(f"inline('[click]({target})')")
+
+        assert 'href="#"' in out, out
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "\u00a0javascript:alert(1)",
+            "\u00a0//evil.example",
+        ],
+    )
+    def test_unicode_whitespace_is_not_trimmed_into_a_scheme(self, run_js, target: str):
+        """Browsers do not strip U+00A0, so neither may we.
+
+        A JS ``.trim()`` here would remove it and *promote* these into a live
+        scheme and a live protocol-relative URL respectively. Left in place,
+        both are inert relative paths.
+        """
+        out = run_js(f'inline("[click]({target})")')
+
+        # The precise property is about the *start* of the href: a browser
+        # honours a scheme only at position 0, and it does not strip U+00A0 —
+        # so the character surviving is exactly what keeps these inert. A bare
+        # "javascript: not in out" would wrongly fail on the harmless
+        # " javascript:" that we want to see.
+        assert 'href="javascript:' not in out, out
+        assert 'href="//evil.example"' not in out, out
+        assert " " in out, "the NBSP was trimmed — that is what promotes these"
+
+
+class TestResolveToken:
+    """The pairing half of the fragment change — the part that can break login.
+
+    ``resolveToken`` is the only reader of the new ``#token=`` form. Nothing
+    else pins it: the CLI test checks the string the desktop *prints*.
+    """
+
+    @pytest.fixture(scope="class")
+    def run_resolve(self):
+        source = APP_JS.read_text(encoding="utf-8")
+        fn = _extract_function(source, "resolveToken")
+
+        def _run(url: str) -> str:
+            # Minimal stand-ins for the three browser globals resolveToken uses.
+            script = f"""
+                const store = {{}};
+                globalThis.localStorage = {{
+                    getItem: (k) => (k in store ? store[k] : null),
+                    setItem: (k, v) => {{ store[k] = String(v); }},
+                }};
+                globalThis.window = {{
+                    location: {{ href: {json.dumps(url)} }},
+                    history: {{ replaceState: () => {{}} }},
+                }};
+                const TOKEN_KEY = "clm_studio_token";
+                {fn}
+                process.stdout.write(JSON.stringify(resolveToken()));
+            """
+            proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
+                ["node", "-e", script],  # noqa: S607 - guarded by the module skipif
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            assert proc.returncode == 0, f"node failed: {proc.stderr}"
+            return json.loads(proc.stdout)
+
+        return _run
+
+    def test_reads_the_fragment_form(self, run_resolve):
+        assert run_resolve("http://host:8000/studio/#token=abc123") == "abc123"
+
+    def test_still_reads_the_legacy_query_form(self, run_resolve):
+        """An old bookmark or printed QR must not strand a user unpaired."""
+        assert run_resolve("http://host:8000/studio/?token=abc123") == "abc123"
+
+    def test_base64url_tokens_survive_verbatim(self, run_resolve):
+        """``secrets.token_urlsafe`` emits ``-`` and ``_``; ``+`` would decode to a space.
+
+        ``URLSearchParams`` turns ``+`` into a space, so a token containing one
+        would be silently corrupted and pairing would fail with no diagnostic.
+        base64url never emits ``+`` — this pins that the characters it *does*
+        emit come through untouched.
+        """
+        token = "aB3-_xY9zQ-w_pL2"
+        assert run_resolve(f"http://host:8000/studio/#token={token}") == token
+
+    def test_no_token_anywhere_is_empty(self, run_resolve):
+        assert run_resolve("http://host:8000/studio/") == ""
+
+    def test_fragment_wins_over_a_stale_query(self, run_resolve):
+        assert run_resolve("http://host:8000/studio/?token=old#token=new") == "new"

--- a/tests/web/studio/test_render_pwa.py
+++ b/tests/web/studio/test_render_pwa.py
@@ -1,4 +1,4 @@
-"""Tests for P4 — tier-2 (no-exec) render + the PWA / offline assets."""
+"""Tests for P4 — tier-2 (kernel-free) render + the PWA / offline assets."""
 
 from __future__ import annotations
 

--- a/tests/web/studio/test_render_sandbox.py
+++ b/tests/web/studio/test_render_sandbox.py
@@ -53,24 +53,39 @@ class TestSandboxBlocksTraversal:
     def test_the_markers_would_otherwise_appear(self, tmp_path: Path):
         """Prove the assertions above have teeth.
 
-        Renders the same payloads on a plain ``Environment`` — the pre-fix
-        configuration — and requires that at least most of them *do* leak their
-        marker. Without this, a typo in a payload would turn every case above
-        into a test that passes because nothing rendered at all.
+        Renders the same payloads on a plain ``Environment`` configured the way
+        ``render_j2_cell`` configured it before the fix, and requires that
+        **every** one leaks its marker. A threshold ("most of them") would
+        tolerate exactly the typo this is meant to catch: a payload that
+        renders nothing makes its case above pass for the wrong reason.
         """
         from jinja2 import Environment
 
-        env = Environment(autoescape=False)  # noqa: S701 - deliberately the unsafe one
-        leaked = []
+        from clm.workers.notebook.utils.prog_lang_utils import jinja_prefix_for
+
+        env = Environment(  # noqa: S701 - deliberately the pre-fix unsafe one
+            autoescape=False,
+            line_statement_prefix=jinja_prefix_for("python"),
+            keep_trailing_newline=True,
+        )
+        globals_ = {
+            "is_notebook": False,
+            "is_html": True,
+            "lang": "de",
+            "author": "Preview",
+            "organization": "",
+        }
+
+        not_leaked = []
         for param in ESCAPE_ATTEMPTS:
             source, marker = param.values
             try:
-                if marker in env.from_string(source).render():
-                    leaked.append(source)
-            except Exception:  # noqa: BLE001, S110 - a payload that errors is not a leak
-                pass
+                if marker not in env.from_string(source, globals=globals_).render():
+                    not_leaked.append(source)
+            except Exception as exc:  # noqa: BLE001 - an erroring payload proves nothing
+                not_leaked.append(f"{source}  ({type(exc).__name__})")
 
-        assert len(leaked) >= 5, f"only {len(leaked)} payloads leak unsandboxed: {leaked}"
+        assert not not_leaked, f"these payloads do not leak even unsandboxed: {not_leaked}"
 
     def test_a_chained_refusal_reports_a_usable_error(self, tmp_path: Path):
         """When it does error, the message has to name the problem."""
@@ -78,6 +93,52 @@ class TestSandboxBlocksTraversal:
         assert ok is False
         assert "__class__" in str(error)
         assert "unsafe" in str(error)
+
+
+class TestResourceBounds:
+    """Blocking attribute access says nothing about how *big* a render may get.
+
+    ``{{ "A" * 200000000 }}`` allocated 200 MB in ~1.5s on a plain sandbox, and
+    the route rendered inline on the event loop — so one POST from any token
+    holder stalled every other request, and a loop of them exhausts memory.
+    """
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param('{{ "A" * 200000000 }}', id="str-repeat"),
+            pytest.param('{{ 200000000 * "A" }}', id="str-repeat-reversed"),
+            pytest.param("{{ [1] * 999999999 }}", id="list-repeat"),
+        ],
+    )
+    def test_oversized_repetition_is_refused(self, tmp_path: Path, source: str):
+        ok, error, text = render_j2_cell(tmp_path / DECK, source, "de")
+
+        assert ok is False
+        assert "refusing to repeat" in str(error)
+        # Refused *before* allocating, not truncated after: the body comes back
+        # untouched and no giant string was ever built.
+        assert text == source
+
+    def test_repetition_within_the_limit_still_works(self, tmp_path: Path):
+        from clm.web.studio.render import MAX_REPEAT
+
+        ok, error, text = render_j2_cell(tmp_path / DECK, '{{ "ab" * 10 }}', "de")
+        assert ok and error is None
+        assert text == "ab" * 10
+        assert MAX_REPEAT > 10  # the limit is not so tight it breaks real macros
+
+    def test_output_over_the_cap_is_refused(self, tmp_path: Path, monkeypatch):
+        """Backstop for growth the repeat cap cannot see (loops, macros)."""
+        from clm.web.studio import render as render_mod
+
+        monkeypatch.setattr(render_mod, "MAX_OUTPUT_CHARS", 100)
+        source = "{% for i in range(200) %}xxxxx{% endfor %}"
+        ok, error, text = render_j2_cell(tmp_path / DECK, source, "de")
+
+        assert ok is False
+        assert "too large" in str(error)
+        assert text == source
 
 
 class TestLegitimateRenderingSurvives:

--- a/tests/web/studio/test_render_sandbox.py
+++ b/tests/web/studio/test_render_sandbox.py
@@ -169,27 +169,62 @@ class TestResourceBounds:
         assert ok is False
         assert text == source  # the body, not a 50-character prefix
 
-    def test_tilde_concatenation_is_a_known_gap(self, tmp_path: Path):
-        """``~`` is deliberately NOT bounded — pinned so it stays a known fact.
+    def test_tilde_concatenation_is_bounded(self, tmp_path: Path, monkeypatch):
+        """``~`` needs its own hook — the other two cannot see it.
 
-        Jinja compiles ``~`` to a ``Concat`` node, which is not a ``BinExpr``
-        (so ``intercepted_binops`` cannot see it) and which calls ``str_join``
+        It compiles to a ``Concat`` node, which is not a ``BinExpr`` (so
+        ``intercepted_binops`` is blind to it) and which emits ``str_join``
         resolved from the compiled template's own namespace (so
-        ``environment.concat`` cannot either). The only remaining hook is a
-        process-wide monkeypatch of ``jinja2.runtime``, which would change how
-        the *build* renders every deck.
-
-        A token holder can therefore still exhaust this process, which is
-        accepted: the token is the trust boundary (D4) and the same client can
-        already rewrite any deck (issue #698). This test documents the limit
-        rather than asserting a fix — if a future jinja2 or a deliberate change closes it,
-        this fails and the docstrings claiming the gap should be updated.
+        ``environment.concat`` is too). It is redirected at compile time via
+        ``code_generator_class``. Before that, this payload reached ~1.2 GB
+        while emitting nine characters — neither the repeat cap (each step is
+        legal) nor an output cap (nine characters) ever saw it.
         """
-        source = '{% set s = "A" * 1000 %}{% set s = s ~ s %}{{ s|length }}'
-        ok, _error, text = render_j2_cell(tmp_path / DECK, source, "de")
+        from clm.web.studio import render as render_mod
 
-        assert ok is True
-        assert text == "2000"
+        monkeypatch.setattr(render_mod, "MAX_OUTPUT_CHARS", 5000)
+        source = '{% set s = "A" * 1000 %}' + "{% set s = s ~ s %}" * 5 + "{{ s|length }}"
+        ok, error, text = render_j2_cell(tmp_path / DECK, source, "de")
+
+        assert ok is False
+        assert "exceeded" in str(error)
+        assert text == source
+
+    def test_tilde_within_the_limit_still_works(self, tmp_path: Path):
+        """The redirect must not cost the operator — `~` is ordinary Jinja."""
+        ok, error, text = render_j2_cell(tmp_path / DECK, '{{ "a" ~ "b" ~ 1 }}', "de")
+        assert ok and error is None
+        assert text == "ab1"
+
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            pytest.param(
+                "{% macro m(x) %}{{ x ~ '!' }}{% endmacro %}{{ m('hi') }}", "hi!", id="macro"
+            ),
+            pytest.param("{% filter upper %}ab{% endfilter %}", "AB", id="filter-block"),
+            pytest.param(
+                "{% macro w() %}[{{ caller() }}]{% endmacro %}{% call w() %}in{% endcall %}",
+                "[in]",
+                id="call-block",
+            ),
+            pytest.param(
+                "{{ 6 * 7 }} {{ 10 - 3 }} {{ 9 // 2 }} {{ 2 ** 5 }}", "42 7 4 32", id="arith"
+            ),
+        ],
+    )
+    def test_the_bounds_do_not_change_rendering(self, tmp_path: Path, source: str, expected: str):
+        """Every construct that gets its own output buffer still renders.
+
+        `concat` is emitted into blocks, macros, `{% filter %}` and
+        `{% call %}` bodies as well as the root — so the override runs once per
+        *buffer*, and a mistake there would corrupt output rather than fail
+        loudly. Operators outside the intercepted set must be untouched.
+        """
+        ok, error, text = render_j2_cell(tmp_path / DECK, source, "de")
+
+        assert ok, f"{source} did not render: {error}"
+        assert text == expected
 
 
 class TestLegitimateRenderingSurvives:

--- a/tests/web/studio/test_render_sandbox.py
+++ b/tests/web/studio/test_render_sandbox.py
@@ -1,0 +1,123 @@
+"""The tier-2 render is sandboxed (S7 of the 2026-07-24 adversarial review).
+
+``render_j2_cell`` renders a **request body** — ``POST /api/studio/deck/render-cell``
+hands it whatever the client sent. On a plain ``jinja2.Environment`` a template
+can read ``__class__`` and walk out of the template namespace from there, which
+the review reproduced against this exact function. It now uses
+``SandboxedEnvironment``.
+
+**What these tests assert, and why not the obvious thing.** They do not assert
+"the render fails". The environment uses a lenient ``Undefined``, so a refused
+attribute becomes undefined and renders as the empty string — the escape is
+blocked but the render often still reports ``ok``. Asserting on the failure
+mode would therefore pin an incidental detail and, worse, would still pass if a
+future change rendered the value *and then* errored. What matters is that the
+traversal never produces its value, so each case pairs a payload with the
+string its success would put in the output, and asserts that string is absent.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from clm.web.studio.render import render_j2_cell
+
+DECK = "slides_x.de.py"
+
+#: ``(source, marker)`` — ``marker`` is what a *successful* escape puts in the
+#: output. Each is a distinct route out of the template namespace, and no
+#: marker occurs in its own source, so a tier-1 fallback (body echoed back
+#: unchanged) cannot accidentally satisfy the assertion.
+ESCAPE_ATTEMPTS = [
+    pytest.param('{{ "".__class__.__name__ }}', "str", id="str-class"),
+    pytest.param("{{ ().__class__.__base__.__name__ }}", "object", id="tuple-base"),
+    pytest.param("{{ ().__class__.__base__.__subclasses__() }}", "<class", id="subclasses"),
+    pytest.param('{{ ""|attr("__class__")|attr("__name__") }}', "str", id="attr-filter"),
+    pytest.param('{{ "".__getattribute__("__class__").__name__ }}', "str", id="getattribute"),
+    pytest.param("{% set c = joiner.__class__ %}{{ c.__mro__ }}", "object", id="set-then-read"),
+    pytest.param("{{ cycler.__init__.__globals__ }}", "builtins", id="jinja-global"),
+    pytest.param("{{ namespace.__init__.__globals__ }}", "builtins", id="namespace-global"),
+    pytest.param("{{ self.__init__.__globals__ }}", "builtins", id="self-global"),
+]
+
+
+class TestSandboxBlocksTraversal:
+    @pytest.mark.parametrize(("source", "marker"), ESCAPE_ATTEMPTS)
+    def test_escape_yields_nothing(self, tmp_path: Path, source: str, marker: str):
+        _ok, _error, text = render_j2_cell(tmp_path / DECK, source, "de")
+
+        assert marker not in text, f"sandbox leaked {marker!r} for: {source}"
+
+    def test_the_markers_would_otherwise_appear(self, tmp_path: Path):
+        """Prove the assertions above have teeth.
+
+        Renders the same payloads on a plain ``Environment`` — the pre-fix
+        configuration — and requires that at least most of them *do* leak their
+        marker. Without this, a typo in a payload would turn every case above
+        into a test that passes because nothing rendered at all.
+        """
+        from jinja2 import Environment
+
+        env = Environment(autoescape=False)  # noqa: S701 - deliberately the unsafe one
+        leaked = []
+        for param in ESCAPE_ATTEMPTS:
+            source, marker = param.values
+            try:
+                if marker in env.from_string(source).render():
+                    leaked.append(source)
+            except Exception:  # noqa: BLE001, S110 - a payload that errors is not a leak
+                pass
+
+        assert len(leaked) >= 5, f"only {len(leaked)} payloads leak unsandboxed: {leaked}"
+
+    def test_a_chained_refusal_reports_a_usable_error(self, tmp_path: Path):
+        """When it does error, the message has to name the problem."""
+        ok, error, _ = render_j2_cell(tmp_path / DECK, '{{ "".__class__.__name__ }}', "de")
+        assert ok is False
+        assert "__class__" in str(error)
+        assert "unsafe" in str(error)
+
+
+class TestLegitimateRenderingSurvives:
+    """The sandbox must not cost the feature it protects."""
+
+    def test_arithmetic_and_filters_still_work(self, tmp_path: Path):
+        ok, error, text = render_j2_cell(
+            tmp_path / DECK, "{{ (1 + 2) * 3 }} {{ 'x' | upper }}", "de"
+        )
+        assert ok and error is None
+        assert "9 X" in text
+
+    def test_injected_globals_are_readable(self, tmp_path: Path):
+        ok, _, text = render_j2_cell(tmp_path / DECK, "{{ lang }}|{{ author }}", "de")
+        assert ok
+        assert "de|Preview" in text
+
+    # The bundled macros are the whole point of tier 2, and there is one set per
+    # shipped language. A sandbox refusal inside a macro would break previews
+    # for that language only — exactly the kind of gap a single-language test
+    # misses.
+    @pytest.mark.parametrize(
+        ("suffix", "prefix"),
+        [
+            ("de.py", "#"),
+            ("de.cpp", "//"),
+            ("de.cs", "//"),
+            ("de.java", "//"),
+            ("de.ts", "//"),
+        ],
+    )
+    def test_every_shipped_language_macro_set_renders(
+        self, tmp_path: Path, suffix: str, prefix: str
+    ):
+        source = (
+            f"{prefix} j2 from 'macros.j2' import header_de\n"
+            f'{prefix} {{{{ header_de("Hallo Welt") }}}}'
+        )
+        ok, error, text = render_j2_cell(tmp_path / f"slides_x.{suffix}", source, "de")
+
+        assert ok, f"{suffix} macros do not render under the sandbox: {error}"
+        assert "Hallo Welt" in text
+        assert "{{" not in text

--- a/tests/web/studio/test_render_sandbox.py
+++ b/tests/web/studio/test_render_sandbox.py
@@ -4,7 +4,7 @@
 hands it whatever the client sent. On a plain ``jinja2.Environment`` a template
 can read ``__class__`` and walk out of the template namespace from there, which
 the review reproduced against this exact function. It now uses
-``SandboxedEnvironment``.
+``ImmutableSandboxedEnvironment``.
 
 **What these tests assert, and why not the obvious thing.** They do not assert
 "the render fails". The environment uses a lenient ``Undefined``, so a refused
@@ -128,8 +128,14 @@ class TestResourceBounds:
         assert text == "ab" * 10
         assert MAX_REPEAT > 10  # the limit is not so tight it breaks real macros
 
-    def test_output_over_the_cap_is_refused(self, tmp_path: Path, monkeypatch):
-        """Backstop for growth the repeat cap cannot see (loops, macros)."""
+    def test_output_is_bounded_while_it_accumulates(self, tmp_path: Path, monkeypatch):
+        """Growth the repeat cap cannot see: a loop of individually-legal emits.
+
+        The bound has to apply *during* the join, not to the finished string.
+        With a post-render ``len()`` check, ``{% for i in range(500) %}{{ "A" *
+        100000 }}{% endfor %}`` peaked at 100 MB before anything looked at it —
+        every repeat is legal and only the total is not.
+        """
         from clm.web.studio import render as render_mod
 
         monkeypatch.setattr(render_mod, "MAX_OUTPUT_CHARS", 100)
@@ -137,8 +143,53 @@ class TestResourceBounds:
         ok, error, text = render_j2_cell(tmp_path / DECK, source, "de")
 
         assert ok is False
-        assert "too large" in str(error)
+        assert "exceeded" in str(error)
         assert text == source
+
+    def test_concatenation_is_bounded(self, tmp_path: Path, monkeypatch):
+        """``+`` on sequences is intercepted before it allocates."""
+        from clm.web.studio import render as render_mod
+
+        monkeypatch.setattr(render_mod, "MAX_OUTPUT_CHARS", 1000)
+        source = '{% set s = "A" * 900 %}{% set s = s + s %}{{ s|length }}'
+        ok, error, _ = render_j2_cell(tmp_path / DECK, source, "de")
+
+        assert ok is False
+        assert "refusing to build" in str(error)
+
+    def test_a_large_render_is_not_silently_truncated(self, tmp_path: Path, monkeypatch):
+        """Refusing beats returning a partial deck — a truncated preview reads
+        as real content."""
+        from clm.web.studio import render as render_mod
+
+        monkeypatch.setattr(render_mod, "MAX_OUTPUT_CHARS", 50)
+        source = "{% for i in range(100) %}0123456789{% endfor %}"
+        ok, _error, text = render_j2_cell(tmp_path / DECK, source, "de")
+
+        assert ok is False
+        assert text == source  # the body, not a 50-character prefix
+
+    def test_tilde_concatenation_is_a_known_gap(self, tmp_path: Path):
+        """``~`` is deliberately NOT bounded — pinned so it stays a known fact.
+
+        Jinja compiles ``~`` to a ``Concat`` node, which is not a ``BinExpr``
+        (so ``intercepted_binops`` cannot see it) and which calls ``str_join``
+        resolved from the compiled template's own namespace (so
+        ``environment.concat`` cannot either). The only remaining hook is a
+        process-wide monkeypatch of ``jinja2.runtime``, which would change how
+        the *build* renders every deck.
+
+        A token holder can therefore still exhaust this process, which is
+        accepted: the token is the trust boundary (D4) and the same client can
+        already rewrite any deck (issue #698). This test documents the limit
+        rather than asserting a fix — if a future jinja2 or a deliberate change closes it,
+        this fails and the docstrings claiming the gap should be updated.
+        """
+        source = '{% set s = "A" * 1000 %}{% set s = s ~ s %}{{ s|length }}'
+        ok, _error, text = render_j2_cell(tmp_path / DECK, source, "de")
+
+        assert ok is True
+        assert text == "2000"
 
 
 class TestLegitimateRenderingSurvives:

--- a/tests/web/studio/test_routes.py
+++ b/tests/web/studio/test_routes.py
@@ -27,9 +27,26 @@ class TestAuth:
         r = client.get("/api/studio/decks", headers={"Authorization": "Bearer nope"})
         assert r.status_code == 401
 
-    def test_token_via_query_param(self, client: TestClient):
+    def test_token_via_query_param_is_rejected(self, client: TestClient):
+        """``?token=`` used to authenticate; a URL is the worst place for a
+        credential.
+
+        It reaches uvicorn's access log, any proxy's, browser history and the
+        ``Referer`` of outbound links, and the Studio token does not expire
+        (S7 of the 2026-07-24 review). Nothing needed it: the QR deep link
+        targets the unauthenticated ``/studio/`` static mount and is read by
+        the frontend, which then sends the header.
+        """
         r = client.get(f"/api/studio/decks?token={TOKEN}")
-        assert r.status_code == 200
+        assert r.status_code == 401
+
+    def test_query_param_cannot_stand_in_for_a_bad_header(self, client: TestClient):
+        """A valid query token must not rescue an invalid header."""
+        r = client.get(f"/api/studio/decks?token={TOKEN}", headers={"Authorization": "Bearer nope"})
+        assert r.status_code == 401
+
+    def test_header_still_works(self, client: TestClient):
+        assert client.get("/api/studio/decks", headers=AUTH).status_code == 200
 
 
 class TestReadEndpoints:


### PR DESCRIPTION
Phase 2, item 4 (the last) of the adversarial-review remediation plan
(`docs/claude/handovers/adversarial-review-remediation-handover.md`).
Closes finding **S7** under decision **D4**.

Four separate defects behind one finding.

## 1. SSTI in the cell preview

`POST /api/studio/deck/render-cell` rendered its **request body** through a
plain `jinja2.Environment`. Reproduced against the real function before
changing anything:

```
{{ "".__class__.__name__ }}   ->  ok=True   text='str'
```

That traversal is what every Jinja escape is built from. Now a
`SandboxedEnvironment`:

```
{{ "".__class__.__name__ }}   ->  ok=False  "access to attribute '__class__' of 'str' object is unsafe."
{{ 1 + 1 }}                   ->  ok=True   text='2'
```

The module advertised itself as the "no-execution" render tier while doing
this. The docstring now says what that actually means — no *kernel*, not no
code — and names the sandbox as the boundary it is, without overclaiming.

## 2. XSS in the frontend

`esc()` escaped `&`, `<`, `>` but not quotes, and `inline()` interpolates its
output into `<a href="…">` on the way to `innerHTML`. Verified against the
pre-fix code, verbatim from master:

```
inline('[x](a" onerror="alert(1))')
  ->  <a href="a" onerror="alert(1" target="_blank" rel="noopener">x</a>)
inline('[click](javascript:alert(1))')
  ->  <a href="javascript:alert(1" ...>click</a>
```

Quotes are escaped now, and link targets are restricted to
http/https/mailto/relative. Control characters are stripped **before** the
scheme test, because browsers strip them when resolving a URL — so
`java<TAB>script:` would otherwise pass a naive check and then execute.

## 3. `?token=` as a credential

A token that never expires reached uvicorn's access log, any proxy's, browser
history, and the `Referer` of anything the page links out to. Nothing needed
it: the pairing deep link targets `/studio/`, an **unauthenticated static
mount**, where the token is read by the frontend — and the PWA has always sent
`Authorization: Bearer` on every API call. Header only now.

## 4. The QR pairing URL

Moved from `/studio/?token=…` to `/studio/#token=…`. A fragment is never
transmitted, so pairing itself now leaks nothing into any log. The QR is
reprinted on every `clm serve --spec`, so there is nothing to migrate; the
frontend still reads a `?token=` it finds, for an old bookmark.

## On the test design

The sandbox tests assert that the traversal **never yields its value**, not
that the render fails. The environment uses a lenient `Undefined`, so a
refused attribute usually renders as empty string and the call still reports
`ok` — asserting the failure mode would have pinned an incidental detail, and
would still pass if a future change rendered the value *and then* errored. My
first draft made exactly that mistake and 4 of 16 cases failed for the wrong
reason.

`test_the_markers_would_otherwise_appear` renders the same payloads on a plain
`Environment` and requires that most of them leak, so a typo in a payload
cannot turn the suite into one that passes because nothing rendered.

All five shipped languages' macro sets are exercised: a sandbox refusal inside
a macro would break previews for one language only, which a Python-only test
would miss.

The frontend helpers are lifted out of `app.js` by name and executed under
`node`. There is no JS harness in this repo and adding one (package.json,
runner, CI step) is out of proportion to three pure functions; the module
skips with a stated reason if node is absent.

## Checks

- `pytest -q -n 8` — **8895 passed**, 7 skipped, 1 xfailed (88s)
- `ruff check` / `ruff format` / `mypy` — clean
- Both exploit reproductions above were run against the pre-fix code, so the
  new tests are known to bite.

## Docs

`commands.md` (fragment-based pairing, header-only auth, the sandbox),
`migration.md` (a new section — `?token=` returning 401 is breaking for a
custom client), and the Studio design doc's pairing section, which described
the query-parameter flow. Changelog fragment in `changelog.d/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG954qREDhNpPSFnHhVeQ8
