### PR TITLE
fix(studio): wire up the tier-2 preview, sanitizing macro HTML server-side

### DIFF
--- a/changelog.d/697-studio-tier2-preview.fixed.md
+++ b/changelog.d/697-studio-tier2-preview.fixed.md
@@ -1,0 +1,19 @@
+- **The Mobile Deck Studio's tier-2 cell preview now actually runs, with its HTML
+  sanitized on the server.** The tier expands a cell's Jinja server-side so the
+  phone shows a rendered header instead of raw `{{ header_de("…") }}` — and its
+  in-page consumer had been unreachable since it was written, gated on
+  `cell.cell_type === "markdown"` while the API types a Jinja cell as `"j2"`. The
+  gate is now the cell's own `is_j2` flag, as a named function with tests on both
+  sides of the contract (the predicate under `node`, and the payload the real
+  service emits). Because the header macros deliberately emit markup — centered
+  `<div>`s and the course logo as a `data:` image — escaping the output would
+  delete the feature, so `POST /api/studio/deck/render-cell` now returns a
+  **sanitized** `html` fragment (allowlist in `clm.web.studio.sanitize`, backed by
+  `nh3`, new in the `[web]` extra) that the client injects verbatim, with `body`
+  echoing the request for the tier-1 fallback. The `%%`-delimiter drop and
+  comment-prefix strip moved server-side in the same change, so what gets injected
+  is exactly what was sanitized. Without `nh3` the preview fails closed to tier-1
+  rather than injecting unchecked HTML. `data:` URIs are confined to `<img src>`
+  images (a `data:` link is a navigation vector), `style` is reduced to an inert
+  property allowlist, and script/iframe/svg/style/form content is removed
+  outright.

--- a/changelog.d/697-studio-tier2-preview.fixed.md
+++ b/changelog.d/697-studio-tier2-preview.fixed.md
@@ -14,6 +14,11 @@
   comment-prefix strip moved server-side in the same change, so what gets injected
   is exactly what was sanitized. Without `nh3` the preview fails closed to tier-1
   rather than injecting unchecked HTML. `data:` URIs are confined to `<img src>`
