### PR TITLE
docs: retire Phase 3 item 1's migration risk — the blast radius is zero

### DIFF
--- a/docs/claude/handovers/adversarial-review-remediation-handover.md
+++ b/docs/claude/handovers/adversarial-review-remediation-handover.md
@@ -689,9 +689,54 @@ a drive-by.
 
 ---
 
-### Phase 3 — Sync engine correctness  ▸ STATUS: not started
+### Phase 3 — Sync engine correctness  ▸ STATUS: not started (item 1's migration prerequisite is DONE — see below)
 **Depends on**: Phase 1 (sync unit coverage is the best in the repo — keep it
 that way and extend it here).
+
+> **Item 1's blast-radius sweep is done, and the answer is zero (2026-07-26).**
+> The plan says to "sweep the course repos to size the blast radius, and
+> prepare the fix-forward instructions" before shipping the strict gate. That
+> was measured rather than estimated, and **no deck regresses**, so there is no
+> migration to prepare and the item is safe to ship on its own.
+>
+> Method — for every split pair, compare what `record` checks today against
+> what D8 will make it check:
+> `structural_gate(raw_de, raw_en)` vs
+> `structural_gate(*project_pair(...))`. A deck regresses iff the first is
+> empty and the second is not.
+>
+> | repo | split pairs | clean both ways | newly failing |
+> |---|---|---|---|
+> | PythonCourses | 956 | 956 | **0** |
+> | CppCourses | 340 | 340 | **0** |
+> | CSharpCourses | 0 | — | — |
+>
+> **The result is not vacuous**: projection genuinely differs from raw text on
+> **230 of the 956** PythonCourses pairs (those with separated voiceover
+> companions), and all 230 still gate clean. **CSharpCourses is out of scope by
+> format**, not by accident — it is entirely *unsplit* (one `slides_x.cs` per
+> topic carrying both `lang="de"` and `lang="en"` cells; no `.de.*` file exists
+> anywhere in the repo), so the split-pair engine never runs on it.
+>
+> Re-measure if this sits unimplemented for long — the sweep reflects the
+> committed state of three working trees on 2026-07-26. The script is trivial
+> to rebuild from the method line above.
+
+> **Two corrections to item 1 as written, found while sizing it:**
+>
+> 1. **There are four gate call sites, not two.** The plan names
+>    `sync_v3.py:239-250` and `:375-385`, but `cli/commands/harvest.py:544`
+>    and `voiceover/harvest_accept.py:442` call `structural_gate` on raw text
+>    too. Fixing only the named two would leave the gate projecting on some
+>    paths and not others — drift *by call site* instead of by function, which
+>    is harder to notice than what is there now.
+> 2. **The "can never drift" claim is at `sync_verify.py:300`**, inside
+>    `structural_gate`'s own docstring, and it is true about the *function*
+>    (the gate is literally the error subset of `structural_violations`) while
+>    being false about its *input* — `verify_pair` projects companions at
+>    `:476` before calling it, and all four gate callers do not. That is
+>    exactly the bug. Whatever shape the fix takes, the shared thing has to be
+>    the **projection**, not just the violation computation.
 
 **Goal**: no path silently destroys authored content. Order within this phase
 matters: **D8 first**, because the gate is what creates the divergent baselines


### PR DESCRIPTION
Docs only. Phase 3 item 1 (Y2 + D8, the strict `record` gate) is gated in the
plan on sweeping the course repos to size how many decks will start failing,
and preparing fix-forward instructions. I measured it instead of estimating.

## Result: no deck regresses

A deck regresses iff what `record` checks today passes and what D8 will make
it check fails — i.e. `structural_gate(raw_de, raw_en)` is empty while
`structural_gate(*project_pair(...))` is not.

| repo | split pairs | clean both ways | newly failing |
|---|---|---|---|
| PythonCourses | 956 | 956 | **0** |
| CppCourses | 340 | 340 | **0** |
| CSharpCourses | 0 | — | — |

So there is **no migration to prepare**, and the item can ship on its own
rather than as a coordinated change across three course repos. That is the
single biggest risk the plan attached to Phase 3, retired.

## Why this is not a vacuous zero

I checked, because "0 regressions" is exactly the result a broken sweep
produces:

- **Projection genuinely differs from raw text on 230 of the 956**
  PythonCourses pairs — those with separated voiceover companions. All 230
  still gate clean. If projection had been a no-op everywhere, the comparison
  would have proved nothing.
- **CSharpCourses is out of scope by format, not by a failed scan.** It is
  entirely *unsplit*: one `slides_x.cs` per topic carrying both `lang="de"`
  and `lang="en"` cells, and no `.de.*` file exists anywhere in the repo. The
  split-pair engine never runs on it. (Verified on a sample deck: 11 DE cells
  and 11 EN cells in the same file.)

## Two corrections to the item as written

Both found while sizing it, and both change what the fix has to look like:

1. **There are four gate call sites, not two.** The plan names
   `sync_v3.py:239-250` and `:375-385`. But `cli/commands/harvest.py:544` and
   `voiceover/harvest_accept.py:442` call `structural_gate` on raw text too.
   Fixing only the named pair would leave the gate projecting on some paths
   and not others — drift *by call site* rather than by function, which is
   harder to notice than the uniform wrongness there now.
2. **The "can never drift" claim is inside `structural_gate`'s own docstring**
   (`sync_verify.py:300`), and it is true about the *function* while false
   about its *input*: `verify_pair` projects companions at `:476` and no gate
   caller does. So the thing that must be shared is the **projection**, not
   the violation computation — which is what the plan's "have both call one
   function" note should be read as requiring.

## Scope

Handover only — no code. The implementation of Y2/D8 is deliberately not in
this PR so the measurement lands separately from the behaviour change.

Re-measure if this sits unimplemented for a while; the sweep reflects three
working trees as of 2026-07-26, and the method line in the handover is enough
to rebuild the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JG954qREDhNpPSFnHhVeQ8
