### PR TITLE
docs: make "claimed behavior needs an executing test" a standing rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,11 @@ Docker-marked tests require CI-built images and are validated in CI only —
 **use `pytest -m "not docker"` for pre-release local testing**. Full marker
 list and strategy in `docs/developer-guide/testing.md`.
 
+**Claimed-wired rule**: a build record or design doc that claims a path is
+wired must cite the test that executes it, and a security claim in a docstring
+must cite the test that proves it — see "The claimed-wired rule" in
+`docs/developer-guide/testing.md`.
+
 ## Code Conventions
 
 - **Type hints**: required for all public APIs.

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -262,6 +262,48 @@ test with `@pytest.mark.timeout(N)`; it takes precedence over all of the above.
 > `uv sync` / `uv run pytest` always has it; without it those tests
 > `importorskip`-skip rather than run.
 
+## The claimed-wired rule: claims about behavior need an executing test
+
+Two failures in the Mobile Deck Studio (issues #696/#697, PR #704) share one
+root cause, and it was not a coding mistake:
+
+- The tier-2 preview was signed off as "P4 ✅ implemented" while its in-page
+  consumer had been **unreachable from the day it was written** — gated on a
+  contract (`cell_type === "markdown"`) the API never produced. Nothing
+  noticed, because nothing executed the frontend path.
+- Sanitizer docstrings stated security properties ("the filter can only ever
+  be more restrictive") that were false, and the suite passed while the bug
+  that contradicted them was live.
+
+So, as a standing rule:
+
+1. **A build record, phase sign-off, or design doc that claims a path is
+   wired must cite the test that executes it.** "Wired" means the test drives
+   the real call chain — for a frontend feature, the predicate *and* the
+   consumer *and* the payload contract, not just the server endpoint. If no
+   executing test exists, the record says "scaffolded", not "done".
+2. **A security-relevant claim in a docstring or comment** ("X can never
+   happen", "this is strictly more restrictive", "active content is removed")
+   **must cite the test that proves it** — and the test must be able to fail
+   for the reason the claim names. (An earlier version of "active content is
+   removed" passed vacuously: the tag set it relied on was a library default,
+   so the assertion held while the claim was false as written.)
+3. **Test both sides of a contract.** The tier-2 gate is pinned by executing
+   the JS predicate under `node` *and* by asserting the payload the real
+   service emits; either half alone would have missed the original bug — a
+   predicate can be right about a contract that changed, and a contract can be
+   right with nobody consulting it.
+4. **Static source checks are a legitimate last resort** (e.g. pinning that a
+   call site exists when executing it would require stubbing a DOM), but name
+   them as static checks in the test's name or docstring, so the next reader
+   knows what is *not* proven.
+
+For security boundaries, property-style tests beat case-by-case regression
+tests: the sanitizer's prefix×scheme cross-product caught a normalization
+desync that two rounds of individually written cases had missed.
+`tests/web/studio/test_tier2_preview.py` is the reference example for all of
+the above.
+
 ## Troubleshooting
 
 ### "I don't see any logs during test execution"


### PR DESCRIPTION
Promotes the pattern that fixed #696/#697/#704 into a standing rule, as
recommended by the third adversarial pass on #704.

## What

- **`docs/developer-guide/testing.md`** gains \"The claimed-wired rule\":
  1. A build record / phase sign-off / design doc claiming a path is wired
     must cite the test that executes it — otherwise the record says
     \"scaffolded\", not \"done\".
  2. A security-relevant docstring claim must cite the test that proves it,
     and that test must be able to fail for the reason the claim names.
  3. Contracts are tested from both sides (predicate *and* payload).
  4. Static source checks are fine as a last resort, but must be named as
     static checks.
  Plus the note that property-style tests beat case-by-case regression tests
  on security boundaries, pointing at
  `tests/web/studio/test_tier2_preview.py` as the reference example.
- **`AGENTS.md`** gets a two-line pointer in the Testing section so every
  agent session sees the rule.

## Why

Two failure modes recurred across the Studio adversarial reviews, and neither
was a coding mistake: the tier-2 preview was signed off \"P4 ✅\" while its
in-page consumer had been unreachable from the day it was written, and
sanitizer docstrings stated security properties the suite passed against
while the contradicting bug was live. The fixes in #704 were instances of
one pattern; this makes the pattern the rule.

Refs #696, #697, #704.