### PR TITLE
fix(sync): the ledger write gate now reads the voiceover companions (Y2 / D8)

### DIFF
--- a/changelog.d/702-sync-record-gate-projects-companions.fixed.md
+++ b/changelog.d/702-sync-record-gate-projects-companions.fixed.md
@@ -1,0 +1,20 @@
+- **`clm slides sync record` no longer blesses a divergence hidden in a voiceover
+  companion.** The ledger write gate ran the structural checks on the two deck
+  halves while `sync verify` ran them on the companion-inlined projection, so the
+  two verbs disagreed about the same pair: `verify` failed on a byte-diverged
+  *shared* narration cell while `record` banked it as verified — and a banked
+  "verified" divergence is what later lets a mirror or a propagation overwrite
+  content that only ever existed on one side. `record` and `apply`'s post-write
+  ledger save now gate on the same projection `verify` reads, so a one-sided
+  id'd narrative member, a diverged shared companion cell, a duplicated companion
+  id, or a pair CLM cannot project at all (mixed / cross-language layout, orphaned
+  `for_slide`) refuses the write instead of being trusted.
+  `--allow-diverged-companion` is the documented override on both verbs: it drops
+  **only** the violations the companion projection introduced — a corruption in
+  the deck halves themselves still refuses — and logs each one at WARNING.
+  Measured before shipping: of 1063 split pairs across PythonCourses, CppCourses
+  and CSharpCourses, zero start failing (229 project differently and all stay
+  clean). `clm harvest`'s write path deliberately keeps the deck-halves-only gate
+  — a one-sided narrative member is its sanctioned pending state, and the two
+  entry points now sit side by side in `clm.slides.sync_verify` so the difference
+  is a documented choice rather than a per-call-site accident.

--- a/docs/claude/handovers/adversarial-review-remediation-handover.md
+++ b/docs/claude/handovers/adversarial-review-remediation-handover.md
@@ -1,6 +1,18 @@
 # Adversarial Review Remediation — Handover
 