-  images (a `data:` link is a navigation vector), `style` is reduced to an inert
-  property allowlist, and script/iframe/svg/style/form content is removed
-  outright.
+  images (a `data:` link is a navigation vector); authority-relative targets
+  (`//host`, and the `\\` / `/\` / `\/` spellings a URL parser treats the same
+  way) are refused, as the client's tier-1 `safeUrl()` already refused them;
+  `style` is reduced to an inert property allowlist, with `class` disallowed
+  because the app's own `.toast { position: fixed }` would otherwise hand
+  injected markup the overlay that allowlist exists to refuse; and script /
+  iframe / object / form content is removed *with its text* rather than
+  unwrapped.

--- a/docs/claude/design/mobile-deck-studio.md
+++ b/docs/claude/design/mobile-deck-studio.md
@@ -422,10 +422,14 @@ taken while building, several resolving open calls left by §9.1–§9.5:
 - **Self-write echo suppression:** after a Studio write the service records a
   short (`SELF_WRITE_WINDOW_SECONDS`) window so the watcher does not report the
   app's *own* save back to the phone as an external "changed on disk" event.
-- **Tier-2 render scaffolded:** the working preview is **tier-1 client-side
+- **Tier-2 render scaffolded:** ~~the working preview is **tier-1 client-side
   markdown**. `POST /api/studio/deck/render-cell` exists but echoes the body
   with `rendered=false`; wiring the jupytext+Jinja kernel-free expansion for
-  `is_j2` cells is a focused follow-up (still inside the P0 design scope).
+  `is_j2` cells is a focused follow-up (still inside the P0 design scope).~~
+  **Done, twice over**: the server-side expansion landed in P4 (§9.10) and the
+  in-page consumer — which was dead on arrival — in **#697**, where the endpoint
+  also started returning *sanitized* HTML rather than text. Read the correction
+  in §9.10 before trusting anything else in this doc about tier 2.
 - **WS auth:** ~~REST is fully token-gated; the shared `/ws` endpoint is not
   yet token-checked. Gating WS without disrupting the Monitor channel is a
   follow-up.~~ **Done** (S6 of the 2026-07-24 adversarial review): `/ws`

--- a/docs/claude/design/mobile-deck-studio.md
+++ b/docs/claude/design/mobile-deck-studio.md
@@ -241,7 +241,7 @@ structural op. No naïve whole-file re-emit.
 | **P2** ✅ | **Structural ops** (`insert` / `delete` / `move` / mint-id) via the byte-exact serializer; reorder mode in the UI; byte-exact untouched-cell tests. *(Implemented — see §9.7.)* |
 | **P3a** ✅ | **Bilingual lock core**: language toggle (switch to the split twin) + watermark-derived lock (read-only `build_sync_plan`) + stale badges + **423** enforcement on every write. *(Implemented — see §9.8.)* |
 | **P3b** ✅ | **Sync-to-other-language**: a streamed server-side `clm slides sync` subprocess (LLM reconciliation) over WS; the lock releases when it completes. *(Implemented — see §9.9. **Discard & unlock deferred** by decision: its revert is git-coupled and risky — use the desktop.)* |
-| **P4** ✅ | **Tier-2 preview** (kernel-free Jinja macro/header expansion per cell) + tier-1 comment-prefix fix + **installable PWA** + **read-only offline cache** of opened decks. *(Implemented — see §9.10. Editor de-prefix ergonomics deferred.)* |
+| **P4** ✅ | **Tier-2 preview** (kernel-free Jinja macro/header expansion per cell) + tier-1 comment-prefix fix + **installable PWA** + **read-only offline cache** of opened decks. *(Implemented — see §9.10. The in-page tier-2 consumer was dead on arrival and only actually shipped in #697; see the correction in §9.10. Editor de-prefix ergonomics deferred.)* |
 | **Later / optional** | **Full executed single-deck build** (tier 3) for code outputs and rendered diagrams. |
 
 ---
@@ -620,6 +620,30 @@ The preview + PWA phase — **completes the initial plan**. Three pieces:
    centered title) wrapped in a `# %% [markdown]` boundary, so the client strips
    prefixes, drops the `%%` remnant line, and injects as **HTML** (trusted — it's
    the user's own deck from their own desktop over an authed channel).
+
+   > **Correction (2026-07-26, issues #696/#697).** Item 2 above overstated what
+   > shipped, in two ways worth keeping visible.
+   >
+   > **The in-page consumer never ran.** It was gated on
+   > `cell.cell_type === "markdown"`, but the API types a Jinja cell as
+   > `cell_type: "j2"` and a `markdown` cell always has `is_j2 === false` — so
+   > "the frontend calls it only for `is_j2` cells" was true of the *intent* and
+   > false of the code. The tier was dead from the day it was written; only the
+   > server half was real. **Generalisable: a build record that says a path is
+   > wired should be backed by a test that executes it** — nothing here asserted
+   > the frontend path, which is why a contradiction between two lines of the
+   > same feature survived a phase sign-off.
+   >
+   > **"Injects as HTML (trusted)" is no longer the model.** The body being
+   > rendered is a *request* body, not a file from the desktop, so #696 sandboxed
+   > and size-bounded the render, and #697 replaced "trusted" with a
+   > **server-side sanitizer** (`clm/web/studio/sanitize.py`, `nh3` from the
+   > `[web]` extra): the endpoint now returns a sanitized `html` field the client
+   > injects verbatim, and `body` echoes the request for the tier-1 fallback. The
+   > `%%`-line drop and prefix strip moved **server-side too**, because the thing
+   > that gets injected has to be exactly the thing that was sanitized. Missing
+   > `nh3` fails closed to tier-1. Remaining, tracked as **#698**: the render's
+   > CPU is still unbounded (decision D14 — subprocess + wall-clock limit).
 3. **PWA + offline (`manifest.json`, `icon.svg`, `sw.js`).** Installable
    (standalone, SVG maskable icon, `theme-color`). The service worker caches the
    `/studio/` app shell **cache-first** and `/api/studio/deck{,s}` **network-

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -130,9 +130,12 @@ CLM has several optional dependency groups for different features:
 - **[tui]**: textual, rich
   - Required for: `clm monitor` command
   - Install: `pip install -e ".[tui]"`
-- **[web]**: wsproto, httptools, watchfiles
+- **[web]**: wsproto, httptools, watchfiles, segno, nh3
   - Required for: `clm serve` command
   - Install: `pip install -e ".[web]"`
+  - `segno` renders the Mobile Deck Studio pairing QR code; `nh3` sanitizes the
+    Studio's server-side cell preview. Without `nh3` that preview degrades to
+    client-side markdown rather than shipping unsanitized HTML.
 
 **LLM Features**:
 - **[summarize]**: openai

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,14 @@ web = [
     "httptools>=0.6.2",  # HTTP protocol handling
     "watchfiles>=0.18.0",  # For --reload support + the Studio external-change watcher
     "segno>=1.6.0",  # Pure-Python QR codes for Mobile Deck Studio pairing
+    # HTML sanitizer for the Studio's tier-2 cell preview (issue #697): the
+    # header macros deliberately emit markup, so the preview cannot escape its
+    # way out of the problem — it sanitizes server-side against an allowlist
+    # before the phone injects it. `nh3` (Rust/ammonia) rather than `bleach`,
+    # which is deprecated upstream. Belongs to `[web]` — the extra the Studio
+    # already requires — so an install without it fails closed (the preview
+    # degrades to tier-1) instead of injecting unsanitized HTML.
+    "nh3>=0.2.18",
 ]
 # Everything
 # NOTE: `all` carries no ML/data-science stack. That stack (torch/pandas/

--- a/src/clm/web/static/studio/app.js
+++ b/src/clm/web/static/studio/app.js
@@ -140,22 +140,43 @@ function stripCommentPrefix(text, token) {
   }).join("\n");
 }
 
-// Tier-2 in-page preview (P4) is NOT wired up, and the code that used to sit
-// here has been removed rather than left dormant.
+// --- tier-2 in-page preview (P4, wired up in #697) ---------------------------
 //
-// It could never run: it was gated on `cell.cell_type === "markdown"`, but the
-// API gives an is_j2 cell `cell_type === "j2"` (a `markdown` cell always has
-// `is_j2 === false`), so the branch was unreachable from the day it was
-// written. What it *did* contain was `bodyEl.innerHTML = <server response>`
-// with no escaping — the one raw-HTML sink in this file, and the exact sink
-// the S7 hardening of esc()/safeUrl() above exists to close. Keeping a latent
-// one behind a broken gate is the worst of the options.
-//
-// Wiring it up properly is a real design question, not a one-line fix: the
-// header macros legitimately emit HTML, so the answer cannot just be "escape
-// it" — it needs a decision about sanitizing macro output. Tracked as issue
-// #697. The server side (`POST /api/studio/deck/render-cell`) is
-// live, sandboxed and tested; only the in-page consumer is absent.
+// The gate is `cell.is_j2` and nothing else. It used to be
+// `cell.cell_type === "markdown"`, which could never fire: the API types a
+// Jinja cell as `cell_type: "j2"`, and a `markdown` cell always has
+// `is_j2 === false`. That mismatch is why this tier never ran, so the
+// predicate is a named function with a test against the real API payload
+// (tests/web/studio/test_tier2_preview.py) rather than an inline condition.
+function needsServerRender(cell) {
+  return !!(cell && cell.is_j2);
+}
+
+// The server returns HTML it has already sanitized against an allowlist
+// (clm/web/studio/sanitize.py — the header macros emit `<div>`, `<br>` and a
+// data: logo, so escaping here would delete the feature). Inject it verbatim:
+// only the exact bytes the server checked are safe, so this must not
+// post-process them. If anything fails, the tier-1 markdown already in the
+// element stays — a preview is best-effort by design.
+async function renderJ2(cell, bodyEl) {
+  let res;
+  try {
+    res = await api("/deck/render-cell", {
+      method: "POST",
+      body: JSON.stringify({
+        deck_id: currentDeck.deck_id,
+        body: cell.body,
+        is_j2: true,
+        lang: cell.lang || null,
+      }),
+    });
+  } catch (e) {
+    return; // offline, 401, 5xx — keep tier-1
+  }
+  if (!res || !res.rendered || typeof res.html !== "string") return;
+  bodyEl.innerHTML = res.html;
+  bodyEl.classList.add("j2-preview");
+}
 
 // --- UI helpers ---------------------------------------------------------------
 const appEl = document.getElementById("app");
@@ -363,11 +384,14 @@ function cellCard(cell, idx, locked) {
     // are comment-prefixed, so strip the token for the tier-1 preview.
     const md = cell.body_format === "clean" ? cell.body : stripCommentPrefix(cell.body, token);
     body.innerHTML = renderMarkdown(md);
-    // No tier-2 call here: a `markdown` cell always has is_j2 === false (the
-    // API types a j2 cell as `cell_type: "j2"`), so the condition that used to
-    // sit here was dead. See the note where renderJ2 was removed.
   } else {
     body.innerHTML = `<pre><code>${esc(cell.body)}</code></pre>`;
+  }
+  if (needsServerRender(cell)) {
+    // Tier 2: replace the raw `{{ header_de("…") }}` above with the expansion.
+    // Fire-and-forget — the card is already in the DOM with its tier-1 body, and
+    // a failed or slow preview must not block rendering the rest of the deck.
+    renderJ2(cell, body);
   }
 
   const controls = card.querySelector(".cell-controls");

--- a/src/clm/web/static/studio/app.js
+++ b/src/clm/web/static/studio/app.js
@@ -159,12 +159,19 @@ function needsServerRender(cell) {
 // post-process them. If anything fails, the tier-1 markdown already in the
 // element stays — a preview is best-effort by design.
 async function renderJ2(cell, bodyEl) {
+  // Captured before the await so a reply can never be attributed to whatever
+  // deck is open when it lands, and so the staleness check below has something
+  // to compare against. (Navigating away also empties `appEl`, which detaches
+  // this node — but that is an accident of how the views re-render, not a
+  // guarantee, so the check is explicit.)
+  const deckId = currentDeck && currentDeck.deck_id;
+  if (!deckId) return;
   let res;
   try {
     res = await api("/deck/render-cell", {
       method: "POST",
       body: JSON.stringify({
-        deck_id: currentDeck.deck_id,
+        deck_id: deckId,
         body: cell.body,
         is_j2: true,
         lang: cell.lang || null,
@@ -173,6 +180,7 @@ async function renderJ2(cell, bodyEl) {
   } catch (e) {
     return; // offline, 401, 5xx — keep tier-1
   }
+  if (!currentDeck || currentDeck.deck_id !== deckId) return; // navigated away
   if (!res || !res.rendered || typeof res.html !== "string") return;
   bodyEl.innerHTML = res.html;
   bodyEl.classList.add("j2-preview");

--- a/src/clm/web/static/studio/app.js
+++ b/src/clm/web/static/studio/app.js
@@ -182,6 +182,10 @@ async function renderJ2(cell, bodyEl) {
   }
   if (!currentDeck || currentDeck.deck_id !== deckId) return; // navigated away
   if (!res || !res.rendered || typeof res.html !== "string") return;
+  // An empty expansion (a cell that is only a `{% import %}`, or a comment)
+  // must keep tier-1 rather than blank the card: `typeof "" === "string"`, so
+  // the guard above is not enough.
+  if (!res.html) return;
   bodyEl.innerHTML = res.html;
   bodyEl.classList.add("j2-preview");
 }

--- a/src/clm/web/static/studio/index.html
+++ b/src/clm/web/static/studio/index.html
@@ -67,10 +67,16 @@
       border-radius: 8px; }
     .cell-body code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
     /* Tier-2 preview (#697): the header macros size their own text for a
-       projector (font-size: 200%), which on a phone overflows the card. */
-    .cell-body.j2-preview { font-size: .82rem; overflow-x: auto; }
+       projector (font-size: 200%), which on a phone overflows the card. These
+       are *legibility* rules for the bundled macros, not a security boundary —
+       an inline `!important` outranks an author-stylesheet `!important`, so
+       preview content can always out-declare them. The one that does bound
+       something is max-height: it keeps a preview inside its own card, so it
+       cannot become a full-viewport tappable panel. Everything that actually
+       matters is enforced server-side (clm/web/studio/sanitize.py). */
+    .cell-body.j2-preview { font-size: .82rem; overflow: auto; max-height: 55vh; }
     .cell-body.j2-preview img { max-width: 100%; height: auto; }
-    .cell-body.j2-preview div { font-size: inherit !important; }
+    .cell-body.j2-preview div { font-size: inherit; }
     .cell.editable .cell-head { cursor: pointer; }
     .banner { padding: 10px 12px; border-radius: 8px; margin: 10px 0; }
     .banner.warn { background: var(--warn-bg); color: var(--warn-fg); }

--- a/src/clm/web/static/studio/index.html
+++ b/src/clm/web/static/studio/index.html
@@ -66,6 +66,11 @@
     .cell-body pre { overflow-x: auto; background: rgba(127,127,127,.08); padding: 10px;
       border-radius: 8px; }
     .cell-body code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    /* Tier-2 preview (#697): the header macros size their own text for a
+       projector (font-size: 200%), which on a phone overflows the card. */
+    .cell-body.j2-preview { font-size: .82rem; overflow-x: auto; }
+    .cell-body.j2-preview img { max-width: 100%; height: auto; }
+    .cell-body.j2-preview div { font-size: inherit !important; }
     .cell.editable .cell-head { cursor: pointer; }
     .banner { padding: 10px 12px; border-radius: 8px; margin: 10px 0; }
     .banner.warn { background: var(--warn-bg); color: var(--warn-fg); }

--- a/src/clm/web/static/studio/sw.js
+++ b/src/clm/web/static/studio/sw.js
@@ -21,7 +21,7 @@
 // times under `-v1`, so the S7 XSS fix would have reached no installed PWA at
 // all. The stale-while-revalidate handler below is the belt to this braces —
 // it means a missed bump costs one stale load rather than permanent staleness.
-const SHELL_CACHE = "clm-studio-shell-v2";
+const SHELL_CACHE = "clm-studio-shell-v3";
 const API_CACHE = "clm-studio-api-v1";
 const SHELL = [
   "/studio/",

--- a/src/clm/web/studio/models.py
+++ b/src/clm/web/studio/models.py
@@ -248,13 +248,22 @@ class RenderCellRequest(BaseModel):
 
 
 class RenderCellResult(BaseModel):
-    """Tier-2 render result (P4).
+    """Tier-2 render result (P4; ``html`` added for issue #697).
 
-    ``rendered`` True → ``body`` is the Jinja-expanded text (still markdown the
-    client renders); False → ``body`` is the original and ``error`` (if any) says
-    why, so the phone falls back to tier-1 client markdown.
+    ``rendered`` True → ``html`` is the expanded cell as an **HTML fragment,
+    already sanitized server-side** (:mod:`clm.web.studio.sanitize`) and
+    therefore safe to assign to ``innerHTML`` as-is — do not transform it
+    further client-side, since only the exact bytes returned here were checked.
+    False → ``html`` is ``None`` and ``error`` (if any) says why, so the phone
+    falls back to tier-1 client markdown.
+
+    ``body`` is always the caller's **original** cell body, echoed back for that
+    fallback. It is deliberately *not* the expanded text: shipping unsanitized
+    expansion alongside the sanitized fragment would just invite the next
+    consumer to inject the wrong field.
     """
 
     rendered: bool
     body: str
+    html: str | None = None
     error: str | None = None

--- a/src/clm/web/studio/models.py
+++ b/src/clm/web/studio/models.py
@@ -260,7 +260,9 @@ class RenderCellResult(BaseModel):
     ``body`` is always the caller's **original** cell body, echoed back for that
     fallback. It is deliberately *not* the expanded text: shipping unsanitized
     expansion alongside the sanitized fragment would just invite the next
-    consumer to inject the wrong field.
+    consumer to inject the wrong field. (So *this endpoint* never emits
+    unsanitized HTML — ``render_j2_cell`` still exists and still returns raw
+    expanded text for tests and future non-browser callers.)
     """
 
     rendered: bool

--- a/src/clm/web/studio/render.py
+++ b/src/clm/web/studio/render.py
@@ -71,9 +71,14 @@ raising — preview, not parity.
 drop the ``%% [markdown]`` delimiter line, strip the comment prefix, and
 **sanitize** the result (:mod:`clm.web.studio.sanitize`). The order is the point:
 the client injects the sanitizer's output verbatim, so every byte-changing step
-happens before sanitizing, never after. The expanded text itself is never sent —
-the response carries the sanitized fragment plus the caller's original body, so
-there is nothing unsanitized for a consumer to reach for by mistake.
+happens before sanitizing, never after.
+
+The endpoint sends the sanitized fragment plus the caller's *original* body (for
+the tier-1 fallback) and never the expanded text — so no route hands a consumer
+something unsanitized to reach for by mistake. Note that is a property of the
+callers, not of this module: :func:`render_j2_cell` is public and still returns
+raw expanded text, because the expansion is worth testing on its own. Anything
+new that calls it and ships the result to a browser owes it a sanitize pass.
 """
 
 from __future__ import annotations

--- a/src/clm/web/studio/render.py
+++ b/src/clm/web/studio/render.py
@@ -96,7 +96,11 @@ logger = logging.getLogger(__name__)
 #: expansion happens before cell splitting. A single-cell preview must drop it
 #: (with or without the language's comment prefix, which the source line carries
 #: and the macro's own first line does not).
-_CELL_DELIMITER = re.compile(r"^\s*(?:#|//)?\s*%%.*$")
+#:
+#: ``%%`` must be followed by whitespace, ``[``, or end-of-line: jupytext's own
+#: rule, and without it prose that merely begins ``%%something`` disappears from
+#: the preview.
+_CELL_DELIMITER = re.compile(r"^\s*(?:#|//)?\s*%%(?:\s.*|\[.*)?$")
 
 #: Identity globals the build injects from the course; a header macro only needs
 #: them to be *defined* for a preview, so placeholders are fine.

--- a/src/clm/web/studio/render.py
+++ b/src/clm/web/studio/render.py
@@ -65,14 +65,33 @@ context, a missing include, a sandbox refusal) is caught and returned as
 than failing. It also runs with a **lenient** ``Undefined`` (not the build's
 ``StrictUndefined``) so a missing course variable renders empty instead of
 raising — preview, not parity.
+
+**What reaches the phone (issue #697).** :func:`render_j2_cell` returns expanded
+*text*; :func:`render_j2_cell_html` is what the endpoint uses, and it goes on to
+drop the ``%% [markdown]`` delimiter line, strip the comment prefix, and
+**sanitize** the result (:mod:`clm.web.studio.sanitize`). The order is the point:
+the client injects the sanitizer's output verbatim, so every byte-changing step
+happens before sanitizing, never after. The expanded text itself is never sent —
+the response carries the sanitized fragment plus the caller's original body, so
+there is nothing unsanitized for a consumer to reach for by mistake.
 """
 
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 
+from clm.web.studio.sanitize import SanitizerUnavailableError, sanitize_preview_html
+
 logger = logging.getLogger(__name__)
+
+#: A cell-delimiter line in the expanded output. The header macros emit a whole
+#: *cell* — ``%% [markdown] lang="de" tags=["slide"]`` — because in the build the
+#: expansion happens before cell splitting. A single-cell preview must drop it
+#: (with or without the language's comment prefix, which the source line carries
+#: and the macro's own first line does not).
+_CELL_DELIMITER = re.compile(r"^\s*(?:#|//)?\s*%%.*$")
 
 #: Identity globals the build injects from the course; a header macro only needs
 #: them to be *defined* for a preview, so placeholders are fine.
@@ -274,3 +293,65 @@ def render_j2_cell(deck_path: Path, body: str, lang: str | None) -> tuple[bool, 
     except Exception as exc:  # noqa: BLE001 - preview must never crash the request
         logger.debug("Studio tier-2 render failed for %s: %s", deck_path, exc)
         return False, str(exc), body
+
+
+def _to_preview_html(text: str, comment_token: str) -> str:
+    """Turn expanded cell text into the HTML fragment the client injects.
+
+    Two transforms, both of which must happen **before** sanitizing — the client
+    injects the sanitizer's output verbatim, so anything that changes the bytes
+    afterwards would be injecting something nobody checked:
+
+    1. drop the ``%% [markdown] …`` cell-delimiter lines the header macros emit
+       (see :data:`_CELL_DELIMITER`);
+    2. strip the language's comment prefix, since the macro output is
+       comment-prefixed source (``# <div …>`` / ``// <div …>``) and the ``<`` has
+       to reach the browser as markup.
+
+    The prefix strip is the editor's own :func:`~clm.web.studio.prefix.deprefix`
+    rather than a second implementation — it is already the per-line,
+    leave-unprefixed-lines-alone rule this needs, which matters because the
+    base64 logo the macros embed continues on *unprefixed* continuation lines.
+    """
+    from clm.web.studio.prefix import deprefix
+
+    kept = [line for line in text.split("\n") if not _CELL_DELIMITER.match(line)]
+    return deprefix("\n".join(kept), comment_token).strip("\n")
+
+
+def render_j2_cell_html(
+    deck_path: Path, body: str, lang: str | None
+) -> tuple[bool, str | None, str | None]:
+    """Expand ``body``'s Jinja and return **sanitized HTML** for the phone.
+
+    Returns ``(ok, error, html)``. ``ok`` True → ``html`` is safe to assign to
+    ``innerHTML`` (:mod:`clm.web.studio.sanitize` is the allowlist, and see
+    :func:`_to_preview_html` for why the de-prefixing runs first). False →
+    ``html`` is ``None``, ``error`` says why, and the caller falls back to
+    tier-1 client-side markdown.
+
+    Fails closed when the sanitizer is missing: no HTML leaves this function
+    unless it went through :func:`sanitize_preview_html`.
+    """
+    ok, error, text = render_j2_cell(deck_path, body, lang)
+    if not ok:
+        return False, error, None
+    try:
+        from clm.infrastructure.utils.path_utils import path_to_prog_lang
+        from clm.workers.notebook.utils.prog_lang_utils import line_comment_for
+
+        try:
+            prog_lang = path_to_prog_lang(deck_path)
+        except (KeyError, ValueError):
+            prog_lang = "python"
+        comment_token = line_comment_for(prog_lang)
+    except Exception as exc:  # noqa: BLE001 - missing optional dep → tier-1 fallback
+        return False, f"render unavailable: {exc}", None
+
+    try:
+        return True, None, sanitize_preview_html(_to_preview_html(text, comment_token))
+    except SanitizerUnavailableError as exc:
+        return False, str(exc), None
+    except Exception as exc:  # noqa: BLE001 - preview must never crash the request
+        logger.debug("Studio tier-2 sanitize failed for %s: %s", deck_path, exc)
+        return False, f"sanitize failed: {exc}", None

--- a/src/clm/web/studio/routes.py
+++ b/src/clm/web/studio/routes.py
@@ -257,8 +257,11 @@ async def render_cell(request: Request, req: RenderCellRequest) -> RenderCellRes
     """Tier-2 (kernel-free) render of one ``is_j2`` cell (P4).
 
     Expands the cell's Jinja (header macros, ``{{ … }}``) server-side through the
-    build's bundled macros, no kernel. Plain cells (or any failure) return the
-    body unchanged with ``rendered=False`` so the phone falls back to tier-1.
+    build's bundled macros, no kernel, and returns it as an HTML fragment that has
+    been **sanitized here** (issue #697) — the header macros emit markup, so the
+    client cannot escape its way to safety. Plain cells (or any failure, including
+    a missing sanitizer) return ``rendered=False`` with ``html=None`` so the phone
+    falls back to tier-1.
 
     Runs in a worker thread: Jinja rendering is CPU-bound and the body is
     client-supplied, so doing it inline would let one request hold the event
@@ -266,9 +269,9 @@ async def render_cell(request: Request, req: RenderCellRequest) -> RenderCellRes
     """
     service = get_service(request)
     try:
-        rendered, error, text = await run_in_threadpool(
+        rendered, error, html = await run_in_threadpool(
             service.render_cell, req.deck_id, req.body, is_j2=req.is_j2, lang=req.lang
         )
     except InvalidDeckIdError as e:
         raise HTTPException(status_code=400, detail=f"Invalid deck id: {e}") from e
-    return RenderCellResult(rendered=rendered, body=text, error=error)
+    return RenderCellResult(rendered=rendered, body=req.body, html=html, error=error)

--- a/src/clm/web/studio/sanitize.py
+++ b/src/clm/web/studio/sanitize.py
@@ -1,0 +1,220 @@
+"""Server-side HTML sanitizing for the Studio's tier-2 cell preview (issue #697).
+
+The tier-2 preview expands a cell's Jinja server-side so the phone sees a
+rendered header instead of raw ``{{ header_de("…") }}``. The expansion is
+**deliberately HTML** — the bundled ``macros.j2`` header macros emit
+``<div style="text-align:center">``, a ``<br/>``, and the course logo as an
+``<img src="data:image/…;base64,…">`` — so the client cannot escape its way out
+of the problem: escaping the output *is* removing the feature.
+
+The decision (maintainer, 2026-07-26; D13 in the adversarial-review handover)
+is to **sanitize on the server** and keep the client's ``innerHTML``
+assignment. Two consequences worth stating plainly:
+
+* The client injects this output **verbatim**. So everything that changes the
+  bytes — dropping the ``%% [markdown]`` delimiter line the macro emits,
+  stripping the per-language comment prefix — happens *before* the sanitizer
+  runs, never after. Sanitize exactly what gets injected.
+* If :mod:`nh3` is missing (an install without the ``[web]`` extra), the
+  preview **fails closed**: :func:`sanitize_preview_html` raises and the caller
+  degrades to tier-1 client-side markdown. There is no unsanitized fallback.
+
+**The ``data:`` question, measured rather than assumed.** The logo is a
+``data:`` URI, so the scheme has to be allowed; but with ``data`` merely added
+to nh3's ``url_schemes``, ``<a href="data:text/html,<script>…">`` survives too
+(verified — it is a navigation vector, not a decoration). nh3's
+``attribute_filter`` *can* drop a value before the scheme check but cannot
+re-permit a scheme the allowlist rejects (also verified), so the working
+combination is: allow ``data`` globally, then have the filter refuse it
+everywhere except an ``<img src>`` that is specifically ``data:image/``.
+
+**Not sanitized: the contents of ``style``.** Ammonia does not parse CSS, so
+the property allowlist here is CLM's own — the properties the bundled macros
+actually use plus a few text-formatting ones — with any declaration containing
+``url(`` / ``expression(`` / a backslash escape dropped. CSS cannot execute
+script in a current browser; the residual risk is visual (an overlay), inside a
+page whose content the token holder can rewrite anyway.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: Tags a preview may contain: the macro output (``img``/``div``/``b``/``br``)
+#: plus ordinary prose markup, since a j2 cell can carry markdown-ish HTML
+#: around its macro call. Everything else — ``script``, ``style``, ``iframe``,
+#: ``svg``, ``form``, ``math`` — is removed with its content.
+ALLOWED_TAGS: frozenset[str] = frozenset(
+    {
+        "a",
+        "abbr",
+        "b",
+        "blockquote",
+        "br",
+        "center",
+        "code",
+        "dd",
+        "del",
+        "div",
+        "dl",
+        "dt",
+        "em",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "hr",
+        "i",
+        "img",
+        "ins",
+        "kbd",
+        "li",
+        "ol",
+        "p",
+        "pre",
+        "s",
+        "samp",
+        "small",
+        "span",
+        "strong",
+        "sub",
+        "sup",
+        "table",
+        "tbody",
+        "td",
+        "tfoot",
+        "th",
+        "thead",
+        "tr",
+        "ul",
+        "var",
+    }
+)
+
+#: Per-tag attribute allowlist. ``rel`` is absent on purpose: nh3 manages it
+#: (it adds ``rel="noopener noreferrer"`` to every link) and rejects the config
+#: outright if both are set.
+ALLOWED_ATTRIBUTES: dict[str, set[str]] = {
+    "a": {"href", "title"},
+    "img": {"src", "alt", "title", "width", "height"},
+    "td": {"colspan", "rowspan"},
+    "th": {"colspan", "rowspan", "scope"},
+    "*": {"style", "class", "align"},
+}
+
+#: Link schemes a preview may point at. ``data`` is here **only** so the logo
+#: image works; :func:`_attribute_filter` is what confines it to ``<img src>``.
+ALLOWED_URL_SCHEMES: frozenset[str] = frozenset({"http", "https", "mailto", "data"})
+
+#: CSS properties kept inside a surviving ``style`` attribute. The first five
+#: are what the bundled header macros use; the rest are inert text formatting.
+ALLOWED_CSS_PROPERTIES: frozenset[str] = frozenset(
+    {
+        "display",
+        "font-size",
+        "font-style",
+        "font-weight",
+        "margin",
+        "margin-bottom",
+        "margin-left",
+        "margin-right",
+        "margin-top",
+        "padding",
+        "text-align",
+        "text-decoration",
+        "vertical-align",
+        "width",
+        "max-width",
+        "height",
+        "color",
+        "background-color",
+    }
+)
+
+#: Declaration content that is never kept, whatever the property: ``url()``
+#: fetches, the legacy IE ``expression()``, and CSS backslash escapes (which
+#: exist to spell any of the above without spelling it).
+_CSS_REJECT = re.compile(r"url\s*\(|expression\s*\(|\\", re.IGNORECASE)
+
+#: Whitespace is not significant inside a URL scheme, and ``da\nta:`` is a real
+#: obfuscation, so the scheme check runs against a whitespace-stripped copy.
+_WHITESPACE = re.compile(r"\s+")
+
+
+class SanitizerUnavailableError(RuntimeError):
+    """:mod:`nh3` is not installed, so no HTML may be handed to the client.
+
+    Raised instead of returning unsanitized markup: the ``[web]`` extra carries
+    the sanitizer, and an install without it must lose the *feature*, not the
+    guarantee.
+    """
+
+
+def _scheme_of(value: str) -> str:
+    """The URL scheme of ``value``, lowercased, or ``""`` if it names none."""
+    candidate = _WHITESPACE.sub("", value)
+    head, sep, _rest = candidate.partition(":")
+    if not sep or not head or not head.isascii():
+        return ""
+    return head.lower()
+
+
+def _attribute_filter(tag: str, attribute: str, value: str) -> str | None:
+    """nh3 per-attribute hook: confine ``data:`` and filter CSS declarations.
+
+    Returning ``None`` drops the attribute. nh3 still applies its own scheme
+    allowlist afterwards, so this can only ever be *more* restrictive — which
+    is why ``data`` has to be in :data:`ALLOWED_URL_SCHEMES` for the ``img``
+    case to survive at all.
+    """
+    if attribute == "style":
+        return _filter_style(value)
+    if _scheme_of(value) == "data":
+        # The one legitimate use is the logo the header macros embed.
+        if tag == "img" and attribute == "src":
+            head = _WHITESPACE.sub("", value).lower()
+            return value if head.startswith("data:image/") else None
+        return None
+    return value
+
+
+def _filter_style(value: str) -> str | None:
+    """Keep only allowlisted, inert CSS declarations; ``None`` if none survive."""
+    kept: list[str] = []
+    for declaration in value.split(";"):
+        prop, sep, val = declaration.partition(":")
+        if not sep:
+            continue
+        name = prop.strip().lower()
+        body = val.strip()
+        if name not in ALLOWED_CSS_PROPERTIES or not body:
+            continue
+        if _CSS_REJECT.search(declaration):
+            continue
+        kept.append(f"{name}:{body}")
+    return "; ".join(kept) if kept else None
+
+
+def sanitize_preview_html(html: str) -> str:
+    """Return ``html`` reduced to the preview allowlist.
+
+    Raises :class:`SanitizerUnavailableError` when :mod:`nh3` is missing — the
+    caller must then fall back to tier-1 rather than ship the input onward.
+    """
+    try:
+        import nh3
+    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+        raise SanitizerUnavailableError(
+            "the HTML sanitizer (nh3) is not installed, so the server-side cell "
+            "preview is unavailable; install clm[web]"
+        ) from exc
+
+    return nh3.clean(
+        html,
+        tags=set(ALLOWED_TAGS),
+        attributes={tag: set(attrs) for tag, attrs in ALLOWED_ATTRIBUTES.items()},
+        url_schemes=set(ALLOWED_URL_SCHEMES),
+        attribute_filter=_attribute_filter,
+    )

--- a/src/clm/web/studio/sanitize.py
+++ b/src/clm/web/studio/sanitize.py
@@ -22,11 +22,19 @@ assignment. Two consequences worth stating plainly:
 **The ``data:`` question, measured rather than assumed.** The logo is a
 ``data:`` URI, so the scheme has to be allowed; but with ``data`` merely added
 to nh3's ``url_schemes``, ``<a href="data:text/html,<script>…">`` survives too
-(verified — it is a navigation vector, not a decoration). nh3's
-``attribute_filter`` *can* drop a value before the scheme check but cannot
-re-permit a scheme the allowlist rejects (also verified), so the working
-combination is: allow ``data`` globally, then have the filter refuse it
-everywhere except an ``<img src>`` that is specifically ``data:image/``.
+(verified — it is a navigation vector, not a decoration). So the working
+combination is: allow ``data`` globally, then have
+:func:`_attribute_filter` refuse it everywhere except an ``<img src>`` that is
+specifically ``data:image/``.
+
+**And the filter may only reject, never rewrite.** nh3 checks its scheme
+allowlist against the *incoming* value and then writes whatever the filter
+returns — nothing re-validates that. An adversarial review caught this the hard
+way: a version of the filter that merely *normalized* a kept URL (stripping the
+leading characters a URL parser ignores) turned nh3's already-vetted, inert
+``\x7fjavascript:…`` *relative path* into a live ``javascript:`` URL. Rewriting
+a value is escaping the check, so every URL branch here returns ``value``
+unchanged or ``None``.
 
 **Not sanitized: the contents of ``style``.** Ammonia does not parse CSS, so
 the property allowlist here is CLM's own — the properties the bundled macros
@@ -44,6 +52,15 @@ allowlist is only as tight as the page's own class names. Found by an
 adversarial review of this module; **a property allowlist and a class allowlist
 have to be reasoned about together.**
 
+Be precise about what that closes: only *escaping the card*. With
+``height``/``width``/``background-color`` a preview can still paint a large
+tappable panel **inside** its own cell (bounded by ``.j2-preview``'s
+``max-height`` in ``index.html``, with the sticky header still visible above
+it), and an off-origin ``https://`` link on it is allowed by the same tier-1
+parity rule above. Preview content is *content*; the guarantee here is "no
+script, no fixed-position impersonation of the app chrome", not "cannot look
+inviting".
+
 **URL rules, and why they are here rather than left to nh3.** Two decisions
 nh3's declarative config cannot express, both in :func:`_attribute_filter`:
 
@@ -51,8 +68,11 @@ nh3's declarative config cannot express, both in :func:`_attribute_filter`:
 * an **authority-relative** target (``//host``, and the ``\\`` / ``/\`` / ``\/``
   spellings WHATWG parsing treats identically) is refused, matching the client's
   ``safeUrl()`` for tier-1 markdown links. Both tiers render into the same page,
-  which holds a non-expiring bearer token, so both get the same rule — and an
-  ``<img>`` needs no click, so opening a deck would otherwise beacon.
+  which holds a non-expiring bearer token, so both get the same rule. Note the
+  point is **parity, not anti-beacon defence**: an explicit ``https://`` target
+  is allowed here exactly as tier-1 allows it, so a hostile deck can still fetch
+  an off-origin image. What the rule removes is the *scheme-less* form, which
+  reads as a path and is easy to miss in review.
 
 Both decisions depend on normalizing a URL the way ammonia and the browser do,
 which is **not** Python's ``\s`` — see :data:`_URL_INSIGNIFICANT` for the
@@ -229,15 +249,22 @@ def _scheme_of(normalized: str) -> str:
 def _attribute_filter(tag: str, attribute: str, value: str) -> str | None:
     """nh3 per-attribute hook: the decisions nh3's own config cannot express.
 
-    Returning ``None`` drops the attribute. nh3 still applies its own scheme
-    allowlist afterwards, so this can only ever be *more* restrictive — which
-    is why ``data`` has to be in :data:`ALLOWED_URL_SCHEMES` for the ``img``
-    case to survive at all.
+    **This hook may only reject, never rewrite.** nh3 applies its scheme
+    allowlist to the *incoming* value and writes whatever the filter returns —
+    so a returned value is final and nothing downstream re-checks it. A previous
+    version of this function "tidied" kept URLs by stripping the leading
+    characters a URL parser ignores, and that alone reintroduced script
+    execution: nh3 had already vetted ``\x7fjavascript:…`` as an inert
+    *relative path* (``\x7f`` is not a valid scheme start), and stripping the
+    ``\x7f`` handed the browser a live ``javascript:`` URL that no layer looked
+    at again. Hence: every branch below returns either ``value`` unchanged or
+    ``None``. :func:`_filter_style` is the one exception, and it is not a URL —
+    it can only ever *remove* declarations.
 
-    Three rules: CSS is filtered (:func:`_filter_style`); ``data:`` is confined
-    to an ``<img src>`` that is an image; and an **authority-relative** target is
-    refused outright, matching the client's ``safeUrl()`` for tier-1 links (both
-    land in the same token-holding page, so both get the same rule).
+    Three rules: CSS is filtered; ``data:`` is confined to an ``<img src>`` that
+    is an image; and an **authority-relative** target is refused, matching the
+    client's ``safeUrl()`` for tier-1 links (both land in the same token-holding
+    page, so both get the same rule).
     """
     if attribute == "style":
         return _filter_style(value)
@@ -246,16 +273,22 @@ def _attribute_filter(tag: str, attribute: str, value: str) -> str | None:
     normalized = _normalize_url(value)
     if normalized.startswith(_AUTHORITY_RELATIVE):
         return None
-    # Strip the leading characters a URL parser ignores — case-preserving, so a
-    # base64 payload survives — rather than shipping invisible control bytes the
-    # client would then have to be trusted to normalize the same way we did.
-    kept = value.lstrip("".join(chr(c) for c in range(0x21)) + "\x7f")
-    if _scheme_of(normalized) == "data":
+    scheme = _scheme_of(normalized)
+    if scheme == "data":
         # The one legitimate use is the logo the header macros embed.
         if tag == "img" and attribute == "src" and normalized.startswith("data:image/"):
-            return kept
+            return value
         return None
-    return kept
+    if scheme and scheme not in ALLOWED_URL_SCHEMES:
+        # The scheme allowlist, applied over *this* module's normalization rather
+        # than deferring to nh3's. They do not agree: measured, ammonia reads
+        # ``<tab>blob:x`` as a scheme-less relative path and keeps it, while this
+        # view resolves the scheme the browser will act on. Since the filter can
+        # only reject, being the stricter of the two costs nothing — and it means
+        # a scheme is refused because it is unlisted, not because a second
+        # implementation happened to spell normalization the same way.
+        return None
+    return value
 
 
 def _filter_style(value: str) -> str | None:

--- a/src/clm/web/studio/sanitize.py
+++ b/src/clm/web/studio/sanitize.py
@@ -1,4 +1,4 @@
-"""Server-side HTML sanitizing for the Studio's tier-2 cell preview (issue #697).
+r"""Server-side HTML sanitizing for the Studio's tier-2 cell preview (issue #697).
 
 The tier-2 preview expands a cell's Jinja server-side so the phone sees a
 rendered header instead of raw ``{{ header_de("…") }}``. The expansion is
@@ -31,9 +31,32 @@ everywhere except an ``<img src>`` that is specifically ``data:image/``.
 **Not sanitized: the contents of ``style``.** Ammonia does not parse CSS, so
 the property allowlist here is CLM's own — the properties the bundled macros
 actually use plus a few text-formatting ones — with any declaration containing
-``url(`` / ``expression(`` / a backslash escape dropped. CSS cannot execute
-script in a current browser; the residual risk is visual (an overlay), inside a
-page whose content the token holder can rewrite anyway.
+``url(`` / ``expression(`` / a backslash escape dropped (after comments are
+stripped, since ``url/*x*/(`` otherwise walks past that check). CSS cannot
+execute script in a current browser, so the residual risk is visual: a
+fixed-position overlay that impersonates the app's own UI and links out.
+
+That is also why ``class`` is **not** an allowed attribute even though it looks
+inert. The Studio's own stylesheet defines ``.toast { position: fixed;
+z-index: 20 }``, so injected markup could *name* that class and get the exact
+overlay :data:`ALLOWED_CSS_PROPERTIES` refuses to grant through ``style`` — an
+allowlist is only as tight as the page's own class names. Found by an
+adversarial review of this module; **a property allowlist and a class allowlist
+have to be reasoned about together.**
+
+**URL rules, and why they are here rather than left to nh3.** Two decisions
+nh3's declarative config cannot express, both in :func:`_attribute_filter`:
+
+* ``data:`` is confined to an ``<img src>`` that is ``data:image/…`` (the logo).
+* an **authority-relative** target (``//host``, and the ``\\`` / ``/\`` / ``\/``
+  spellings WHATWG parsing treats identically) is refused, matching the client's
+  ``safeUrl()`` for tier-1 markdown links. Both tiers render into the same page,
+  which holds a non-expiring bearer token, so both get the same rule — and an
+  ``<img>`` needs no click, so opening a deck would otherwise beacon.
+
+Both decisions depend on normalizing a URL the way ammonia and the browser do,
+which is **not** Python's ``\s`` — see :data:`_URL_INSIGNIFICANT` for the
+control-character gap that made this a real bypass.
 """
 
 from __future__ import annotations
@@ -93,15 +116,31 @@ ALLOWED_TAGS: frozenset[str] = frozenset(
     }
 )
 
-#: Per-tag attribute allowlist. ``rel`` is absent on purpose: nh3 manages it
-#: (it adds ``rel="noopener noreferrer"`` to every link) and rejects the config
-#: outright if both are set.
+#: Tags removed **with their text content**, not just unwrapped. Without this,
+#: ``<iframe>fallback</iframe>`` leaves ``fallback`` behind as prose — harmless
+#: on its own, but it makes "active content is removed" false as stated, and
+#: fallback text is exactly where a payload's social-engineering copy lives.
+CLEAN_CONTENT_TAGS: frozenset[str] = frozenset(
+    {"script", "style", "iframe", "object", "embed", "form", "noscript", "template"}
+)
+
+#: Per-tag attribute allowlist. Two deliberate absences:
+#:
+#: * ``rel`` — nh3 manages it (it adds ``rel="noopener noreferrer"`` to every
+#:   link) and rejects the config outright if both are set.
+#: * ``class`` — it was here, and it made :data:`ALLOWED_CSS_PROPERTIES`
+#:   decorative: the Studio's own stylesheet defines ``.toast { position: fixed;
+#:   z-index: 20 }``, so injected markup could *name* that class and get the
+#:   fixed-position overlay the CSS allowlist exists to refuse — no ``style``
+#:   attribute needed. An allowlist that omits a property while allowing the
+#:   page's own class that sets it is not an allowlist. The macros emit inline
+#:   ``style``, never ``class``, so nothing legitimate wanted it.
 ALLOWED_ATTRIBUTES: dict[str, set[str]] = {
     "a": {"href", "title"},
     "img": {"src", "alt", "title", "width", "height"},
     "td": {"colspan", "rowspan"},
     "th": {"colspan", "rowspan", "scope"},
-    "*": {"style", "class", "align"},
+    "*": {"style", "align"},
 }
 
 #: Link schemes a preview may point at. ``data`` is here **only** so the logo
@@ -135,12 +174,29 @@ ALLOWED_CSS_PROPERTIES: frozenset[str] = frozenset(
 
 #: Declaration content that is never kept, whatever the property: ``url()``
 #: fetches, the legacy IE ``expression()``, and CSS backslash escapes (which
-#: exist to spell any of the above without spelling it).
+#: exist to spell any of the above without spelling it). Comments are stripped
+#: first (:data:`_CSS_COMMENT`) — ``url/*x*/(…)`` otherwise walks past a naive
+#: ``url\s*\(``.
 _CSS_REJECT = re.compile(r"url\s*\(|expression\s*\(|\\", re.IGNORECASE)
 
-#: Whitespace is not significant inside a URL scheme, and ``da\nta:`` is a real
-#: obfuscation, so the scheme check runs against a whitespace-stripped copy.
-_WHITESPACE = re.compile(r"\s+")
+#: A CSS comment, which may appear *inside* a declaration.
+_CSS_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+#: Characters to remove before judging a URL's scheme. **Not** Python ``\s``:
+#: ammonia (and the WHATWG URL parser) strip every C0 control plus space, and
+#: Python's ``\s`` misses U+0001–U+0008 and U+000E–U+001B. That gap was a real
+#: bypass — ``<a href="&#1;data:text/html;base64,…">`` left this filter seeing
+#: the scheme ``"\x01data"`` (no match, so no refusal) while nh3 normalized the
+#: control away, saw ``data:``, found it allowlisted, and kept the attribute.
+#: The two normalizations have to agree, so this one is the stricter superset.
+_URL_INSIGNIFICANT = re.compile(r"[\x00-\x20\x7f]+|\s+")
+
+#: Leading pairs that make a URL **authority-relative** — an off-origin
+#: navigation from a page holding a non-expiring bearer token. WHATWG parsing
+#: treats ``\`` as ``/`` for http(s), so all four combinations reach the same
+#: host. The Studio's client-side ``safeUrl()`` refuses these for tier-1
+#: markdown links; tier-2 output lands in the same page and gets the same rule.
+_AUTHORITY_RELATIVE = ("//", r"\\", "/\\", "\\/")
 
 
 class SanitizerUnavailableError(RuntimeError):
@@ -152,38 +208,60 @@ class SanitizerUnavailableError(RuntimeError):
     """
 
 
-def _scheme_of(value: str) -> str:
-    """The URL scheme of ``value``, lowercased, or ``""`` if it names none."""
-    candidate = _WHITESPACE.sub("", value)
-    head, sep, _rest = candidate.partition(":")
+def _normalize_url(value: str) -> str:
+    """``value`` with the characters a URL parser ignores removed, lowercased.
+
+    The comparison form for every URL decision in this module, so all of them
+    agree with the normalization nh3 and the browser perform. See
+    :data:`_URL_INSIGNIFICANT` for why this is not ``\\s``.
+    """
+    return _URL_INSIGNIFICANT.sub("", value).lower()
+
+
+def _scheme_of(normalized: str) -> str:
+    """The scheme of an already-:func:`_normalize_url`\\ ed value, or ``""``."""
+    head, sep, _rest = normalized.partition(":")
     if not sep or not head or not head.isascii():
         return ""
-    return head.lower()
+    return head
 
 
 def _attribute_filter(tag: str, attribute: str, value: str) -> str | None:
-    """nh3 per-attribute hook: confine ``data:`` and filter CSS declarations.
+    """nh3 per-attribute hook: the decisions nh3's own config cannot express.
 
     Returning ``None`` drops the attribute. nh3 still applies its own scheme
     allowlist afterwards, so this can only ever be *more* restrictive — which
     is why ``data`` has to be in :data:`ALLOWED_URL_SCHEMES` for the ``img``
     case to survive at all.
+
+    Three rules: CSS is filtered (:func:`_filter_style`); ``data:`` is confined
+    to an ``<img src>`` that is an image; and an **authority-relative** target is
+    refused outright, matching the client's ``safeUrl()`` for tier-1 links (both
+    land in the same token-holding page, so both get the same rule).
     """
     if attribute == "style":
         return _filter_style(value)
-    if _scheme_of(value) == "data":
-        # The one legitimate use is the logo the header macros embed.
-        if tag == "img" and attribute == "src":
-            head = _WHITESPACE.sub("", value).lower()
-            return value if head.startswith("data:image/") else None
+    if attribute not in ("href", "src"):
+        return value
+    normalized = _normalize_url(value)
+    if normalized.startswith(_AUTHORITY_RELATIVE):
         return None
-    return value
+    # Strip the leading characters a URL parser ignores — case-preserving, so a
+    # base64 payload survives — rather than shipping invisible control bytes the
+    # client would then have to be trusted to normalize the same way we did.
+    kept = value.lstrip("".join(chr(c) for c in range(0x21)) + "\x7f")
+    if _scheme_of(normalized) == "data":
+        # The one legitimate use is the logo the header macros embed.
+        if tag == "img" and attribute == "src" and normalized.startswith("data:image/"):
+            return kept
+        return None
+    return kept
 
 
 def _filter_style(value: str) -> str | None:
     """Keep only allowlisted, inert CSS declarations; ``None`` if none survive."""
     kept: list[str] = []
-    for declaration in value.split(";"):
+    for declaration in _CSS_COMMENT.sub("", value).split(";"):
         prop, sep, val = declaration.partition(":")
         if not sep:
             continue
@@ -205,7 +283,7 @@ def sanitize_preview_html(html: str) -> str:
     """
     try:
         import nh3
-    except ImportError as exc:  # pragma: no cover - exercised via monkeypatch
+    except ImportError as exc:
         raise SanitizerUnavailableError(
             "the HTML sanitizer (nh3) is not installed, so the server-side cell "
             "preview is unavailable; install clm[web]"
@@ -214,6 +292,7 @@ def sanitize_preview_html(html: str) -> str:
     return nh3.clean(
         html,
         tags=set(ALLOWED_TAGS),
+        clean_content_tags=set(CLEAN_CONTENT_TAGS),
         attributes={tag: set(attrs) for tag, attrs in ALLOWED_ATTRIBUTES.items()},
         url_schemes=set(ALLOWED_URL_SCHEMES),
         attribute_filter=_attribute_filter,

--- a/src/clm/web/studio/service.py
+++ b/src/clm/web/studio/service.py
@@ -443,19 +443,21 @@ class StudioService:
 
     def render_cell(
         self, deck_id: str, body: str, *, is_j2: bool, lang: str | None = None
-    ) -> tuple[bool, str | None, str]:
-        """Tier-2 (kernel-free) render of one cell. Returns ``(rendered, error, text)``.
+    ) -> tuple[bool, str | None, str | None]:
+        """Tier-2 (kernel-free) render of one cell. Returns ``(rendered, error, html)``.
 
         Only ``is_j2`` cells are expanded server-side (through the build's bundled
-        macros); plain cells are returned unchanged for the client to render as
-        markdown (tier 1). Never raises — preview degrades to tier-1 on failure.
+        macros); a plain cell returns ``html=None`` for the client to render as
+        markdown (tier 1). On success ``html`` is a **sanitized** fragment
+        (issue #697) — the client injects it verbatim. Never raises: the preview
+        degrades to tier-1 on any failure, including a missing sanitizer.
         """
         if not is_j2:
-            return False, None, body
-        from clm.web.studio.render import render_j2_cell
+            return False, None, None
+        from clm.web.studio.render import render_j2_cell_html
 
         path = self._resolve_deck_id(deck_id)
-        return render_j2_cell(path, body, lang)
+        return render_j2_cell_html(path, body, lang)
 
     def try_begin_sync(self, key: str) -> bool:
         """Claim the in-flight slot for ``key`` (the DE deck id). False if taken."""

--- a/tests/web/studio/test_render_pwa.py
+++ b/tests/web/studio/test_render_pwa.py
@@ -34,8 +34,10 @@ class TestTier2Render:
         assert text == bad  # body returned unchanged for tier-1 fallback
 
     def test_service_skips_non_j2(self, service: StudioService, course: Course):
-        ok, error, text = service.render_cell(course.deck_id, "# plain", is_j2=False)
-        assert ok is False and text == "# plain"
+        # Since #697 the third element is the sanitized HTML, so "no render" is
+        # `None` — the client keeps the tier-1 markdown it already drew.
+        ok, error, html = service.render_cell(course.deck_id, "# plain", is_j2=False)
+        assert ok is False and html is None and error is None
 
 
 class TestRenderEndpoint:
@@ -53,7 +55,11 @@ class TestRenderEndpoint:
         assert r.status_code == 200
         data = r.json()
         assert data["rendered"] is True
-        assert "Hallo Welt" in data["body"]
+        # Assert on `html`, not `body`: since #697 `body` echoes the *request*
+        # (which contains "Hallo Welt" as the macro argument), so asserting there
+        # would pass even if rendering did nothing at all.
+        assert "Hallo Welt" in data["html"]
+        assert data["body"] == J2_HEADER
 
     def test_render_cell_non_j2_passthrough(self, client: TestClient, course: Course):
         r = client.post(

--- a/tests/web/studio/test_tier2_preview.py
+++ b/tests/web/studio/test_tier2_preview.py
@@ -56,20 +56,50 @@ class TestSanitizer:
     @pytest.mark.parametrize(
         "html",
         [
-            "<script>alert(1)</script>",
-            "<iframe src='https://evil'></iframe>",
-            "<svg onload=alert(1)><circle/></svg>",
-            "<style>body{display:none}</style>",
-            "<form action='https://evil'><input name=a></form>",
-            "<math><mtext><table><mglyph><style><img src=x onerror=alert(1)>",
-            "<object data='x'></object>",
+            "<script>PAYLOAD</script>",
+            "<iframe src='https://evil'>PAYLOAD</iframe>",
+            "<style>PAYLOAD</style>",
+            "<form action='https://evil'>PAYLOAD<input name=a></form>",
+            "<object data='x'>PAYLOAD</object>",
+            "<noscript>PAYLOAD</noscript>",
+            "<template>PAYLOAD</template>",
         ],
     )
-    def test_active_content_is_removed_with_its_contents(self, html: str) -> None:
+    def test_active_content_is_removed_with_its_text(self, html: str) -> None:
+        """Not just unwrapped — the text goes too.
+
+        An adversarial review found the original version of this test vacuous:
+        nh3's ``clean_content_tags`` defaults to ``{script, style}``, so
+        ``<iframe>fallback</iframe>`` left ``fallback`` behind as prose. Harmless
+        in itself, but fallback text is exactly where a payload's "your session
+        expired, tap here" copy lives, and the test's name claimed otherwise.
+        ``PAYLOAD`` is the marker so the assertion cannot pass by accident.
+        """
+        assert sanitize_preview_html(html) == ""
+
+    @pytest.mark.parametrize(
+        "html",
+        [
+            "<svg onload=alert(1)><circle/></svg>",
+            "<math><mtext><table><mglyph><style><img src=x onerror=alert(1)>",
+            "<xmp><p></xmp><img src=x onerror=alert(1)>",
+            "<select><noembed></select><img src=x onerror=alert(1)>",
+        ],
+    )
+    def test_namespace_confusion_payloads_are_inert(self, html: str) -> None:
         cleaned = sanitize_preview_html(html)
         assert "alert" not in cleaned
-        assert "<script" not in cleaned and "<iframe" not in cleaned
-        assert "<svg" not in cleaned and "<style" not in cleaned
+        assert "<svg" not in cleaned and "onerror" not in cleaned
+
+    def test_sanitizing_is_idempotent(self) -> None:
+        """A second pass must not resurrect markup (the mXSS shape)."""
+        for html in (
+            "<math><mtext><table><mglyph><style><img src=x onerror=alert(1)>",
+            '<div style="text-align:center"><b>T</b></div>',
+            '<img src="data:image/png;base64,AAAA">',
+        ):
+            once = sanitize_preview_html(html)
+            assert sanitize_preview_html(once) == once
 
     def test_event_handlers_are_dropped(self) -> None:
         cleaned = sanitize_preview_html('<img src="https://x/y.png" onerror="alert(1)">')
@@ -108,6 +138,15 @@ class TestSanitizer:
             '<a href="da\nta:text/html,x">x</a>',
             '<a href="javascript:alert(1)">x</a>',
             '<a href="vbscript:msgbox(1)">x</a>',
+            # The C0-control prefixes an adversarial review used to bypass this:
+            # ammonia and the URL parser strip every C0 control, Python's `\s`
+            # does not, so `&#1;data:` looked like the scheme "\x01data" to the
+            # filter and like `data:` to nh3. `&#N;` needs no raw control byte in
+            # the deck — the HTML parser decodes it. See _URL_INSIGNIFICANT.
+            '<a href="&#1;data:text/html;base64,PHNjcmlwdD4=">x</a>',
+            '<a href="&#8;data:text/html,x">x</a>',
+            '<a href="&#14;data:text/html,x">x</a>',
+            '<a href="&#27;javascript:alert(1)">x</a>',
         ],
     )
     def test_a_link_can_never_carry_data_or_script_schemes(self, html: str) -> None:
@@ -115,9 +154,74 @@ class TestSanitizer:
         cleaned = sanitize_preview_html(html)
         assert "href" not in cleaned
 
-    def test_a_non_image_data_uri_is_refused_even_on_img(self) -> None:
-        cleaned = sanitize_preview_html('<img src="data:text/html,<b>x</b>">')
+    @pytest.mark.parametrize(
+        "html",
+        [
+            '<img src="data:text/html,<b>x</b>">',
+            '<img src="&#1;data:text/html,x">',
+            '<img src="&#14;data:application/javascript,x">',
+        ],
+    )
+    def test_a_non_image_data_uri_is_refused_even_on_img(self, html: str) -> None:
+        """Cases 2–3 are the control-prefix bypass: the confinement to
+        ``data:image/`` has to normalize the same way nh3's scheme check does, or
+        the prefix defeats one check and not the other."""
+        cleaned = sanitize_preview_html(html)
         assert "data:" not in cleaned
+
+    def test_a_kept_url_carries_no_leading_control_characters(self) -> None:
+        """A legitimate image with a stray prefix is kept — normalized, not raw.
+
+        The prefix is inert (every URL parser drops it), but shipping invisible
+        bytes to the client would mean trusting the client to normalize the same
+        way the filter did. Case is preserved: base64 is case-sensitive.
+        """
+        cleaned = sanitize_preview_html('<img src="&#8;data:image/svg+xml;base64,AAaaBB">')
+        assert 'src="data:image/svg+xml;base64,AAaaBB"' in cleaned
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "//evil.example/x",
+            "\\\\evil.example/x",
+            "/\\evil.example/x",
+            "\\/evil.example/x",
+            "&#1;//evil.example/x",
+            "/\t/evil.example/x",
+        ],
+    )
+    @pytest.mark.parametrize("markup", ['<a href="{}">x</a>', '<img src="{}">'])
+    def test_authority_relative_targets_are_refused(self, markup: str, url: str) -> None:
+        """The rule the client's ``safeUrl()`` already applies to tier-1 links.
+
+        Tier-2 output lands in the same page — one holding a non-expiring bearer
+        token — so it gets the same rule. WHATWG parsing treats ``\\`` as ``/``
+        for http(s), so all four leading pairs reach the same host, and an
+        ``<img>`` needs no click at all: opening the deck is the beacon. The
+        tier-1 markdown renderer has no image syntax, so this vector arrives
+        *with* this feature.
+        """
+        cleaned = sanitize_preview_html(markup.format(url))
+        assert "evil.example" not in cleaned
+
+    @pytest.mark.parametrize(
+        "url", ["https://ok.example/x", "/root/relative", "img/logo.png", "#anchor"]
+    )
+    def test_same_origin_and_absolute_targets_still_work(self, url: str) -> None:
+        cleaned = sanitize_preview_html(f'<a href="{url}">x</a>')
+        assert url in cleaned
+
+    def test_class_is_not_allowed(self) -> None:
+        """Because the page's own stylesheet is a CSS-allowlist bypass.
+
+        ``.toast`` is ``position: fixed; z-index: 20`` in index.html, so injected
+        markup that merely *names* it gets the fixed overlay
+        :data:`ALLOWED_CSS_PROPERTIES` exists to refuse — no ``style`` needed.
+        Found by an adversarial review; the macros only ever emit inline styles.
+        """
+        cleaned = sanitize_preview_html('<div class="toast show">Sitzung abgelaufen</div>')
+        assert "class" not in cleaned
+        assert "Sitzung abgelaufen" in cleaned  # the text is prose, not a threat
 
     def test_https_links_still_work(self) -> None:
         cleaned = sanitize_preview_html('<a href="https://ok.example">ok</a>')
@@ -140,6 +244,24 @@ class TestSanitizer:
     def test_backslash_escaped_css_is_dropped(self) -> None:
         cleaned = sanitize_preview_html(r'<div style="width:expre\ssion(alert(1))">x</div>')
         assert "expre" not in cleaned
+
+    @pytest.mark.parametrize(
+        "style",
+        [
+            "width:url/*x*/(javascript:alert(1))",
+            "width:expression/*x*/(alert(1))",
+            "width:/*}*/url(x)",
+        ],
+    )
+    def test_css_comments_cannot_hide_a_rejected_construct(self, style: str) -> None:
+        """A comment splits ``url(`` so a naive ``url\\s*\\(`` walks past it.
+
+        No impact on its own — none of the allowlisted properties accepts
+        ``url()`` — but the guard has to do what its docstring says, and nothing
+        covered it before an adversarial review pointed at it.
+        """
+        cleaned = sanitize_preview_html(f'<div style="{style}">x</div>')
+        assert "url" not in cleaned and "expression" not in cleaned
 
     def test_fails_closed_without_nh3(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """An install without ``[web]`` loses the feature, not the guarantee."""
@@ -219,6 +341,19 @@ class TestRenderJ2CellHtml:
         monkeypatch.setattr("clm.web.studio.render.sanitize_preview_html", _boom)
         ok, error, html = render_j2_cell_html(tmp_path / "slides_x.de.py", J2_HEADER, "de")
         assert ok is False and html is None and error == "nh3 missing"
+
+    def test_an_unexpected_sanitizer_error_also_yields_no_html(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``nh3.clean`` itself raising must fail closed, not fall through."""
+
+        def _boom(_html: str) -> str:
+            raise ValueError("nh3 config rejected")
+
+        monkeypatch.setattr("clm.web.studio.render.sanitize_preview_html", _boom)
+        ok, error, html = render_j2_cell_html(tmp_path / "slides_x.de.py", J2_HEADER, "de")
+        assert ok is False and html is None
+        assert error is not None and "sanitize failed" in error
 
 
 # ---------------------------------------------------------------------------
@@ -325,3 +460,139 @@ class TestClientGate:
     def test_a_missing_cell_is_handled(self) -> None:
         assert self._run("needsServerRender(undefined)") is False
         assert self._run("needsServerRender({})") is False
+
+
+@pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node is not on PATH; the Studio consumer cannot be executed",
+)
+class TestClientConsumer:
+    """``renderJ2`` itself — the line whose absence of coverage caused #696.
+
+    An adversarial review made the point that pinning only the *gate* leaves the
+    consumer exactly as untested as it was when it silently stopped working:
+    rename the server's ``html`` field and every other test here still passes
+    while the feature dies. So this executes ``renderJ2`` under node against a
+    stub ``api()`` and a stub element, and asserts what it sends, what it
+    assigns, and — importantly — when it assigns *nothing*.
+    """
+
+    def _run(self, harness: str) -> dict:
+        from .test_client_escaping import _extract_function
+
+        source = APP_JS.read_text(encoding="utf-8")
+        # The shared extractor keys on `function <name>(`, which drops the
+        # `async` keyword in front of it — and then node rejects the `await`
+        # inside. Re-attach it rather than loosening the shared helper.
+        fn = _extract_function(source, "renderJ2")
+        if "async function renderJ2(" in source:
+            fn = f"async {fn}"
+        assert fn.startswith("async function renderJ2("), fn[:60]
+        script = f"""
+        let currentDeck = {{ deck_id: "m/t/slides_x.de.py" }};
+        const calls = [];
+        let apiImpl = async (path, opts) => {{
+          calls.push({{ path, body: JSON.parse(opts.body) }});
+          return {{ rendered: true, html: "<div>EXPANDED</div>", body: "raw", error: null }};
+        }};
+        const api = (path, opts) => apiImpl(path, opts);
+        function stubEl() {{
+          return {{ innerHTML: "TIER1", classes: [], classList: {{ add(c) {{ this.classes ??= []; }} }} }};
+        }}
+        {fn}
+        (async () => {{
+          {harness}
+        }})().then((out) => process.stdout.write(JSON.stringify(out)))
+             .catch((e) => {{ process.stderr.write(String(e)); process.exit(1); }});
+        """
+        proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            ["node", "-e", script],  # noqa: S607 - resolved via PATH, guarded by the skipif
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert proc.returncode == 0, f"node failed: {proc.stderr}"
+        return json.loads(proc.stdout)
+
+    def test_it_posts_the_cell_to_the_render_endpoint(self) -> None:
+        out = self._run(
+            """
+            const el = stubEl();
+            await renderJ2({ body: "# {{ header_de('T') }}", lang: "de", is_j2: true }, el);
+            return { calls, html: el.innerHTML };
+            """
+        )
+        assert len(out["calls"]) == 1
+        call = out["calls"][0]
+        assert call["path"] == "/deck/render-cell"
+        assert call["body"]["is_j2"] is True
+        assert call["body"]["deck_id"] == "m/t/slides_x.de.py"
+        assert call["body"]["lang"] == "de"
+
+    def test_it_injects_the_servers_html_field(self) -> None:
+        """The contract, executed: rename ``html`` server-side and this fails."""
+        out = self._run(
+            """
+            const el = stubEl();
+            await renderJ2({ body: "x", lang: "de" }, el);
+            return { html: el.innerHTML };
+            """
+        )
+        assert out["html"] == "<div>EXPANDED</div>"
+
+    @pytest.mark.parametrize(
+        "reply",
+        [
+            '{ rendered: false, html: null, body: "x", error: "nope" }',
+            '{ rendered: true, html: null, body: "x", error: null }',
+            "{}",
+        ],
+    )
+    def test_a_non_render_leaves_tier_1_in_place(self, reply: str) -> None:
+        out = self._run(
+            f"""
+            apiImpl = async () => ({reply});
+            const el = stubEl();
+            await renderJ2({{ body: "x" }}, el);
+            return {{ html: el.innerHTML }};
+            """
+        )
+        assert out["html"] == "TIER1"
+
+    def test_a_failed_request_leaves_tier_1_in_place(self) -> None:
+        out = self._run(
+            """
+            apiImpl = async () => { const e = new Error("401"); e.status = 401; throw e; };
+            const el = stubEl();
+            await renderJ2({ body: "x" }, el);
+            return { html: el.innerHTML };
+            """
+        )
+        assert out["html"] == "TIER1"
+
+    def test_a_reply_arriving_after_navigation_is_dropped(self) -> None:
+        """No write into a card belonging to a deck the user already left."""
+        out = self._run(
+            """
+            apiImpl = async () => {
+              currentDeck = { deck_id: "m/t/other.de.py" };   // navigated away
+              return { rendered: true, html: "<div>LATE</div>" };
+            };
+            const el = stubEl();
+            await renderJ2({ body: "x" }, el);
+            return { html: el.innerHTML };
+            """
+        )
+        assert out["html"] == "TIER1"
+
+    def test_no_deck_open_sends_nothing(self) -> None:
+        out = self._run(
+            """
+            currentDeck = null;
+            const el = stubEl();
+            await renderJ2({ body: "x" }, el);
+            return { calls, html: el.innerHTML };
+            """
+        )
+        assert out["calls"] == [] and out["html"] == "TIER1"

--- a/tests/web/studio/test_tier2_preview.py
+++ b/tests/web/studio/test_tier2_preview.py
@@ -1,0 +1,327 @@
+"""The tier-2 in-page preview and its server-side sanitizer (issue #697).
+
+Two failures met here, and they are different in kind:
+
+* **The tier never ran.** Its client gate was ``cell.cell_type === "markdown"``
+  while the API types a Jinja cell as ``"j2"``, so the branch was unreachable
+  from the day it was written and nothing noticed — nothing asserted the
+  frontend path at all. So the gate is now a named function,
+  ``needsServerRender``, executed here under node *and* checked against the
+  cell payload the real service emits. Either half alone would have missed the
+  original bug: the predicate can be right about a contract that changed, and
+  the contract can be right with nobody consulting it.
+* **The consumer was a raw ``innerHTML`` sink.** The expansion is deliberately
+  HTML (the header macros emit ``<div>``, ``<br>`` and a ``data:`` logo), so
+  escaping it deletes the feature. Decision D13: sanitize **server-side**
+  against an allowlist. These tests are the allowlist's teeth — including the
+  case that made ``data:`` awkward, since the logo needs it and a link must not
+  have it.
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from clm.web.studio.render import _to_preview_html, render_j2_cell_html
+from clm.web.studio.sanitize import (
+    SanitizerUnavailableError,
+    sanitize_preview_html,
+)
+
+from .conftest import Course, make_app
+
+TOKEN = "test-studio-token"
+AUTH = {"Authorization": f"Bearer {TOKEN}"}
+
+J2_HEADER = "# j2 from 'macros.j2' import header_de\n# {{ header_de(\"Hallo Welt\") }}"
+
+APP_JS = (
+    Path(__file__).resolve().parents[3] / "src" / "clm" / "web" / "static" / "studio" / "app.js"
+)
+
+
+# ---------------------------------------------------------------------------
+# The sanitizer allowlist.
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizer:
+    @pytest.mark.parametrize(
+        "html",
+        [
+            "<script>alert(1)</script>",
+            "<iframe src='https://evil'></iframe>",
+            "<svg onload=alert(1)><circle/></svg>",
+            "<style>body{display:none}</style>",
+            "<form action='https://evil'><input name=a></form>",
+            "<math><mtext><table><mglyph><style><img src=x onerror=alert(1)>",
+            "<object data='x'></object>",
+        ],
+    )
+    def test_active_content_is_removed_with_its_contents(self, html: str) -> None:
+        cleaned = sanitize_preview_html(html)
+        assert "alert" not in cleaned
+        assert "<script" not in cleaned and "<iframe" not in cleaned
+        assert "<svg" not in cleaned and "<style" not in cleaned
+
+    def test_event_handlers_are_dropped(self) -> None:
+        cleaned = sanitize_preview_html('<img src="https://x/y.png" onerror="alert(1)">')
+        assert "onerror" not in cleaned
+        assert 'src="https://x/y.png"' in cleaned
+
+    def test_the_header_macros_markup_survives(self) -> None:
+        """If this fails the feature is gone, not merely degraded."""
+        cleaned = sanitize_preview_html(
+            '<div style="text-align:center; font-size:200%;">\n'
+            " <b>Titel</b>\n"
+            "</div>\n"
+            "<br/>\n"
+            '<div style="text-align:center; font-size:120%;">Preview</div>'
+        )
+        assert "<b>Titel</b>" in cleaned
+        assert "text-align:center" in cleaned
+        assert "<br>" in cleaned
+
+    def test_the_data_uri_logo_survives(self) -> None:
+        cleaned = sanitize_preview_html(
+            '<img src="data:image/svg+xml;base64,PHN2Zy8+" style="display:block;width:5%">'
+        )
+        assert 'src="data:image/svg+xml;base64,PHN2Zy8+"' in cleaned
+
+    def test_a_line_wrapped_data_uri_survives(self) -> None:
+        """The bundled ``*.base64`` includes are wrapped, so the URI has newlines."""
+        cleaned = sanitize_preview_html('<img src="data:image/svg+xml;base64,PHN2\nZy8+\nAA">')
+        assert "data:image/svg+xml;base64," in cleaned
+
+    @pytest.mark.parametrize(
+        "html",
+        [
+            '<a href="data:text/html,<script>alert(1)</script>">x</a>',
+            '<a href="DATA:text/html,x">x</a>',
+            '<a href="da\nta:text/html,x">x</a>',
+            '<a href="javascript:alert(1)">x</a>',
+            '<a href="vbscript:msgbox(1)">x</a>',
+        ],
+    )
+    def test_a_link_can_never_carry_data_or_script_schemes(self, html: str) -> None:
+        """``data:`` is allowed for the logo, so a link must be refused explicitly."""
+        cleaned = sanitize_preview_html(html)
+        assert "href" not in cleaned
+
+    def test_a_non_image_data_uri_is_refused_even_on_img(self) -> None:
+        cleaned = sanitize_preview_html('<img src="data:text/html,<b>x</b>">')
+        assert "data:" not in cleaned
+
+    def test_https_links_still_work(self) -> None:
+        cleaned = sanitize_preview_html('<a href="https://ok.example">ok</a>')
+        assert 'href="https://ok.example"' in cleaned
+
+    def test_css_is_reduced_to_an_allowlist(self) -> None:
+        cleaned = sanitize_preview_html(
+            '<div style="text-align:center; position:fixed; '
+            'background-image:url(https://evil/x); width:5%">x</div>'
+        )
+        assert "text-align:center" in cleaned
+        assert "width:5%" in cleaned
+        assert "position" not in cleaned
+        assert "url(" not in cleaned
+
+    def test_a_style_with_nothing_allowlisted_is_dropped_entirely(self) -> None:
+        cleaned = sanitize_preview_html('<div style="position:fixed;z-index:9999">x</div>')
+        assert "style" not in cleaned
+
+    def test_backslash_escaped_css_is_dropped(self) -> None:
+        cleaned = sanitize_preview_html(r'<div style="width:expre\ssion(alert(1))">x</div>')
+        assert "expre" not in cleaned
+
+    def test_fails_closed_without_nh3(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An install without ``[web]`` loses the feature, not the guarantee."""
+        real_import = builtins.__import__
+
+        def _no_nh3(name, *args, **kwargs):
+            if name == "nh3":
+                raise ImportError("No module named 'nh3'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _no_nh3)
+        with pytest.raises(SanitizerUnavailableError, match="clm\\[web\\]"):
+            sanitize_preview_html("<b>x</b>")
+
+
+# ---------------------------------------------------------------------------
+# Expanded text → injectable HTML.
+# ---------------------------------------------------------------------------
+
+
+class TestPreviewHtmlNormalisation:
+    def test_the_cell_delimiter_line_is_dropped(self) -> None:
+        text = '# %% [markdown] lang="de" tags=["slide"]\n# <b>Titel</b>'
+        assert _to_preview_html(text, "#") == "<b>Titel</b>"
+
+    def test_an_unprefixed_delimiter_is_dropped_too(self) -> None:
+        """The macro's own first line carries no comment token."""
+        text = '%% [markdown] lang="de"\n// <b>T</b>'
+        assert _to_preview_html(text, "//") == "<b>T</b>"
+
+    def test_comment_prefixes_are_stripped_per_line(self) -> None:
+        assert _to_preview_html("# <div>\n#  x\n# </div>", "#") == "<div>\n x\n</div>"
+
+    def test_unprefixed_continuation_lines_are_left_alone(self) -> None:
+        """A wrapped base64 logo continues without the comment token."""
+        text = '# <img src="data:image/svg+xml;base64,AAAA\nBBBB\nCCCC">'
+        assert _to_preview_html(text, "#") == (
+            '<img src="data:image/svg+xml;base64,AAAA\nBBBB\nCCCC">'
+        )
+
+
+# ---------------------------------------------------------------------------
+# End to end: a real macro expansion, sanitized.
+# ---------------------------------------------------------------------------
+
+
+class TestRenderJ2CellHtml:
+    def test_a_real_header_becomes_sanitized_html(self, tmp_path: Path) -> None:
+        ok, error, html = render_j2_cell_html(tmp_path / "slides_x.de.py", J2_HEADER, "de")
+        assert ok and error is None and html is not None
+        assert "Hallo Welt" in html
+        assert "{{" not in html  # expanded, not echoed
+        assert "%%" not in html  # the cell delimiter is gone
+        assert "\n# <" not in html  # and so is the comment prefix
+        assert "<div" in html  # the macro's markup survived
+        assert "<script" not in html
+
+    def test_a_body_smuggling_script_is_sanitized_not_reflected(self, tmp_path: Path) -> None:
+        """The body is a *request* body — a token holder can put anything in it."""
+        body = "# <img src=x onerror=alert(1)>\n# <script>alert(2)</script>"
+        ok, error, html = render_j2_cell_html(tmp_path / "slides_x.de.py", body, "de")
+        assert ok and html is not None
+        assert "onerror" not in html and "<script" not in html
+
+    def test_broken_jinja_yields_no_html(self, tmp_path: Path) -> None:
+        ok, error, html = render_j2_cell_html(
+            tmp_path / "slides_x.de.py", "# {{ not valid jinja ", "de"
+        )
+        assert ok is False and error and html is None
+
+    def test_sanitizer_failure_yields_no_html(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(_html: str) -> str:
+            raise SanitizerUnavailableError("nh3 missing")
+
+        monkeypatch.setattr("clm.web.studio.render.sanitize_preview_html", _boom)
+        ok, error, html = render_j2_cell_html(tmp_path / "slides_x.de.py", J2_HEADER, "de")
+        assert ok is False and html is None and error == "nh3 missing"
+
+
+# ---------------------------------------------------------------------------
+# The endpoint, and the contract the frontend gate depends on.
+# ---------------------------------------------------------------------------
+
+
+class TestEndpointContract:
+    @pytest.fixture()
+    def client(self, course: Course) -> TestClient:
+        app = make_app(course.spec_path, course.slides_dir.parent / "jobs.db", TOKEN)
+        return TestClient(app)
+
+    def test_rendered_response_carries_sanitized_html_and_the_original_body(
+        self, client: TestClient, course: Course
+    ) -> None:
+        r = client.post(
+            "/api/studio/deck/render-cell",
+            headers=AUTH,
+            json={"deck_id": course.deck_id, "body": J2_HEADER, "is_j2": True, "lang": "de"},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["rendered"] is True
+        assert "Hallo Welt" in data["html"]
+        # `body` echoes the request so the client can fall back; it is NOT the
+        # unsanitized expansion (shipping that would invite injecting it).
+        assert data["body"] == J2_HEADER
+
+    def test_a_non_j2_cell_gets_no_html(self, client: TestClient, course: Course) -> None:
+        r = client.post(
+            "/api/studio/deck/render-cell",
+            headers=AUTH,
+            json={"deck_id": course.deck_id, "body": "# plain", "is_j2": False},
+        )
+        assert r.status_code == 200
+        assert r.json() == {"rendered": False, "body": "# plain", "html": None, "error": None}
+
+    def test_the_api_marks_a_j2_cell_the_way_the_client_gate_expects(
+        self, client: TestClient, course: Course
+    ) -> None:
+        """The half of the original bug that lived in the *contract*.
+
+        The gate keys on ``is_j2``; this asserts the payload actually sets it,
+        and that ``cell_type`` is ``"j2"`` — i.e. the old
+        ``cell_type === "markdown"`` gate is provably wrong, not merely
+        replaced.
+        """
+        deck_path = course.slides_dir / course.deck_id
+        deck_path.write_text(
+            "# j2 from 'macros.j2' import header_de\n"
+            '# {{ header_de("Hallo") }}\n'
+            "\n"
+            '# %% [markdown] lang="de" tags=["slide"] slide_id="intro-welcome"\n'
+            "# Willkommen\n",
+            encoding="utf-8",
+        )
+        r = client.get("/api/studio/deck", params={"id": course.deck_id}, headers=AUTH)
+        assert r.status_code == 200, r.text
+        cells = r.json()["cells"]
+        j2_cells = [c for c in cells if c["is_j2"]]
+        assert j2_cells, f"no is_j2 cell in {[c['cell_type'] for c in cells]}"
+        assert j2_cells[0]["cell_type"] == "j2"
+        assert all(c["is_j2"] is False for c in cells if c["cell_type"] == "markdown")
+
+
+# ---------------------------------------------------------------------------
+# The frontend gate, executed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    shutil.which("node") is None,
+    reason="node is not on PATH; the Studio frontend gate cannot be executed",
+)
+class TestClientGate:
+    def _run(self, expr: str) -> object:
+        from .test_client_escaping import _extract_function
+
+        source = APP_JS.read_text(encoding="utf-8")
+        fn = _extract_function(source, "needsServerRender")
+        script = f"{fn}\nprocess.stdout.write(JSON.stringify({expr}));"
+        proc = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            ["node", "-e", script],  # noqa: S607 - resolved via PATH, guarded by the skipif
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert proc.returncode == 0, f"node failed: {proc.stderr}"
+        return json.loads(proc.stdout)
+
+    def test_a_j2_cell_is_sent_to_the_server(self) -> None:
+        assert self._run('needsServerRender({cell_type: "j2", is_j2: true})') is True
+
+    def test_a_markdown_cell_is_not(self) -> None:
+        assert self._run('needsServerRender({cell_type: "markdown", is_j2: false})') is False
+
+    def test_the_gate_does_not_key_on_cell_type(self) -> None:
+        """The original bug, pinned: a j2 cell is not typed ``markdown``."""
+        assert self._run('needsServerRender({cell_type: "markdown", is_j2: true})') is True
+        assert self._run('needsServerRender({cell_type: "j2", is_j2: false})') is False
+
+    def test_a_missing_cell_is_handled(self) -> None:
+        assert self._run("needsServerRender(undefined)") is False
+        assert self._run("needsServerRender({})") is False

--- a/tests/web/studio/test_tier2_preview.py
+++ b/tests/web/studio/test_tier2_preview.py
@@ -91,15 +91,27 @@ class TestSanitizer:
         assert "alert" not in cleaned
         assert "<svg" not in cleaned and "onerror" not in cleaned
 
-    def test_sanitizing_is_idempotent(self) -> None:
-        """A second pass must not resurrect markup (the mXSS shape)."""
-        for html in (
+    @pytest.mark.parametrize(
+        "html",
+        [
             "<math><mtext><table><mglyph><style><img src=x onerror=alert(1)>",
             '<div style="text-align:center"><b>T</b></div>',
             '<img src="data:image/png;base64,AAAA">',
-        ):
-            once = sanitize_preview_html(html)
-            assert sanitize_preview_html(once) == once
+            # Non-idempotence is the *signature* of a filter that rewrites a
+            # value: pass 1 emits something pass 2 refuses. The `&#127;`
+            # javascript bypass showed up here first, so the corpus now carries
+            # the shapes that would expose the next one.
+            '<a href="&#127;javascript:alert(1)">x</a>',
+            '<a href="&#1;data:text/html,x">x</a>',
+            '<a href="&#127;//evil.example/x">x</a>',
+            '<img src="&#8;data:image/svg+xml;base64,AAaa">',
+            '<a href="&#9;https://ok.example">x</a>',
+        ],
+    )
+    def test_sanitizing_is_idempotent(self, html: str) -> None:
+        """A second pass must neither resurrect markup nor refuse pass 1's output."""
+        once = sanitize_preview_html(html)
+        assert sanitize_preview_html(once) == once
 
     def test_event_handlers_are_dropped(self) -> None:
         cleaned = sanitize_preview_html('<img src="https://x/y.png" onerror="alert(1)">')
@@ -147,12 +159,53 @@ class TestSanitizer:
             '<a href="&#8;data:text/html,x">x</a>',
             '<a href="&#14;data:text/html,x">x</a>',
             '<a href="&#27;javascript:alert(1)">x</a>',
+            # &#127; (DEL) is the case the *first* round of fixes got wrong: it is
+            # in this module's strip set but NOT in ammonia's, so a filter that
+            # rewrote kept values turned an inert relative path into a live
+            # `javascript:` URL that nothing re-checked. See _attribute_filter.
+            '<a href="&#127;javascript:alert(1)">x</a>',
+            '<a href="&#x7f;javascript:alert(1)">x</a>',
+            '<a href="&#127;&#1; javascript:alert(1)">x</a>',
+            '<a href="&#127;vbscript:msgbox(1)">x</a>',
+            '<a href="&#127;data:text/html,x">x</a>',
         ],
     )
     def test_a_link_can_never_carry_data_or_script_schemes(self, html: str) -> None:
         """``data:`` is allowed for the logo, so a link must be refused explicitly."""
         cleaned = sanitize_preview_html(html)
         assert "href" not in cleaned
+
+    @pytest.mark.parametrize(
+        "prefix",
+        ["", "&#1;", "&#8;", "&#9;", "&#14;", "&#27;", "&#127;", "&#x7f;", " ", "&#127;&#1;"],
+    )
+    @pytest.mark.parametrize(
+        "scheme",
+        [
+            "javascript:alert(1)",
+            "jAvAsCrIpT:alert(1)",
+            "vbscript:msgbox(1)",
+            "about:blank",
+            "blob:https://x/y",
+            "filesystem:https://x/y",
+            "data:text/html,x",
+        ],
+    )
+    def test_no_prefix_can_smuggle_an_unlisted_scheme_out(self, prefix: str, scheme: str) -> None:
+        """The property that replaced two rounds of case-by-case patching.
+
+        nh3 checks its scheme allowlist against the *incoming* value and writes
+        whatever the filter returns, and the two normalizations do not agree in
+        either direction (``&#127;`` is stripped here and not by ammonia;
+        ``<tab>blob:`` reads as a relative path to ammonia and as a scheme here).
+        So the filter applies the allowlist itself, over its own normalization,
+        and only ever rejects. This cross-product is that invariant: no padding,
+        in any spelling, may cause an unlisted scheme to reach the client.
+        """
+        for markup in ('<a href="{}">x</a>', '<img src="{}">'):
+            cleaned = sanitize_preview_html(markup.format(prefix + scheme)).lower()
+            for unlisted in ("javascript", "vbscript", "about:", "blob:", "filesystem:", "data:"):
+                assert unlisted not in cleaned, f"{unlisted!r} survived in {cleaned!r}"
 
     @pytest.mark.parametrize(
         "html",
@@ -169,15 +222,18 @@ class TestSanitizer:
         cleaned = sanitize_preview_html(html)
         assert "data:" not in cleaned
 
-    def test_a_kept_url_carries_no_leading_control_characters(self) -> None:
-        """A legitimate image with a stray prefix is kept — normalized, not raw.
+    def test_a_kept_url_is_returned_byte_for_byte(self) -> None:
+        """The filter must not "tidy" a value it keeps — that escapes nh3's check.
 
-        The prefix is inert (every URL parser drops it), but shipping invisible
-        bytes to the client would mean trusting the client to normalize the same
-        way the filter did. Case is preserved: base64 is case-sensitive.
+        This test used to assert the opposite (that a stray control prefix was
+        stripped from a kept URL), and satisfying it is what produced the
+        ``&#127;javascript:`` bypass: nh3 validates the *incoming* value, so a
+        rewritten return value is never re-checked. The prefix is inert — a URL
+        parser resolves ``\x7fjavascript:…`` as a same-origin path — so leaving it
+        alone is both safer and simpler.
         """
         cleaned = sanitize_preview_html('<img src="&#8;data:image/svg+xml;base64,AAaaBB">')
-        assert 'src="data:image/svg+xml;base64,AAaaBB"' in cleaned
+        assert "\x08data:image/svg+xml;base64,AAaaBB" in cleaned
 
     @pytest.mark.parametrize(
         "url",
@@ -301,6 +357,18 @@ class TestPreviewHtmlNormalisation:
         assert _to_preview_html(text, "#") == (
             '<img src="data:image/svg+xml;base64,AAAA\nBBBB\nCCCC">'
         )
+
+    @pytest.mark.parametrize(
+        "line",
+        ["# %%not a delimiter, prose", "# 100%% sicher", "# %%%"],
+    )
+    def test_prose_that_merely_starts_with_percent_percent_survives(self, line: str) -> None:
+        """``%%`` needs whitespace or ``[`` after it — jupytext's own rule.
+
+        The first version of the delimiter pattern was ``%%.*``, which silently
+        deleted any line beginning that way.
+        """
+        assert line.split("# ", 1)[1] in _to_preview_html(line, "#")
 
 
 # ---------------------------------------------------------------------------
@@ -497,7 +565,12 @@ class TestClientConsumer:
         }};
         const api = (path, opts) => apiImpl(path, opts);
         function stubEl() {{
-          return {{ innerHTML: "TIER1", classes: [], classList: {{ add(c) {{ this.classes ??= []; }} }} }};
+          const el = {{ innerHTML: "TIER1", classes: [] }};
+          // Record the argument on the *element*: a stub that drops it cannot
+          // observe the one side effect this exists to check (an earlier version
+          // did exactly that, so deleting the classList.add call passed).
+          el.classList = {{ add: (c) => el.classes.push(c) }};
+          return el;
         }}
         {fn}
         (async () => {{
@@ -536,10 +609,29 @@ class TestClientConsumer:
             """
             const el = stubEl();
             await renderJ2({ body: "x", lang: "de" }, el);
-            return { html: el.innerHTML };
+            return { html: el.innerHTML, classes: el.classes };
             """
         )
         assert out["html"] == "<div>EXPANDED</div>"
+        # The class carries the phone-legibility CSS (and the max-height that
+        # keeps a preview inside its own card), so losing it is a real defect.
+        assert out["classes"] == ["j2-preview"]
+
+    def test_an_empty_expansion_keeps_tier_1(self) -> None:
+        """``typeof "" === "string"``, so an empty render must be caught by name.
+
+        A cell that is only a ``{% import %}`` expands to nothing; blanking the
+        card would be worse than showing the raw source.
+        """
+        out = self._run(
+            """
+            apiImpl = async () => ({ rendered: true, html: "" });
+            const el = stubEl();
+            await renderJ2({ body: "x" }, el);
+            return { html: el.innerHTML, classes: el.classes };
+            """
+        )
+        assert out["html"] == "TIER1" and out["classes"] == []
 
     @pytest.mark.parametrize(
         "reply",
@@ -596,3 +688,22 @@ class TestClientConsumer:
             """
         )
         assert out["calls"] == [] and out["html"] == "TIER1"
+
+    def test_cell_card_wires_the_gate_to_the_consumer(self) -> None:
+        """The *wiring*, which is the third thing that can silently rot.
+
+        The gate is executed, the consumer is executed — and #696 was neither of
+        those, it was the call between them. Executing ``cellCard`` would mean
+        stubbing a DOM (``el()``, ``renderMarkdown``, ``querySelector``…), out of
+        proportion here; so this reads the source and requires that the call
+        exists, is guarded by the gate, and passes the cell and its body element.
+        A static check, deliberately, and named as one.
+        """
+        from .test_client_escaping import _extract_function
+
+        card = _extract_function(APP_JS.read_text(encoding="utf-8"), "cellCard")
+        assert "needsServerRender(cell)" in card
+        assert "renderJ2(cell, body)" in card
+        gate = card.index("needsServerRender(cell)")
+        call = card.index("renderJ2(cell, body)")
+        assert gate < call, "the tier-2 call must sit inside the gate, not before it"

--- a/uv.lock
+++ b/uv.lock
@@ -581,6 +581,7 @@ all = [
     { name = "mypy" },
     { name = "nbconvert" },
     { name = "nbformat" },
+    { name = "nh3" },
     { name = "numpy" },
     { name = "obsws-python" },
     { name = "onnxruntime" },
@@ -709,6 +710,7 @@ voiceover-granite = [
 ]
 web = [
     { name = "httptools" },
+    { name = "nh3" },
     { name = "segno" },
     { name = "watchfiles" },
     { name = "wsproto" },
@@ -765,6 +767,7 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
     { name = "nbconvert", marker = "extra == 'notebook'", specifier = "~=7.16.4" },
     { name = "nbformat", marker = "extra == 'notebook'", specifier = "~=5.10.4" },
+    { name = "nh3", marker = "extra == 'web'", specifier = ">=0.2.18" },
     { name = "numpy", marker = "extra == 'recordings'", specifier = ">=1.24.0" },
     { name = "obsws-python", marker = "extra == 'recordings'", specifier = ">=1.7.0" },
     { name = "onnxruntime", marker = "extra == 'recordings'", specifier = ">=1.17.0" },
@@ -1026,7 +1029,7 @@ name = "cuda-bindings"
 version = "13.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/e0/4b3fdba08ff177e9451f376a4ba2df18d76f9158e6a16cdc062bd83db9fa/cuda_bindings-13.3.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f72f67f5790e7fa51e3f893e007e49567573ccdf4ed1ca988fbbbd36cd77847c", size = 6020531, upload-time = "2026-05-27T03:59:07.942Z" },
@@ -1062,34 +1065,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -1105,43 +1108,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusolver", marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -2404,6 +2407,40 @@ wheels = [
 ]
 
 [[package]]
+name = "nh3"
+version = "0.3.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/5f/1d19bdc7d27238e37f3672cdc02cb77c56a4a86d140cd4f4f23c90df6e16/nh3-0.3.5.tar.gz", hash = "sha256:45855e14ff056064fec77133bfcf7cd691838168e5e17bbef075394954dc9dc8", size = 20743, upload-time = "2026-04-25T10:44:16.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/b0/8587ac42a9627ab88e7e221601f1dfccbf4db80b2a29222ea63266dc9abc/nh3-0.3.5-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:23a312224875f72cd16bde417f49071451877e29ef646a60e50fcb69407cc18a", size = 1420126, upload-time = "2026-04-25T10:43:39.834Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/1dbc4d0c43f12e8c1784ede17eaee6f061d4fbe5505757c65c49b2ceab95/nh3-0.3.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:387abd011e81959d5a35151a11350a0795c6edeb53ebfa02d2e882dc01299263", size = 793943, upload-time = "2026-04-25T10:43:41.363Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9f/d6758d7a14ee964bf439cc35ae4fa24a763a93399c8ef6f22bd11d532d29/nh3-0.3.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:48f45e3e914be93a596431aa143dedf1582557bf41a58153c296048d6e3798c9", size = 841150, upload-time = "2026-04-25T10:43:43.007Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/d5d1ae8374612c98f390e1ea7c610fa6c9716259a03bbf4d15b269f40073/nh3-0.3.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0a09f51806fd51b4fedbf9ea2b61fef388f19aef0d62fe51199d41648be14588", size = 1008415, upload-time = "2026-04-25T10:43:44.324Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8f/d13a9c3fd2d9c131a2a281737380e9379eb0f8c33fea24c2b923aaafbb15/nh3-0.3.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c357f1d042c67f135a5e6babb2b0e3b9d9224ff4a3543240f597767b01384ffd", size = 1092706, upload-time = "2026-04-25T10:43:45.653Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/57/2f3add7f8680fcc896afa6a675cb2bab09982853ee8af40bad621f6b61c4/nh3-0.3.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:38748140bf76383ab7ce2dce0ad4cb663855d8fbc9098f7f3483673d09616a17", size = 1048346, upload-time = "2026-04-25T10:43:46.974Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/c3/2f9e4ffa82863074d1361bfe949bc46393d91b3411579dfbbd090b24cac5/nh3-0.3.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:84bdeb082544fbcb77a12c034dd77d7da0556fdc0727b787eb6214b958c15e29", size = 1029038, upload-time = "2026-04-25T10:43:48.569Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/10/2804deb3f3315184c9cae41702e293c87524b5a21f766b07d7fe3ffbcfbb/nh3-0.3.5-cp314-cp314t-win32.whl", hash = "sha256:c3aae321f67ae66cff2a627115f106a377d4475d10b0e13d97959a13486b9a88", size = 603263, upload-time = "2026-04-25T10:43:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/a2/f6685248b49f7548fc9a8c335ab3a52f68610b72e8a61576447151e4e2e6/nh3-0.3.5-cp314-cp314t-win_amd64.whl", hash = "sha256:c88605d8d468f7fc1b31e06129bc91d6c96f6c621776c9b504a0da9beac9df5f", size = 616866, upload-time = "2026-04-25T10:43:51.005Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b6/d8c9018635d4acfefde6b68470daa510eed715a350cbaa2f928ba0609f81/nh3-0.3.5-cp314-cp314t-win_arm64.whl", hash = "sha256:72c5bdedec27fa33de6a5326346ea8aa3fe54f6ac294d54c4b204fb66a9f1e79", size = 602566, upload-time = "2026-04-25T10:43:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/85/30/d162e99746a2fb1d98bb0ef23af3e201b156cf09f7de867c7390c8fe1c06/nh3-0.3.5-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:3bb854485c9b33e5bb143ff3e49e577073bc6bc320f0ff8fc316dd89c0d3c101", size = 1442393, upload-time = "2026-04-25T10:43:53.556Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8c/072120d506978ab053e1732d0efa7c86cb478fee0ee098fda0ac0d31cb34/nh3-0.3.5-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50d401ab2d8e86d59e2126e3ab2a2f45840c405842b626d9a51624b3a33b6878", size = 837722, upload-time = "2026-04-25T10:43:55.073Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/d4e06e28c5ad1c4b065f89737d02631bd49f1660b6ebcf17a87ffcd201da/nh3-0.3.5-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:acfd354e61accbe4c74f8017c6e397a776916dfe47c48643cf7fd84ade826f93", size = 822872, upload-time = "2026-04-25T10:43:56.581Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/62/50659255213f241ec5797ae7427464c969397373e83b3659372b341ae869/nh3-0.3.5-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:52d877980d7ca01dc3baf3936bf844828bc6f332962227a684ed79c18cce14c3", size = 1100031, upload-time = "2026-04-25T10:43:58.098Z" },
+    { url = "https://files.pythonhosted.org/packages/00/7a/a12ae77593b2fcf3be25df7bc1c01967d0de448bdb4b6c7ec80fe4f5a74f/nh3-0.3.5-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:207c01801d3e9bb8ec08f08689346bdd30ce15b8bf60013a925d08b5388962a4", size = 1057669, upload-time = "2026-04-25T10:43:59.328Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/71/5647dc04c0233192a3956fc91708822b21403a06508cacf78083c68e7bf0/nh3-0.3.5-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea232933394d1d58bf7c4bb348dc4660eae6604e1ae81cd2ba6d9ed80d390f3b", size = 914795, upload-time = "2026-04-25T10:44:00.52Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/0e/bf298920729f216adcb002acf7ea01b90842603d2e4e2ce9b900d9ee8fab/nh3-0.3.5-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fe3a787dc76b50de6bee54ef242f26c41dfe47654428e3e94f0fae5bb6dd2cc1", size = 806976, upload-time = "2026-04-25T10:44:01.743Z" },
+    { url = "https://files.pythonhosted.org/packages/85/01/26761e1dc2b848e65a62c19e5d39ad446283287cd4afddc89f364ab86bc9/nh3-0.3.5-cp38-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:488928988caad25ba14b1eb5bc74e25e21f3b5e40341d956f3ce4a8bc19460dc", size = 834904, upload-time = "2026-04-25T10:44:03.454Z" },
+    { url = "https://files.pythonhosted.org/packages/33/53/0766113e679540ac1edc1b82b1295aecd321eeb75d6fead70109a838b6ee/nh3-0.3.5-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2c069570b06aa848457713ad7af4a9905691291548c4466a9ad78ee95808382b", size = 857159, upload-time = "2026-04-25T10:44:05.003Z" },
+    { url = "https://files.pythonhosted.org/packages/58/36/734d353dfaf292fed574b8b3092f0ef79dc6404f3879f7faaa61a4701fad/nh3-0.3.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:eeedc90ed8c42c327e8e10e621ccfa314fc6cce35d5929f4297ff1cdb89667c4", size = 1018600, upload-time = "2026-04-25T10:44:06.18Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/aa/d9c59c1b49669fcb7bababa55df82385f029ad5c2651f583c3a1141cfdd1/nh3-0.3.5-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:de8e8621853b6470fe928c684ee0d3f39ea8086cebafe4c416486488dea7b68d", size = 1103530, upload-time = "2026-04-25T10:44:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/90/b0/cdd210bfb8d9d43fb02fc3c868336b9955934d8e15e66eb1d15a147b8af0/nh3-0.3.5-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:6ea58cc44d274c643b83547ca9654a0b1a817609b160601356f76a2b744c49ad", size = 1061754, upload-time = "2026-04-25T10:44:09.362Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/cb/7a39e72e668c8445bdd95e494b3e21cfdddc68329be8ea3522c8befb46c4/nh3-0.3.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e49c9b564e6bcb03ecd2f057213df9a0de15a95812ac9db9600b590db23d3ae9", size = 1040938, upload-time = "2026-04-25T10:44:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/af/4c/fc2f9ed208a3801a319f59b5fea03cdc20cf3bd8af14be930d3a8de01224/nh3-0.3.5-cp38-abi3-win32.whl", hash = "sha256:559e4c73b689e9a7aa97ac9760b1bc488038d7c1a575aa4ab5a0e19ee9630c0f", size = 611445, upload-time = "2026-04-25T10:44:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/db/1a/e4c9b5e2ae13e6092c9ec16d8ca30646cb01fcdea245f36c5b08fd21fbd5/nh3-0.3.5-cp38-abi3-win_amd64.whl", hash = "sha256:45e6a65dc88a300a2e3502cb9c8e6d1d6b831d6fba7470643333609c6aab1f30", size = 626502, upload-time = "2026-04-25T10:44:13.682Z" },
+    { url = "https://files.pythonhosted.org/packages/80/7c/19cd0671d1ba2762fb388fc149697d20d0568ccfeef833b11280a619e526/nh3-0.3.5-cp38-abi3-win_arm64.whl", hash = "sha256:8f85285700a18e9f3fc5bff41fe573fa84f81542ef13b48a89f9fecca0474d3b", size = 611069, upload-time = "2026-04-25T10:44:14.934Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2478,7 +2515,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2517,7 +2554,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2529,8 +2566,8 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.15'" },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.15'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2560,10 +2597,10 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform == 'win32')" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.15'" },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.15'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2575,8 +2612,8 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.15'" },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.15'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -4183,21 +4220,21 @@ resolution-markers = [
     "(python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform == 'win32')",
 ]
 dependencies = [
-    { name = "cuda-bindings", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
-    { name = "cuda-toolkit", version = "13.0.2", source = { registry = "https://pypi.org/simple" }, extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
-    { name = "filelock", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
-    { name = "fsspec", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
-    { name = "jinja2", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
-    { name = "networkx", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
-    { name = "nvidia-cublas", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu13", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
-    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
-    { name = "sympy", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
-    { name = "triton", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "(python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and sys_platform == 'win32')" },
+    { name = "cuda-bindings", marker = "sys_platform != 'win32'" },
+    { name = "cuda-toolkit", version = "13.0.2", source = { registry = "https://pypi.org/simple" }, extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform != 'win32'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform != 'win32'" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform != 'win32'" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.12.0%2Bcu130-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:cb95bd4626150e41aeea2b60e4635a878ebe01e63f3344409f4b7353fdb7998c", upload-time = "2026-05-12T23:49:12Z" },
@@ -4228,13 +4265,13 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "fsspec", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "jinja2", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "networkx", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "sympy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "typing-extensions", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
@@ -4251,18 +4288,18 @@ resolution-markers = [
     "(python_full_version >= '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform == 'win32')",
 ]
 dependencies = [
-    { name = "cuda-toolkit", version = "13.0.3.0", source = { registry = "https://pypi.org/simple" }, extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "python_full_version >= '3.15' and sys_platform == 'linux'" },
-    { name = "filelock", marker = "(python_full_version >= '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform == 'win32')" },
-    { name = "fsspec", marker = "(python_full_version >= '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform == 'win32')" },
-    { name = "jinja2", marker = "(python_full_version >= '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform == 'win32')" },
-    { name = "networkx", marker = "(python_full_version >= '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform == 'win32')" },
-    { name = "nvidia-cudnn-cu13", marker = "python_full_version >= '3.15' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", marker = "python_full_version >= '3.15' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", marker = "python_full_version >= '3.15' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "python_full_version >= '3.15' and sys_platform == 'linux'" },
-    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform == 'win32')" },
-    { name = "sympy", marker = "(python_full_version >= '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform == 'win32')" },
-    { name = "typing-extensions", marker = "(python_full_version >= '3.15' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform == 'win32')" },
+    { name = "cuda-toolkit", version = "13.0.3.0", source = { registry = "https://pypi.org/simple" }, extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform != 'win32'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform != 'win32'" },
+    { name = "setuptools", version = "82.0.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu130/torch-2.13.0%2Bcu130-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5ebd552c887e707c8e64927aceb8377ca2e81588c4e7494bcd23cb8ac0aca14d", upload-time = "2026-07-08T20:24:19Z" },


### PR DESCRIPTION
Closes #697. Draft until the adversarial review round comes back.

## What was wrong

The tier-2 preview expands a cell's Jinja server-side so the phone shows a
rendered header instead of raw `{{ header_de("…") }}`. **Its in-page consumer
had never run**: gated on `cell.cell_type === "markdown"`, while the API types a
Jinja cell as `cell_type: "j2"` and a `markdown` cell always has
`is_j2 === false`. #696 removed the dead code rather than leave a raw
`innerHTML` sink behind a broken gate, and left the design decision open.

## The decision it was waiting on

**D13 (maintainer, 2026-07-26): option 2 — sanitize on the server**, keeping the
client's `innerHTML` assignment. Escaping is not available as an answer: the
header macros deliberately emit markup (centred `<div>`s, `<br>`, and the course
logo as a `data:` image), so escaping the output removes the feature.

## Implementation

- **`clm.web.studio.sanitize`** — an `nh3` allowlist sized to what the bundled
  macros actually emit. `nh3` goes into the **`[web]` extra** (the one the Studio
  already requires), so an install without it **fails closed**: the preview
  degrades to tier-1 instead of injecting unchecked HTML.
- **`data:` is the awkward case, and the config is measured, not assumed.** The
  logo needs the scheme allowed; but with `data` merely added to `url_schemes`,
  `<a href="data:text/html,<script>…">` survives too (verified). nh3's
  `attribute_filter` *can* drop a value before the scheme check but *cannot*
  re-permit a rejected scheme (also verified) — so the working combination is:
  allow `data` globally, then refuse it everywhere except an `<img src>` that is
  specifically `data:image/`.
- **`style` survives, its contents do not.** Ammonia does not parse CSS, so the
  property allowlist is CLM's own (the five the macros use plus inert text
  formatting), with any declaration containing `url(` / `expression(` / a
  backslash escape dropped.
- **Order matters, and it is now enforced by structure.** `render_j2_cell_html`
  drops the `%% [markdown]` delimiter line and strips the comment prefix
  **before** sanitizing, because the client injects the result verbatim — what
  gets injected has to be exactly what was checked. Prefix stripping reuses the
  editor's `deprefix` rather than adding a second implementation.
- **The response shape says which field is safe**: `html` (sanitized fragment,
  inject as-is) plus `body` (the caller's original, for the fallback). The
  expanded text is never sent — shipping it next to the sanitized fragment would
  just invite the next consumer to inject the wrong field.
- **Client**: the gate is a named `needsServerRender(cell)` keyed on `is_j2`;
  `SHELL_CACHE` bumped to `v3` (a shell asset changed, and a missed bump is
  served from cache indefinitely — the #696 lesson); a little CSS so a header
  sized `font-size: 200%` for a projector does not overflow a phone card.

## Tests — 37 in `tests/web/studio/test_tier2_preview.py`

Sanitizer: script/iframe/svg/style/form/`mglyph` mXSS removed with contents,
event handlers dropped, `data:`/`javascript:`/`vbscript:` links refused
(including `DATA:` and `da\nta:` obfuscation), the logo preserved **including its
line-wrapped base64**, CSS reduced to the allowlist, fail-closed without nh3.
Normalisation: delimiter lines (prefixed and not), per-line prefix strip,
unprefixed continuation lines untouched. End-to-end: a real macro header expands
to sanitized HTML; a body smuggling `<script>`/`onerror` comes back clean.

**Both halves of the original bug are pinned**, deliberately: the gate predicate
executed under `node`, *and* the cell payload the real service emits (`is_j2`
true, `cell_type == "j2"`). Either alone would have missed it — a predicate can
be right about a contract that changed, and a contract can be right with nobody
consulting it.

I also had to fix a test that passed for the wrong reason: `test_render_cell_expands_j2`
asserted `"Hallo Welt" in data["body"]`, which is now the echoed *request* (the
macro argument), so it would pass with rendering entirely broken.

## Checks

- `pytest` (fast suite): **8976 passed**, 7 skipped, 1 xfailed
- `tests/web/studio`: 213 passed
- `ruff check` / `ruff format --check` / `mypy`: clean
- `node --check` on both touched JS files; byte-scanned the edited files for
  stray control characters (the Windows editing-tool hazard from #696)
- Verified against the real corpus: a PythonCourses `.de.py` header and a
  CppCourses `.de.cpp` header both render with logo, title and centring intact

## Docs

- `docs/claude/design/mobile-deck-studio.md` — the P4 build record said the
  frontend "calls it only for `is_j2` cells" and called the injected HTML
  "trusted"; both are corrected in place, with the generalisable note that a
  build record claiming a path is wired should be backed by a test that executes
  it.
- `docs/user-guide/installation.md` — the `[web]` extra's contents.
- `changelog.d/697-studio-tier2-preview.fixed.md`.

**Out of scope, tracked**: #698 (bound the render's CPU — decision D14, a
subprocess with a wall-clock limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnTVuA19gGSGejKGoGDdyv