-**Created**: 2026-07-24 | **Status**: Phases 0–2 DONE; Phase 3 next | **Owner**: unassigned
+**Created**: 2026-07-24 | **Status**: Phases 0–2 DONE; Phase 3 in progress (item 1 DONE) | **Owner**: unassigned
+
+**2026-07-26 update (3)**: **release 1.23.0 shipped** (Phase 2's whole body of
+work is now on PyPI), and **Phase 3 item 1 (Y2 + D8) is DONE** — the strict
+`record` gate. Notes at the end of Phase 3. Two maintainer decisions were fixed
+in the same session and are recorded in §2 as **D13** (#697 — sanitize
+macro-emitted HTML *on the server*) and **D14** (#698 — render the preview in a
+**subprocess**); both are now unblocked issues for the normal backlog, not phase
+work. **S5 has been pulled forward** out of Phase 4 into its own **Phase 3a**
+(see §4) — repo-supplied executable paths are the same finding class as the
+Phase 0 cassette RCE, which is information the original risk×independence
+ordering predates. Next: Phase 3a (S5, plus the adjacent S4/S8 if they ride
+cheaply), then the rest of Phase 3 starting at Y1.
 
 **2026-07-26 update**: **Phase 2 is DONE** — items 3 (`clm serve`, PR #695)
 and 4 (Studio render, PR #696) landed, closing S6 and S7. Two follow-ups were
@@ -65,6 +77,8 @@ landed; §4 states dependencies explicitly where they are hard.
 | D10 | Architecture remediation scope | **Full re-layering, including extracting build orchestration — gated behind test coverage** | The test prerequisite (D11) is a *hard gate*: no re-layering commit lands before Phase 7 is complete and green. |
 | D11 | Re-layering test prerequisite | **All four**: golden e2e characterization suite, layer-boundary contract tests, real unmocked build-pipeline tests in the fast suite, and a coverage threshold on the modules being moved | Phase 7 exists solely to satisfy this. It is the largest single investment in the plan and it is deliberate. |
 | D12 | Test policy | **Fix the dead tests + add a nightly CI job for the `slow` tier** | Recovers lost coverage without lengthening PR CI. Nightly failures need a watcher — see Phase 1 landmines. |
+| D13 | #697 — the Studio's tier-2 preview and macro-emitted HTML | **Sanitize on the server** (option 2) | The preview is rewired, and the macro-emitted HTML is sanitized **server-side** before it reaches the page — not by trusting the macro output, and not by sanitizing in the browser where the sink already exists. Add the sanitizer dependency to the **correct dependency group**: the `[web]` extra in `pyproject.toml` (what the Studio already requires) — not core, not `[dev]`, and `[all]` picks it up through `web`. `nh3` over `bleach` (bleach is deprecated upstream). An install without `[web]` must fail closed rather than fall back to unsanitized HTML. |
+| D14 | #698 — bounding the preview's CPU | **Render in a subprocess** | The in-process memory bounds shipped with S7; CPU needs a boundary a Jinja hook cannot give. A subprocess is killable on a wall-clock timeout, which is the only mechanism that survives a template that loops without allocating. Accepts the per-render process cost. |
 
 **Session scope note**: the maintainer chose *handover document only* for the
 session that produced this plan. No code was changed on 2026-07-24. Phase 0 is
@@ -612,7 +626,7 @@ cache path; SSTI proof-of-concept from the review no longer executes.
   stale-while-revalidate so a missed bump costs one stale load rather than
   permanent staleness.
 - **Windows-first landmines hit again, both in tooling rather than product
-  code**: writing a JS regex containing ` - ` through the editing
+  code**: writing a JS regex containing a literal control-character range through the editing
   tools twice produced *literal control bytes* in the file, and once collapsed
   `\` to `\` (silently breaking a character class). Verify byte content
   after writing regex-heavy JS — `node --check` catches the syntax errors but
@@ -689,7 +703,7 @@ a drive-by.
 
 ---
 
-### Phase 3 — Sync engine correctness  ▸ STATUS: not started (item 1's migration prerequisite is DONE — see below)
+### Phase 3 — Sync engine correctness  ▸ STATUS: item 1 (Y2 + D8) DONE 2026-07-26; next is item 2 (Y1)
 **Depends on**: Phase 1 (sync unit coverage is the best in the repo — keep it
 that way and extend it here).
 
@@ -744,7 +758,10 @@ the other bugs consume.
 
 **Work**
 
-1. **Y2 + D8 — the ledger write gate.** `src/clm/cli/commands/slides/sync_v3.py:239-250`
+1. **Y2 + D8 — the ledger write gate.** ▸ **DONE** (2026-07-26) —
+   `src/clm/slides/sync_verify.py` grew the two named gate entry points and the
+   shared projection; see "Notes from item 1" at the end of this phase.
+   `src/clm/cli/commands/slides/sync_v3.py:239-250`
    and `:375-385`: `structural_gate` must run on the **projected** pair (companions
    inlined via `project_pair`), exactly as `verify_pair` does
    (`sync_verify.py:329-333`). Add the documented override flag; make it log at
@@ -808,9 +825,93 @@ the other bugs consume.
 `record` and `verify` provably agree on the same projected pair; course repos
 migrated to the new decision format.
 
+**Notes from item 1 — Y2 + D8 (2026-07-26)**
+
+- **There are two correct gates, not one, and the plan's "fix all four call
+  sites" would have broken `clm harvest`.** The two sync sites (`record`,
+  `apply`) must project; the two harvest sites must **not**. A harvest write
+  lands narration on one language side, and proposal §6 *requires* that
+  one-sided member to be recorded — it is what makes the next sync report frame
+  the twin as `translate_new`. Measured: a one-sided **id'd** companion member
+  projects to an `id-asymmetry` error, so projecting at
+  `harvest_accept._record_members` would have withheld exactly that ledger
+  entry, breaking `test_one_sided_create_with_record_frames_translate_new`.
+  `harvest verify`'s docstring had said so all along ("the corruption misreading
+  harvest must avoid — §6"); the sizing note in this plan missed it.
+  **The drift-by-call-site worry was real, though**, so the fix is two *named*
+  functions living next to each other in `sync_verify.py` —
+  `gate_projected_pair` and `gate_deck_halves` — each documenting when it is
+  correct, with the projection itself behind one shared `projected_pair`. A
+  boolean parameter was rejected: the call site should read as a choice.
+- **Which shapes projection actually changes** (measured, not reasoned — the
+  probe is trivial to rebuild): a **byte-diverged shared** companion cell →
+  `unify` error (this is Y2's exact shape: raw gate clean, projected not); a
+  **one-sided id'd** narrative member → `id-asymmetry`; a duplicated companion
+  `(slide_id, role)` → `duplicate-id`. An **id-less** one-sided companion cell
+  is clean both ways (`unify_texts` degrades gracefully), which is why the
+  existing `test_one_sided_companion_is_not_a_structural_error` was never
+  evidence that the gate was fine.
+- **A projection *refusal* had to become a gate error, and that is a second
+  hole the finding did not name.** For a mixed / cross-language layout, or a
+  companion whose `for_slide` matches no slide, `project_pair` refuses and
+  returns the *raw* texts — so a gate that just used them reached a clean
+  verdict by not looking. `gate_projected_pair` emits an error-severity
+  `companion-refusal` instead. **Do not assume the v3 lens already stops these**:
+  measured with id'd cells, `load_bundle` *parses* all three (the layout checks
+  at `doc_lenses.py:937-957` are `observe`, not `refuse`), so before this change
+  `record` banked them.
+- **`verify` reports the same refusal as a *warning*, deliberately.** Its
+  contract is "did an edit corrupt this pair?" and an unprojectable *layout* is
+  not that; the gate's question is "may I record this as verified?", which it may
+  not, having been unable to read the narration. This is the one place gate and
+  verify differ, and it is stated in both docstrings.
+- **The escape hatch is scoped by construction, not by discipline.**
+  `--allow-diverged-companion` drops only violations the *raw* halves do not
+  also show, keyed on `(kind, slide_id, role)` rather than the message — a
+  `unify` message carries line numbers that inlining shifts, and matching on it
+  would have let the flag override a pre-existing deck-half corruption. It is
+  therefore provably not a `--force`, and the cross-language fixture pins that
+  (its refusal is overridable, its id-asymmetry is not). The WARNING log lives
+  inside the gate, so no call site can forget it.
+- **Re-measured the blast radius against the final semantics** (the earlier
+  sweep predated the refusal-as-error decision): 723 PythonCourses + 340
+  CppCourses + 0 CSharpCourses split pairs, **0 newly failing**, 229 projecting
+  differently, **0 projection refusals anywhere**. Note the earlier sweep's
+  "956" counted `.claude/worktrees/` copies inside the course repo — 5801 of the
+  6524 `*.de.*` files under PythonCourses are nested worktrees. **Exclude
+  `.claude` when sweeping a course repo**, or you measure the same deck a dozen
+  times.
+- **The "fails before the fix" evidence is in the tests, permanently.** Each
+  blindness test asserts `structural_gate` over the *raw* halves is empty in the
+  same breath as asserting the strict gate is not — i.e. the old behaviour is
+  pinned beside the new one, rather than demonstrated once by reverting the
+  source and then lost.
+
 ---
 
-### Phase 4 — Filesystem containment & secrets  ▸ STATUS: not started
+### Phase 3a — Repo-supplied executables (S5, pulled forward)  ▸ STATUS: not started
+
+**Why it is here.** Pulled out of Phase 4 by the maintainer on 2026-07-26. S5 is
+the same finding class as Phase 0's cassette RCE — content that arrives with a
+course repo causing code execution on a normal `clm` invocation — and Phase 0
+established that class as real and exploitable in this codebase. The original
+phase order was set by risk × independence *before* that was known.
+
+**Work** — item 4 of Phase 4, verbatim; see it for the file references. The
+open sub-decision (§6 item 1) still stands: recommendation is that **repo-local
+config may not set executable paths at all** (user/system config only), falling
+back to an allowlist if that proves too restrictive. Same treatment for
+`notebook_kernel_python`, plus the scheme allowlist for spec-supplied
+`repository_base` before it reaches `git` (`ext::` executes its argument).
+
+**Ride-alongs, if and only if they stay cheap**: S4 (the `.clm-include`
+`rmtree`) and S8 (MCP containment) are adjacent and both amount to reusing an
+existing correct normalizer. If either grows, split it back out to Phase 4
+rather than letting this phase sprawl.
+
+---
+
+### Phase 4 — Filesystem containment & secrets  ▸ STATUS: not started (S5 pulled forward to Phase 3a)
 
 **Goal**: content and config from a course repo cannot reach outside the paths
 CLM owns, and secrets stay out of logs and commits.
@@ -837,7 +938,9 @@ CLM owns, and secrets stay out of logs and commits.
    (`text_utils.py:56-70`). Consider requiring a marker file (e.g.
    `.clm-manifest.json`) before the sweep will empty a directory — a
    one-character typo (`<path>.</path>`) currently reaches the sweep.
-4. **S5 — repo-supplied executables.** `config.py:936-947` discovers config from
+4. **S5 — repo-supplied executables.** ▸ **moved to Phase 3a** (pulled forward
+   2026-07-26 — same class as the Phase 0 RCE). Kept here as the reference text.
+   `config.py:936-947` discovers config from
    inside the course repo, and `drawio_converter.py:14,47` runs the resulting
    path with no validation. **Open sub-decision** (recommendation:
    repo-local config may not set executable paths at all — those come from user
@@ -1085,13 +1188,13 @@ Every finding from the review, and where it is handled. IDs match
 | Finding | Phase | Finding | Phase | Finding | Phase |
 |---|---|---|---|---|---|
 | S1 | 0 | C1 | 0 (interim) → 6 (final) | Y1 | 3 |
-| S2 | 2 | C2 | 5 | Y2 | 3 |
+| S2 | 2 | C2 | 5 | Y2 | 3 ✔ DONE |
 | S3 | 2 | C3 | 5 | Y3 | 3 |
-| S4 | 4 | C4 | 5 | Y4 | 3 |
-| S5 | 4 | C5 | 5 | Y5 | 3 |
+| S4 | 4 (3a if cheap) | C4 | 5 | Y4 | 3 |
+| S5 | **3a** (pulled fwd) | C5 | 5 | Y5 | 3 |
 | S6 | 2 | C6 | 5 | Y6 | 3 |
 | S7 | 2 | C7 | 5 | Y7 | 3 |
-| S8 | 4 | C8 | 5 | Y8 | 3 |
+| S8 | 4 (3a if cheap) | C8 | 5 | Y8 | 3 |
 | S9 | 4 | C9 | 5 | Y9 | 3 |
 | S10 | 4 | C10 | 5 | A1 | 8 |
 | S11 | 4 | C11 | 5 | A2 | 8 |
@@ -1122,8 +1225,10 @@ so the maintainer can object:
    at all (user/system config only). Fall back to an allowlist if too restrictive.
 2. **S11 sweep marker** — recommendation: require `.clm-manifest.json` (or
    equivalent) before the sweep will empty a directory.
-3. **D8 override flag name** — something that reads as dangerous at a glance;
-   `--allow-diverged-companion` rather than `--force`.
+3. ~~**D8 override flag name**~~ — **settled and shipped**: the flag is
+   `--allow-diverged-companion` on both `record` and `apply`, and it is not only
+   *named* narrowly, it *is* narrow — it drops only the violations the companion
+   projection introduced, so it cannot act as a `--force`.
 4. **D3 cache migration** — recommendation: bump the cache version so old pickled
    entries are ignored, rather than writing a converter for a cache that
    regenerates itself.

--- a/src/clm/cli/commands/harvest.py
+++ b/src/clm/cli/commands/harvest.py
@@ -507,22 +507,22 @@ def harvest_accept_cmd(
 @click.argument("slides", type=click.Path(exists=True, path_type=Path))
 @click.option("--json", "as_json", is_flag=True, help="Emit the JSON verdict.")
 def harvest_verify_cmd(slides: Path, as_json: bool):
-    """Structural post-check on the pair (v3 lens + the shared write gate).
+    """Structural post-check on the pair (v3 lens + the deck-halves write gate).
 
     Runs the v3 lens gate (the whole bundle must parse back — refusals are
-    corruption) plus the deck-half structural gate `sync record`/`apply`
-    use. One-sided narrative members are NOT failures: a harvest write to
-    one language side is a representable pending state the `clm slides
-    sync` loop resolves as translation work — they are listed as
-    `pending_twin` items. (The v2 `sync verify` projects companions and
-    reads that same state as an id-asymmetry error, which is exactly the
-    "corruption" misreading harvest must avoid — §6.)
+    corruption) plus the **deck-halves-only** structural gate
+    (`gate_deck_halves`). One-sided narrative members are NOT failures: a
+    harvest write to one language side is a representable pending state the
+    `clm slides sync` loop resolves as translation work — they are listed as
+    `pending_twin` items. (`sync verify`, and `sync record`/`apply`'s gate,
+    project the companions and read that same state as an id-asymmetry error,
+    which is exactly the "corruption" misreading harvest must avoid — §6.)
 
     \b
     Exit codes: 0 pass (pending twins allowed) · 2 structural errors.
     """
     from clm.slides.doc_lenses import DocLensError, load_bundle
-    from clm.slides.sync_verify import structural_gate
+    from clm.slides.sync_verify import gate_deck_halves
 
     try:
         bundle = load_bundle(slides)
@@ -541,9 +541,13 @@ def harvest_verify_cmd(slides: Path, as_json: bool):
     else:
         errors.extend(
             f"[{v.kind}] {v.message}"
-            for v in structural_gate(
-                bundle.de_path.read_text(encoding="utf-8"),
-                bundle.en_path.read_text(encoding="utf-8"),
+            # Deck halves only — the §6 exception, see `gate_deck_halves`. The
+            # companion-projecting gate the sync verbs use (D8) reads a
+            # one-sided narrative member as an id-asymmetry error, which is
+            # exactly the "corruption" misreading harvest must avoid.
+            for v in gate_deck_halves(
+                bundle.de_path,
+                bundle.en_path,
                 bundle.comment_token,
             )
         )

--- a/src/clm/cli/commands/slides/sync.py
+++ b/src/clm/cli/commands/slides/sync.py
@@ -533,12 +533,23 @@ def sync_verify_cmd(de_path: Path, en_path: Path | None, as_json: bool) -> None:
     metavar="WHO",
     help="Trust provenance to stamp: 'record', 'agent', or 'semantic:<model>'.",
 )
+@click.option(
+    "--allow-diverged-companion",
+    is_flag=True,
+    help=(
+        "Record even when the only structural failures come from a separated "
+        "voiceover companion (a one-sided or byte-diverged narration). Each "
+        "overridden divergence is logged at WARNING. A corruption in the deck "
+        "halves themselves still refuses."
+    ),
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit the record result as JSON.")
 def sync_record_cmd(
     de_path: Path,
     en_path: Path | None,
     members: tuple[str, ...],
     provenance: str,
+    allow_diverged_companion: bool,
     as_json: bool,
 ) -> None:
     """Record the deck's current verified state into the committed ledger.
@@ -547,9 +558,12 @@ def sync_record_cmd(
     after you have verified — or reconciled — a deck, ``record`` banks its
     members' current fingerprints in ``<topic>/.clm/sync-ledger.json`` so
     ``report`` trusts them until they drift. Gated on the structural verify
-    (a corrupt pair is refused, nothing written). A full record sweeps stale
-    entries and performs the §7.3 pos→id key migration (logged); ``--member``
-    upserts just the named handles. Works over a directory.
+    (a corrupt pair is refused, nothing written) — including the narration in a
+    separated voiceover companion, so a divergence ``verify`` fails on can
+    never be blessed here (``--allow-diverged-companion`` overrides that one
+    class, loudly). A full record sweeps stale entries and performs the §7.3
+    pos→id key migration (logged); ``--member`` upserts just the named handles.
+    Works over a directory.
 
     \b
     This is the efficient answer to an all-cold report (a freshly authored or
@@ -566,6 +580,7 @@ def sync_record_cmd(
             members=members,
             provenance=provenance,
             as_json=as_json,
+            allow_diverged_companion=allow_diverged_companion,
         )
     )
 
@@ -599,6 +614,15 @@ def sync_record_cmd(
     is_flag=True,
     help="Execute and validate everything, write nothing.",
 )
+@click.option(
+    "--allow-diverged-companion",
+    is_flag=True,
+    help=(
+        "Let the post-apply ledger write proceed when the only structural "
+        "failures come from a separated voiceover companion. Logged at WARNING "
+        "per divergence; a corrupt deck half still withholds the ledger."
+    ),
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit the apply result as JSON.")
 def sync_apply_cmd(
     de_path: Path,
@@ -606,6 +630,7 @@ def sync_apply_cmd(
     decisions_spec: str | None,
     members: tuple[str, ...],
     dry_run: bool,
+    allow_diverged_companion: bool,
     as_json: bool,
 ) -> None:
     """Apply the reconciliation per item — writes files, never calls a model.
@@ -636,5 +661,6 @@ def sync_apply_cmd(
             members=members,
             dry_run=dry_run,
             as_json=as_json,
+            allow_diverged_companion=allow_diverged_companion,
         )
     )

--- a/src/clm/cli/commands/slides/sync_v3.py
+++ b/src/clm/cli/commands/slides/sync_v3.py
@@ -182,6 +182,7 @@ def run_apply_v3(
     members: tuple[str, ...],
     dry_run: bool,
     as_json: bool,
+    allow_diverged_companion: bool = False,
 ) -> int:
     """The v3 write verb. Exit 0 all-applied / 1 residue / 2 error."""
     if de_path.is_dir():
@@ -235,15 +236,17 @@ def run_apply_v3(
         # The structural write-gate on the TRUST store (design §5): landed
         # file mutations stay (review them with git), but a pair that fails
         # the structural verify is never recorded as verified — same gate
-        # `record` applies. Lazy import: sync_verify still loads v2 modules.
-        from clm.slides.sync_verify import structural_gate
+        # `record` applies, over the same companion-inlined projection
+        # `verify` reads (D8). Lazy import: sync_verify still loads v2 modules.
+        from clm.slides.sync_verify import gate_projected_pair
 
         verify_violations = [
             v.message
-            for v in structural_gate(
-                bundle.de_path.read_text(encoding="utf-8"),
-                bundle.en_path.read_text(encoding="utf-8"),
+            for v in gate_projected_pair(
+                bundle.de_path,
+                bundle.en_path,
                 bundle.comment_token,
+                allow_diverged_companion=allow_diverged_companion,
             )
         ]
         if not verify_violations:
@@ -269,7 +272,9 @@ def run_apply_v3(
         if verify_violations:
             click.echo(
                 "structural verify failed — applied changes were written but NOT "
-                "recorded into the ledger; fix the pair, then `sync record`",
+                "recorded into the ledger; fix the pair, then `sync record`. If the "
+                "divergence is in a voiceover companion and is intentional, "
+                "`--allow-diverged-companion` records it anyway (logged)",
                 err=True,
             )
     rejected = [r for r in outcome.results if r.status == "rejected"]
@@ -311,6 +316,7 @@ def run_record_v3(
     members: tuple[str, ...],
     provenance: str,
     as_json: bool,
+    allow_diverged_companion: bool = False,
 ) -> int:
     """The v3 trust verb: bless/accept collapsed, gated on structural verify.
 
@@ -324,7 +330,13 @@ def run_record_v3(
     pairs, solos = _scope_pairs(de_path, en_path)
     _warn_solos(solos)
     for de, en in pairs:
-        row = _record_one(de, en, members=members, provenance=provenance)
+        row = _record_one(
+            de,
+            en,
+            members=members,
+            provenance=provenance,
+            allow_diverged_companion=allow_diverged_companion,
+        )
         rows.append(row)
         if row.get("error"):
             errors += 1
@@ -357,6 +369,7 @@ def _record_one(
     *,
     members: tuple[str, ...],
     provenance: str,
+    allow_diverged_companion: bool = False,
 ) -> dict:
     try:
         bundle = _load(de_path, en_path)
@@ -370,14 +383,18 @@ def _record_one(
     assert bundle.outcome.deck is not None
 
     # The structural verify gate (design §5/§8): a structurally corrupt pair
-    # is never recorded as verified. Lazy import — sync_verify still imports
-    # v2 modules, and this module must stay clean of them at import time.
-    from clm.slides.sync_verify import structural_gate
+    # is never recorded as verified. Runs over the companion-inlined projection
+    # `verify` reads, so a divergence hidden in a separated voiceover companion
+    # cannot be blessed here while `verify` fails on it (D8 / finding Y2). Lazy
+    # import — sync_verify still imports v2 modules, and this module must stay
+    # clean of them at import time.
+    from clm.slides.sync_verify import gate_projected_pair
 
-    violations = structural_gate(
-        bundle.de_path.read_text(encoding="utf-8"),
-        bundle.en_path.read_text(encoding="utf-8"),
+    violations = gate_projected_pair(
+        bundle.de_path,
+        bundle.en_path,
         bundle.comment_token,
+        allow_diverged_companion=allow_diverged_companion,
     )
     if violations:
         row["refused"] = True

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1902,9 +1902,11 @@ reference.
 ```
 clm slides sync DECK                       # default → `report` (read-only)
 clm slides sync report DECK|DIR [--json] [--since DATE|REF]
-clm slides sync apply  DECK [--decisions FILE|-] [--member KEY]... [--dry-run] [--json]
+clm slides sync apply  DECK [--decisions FILE|-] [--member KEY]... [--dry-run]
+                            [--allow-diverged-companion] [--json]
 clm slides sync verify DECK|DIR [--json]   # structural integrity check
-clm slides sync record DECK|DIR [--member KEY]... [--provenance WHO] [--json]
+clm slides sync record DECK|DIR [--member KEY]... [--provenance WHO]
+                               [--allow-diverged-companion] [--json]
 ```
 
 | Verb | Writes? | Model? | What it does |
@@ -1999,7 +2001,8 @@ written, and the payload labels its baseline `since:<sha>`.
 #### `clm slides sync apply`
 
 ```
-clm slides sync apply DECK [--decisions FILE|-] [--member KEY]... [--dry-run] [--json]
+clm slides sync apply DECK [--decisions FILE|-] [--member KEY]... [--dry-run]
+                          [--allow-diverged-companion] [--json]
 ```
 
 Writes, **per item**: every mechanical row executes deterministically; framed
@@ -2027,7 +2030,9 @@ record-only rows report status `deferred`, file-mutating rows stay `applied`
 with the reason suffix `(recording deferred: unresolved sibling item on this
 member)`. `--member KEY` limits the pass to the named
 handles; `--dry-run` executes and validates everything, writes nothing. Exit
-`0` all-applied / `1` residue / `2` error. Needs no API key; single deck only
+`0` all-applied / `1` residue / `2` error. The ledger gate projects the
+voiceover companions like `record`'s does, and takes the same
+`--allow-diverged-companion` override (see `record`). Needs no API key; single deck only
 (run `report` over a directory to find work). The `--json` result carries
 `counts` (`applied` / `recorded` / `deferred` / `pending` / `rejected` /
 `failed` / `skipped`), per-item `items[].status` + `reason`,
@@ -2050,13 +2055,17 @@ vs git `HEAD` and on a cross-side tag-parity mismatch (twin cells whose tag
 sets differ — tags are language-independent, and `report` frames the fix as a
 tag row). Exit `0` = structurally sound, `2` = corrupt. Answers *"did
 this edit corrupt the pair?"*, not *"is it in sync?"* — run it in CI freely.
-The same checks gate every ledger write (`record`, and `apply`'s ledger
-updates), so a corrupt pair can never be recorded as trusted.
+The same checks, **over the same companion-inlined projection**, gate every
+ledger write (`record`, and `apply`'s ledger updates), so a corrupt pair can
+never be recorded as trusted (CLM {version}: the gate used to read the deck
+halves alone, so a divergence living in a separated voiceover companion failed
+`verify` while `record` blessed it — see `clm info migration`).
 
 #### `clm slides sync record`
 
 ```
-clm slides sync record DECK|DIR [--member KEY]... [--provenance WHO] [--json]
+clm slides sync record DECK|DIR [--member KEY]... [--provenance WHO]
+                               [--allow-diverged-companion] [--json]
 ```
 
 The bless/accept confirmation paths collapsed into one verb: bank the deck's
@@ -2067,6 +2076,19 @@ stale entries and performs the pos→id key migration when a cell gained an id
 (logged); `--member KEY` upserts just the named handles. `--provenance` stamps
 who asserted the verification: `record` (default), `agent`, or
 `semantic:<model>`.
+
+**The gate reads the separated voiceover companions too (CLM {version}).** It
+runs over the same companion-inlined projection `verify` uses, so a divergence
+that lives only in the narration — a byte-diverged *shared* companion cell, a
+one-sided id'd narrative member, a duplicated companion id — refuses the record
+instead of being banked as verified. A pair CLM cannot project at all (mixed /
+cross-language layout, or a companion cell whose `for_slide` matches no slide)
+is refused for the same reason: the narration could not be checked.
+`--allow-diverged-companion` records anyway, but **only** drops the violations
+the projection introduced — a corruption in the deck halves themselves still
+refuses — and logs each overridden divergence at WARNING. Use it when the
+divergence is a deliberate pending state, not to make a message go away.
+`clm slides sync apply` takes the same flag for its post-write ledger save.
 
 **Re-recording is git-idempotent (CLM {version}).** A member whose recorded
 state (fingerprints, provenance, trust state, hash version) is unchanged keeps

--- a/src/clm/cli/info_topics/harvest-agents.md
+++ b/src/clm/cli/info_topics/harvest-agents.md
@@ -91,10 +91,19 @@ rejected (nothing written).
 
 ## verify — the structural post-check
 
-`clm harvest verify DECK` runs the v3 lens gate plus the deck-half
+`clm harvest verify DECK` runs the v3 lens gate plus the **deck-halves**
 structural gate. One-sided narrative members are listed as
 `pending_twins`, **not** failures — they are the translation work you
 handed to the sync loop. Exit `2` means real corruption; stop and diagnose.
+
+**Deliberately weaker than `clm slides sync record`'s gate**, which since CLM
+{version} projects the voiceover companions and therefore reads a one-sided
+narrative member as an `id-asymmetry` error. That is the correct reading *there*
+(nothing may be banked as verified while the narration diverges) and the wrong
+one *here* (a one-sided harvest write is the pending state this toolkit
+produces). So a deck you have just harvested one language for will pass
+`harvest verify` and be refused by `sync record` until the twin exists — expected,
+and the sync loop is how you clear it.
 
 ## The `dropped` audit list
 

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -2,6 +2,46 @@
 
 This guide covers breaking changes across major CLM versions.
 
+## `clm slides sync record` can now refuse a deck it used to bank ({version})
+
+**Breaking only for a deck whose separated voiceover companion carries a
+divergence.** No deck in the maintained course repos regressed (measured over
+1063 split pairs across PythonCourses, CppCourses and CSharpCourses: zero), and
+a pair with no companions, or with symmetric ones, is unaffected.
+
+`record` (and `apply`'s post-write ledger save) used to run the structural gate
+on the two **deck halves** while `verify` ran it on the companion-inlined
+**projection**. So the two verbs disagreed about the same pair: `verify` failed
+on a byte-diverged shared narration cell while `record` blessed it — and a
+banked "verified" divergence is what later lets a mirror or a propagation
+overwrite content that only ever existed on one side. Both now read the
+projection.
+
+You will see this as a refusal naming the narration, e.g.
+
+```
+slides_x.de.py: REFUSED
+  - shared cell content diverges: DE line 42, EN line 42
+```
+
+Fix forward, in order of preference:
+
+1. Run `clm slides sync report DECK` — the same member is normally already
+   framed as translation work. Answer it, `apply`, then `record`.
+2. If the companion layout itself is the problem (voiceover both inline and in a
+   companion, or inline on one half and separated on the other, or a
+   `for_slide` naming a slide that no longer exists), the refusal says which:
+   `clm voiceover inline` / `clm voiceover extract` to normalize, or fix the
+   `for_slide` / remove the orphaned narration.
+3. If the divergence is a deliberate pending state, `record
+   --allow-diverged-companion` banks it anyway. It drops **only** the
+   violations the companion projection introduced — a corruption in the deck
+   halves themselves still refuses — and logs each one at WARNING.
+
+`clm harvest accept --record` is deliberately unchanged: it lands narration on
+one language side, and recording that one-sided member is exactly what makes the
+next sync report frame the twin as `translate_new`.
+
 ## Mobile Deck Studio no longer accepts `?token=` ({version})
 
 **Breaking only for a custom client.** The bundled PWA is unaffected — it has

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -268,6 +268,29 @@ never recorded. Two ways to converge:
   `--provenance agent` (or `semantic:<model>` when a model attested the
   translation quality).
 
+**`record`'s gate reads the voiceover companions (CLM {version}).** It runs the
+structural checks over the same companion-inlined projection `verify` uses, so a
+divergence that lives only in a separated `voiceover_*` companion — a
+byte-diverged **shared** narration cell, a one-sided id'd narrative member, a
+duplicated companion id, or a companion cell whose `for_slide` matches no slide
+— **refuses the record** (exit 1, `refused` in the JSON, nothing written)
+instead of banking it as verified. Before this, `verify` failed on such a pair
+while `record` blessed it, and the banked "verified" divergence is what let a
+later mirror or propagation overwrite content that existed on one side only.
+
+What to do when `record` refuses: read the reason, fix the narration (usually
+`report` already frames the same member as translation work — answer it and
+`apply`), then record. `--allow-diverged-companion` is the escape hatch for a
+divergence you have judged to be a deliberate pending state; it drops **only**
+the companion-introduced violations (a corrupt deck half still refuses) and logs
+each one at WARNING. Do not reach for it to silence a message you have not read.
+`clm slides sync apply` takes the same flag for its post-write ledger save.
+
+(`clm harvest accept --record` is deliberately **not** subject to this gate: a
+harvest write lands narration on one language side, and recording that one-sided
+member is what frames the twin as `translate_new` — see `clm info
+harvest-agents`.)
+
 **Rule of thumb: when a report is *all* `verify_cold` (the report says so in
 a `hint`), use `record`, not a confirm-all decision document.** They assert
 the same trust; `record` is one command instead of a scripted

--- a/src/clm/slides/doc_report.py
+++ b/src/clm/slides/doc_report.py
@@ -88,12 +88,20 @@ def cold_sweep_hint(diff: DeckDiff) -> str | None:
     An all-``verify_cold`` report is the seeding case, and the efficient
     answer is the ``record`` verb, not a hand-built confirm-all decision
     document — agents reliably scripted the latter when nothing said so.
+
+    The wording keeps "review the pair" load-bearing: ``record`` asserts
+    trust. Since D8 the verb's own gate reads the separated voiceover
+    companions too, so a divergence hidden in the narration refuses the
+    record rather than being swept up by it — but the gate is structural, and
+    only the reader can judge whether the two halves *say the same thing*.
     """
     if diff.items and all(item.action == "verify_cold" for item in diff.items):
         return (
             "every member is cold (no ledger entry) — for a freshly authored or "
-            "never-recorded deck, review the pair and bank it wholesale with "
-            "`clm slides sync record DECK` instead of confirming per item"
+            "never-recorded deck, review both halves (`record` asserts they are in "
+            "sync; its gate only proves the pair is structurally sound, companions "
+            "included) and then bank it wholesale with `clm slides sync record DECK` "
+            "instead of confirming per item"
         )
     return None
 

--- a/src/clm/slides/sync_verify.py
+++ b/src/clm/slides/sync_verify.py
@@ -57,10 +57,28 @@ the gate. It is the only check that touches git and degrades silently to
 "skipped" when the pair is untracked. It is id-based: an id-*less* cell drop is
 invisible here (a known limitation — and, per the design note, the concrete
 trigger for *selectively* adding ids where matching proves fragile).
+
+**What the write gate reads — the two entry points (Y2 / D8).** A structural
+check is only as good as the text it is handed, and a split pair's narration may
+live in a **separated voiceover companion** the deck halves do not contain. The
+two gate entry points differ *only* in that, and they sit next to each other
+here on purpose — the choice belongs at one place, not at four call sites:
+
+* :func:`gate_projected_pair` — the strict gate: it projects the companions the
+  way :func:`verify_pair` does (both go through :func:`projected_pair`), so a
+  divergence hidden in a companion cannot be recorded as verified. **Every
+  trust-store write on a sync verb uses this.**
+* :func:`gate_deck_halves` — deck halves only, no projection. The single
+  sanctioned exception, for ``clm harvest`` (proposal §6): a harvest write
+  lands narration on *one* language side, and that one-sided narrative member is
+  a representable *pending* state there ("translate the twin"), not corruption.
+  Projecting it would read it as an ``id-asymmetry`` error and withhold exactly
+  the ledger entry §6 needs written.
 """
 
 from __future__ import annotations
 
+import logging
 from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -69,8 +87,10 @@ from clm.notebooks.slide_parser import comment_token_for_path
 from clm.slides.git_text import git_ref_text
 from clm.slides.raw_cells import RawCell, split_cells
 from clm.slides.split import UnifyError, unify_texts
-from clm.slides.sync_companion import project_pair
+from clm.slides.sync_companion import ProjectedPair, project_pair
 from clm.slides.sync_writeback import role_of
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -84,8 +104,11 @@ class VerifyViolation:
     """
 
     severity: str  # "error" | "warning"
-    # error kinds: "unify" | "id-asymmetry" | "duplicate-id"
-    # warning kinds: "tag-parity" | "dropped-id"
+    # error kinds: "unify" | "id-asymmetry" | "duplicate-id" | "companion-refusal"
+    #   ("companion-refusal" is gate-only — see :func:`gate_projected_pair`; verify
+    #   reports the same condition as a warning, since an unprojectable *layout* is
+    #   not an edit that corrupted the pair)
+    # warning kinds: "tag-parity" | "dropped-id" | "companion-refusal"
     kind: str
     message: str
     slide_id: str | None = None
@@ -292,15 +315,23 @@ def structural_gate(
 ) -> list[VerifyViolation]:
     """Error-severity structural violations, optionally scoped to one ``(slide_id, role)``.
 
-    The reusable **write-gate** (Issue #455): a ledger / watermark write must never
-    record a pair — or a single slide — as in-sync while it fails a structural
-    invariant, because that would mask a genuine divergence as "trusted". The return
-    value is the *error* subset of :func:`structural_violations` — the exact
-    invariants ``clm slides sync verify`` enforces, computed from the **same**
-    function, so the gate and the CLI can never drift. An **empty list means "safe to
-    record"**; a non-empty list is the reason it is not. It works on in-memory text
-    (no file/git read), so the apply path can gate a watermark write on the
-    post-apply :class:`~clm.slides.split` state without a re-read.
+    The reusable **write-gate** primitive (Issue #455): a ledger / watermark write
+    must never record a pair — or a single slide — as in-sync while it fails a
+    structural invariant, because that would mask a genuine divergence as "trusted".
+    The return value is the *error* subset of :func:`structural_violations` — the
+    exact invariants ``clm slides sync verify`` enforces, computed from the **same**
+    function. An **empty list means "safe to record"**; a non-empty list is the reason
+    it is not. It works on in-memory text (no file/git read), so the apply path can
+    gate a watermark write on the post-apply :class:`~clm.slides.split` state without
+    a re-read.
+
+    **This is the primitive, not the gate a verb should call.** It judges exactly the
+    two texts it is handed, and a caller that hands it the raw deck halves is blind to
+    a separated voiceover companion — the Y2 hole, where ``verify`` failed on a
+    byte-diverged shared companion while ``record`` blessed it. Sharing
+    :func:`structural_violations` never prevented that, because the drift was in the
+    *input*, not the computation. Use :func:`gate_projected_pair` (which owns the
+    projection) unless you are ``clm harvest`` — see :func:`gate_deck_halves`.
 
     **Whole-deck** (``slide_id is None``): every structural error in the pair — the
     gate for batch ``bless`` and the apply-path full watermark write.
@@ -340,6 +371,148 @@ def _scoped_to(violation: VerifyViolation, slide_id: str, role: str | None) -> b
     if role is None:
         return True
     return violation.role is None or violation.role == role
+
+
+def projected_pair(de_path: Path, en_path: Path) -> ProjectedPair:
+    """Read both halves and project their voiceover companions in memory (#501).
+
+    The **single** place the structural checks decide what text they read: both
+    :func:`verify_pair` and :func:`gate_projected_pair` go through here, so "what
+    does a structural check see?" has one answer per pair instead of one per call
+    site (the Y2 bug was exactly that divergence).
+
+    A **plain** pair projects to itself byte-for-byte; a **separated** pair has each
+    half's companion inlined; **mixed** / **cross-language** / unplaceable-companion
+    pairs carry a ``refusal`` and fall back to their raw text — a caller must decide
+    what an unprojectable pair means for it (verify: a warning; the gate: a refusal
+    to record).
+    """
+    return project_pair(
+        de_path,
+        en_path,
+        de_path.read_text(encoding="utf-8"),
+        en_path.read_text(encoding="utf-8"),
+    )
+
+
+def gate_projected_pair(
+    de_path: Path,
+    en_path: Path,
+    comment_token: str | None = None,
+    *,
+    slide_id: str | None = None,
+    role: str | None = None,
+    allow_diverged_companion: bool = False,
+) -> list[VerifyViolation]:
+    """The strict write gate: :func:`structural_gate` over the **projected** pair (D8).
+
+    Reads both halves from disk, projects their voiceover companions
+    (:func:`projected_pair` — the same projection :func:`verify_pair` uses) and gates
+    on the result. Every trust-store write on a sync verb goes through this: ``record``
+    and ``apply``'s post-write ledger save. An **empty list means "safe to record"**.
+
+    Two things the raw-halves primitive cannot see, and this does:
+
+    * a divergence that lives in a **separated companion** — a byte-diverged shared
+      narration cell, a one-sided id'd narrative member, a duplicated companion id;
+    * a pair CLM **cannot project at all** (a mixed / cross-language layout, or a
+      companion cell whose ``for_slide`` no longer resolves), reported as an
+      ``error``-severity ``companion-refusal``. Falling back to the raw halves there
+      would be the Y2 hole again — a clean verdict reached by not looking.
+
+    ``allow_diverged_companion`` is D8's documented escape hatch (surfaced as
+    ``clm slides sync record|apply --allow-diverged-companion``). It drops **only**
+    those violations the raw deck halves do *not* also show — i.e. the ones the
+    projection introduced — and logs each at WARNING. A corruption in the deck halves
+    themselves still blocks the write: the flag is deliberately not a ``--force``.
+    """
+    token = comment_token if comment_token is not None else comment_token_for_path(de_path)
+    projection = projected_pair(de_path, en_path)
+    violations = structural_gate(
+        projection.de_text, projection.en_text, token, slide_id=slide_id, role=role
+    )
+    if projection.refusal is not None:
+        violations.insert(
+            0,
+            VerifyViolation(
+                severity="error",
+                kind="companion-refusal",
+                message=(
+                    "the voiceover companions cannot be projected, so the pair's "
+                    f"narration cannot be verified: {projection.refusal}"
+                ),
+                slide_id=slide_id,
+            ),
+        )
+    if not allow_diverged_companion:
+        return violations
+    raw_violations = structural_gate(
+        de_path.read_text(encoding="utf-8"),
+        en_path.read_text(encoding="utf-8"),
+        token,
+        slide_id=slide_id,
+        role=role,
+    )
+    overridden = _companion_only(violations, raw_violations)
+    for violation in overridden:
+        logger.warning(
+            "--allow-diverged-companion: recording %s / %s despite a companion "
+            "divergence the strict gate refuses — [%s] %s",
+            de_path.name,
+            en_path.name,
+            violation.kind,
+            violation.message,
+        )
+    keep = [v for v in violations if v not in overridden]
+    return keep
+
+
+def gate_deck_halves(
+    de_path: Path,
+    en_path: Path,
+    comment_token: str | None = None,
+    *,
+    slide_id: str | None = None,
+    role: str | None = None,
+) -> list[VerifyViolation]:
+    """The gate over the deck halves **only** — ``clm harvest``'s §6 exception.
+
+    Identical to :func:`gate_projected_pair` except that it does *not* project the
+    voiceover companions. That difference is deliberate and load-bearing for exactly
+    one consumer: ``clm harvest``'s write path (proposal §6) lands narration on one
+    language side and **records that one-sided narrative member on purpose** — it is
+    what makes the next ``sync report`` frame ``translate_new`` for the twin. Under
+    projection a one-sided id'd narrative member reads as an ``id-asymmetry`` error,
+    so the strict gate would withhold precisely the ledger entry §6 requires.
+
+    Do not reach for this from a sync verb — that is the Y2 bug. If you are adding a
+    third caller, the question to answer first is whether a one-sided narrative
+    member is a *pending state* in your workflow (this function) or a *corruption*
+    (:func:`gate_projected_pair`).
+    """
+    token = comment_token if comment_token is not None else comment_token_for_path(de_path)
+    return structural_gate(
+        de_path.read_text(encoding="utf-8"),
+        en_path.read_text(encoding="utf-8"),
+        token,
+        slide_id=slide_id,
+        role=role,
+    )
+
+
+def _companion_only(
+    projected: list[VerifyViolation], raw: list[VerifyViolation]
+) -> list[VerifyViolation]:
+    """Those projected-gate violations the raw deck halves do not also show.
+
+    Keyed on ``(kind, slide_id, role)`` rather than the whole violation: a ``unify``
+    error carries the offending *line numbers* in its message, and inlining a
+    companion shifts them, so message equality would call a pre-existing deck-half
+    violation "companion-introduced" and let ``--allow-diverged-companion`` override
+    it. The coarse key errs the safe way — it keeps such a violation blocking.
+    """
+    raw_keys = {(v.kind, v.slide_id, v.role) for v in raw}
+    return [v for v in projected if (v.kind, v.slide_id, v.role) not in raw_keys]
 
 
 def _id_symmetry_violations(de_ids: list[str], en_ids: list[str]) -> list[VerifyViolation]:
@@ -464,20 +637,35 @@ def verify_pair(de_path: Path, en_path: Path) -> VerifyResult:
     (``git_baseline=False``) when neither is.
     """
     comment_token = comment_token_for_path(de_path)
-    raw_de_text = de_path.read_text(encoding="utf-8")
-    raw_en_text = en_path.read_text(encoding="utf-8")
 
     # Issue #501: verify the companion-inlined projection. A separated-voiceover pair
     # whose narration drifted to one language now leaves an inlined voiceover cell on
     # only one half, which ``unify_texts`` reports as a structural violation; a
     # symmetric companion pair inlines identically on both halves and verifies clean.
     # A plain pair projects to itself, and a mixed / cross-language pair falls back to
-    # its raw text (``sync`` surfaces that refusal separately).
-    projection = project_pair(de_path, en_path, raw_de_text, raw_en_text)
+    # its raw text. Shared with the write gate through :func:`projected_pair` so the
+    # two provably read the same text (D8 / Y2).
+    projection = projected_pair(de_path, en_path)
     de_text = projection.de_text
     en_text = projection.en_text
 
     violations = structural_violations(de_text, en_text, comment_token)
+    if projection.refusal is not None:
+        # A **warning** here, an error in the gate, and the asymmetry is the point:
+        # verify answers "did an edit corrupt this pair?" and an unprojectable
+        # *layout* is not that (it is a supported-elsewhere state `sync` refuses with
+        # its own normalize hint), while the gate answers "may I record this as
+        # verified?" — which it may not, having been unable to read the narration.
+        violations.append(
+            VerifyViolation(
+                severity="warning",
+                kind="companion-refusal",
+                message=(
+                    "the voiceover companions could not be projected, so the checks "
+                    f"below ran on the deck halves alone: {projection.refusal}"
+                ),
+            )
+        )
 
     git_baseline = False
     for path, current, half in ((de_path, de_text, "DE"), (en_path, en_text, "EN")):

--- a/src/clm/voiceover/harvest_accept.py
+++ b/src/clm/voiceover/harvest_accept.py
@@ -33,7 +33,9 @@ one-sided-trust semantics (proposal §6, the load-bearing invariant):
   stale twin — the §6 forbidden state.
 
 The ledger save is additionally gated on the structural verify
-(:func:`clm.slides.sync_verify.structural_gate`), mirroring the sync verbs.
+(:func:`clm.slides.sync_verify.gate_deck_halves`) — the **deck-halves-only**
+gate, deliberately not the companion-projecting one the sync verbs use: a
+one-sided narrative member is §6's pending state here, not corruption.
 """
 
 from __future__ import annotations
@@ -437,11 +439,16 @@ def _record_members(
     save was withheld (the files stay as written — fail-safe, like apply).
     """
     from clm.slides import doc_ledger
-    from clm.slides.sync_verify import structural_gate
+    from clm.slides.sync_verify import gate_deck_halves
 
-    violations = structural_gate(
-        bundle.de_path.read_text(encoding="utf-8"),
-        bundle.en_path.read_text(encoding="utf-8"),
+    # Deck halves only, NOT the companion-projecting gate the sync verbs use
+    # (D8): a harvest write lands narration on one side and §6 *requires* that
+    # one-sided narrative member to be recorded — it is what frames the twin as
+    # translate_new. Projected, it would read as an id-asymmetry error and
+    # withhold exactly this ledger entry. See `gate_deck_halves`.
+    violations = gate_deck_halves(
+        bundle.de_path,
+        bundle.en_path,
         bundle.comment_token,
     )
     if violations:

--- a/tests/cli/test_sync_gate_projection.py
+++ b/tests/cli/test_sync_gate_projection.py
@@ -1,0 +1,477 @@
+"""The strict (companion-projecting) write gate — finding Y2 / decision D8.
+
+``clm slides sync verify`` projects a pair's separated voiceover companions
+before it checks anything (#501), while the ledger write gate used to run on the
+raw deck halves alone. The two therefore disagreed on the one thing they exist
+to agree on: **verify failed on a byte-diverged shared companion while record
+blessed it**, banking the divergence as "verified" — which is what arms the
+mirror-removal and preamble-propagation data-loss paths.
+
+Pinned here:
+
+* the Y2 shape itself — raw gate clean, strict gate not;
+* gate ≡ verify on the projected pair (the property, not just an example);
+* a pair CLM cannot project is a gate *error* (not a clean verdict reached by
+  not looking) and a verify *warning*;
+* ``--allow-diverged-companion`` overrides **only** companion-introduced
+  violations, logs each one, and is not a ``--force``;
+* ``clm harvest``'s deliberate exemption (proposal §6) — its one-sided
+  narrative member is a pending state, and the strict gate would refuse it.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands.slides.sync import slides_sync_group
+from clm.slides.sync_verify import (
+    gate_deck_halves,
+    gate_projected_pair,
+    structural_gate,
+    verify_pair,
+)
+
+HEADER_DE = "# j2 from 'macros.j2' import header_de\n# {{ header_de(\"Titel DE\") }}\n\n"
+HEADER_EN = "# j2 from 'macros.j2' import header_en\n# {{ header_en(\"Title EN\") }}\n\n"
+
+
+def _slide(sid: str, lang: str, title: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{sid}"\n#\n# ## {title}\n\n'
+
+
+def _shared_code(value: str = "1") -> str:
+    return f'# %% tags=["keep"]\nx = {value}\n\n'
+
+
+def _vo_cell(sid: str, lang: str | None, owner: str, text: str) -> str:
+    """A companion voiceover cell; ``lang=None`` makes it language-neutral (shared)."""
+    lang_attr = f' lang="{lang}"' if lang is not None else ""
+    return (
+        f'# %% [markdown]{lang_attr} tags=["voiceover"] for_slide="{owner}" '
+        f'slide_id="{sid}"\n#\n# - {text}\n\n'
+    )
+
+
+def _deck(lang: str, *, code: str = "1") -> str:
+    header = HEADER_DE if lang == "de" else HEADER_EN
+    titles = {"de": ("Einführung", "Ende"), "en": ("Introduction", "The End")}[lang]
+    return (
+        header
+        + _slide("intro", lang, titles[0])
+        + _shared_code(code)
+        + _slide("ende", lang, titles[1])
+    )
+
+
+def _write_pair(
+    folder: Path,
+    *,
+    de_comp: str | None = None,
+    en_comp: str | None = None,
+    de_text: str | None = None,
+    en_text: str | None = None,
+) -> tuple[Path, Path]:
+    de = folder / "slides_t.de.py"
+    en = folder / "slides_t.en.py"
+    de.write_text(de_text if de_text is not None else _deck("de"), encoding="utf-8")
+    en.write_text(en_text if en_text is not None else _deck("en"), encoding="utf-8")
+    if de_comp is not None:
+        (folder / "voiceover_t.de.py").write_text(de_comp, encoding="utf-8")
+    if en_comp is not None:
+        (folder / "voiceover_t.en.py").write_text(en_comp, encoding="utf-8")
+    return de, en
+
+
+def _texts(de: Path, en: Path) -> tuple[str, str]:
+    return de.read_text(encoding="utf-8"), en.read_text(encoding="utf-8")
+
+
+def _raw_gate(de: Path, en: Path) -> list[str]:
+    return [v.message for v in structural_gate(*_texts(de, en), "#")]
+
+
+# Symmetric companions whose ``for_slide`` names a slide the deck does not have:
+# the projection refuses (never drop narration), the deck halves look perfect.
+_ORPHANED_COMPANIONS = {
+    "de_comp": _vo_cell("ghost-vo", "de", "ghost", "Für eine gelöschte Folie."),
+    "en_comp": _vo_cell("ghost-vo", "en", "ghost", "For a deleted slide."),
+}
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    # Click 8.1 needs ``mix_stderr=False``; Click 8.2+ removed the parameter.
+    try:
+        return CliRunner(mix_stderr=False)
+    except TypeError:
+        return CliRunner()
+
+
+def _payload(output: str) -> dict:
+    start = output.index("{")
+    payload, _end = json.JSONDecoder().raw_decode(output[start:])
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# The finding: what the raw-halves gate cannot see.
+# ---------------------------------------------------------------------------
+
+
+class TestCompanionBlindness:
+    def test_byte_diverged_shared_companion_cell(self, tmp_path: Path) -> None:
+        """Y2's exact shape: a *shared* narration cell whose halves differ.
+
+        Language-neutral means byte-identical by definition, so this is a
+        corruption — and the deck halves show no trace of it.
+        """
+        de, en = _write_pair(
+            tmp_path,
+            de_comp=_vo_cell("intro-vo", None, "intro", "Neutrale Erzählung A."),
+            en_comp=_vo_cell("intro-vo", None, "intro", "Neutral narration B."),
+        )
+        assert _raw_gate(de, en) == []
+        strict = gate_projected_pair(de, en, "#")
+        assert [v.kind for v in strict] == ["unify"]
+        assert "diverges" in strict[0].message
+
+    def test_one_sided_idd_narrative_member(self, tmp_path: Path) -> None:
+        de, en = _write_pair(
+            tmp_path,
+            de_comp=_vo_cell("intro-vo", "de", "intro", "Nur auf Deutsch."),
+        )
+        assert _raw_gate(de, en) == []
+        strict = gate_projected_pair(de, en, "#")
+        assert [(v.kind, v.slide_id) for v in strict] == [("id-asymmetry", "intro-vo")]
+
+    def test_duplicate_key_inside_the_companion(self, tmp_path: Path) -> None:
+        twice = _vo_cell("intro-vo", "de", "intro", "Eins.") + _vo_cell(
+            "intro-vo", "de", "intro", "Zwei."
+        )
+        de, en = _write_pair(
+            tmp_path,
+            de_comp=twice,
+            en_comp=_vo_cell("intro-vo", "en", "intro", "One.")
+            + _vo_cell("intro-vo", "en", "intro", "Two."),
+        )
+        assert _raw_gate(de, en) == []
+        assert {v.kind for v in gate_projected_pair(de, en, "#")} == {"duplicate-id"}
+
+    def test_symmetric_companions_still_pass(self, tmp_path: Path) -> None:
+        de, en = _write_pair(
+            tmp_path,
+            de_comp=_vo_cell("intro-vo", "de", "intro", "Willkommen."),
+            en_comp=_vo_cell("intro-vo", "en", "intro", "Welcome."),
+        )
+        assert gate_projected_pair(de, en, "#") == []
+
+    def test_plain_pair_is_untouched_by_the_projection(self, tmp_path: Path) -> None:
+        de, en = _write_pair(tmp_path)
+        assert gate_projected_pair(de, en, "#") == []
+        # And the strict gate still catches a deck-half corruption.
+        en.write_text(
+            en.read_text(encoding="utf-8").replace('slide_id="ende"', 'slide_id="fin"'),
+            encoding="utf-8",
+        )
+        assert {v.kind for v in gate_projected_pair(de, en, "#")} == {"id-asymmetry"}
+
+
+# ---------------------------------------------------------------------------
+# gate ≡ verify, and the one documented asymmetry.
+# ---------------------------------------------------------------------------
+
+
+class TestGateVerifyParity:
+    @pytest.mark.parametrize(
+        "de_comp,en_comp",
+        [
+            (None, None),
+            (
+                _vo_cell("intro-vo", "de", "intro", "Willkommen."),
+                _vo_cell("intro-vo", "en", "intro", "Welcome."),
+            ),
+            (
+                _vo_cell("intro-vo", None, "intro", "Neutral A."),
+                _vo_cell("intro-vo", None, "intro", "Neutral B."),
+            ),
+            (_vo_cell("intro-vo", "de", "intro", "Nur DE."), None),
+        ],
+        ids=["plain", "symmetric", "diverged-shared", "one-sided"],
+    )
+    def test_the_gate_reports_exactly_verifys_errors(
+        self, tmp_path: Path, de_comp: str | None, en_comp: str | None
+    ) -> None:
+        """The property D8 asks for, over every companion shape.
+
+        Not "both call ``structural_violations``" — they always did. The claim is
+        that they run it on the *same text*, which is what Y2 disproved.
+        """
+        de, en = _write_pair(tmp_path, de_comp=de_comp, en_comp=en_comp)
+        gate = [(v.kind, v.message) for v in gate_projected_pair(de, en, "#")]
+        verify = [(v.kind, v.message) for v in verify_pair(de, en).errors]
+        assert gate == verify
+
+    def test_unprojectable_pair_is_a_gate_error_and_a_verify_warning(self, tmp_path: Path) -> None:
+        """Orphaned narration: the companions name a slide the deck no longer has.
+
+        Nothing to project, and the deck halves alone look perfect. The gate must
+        refuse — falling back to the raw halves would be a clean verdict reached
+        by not looking, which is the Y2 hole again. ``verify`` answers a different
+        question ("did an edit corrupt this pair?"), so it says so as a warning
+        and keeps its exit code.
+        """
+        de, en = _write_pair(tmp_path, **_ORPHANED_COMPANIONS)
+        assert _raw_gate(de, en) == []
+        strict = gate_projected_pair(de, en, "#")
+        assert [v.kind for v in strict] == ["companion-refusal"]
+        assert "cannot be projected" in strict[0].message
+        assert "ghost" in strict[0].message
+
+        result = verify_pair(de, en)
+        assert result.ok, "an unprojectable layout is not an edit that corrupted the pair"
+        assert [v.kind for v in result.warnings if v.kind == "companion-refusal"] == [
+            "companion-refusal"
+        ]
+
+    def test_cross_language_layout_also_breaks_the_deck_halves(self, tmp_path: Path) -> None:
+        """DE separated, EN inline — refused *and* asymmetric in the raw halves.
+
+        Worth pinning because it is the shape that makes ``--allow-diverged-companion``
+        scoping matter: the refusal is companion-introduced (overridable), the
+        id-asymmetry is visible without any projection (never overridable).
+        """
+        en_inline = (
+            HEADER_EN
+            + _slide("intro", "en", "Introduction")
+            + '# %% [markdown] lang="en" tags=["voiceover"] for_slide="intro" '
+            'slide_id="intro-vo"\n#\n# - Inline narration.\n\n'
+            + _shared_code()
+            + _slide("ende", "en", "The End")
+        )
+        de, en = _write_pair(
+            tmp_path,
+            en_text=en_inline,
+            de_comp=_vo_cell("intro-vo", "de", "intro", "Erzählung."),
+        )
+        assert [v.kind for v in structural_gate(*_texts(de, en), "#")] == ["id-asymmetry"]
+        assert [v.kind for v in gate_projected_pair(de, en, "#")] == [
+            "companion-refusal",
+            "id-asymmetry",
+        ]
+        assert [
+            v.kind for v in gate_projected_pair(de, en, "#", allow_diverged_companion=True)
+        ] == ["id-asymmetry"]
+
+
+# ---------------------------------------------------------------------------
+# The escape hatch: narrow, loud, and not a --force.
+# ---------------------------------------------------------------------------
+
+
+class TestEscapeHatch:
+    def test_overrides_the_companion_violation_and_logs_it(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        de, en = _write_pair(
+            tmp_path,
+            de_comp=_vo_cell("intro-vo", "de", "intro", "Nur auf Deutsch."),
+        )
+        with caplog.at_level(logging.WARNING, logger="clm.slides.sync_verify"):
+            assert gate_projected_pair(de, en, "#", allow_diverged_companion=True) == []
+        assert any(
+            "--allow-diverged-companion" in r.message and "id-asymmetry" in r.message
+            for r in caplog.records
+        ), caplog.text
+
+    def test_does_not_override_a_deck_half_violation(self, tmp_path: Path) -> None:
+        """The flag is scoped to what the *projection* introduced, by name and by code.
+
+        Here the deck halves are themselves broken (an id present only on DE) and a
+        companion divergence sits on top. The companion violation is dropped; the
+        deck-half one still refuses.
+        """
+        de_broken = (
+            HEADER_DE
+            + _slide("intro", "de", "Einführung")
+            + _slide("nur-de", "de", "Nur DE")
+            + _shared_code()
+            + _slide("ende", "de", "Ende")
+        )
+        de, en = _write_pair(
+            tmp_path,
+            de_text=de_broken,
+            de_comp=_vo_cell("intro-vo", "de", "intro", "Nur auf Deutsch."),
+        )
+        kinds = {v.kind for v in gate_projected_pair(de, en, "#", allow_diverged_companion=True)}
+        assert kinds == {"id-asymmetry"}
+        remaining = gate_projected_pair(de, en, "#", allow_diverged_companion=True)
+        assert [v.slide_id for v in remaining] == ["nur-de"]
+
+    def test_is_a_no_op_on_a_sound_pair(self, tmp_path: Path) -> None:
+        de, en = _write_pair(
+            tmp_path,
+            de_comp=_vo_cell("intro-vo", "de", "intro", "Willkommen."),
+            en_comp=_vo_cell("intro-vo", "en", "intro", "Welcome."),
+        )
+        assert gate_projected_pair(de, en, "#", allow_diverged_companion=True) == []
+
+
+# ---------------------------------------------------------------------------
+# Through the CLI: record and apply.
+# ---------------------------------------------------------------------------
+
+
+class TestRecordVerb:
+    def test_record_refuses_a_diverged_companion(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ) -> None:
+        de, _en = _write_pair(
+            tmp_path,
+            de_comp=_vo_cell("intro-vo", None, "intro", "Neutral A."),
+            en_comp=_vo_cell("intro-vo", None, "intro", "Neutral B."),
+        )
+        result = cli_runner.invoke(slides_sync_group, ["record", str(de), "--json"])
+        assert result.exit_code == 1, result.output
+        payload = _payload(result.output)
+        assert payload["refused"] == 1
+        assert payload["recorded"] == 0
+        assert any("diverges" in r for r in payload["pairs"][0]["reasons"])
+        assert not (tmp_path / ".clm" / "sync-ledger.json").exists()
+
+    def test_record_with_the_flag_banks_it(self, cli_runner: CliRunner, tmp_path: Path) -> None:
+        de, _en = _write_pair(
+            tmp_path,
+            de_comp=_vo_cell("intro-vo", None, "intro", "Neutral A."),
+            en_comp=_vo_cell("intro-vo", None, "intro", "Neutral B."),
+        )
+        result = cli_runner.invoke(
+            slides_sync_group,
+            ["record", str(de), "--allow-diverged-companion", "--json"],
+        )
+        assert result.exit_code == 0, result.output
+        assert _payload(result.output)["refused"] == 0
+        assert (tmp_path / ".clm" / "sync-ledger.json").is_file()
+
+    def test_record_still_refuses_a_corrupt_deck_half_with_the_flag(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ) -> None:
+        de_broken = (
+            HEADER_DE
+            + _slide("intro", "de", "Einführung")
+            + _slide("nur-de", "de", "Nur DE")
+            + _shared_code()
+            + _slide("ende", "de", "Ende")
+        )
+        de, _en = _write_pair(tmp_path, de_text=de_broken)
+        result = cli_runner.invoke(
+            slides_sync_group,
+            ["record", str(de), "--allow-diverged-companion", "--json"],
+        )
+        assert result.exit_code == 1, result.output
+        assert _payload(result.output)["refused"] == 1
+        assert not (tmp_path / ".clm" / "sync-ledger.json").exists()
+
+    def test_a_symmetric_separated_deck_records_unflagged(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ) -> None:
+        de, _en = _write_pair(
+            tmp_path,
+            de_comp=_vo_cell("intro-vo", "de", "intro", "Willkommen."),
+            en_comp=_vo_cell("intro-vo", "en", "intro", "Welcome."),
+        )
+        result = cli_runner.invoke(slides_sync_group, ["record", str(de), "--json"])
+        assert result.exit_code == 0, result.output
+        assert _payload(result.output)["refused"] == 0
+
+
+class TestApplyVerb:
+    """apply's post-write ledger save runs the same strict gate."""
+
+    def _seed(self, cli_runner: CliRunner, folder: Path) -> tuple[Path, Path]:
+        """A recorded pair whose companions the gate refuses to re-verify.
+
+        Orphaned narration: only the *companions* are at fault, so the refusal is
+        exactly what ``--allow-diverged-companion`` is scoped to override — and
+        apply cannot fix it on its own, which keeps the gate the deciding factor.
+        """
+        de, en = _write_pair(folder, **_ORPHANED_COMPANIONS)
+        seed = cli_runner.invoke(
+            slides_sync_group,
+            ["record", str(de), "--allow-diverged-companion", "--json"],
+        )
+        assert seed.exit_code == 0, seed.output
+        # A shared-cell edit on DE — a mechanical item for apply to land.
+        de.write_text(de.read_text(encoding="utf-8").replace("x = 1", "x = 42"), encoding="utf-8")
+        return de, en
+
+    def test_ledger_is_withheld_when_the_gate_refuses(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ) -> None:
+        de, en = self._seed(cli_runner, tmp_path)
+        result = cli_runner.invoke(slides_sync_group, ["apply", str(de), "--json"])
+        payload = _payload(result.output)
+        assert payload["ledger_recorded"] is False
+        assert payload["verify_violations"], payload
+        # Fail-safe, as before: the file write stays, only trust is withheld.
+        assert "x = 42" in en.read_text(encoding="utf-8")
+        assert result.exit_code == 1
+
+    def test_the_flag_lets_the_ledger_write_proceed(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ) -> None:
+        de, en = self._seed(cli_runner, tmp_path)
+        result = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--allow-diverged-companion", "--json"],
+        )
+        payload = _payload(result.output)
+        assert payload["verify_violations"] == []
+        assert payload["ledger_recorded"] is True
+        assert "x = 42" in en.read_text(encoding="utf-8")
+        # Exit 1 here is the orphaned narration reported as framed residue
+        # (`broken_owner`), not the gate — the flag settles the ledger write, and
+        # deliberately does not make the underlying problem disappear from report.
+        assert result.exit_code == 1
+        assert [i["action"] for i in payload["items"] if i["status"] == "pending"] == [
+            "broken_owner"
+        ]
+
+
+# ---------------------------------------------------------------------------
+# harvest's documented exemption (proposal §6).
+# ---------------------------------------------------------------------------
+
+
+class TestHarvestExemption:
+    def test_the_strict_gate_would_refuse_what_harvest_must_record(self, tmp_path: Path) -> None:
+        """Why the two gate entry points exist, stated as a test.
+
+        A harvest write lands narration on one side; §6 *requires* that one-sided
+        member to be recorded (it is what frames the twin as ``translate_new``).
+        The strict gate reads it as an id-asymmetry — so harvest uses
+        ``gate_deck_halves`` and the sync verbs use ``gate_projected_pair``, and
+        neither call site is free to drift on its own.
+        """
+        de, en = _write_pair(
+            tmp_path,
+            de_comp=_vo_cell("intro-vo", "de", "intro", "Frisch geerntet."),
+        )
+        assert [v.kind for v in gate_projected_pair(de, en, "#")] == ["id-asymmetry"]
+        assert gate_deck_halves(de, en, "#") == []
+
+    def test_deck_half_corruption_still_reaches_harvest(self, tmp_path: Path) -> None:
+        """The exemption is about companions only — harvest is not ungated."""
+        de_broken = (
+            HEADER_DE
+            + _slide("intro", "de", "Einführung")
+            + _slide("nur-de", "de", "Nur DE")
+            + _shared_code()
+            + _slide("ende", "de", "Ende")
+        )
+        de, en = _write_pair(tmp_path, de_text=de_broken)
+        assert [v.kind for v in gate_deck_halves(de, en, "#")] == ["id-asymmetry"]


### PR DESCRIPTION
Phase 3 item 1 of the adversarial-review remediation plan — the strict `record`
gate. Its migration prerequisite was retired by #700 (blast radius zero).

## The bug

`sync record`, and `apply`'s post-write ledger save, ran `structural_gate` on
the two **deck halves**. `sync verify` runs the same checks on the
**companion-inlined projection** (#501). So the two verbs disagreed about the
same pair: **verify failed on a byte-diverged *shared* narration cell while
record banked it as verified.** A banked "verified" divergence is what later
lets a mirror or a propagation overwrite content that only ever existed on one
side — it is what arms Y1 and Y6.

`structural_gate`'s docstring claimed gate and CLI "can never drift" because
both call `structural_violations`. True about the function, false about its
input — and the input was the whole bug.

## The fix

One shared `projected_pair` (read + project), and **two named gate entry
points** next to each other in `sync_verify.py`:

| | projects companions? | callers |
|---|---|---|
| `gate_projected_pair` | yes | `sync record`, `sync apply` |
| `gate_deck_halves` | no | `harvest verify`, `harvest accept --record` |

**The plan said "fix all four call sites"; doing that would have broken
`clm harvest`.** A harvest write lands narration on one language side, and
proposal §6 *requires* that one-sided member to be recorded — it is what makes
the next sync report frame the twin as `translate_new`. Measured: a one-sided
**id'd** companion member projects to an `id-asymmetry` error, so projecting at
`harvest_accept._record_members` would have withheld exactly that ledger entry
(`test_one_sided_create_with_record_frames_translate_new` pins it).
`harvest verify`'s docstring had said so all along. The drift-by-call-site
worry was real, so the answer is two documented siblings rather than a boolean
parameter — the call site should read as a choice, and the reason lives with
the functions instead of at four call sites.

**A projection *refusal* is now a gate error**, which is a second hole the
finding did not name. For a mixed / cross-language layout, or a companion whose
`for_slide` matches no slide, `project_pair` refuses and hands back the *raw*
texts — so the old gate reached a clean verdict by not looking. Do not assume
the v3 lens already stops these: measured with id'd cells, `load_bundle`
**parses** all three (the layout checks at `doc_lenses.py:937-957` are
`observe`, not `refuse`), so before this change `record` banked them.

`verify` reports the same condition as a **warning**, deliberately: its
question is "did an edit corrupt this pair?" and an unsupported layout is not
that; the gate's question is "may I record this as verified?", which it may
not, having been unable to read the narration. This is the one place the two
differ and both docstrings say so.

## The escape hatch (D8, sub-decision 3)

`--allow-diverged-companion` on `record` and `apply`. It is narrow **by
construction**, not by naming: it drops only the violations the raw halves do
*not* also show, keyed on `(kind, slide_id, role)` rather than the message —
a `unify` message carries line numbers that inlining shifts, and matching on it
would have let the flag override a pre-existing deck-half corruption. The
WARNING log lives inside the gate, so no call site can forget it. Pinned by a
cross-language fixture where the refusal is overridable and the co-occurring
id-asymmetry is not.

## Blast radius, re-measured against the final semantics

The #700 sweep predated the refusal-as-error decision, so I re-ran it:

| repo | split pairs | newly failing | projection differs | projection refusals |
|---|---|---|---|---|
| PythonCourses | 723 | **0** | 229 | 0 |
| CppCourses | 340 | **0** | 0 | 0 |
| CSharpCourses | 0 (unsplit) | — | — | — |

**Note on #700's "956":** that count included `.claude/worktrees/` copies
inside the course repo — 5801 of the 6524 `*.de.*` files under PythonCourses
are nested worktrees. Exclude `.claude` when sweeping a course repo.

## Tests

`tests/cli/test_sync_gate_projection.py`, 22 tests. Each blindness case asserts
the raw-halves gate is empty *in the same breath* as asserting the strict gate
is not — the old behaviour is pinned beside the new one rather than
demonstrated once by reverting the source and then lost. Includes a
parametrized gate ≡ verify property over four companion shapes, the CLI
record/apply paths, and the harvest exemption stated as a test.

`pytest tests/cli tests/slides tests/voiceover` — 4031 passed. Fast suite green
on the pre-push hook.

## Docs

- `commands.md`, `sync-agents.md`, `harvest-agents.md` — the gate's new reach,
  the flag, and why harvest is exempt (downstream agents read these).
- `migration.md` — a "record can now refuse a deck it used to bank" section with
  fix-forward steps in preference order.
- `cold_sweep_hint` re-worded: it no longer reads as "record sweeps this away".
- Handover: Phase 3 item 1 DONE with notes, decisions **D13** (#697 → sanitize
  server-side, `nh3` in the `[web]` extra) and **D14** (#698 → render in a
  subprocess) recorded, and **S5 pulled forward** into a new Phase 3a.
- Stripped two stray control bytes from the handover — they made `grep` treat it
  as a binary file. (They were inside the Phase 2 note *about* accidentally
  writing control bytes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnTVuA19gGSGejKGoGDdyv
