### PR TITLE
feat(web): send a Content-Security-Policy from clm serve

### DIFF
--- a/changelog.d/705-security-headers.security.md
+++ b/changelog.d/705-security-headers.security.md
@@ -1,0 +1,12 @@
+- **`clm serve` now sends a Content-Security-Policy and related security
+  headers on every response** (except FastAPI's `/docs` and `/redoc`, which
+  need CDN assets and inline script). The policy forbids inline script and
+  event handlers (`script-src 'self'`) and confines `fetch`/XHR/WebSocket to
+  the server's own origin (`connect-src 'self'`), so a miss in any
+  HTML-sanitizing layer — the Studio's tier-2 preview sanitizer or the
+  client-side markdown renderer — can no longer execute script or exfiltrate
+  the Studio's bearer token; it degrades to a defacement bug. Inline styles
+  and off-origin images remain allowed deliberately (the sanitizer governs
+  CSS; the image rule is the documented tier-1 parity decision). The
+  recordings dashboard is not covered yet — its base template embeds an
+  inline `<script>` by design — and `SecurityHeadersMiddleware` documents why.

--- a/docs/claude/design/mobile-deck-studio.md
+++ b/docs/claude/design/mobile-deck-studio.md
@@ -446,6 +446,20 @@ taken while building, several resolving open calls left by §9.1–§9.5:
   an unannotated route parameter made FastAPI treat it as a required query
   parameter — so the "low-sensitivity notifications" it was assumed to be
   carrying were never delivered at all.
+- **CSP (#705, 2026-07-26):** `clm serve` now sends
+  `script-src 'self'; connect-src 'self'` (plus `object-src`/`base-uri`/
+  `frame-ancestors`/`form-action 'none'`, `nosniff`, `no-referrer`) on every
+  response except `/docs` and `/redoc`. This is the backstop the token
+  model needed: the page holds a non-expiring bearer token in `localStorage`,
+  so before this, *any* sanitizer miss (tier-2 server sanitizer or tier-1
+  client markdown) was script execution with the token in reach. Now the same
+  miss is defacement. `style-src` keeps `'unsafe-inline'` (the sanitizer owns
+  CSS policy) and `img-src` keeps `https:` (tier-1 parity, above). The
+  recordings dashboard is excluded — its base template embeds an inline
+  `<script>` — see `SecurityHeadersMiddleware`. **Still open, accepted for
+  now:** the token itself has no lifecycle (persistent until
+  `--rotate-token`); short-lived pairing tokens would shrink the window a
+  future content-injection bug could exploit.
 - **Reuse (§9.3):** only `qr.py` was lifted from the closed #394 branch (with
   the `[edit]`→`[web]` adaptation); the byte-exact "untouched cells unchanged"
   test pattern was re-authored against `FileState`. `DeckFile`, routes, and

--- a/src/clm/infrastructure/web_security.py
+++ b/src/clm/infrastructure/web_security.py
@@ -81,10 +81,13 @@ SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
 #: serve loads its JavaScript from static files, so inline script and event
 #: handlers (the two things injected markup needs) never run. ``connect-src
 #: 'self'`` confines fetch/XHR/WebSocket to this origin, closing the exfil
-#: channel for the Studio's non-expiring bearer token; CSP3 browsers match
-#: ``'self'`` to a same-origin ``ws:``/``wss:``, which ``/ws`` needs. The two
-#: relaxations — ``style-src 'unsafe-inline'`` and ``img-src … https:`` — are
-#: deliberate; see the middleware's docstring.
+#: channel for the Studio's non-expiring bearer token. CSP3 matches ``'self'``
+#: to a same-origin ``ws:``/``wss:`` — in WebKit only since Safari 15.4
+#: (bug 235873), so an older iOS phone loses the ``/ws`` live-updates channel
+#: (disk-change banner, sync progress); REST is unaffected, and the policy is
+#: deliberately not widened for it. The two relaxations — ``style-src
+#: 'unsafe-inline'`` and ``img-src … https:`` — are deliberate; see the
+#: middleware's docstring.
 CONTENT_SECURITY_POLICY = (
     "default-src 'self'; "
     "script-src 'self'; "
@@ -564,6 +567,12 @@ class SecurityHeadersMiddleware:
     A response that already carries a ``Content-Security-Policy`` keeps it:
     a route that sets one deliberately has the last word.
 
+    One uncovered case, by construction: Starlette's ``ServerErrorMiddleware``
+    sits outside all user middleware, so the fixed plain-text 500 for an
+    *unhandled* exception carries no headers. That body has no user content
+    and no script, so the gap is cosmetic — but "every response" above means
+    every response this middleware sees.
+
     Pure ASGI like the two guards above — ``BaseHTTPMiddleware`` wraps
     streaming responses badly, and headers cost nothing to add by hand.
     """
@@ -584,13 +593,30 @@ class SecurityHeadersMiddleware:
         self.exempt_prefixes = tuple(exempt_prefixes)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] != "http" or scope.get("path", "").startswith(self.exempt_prefixes):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        path = scope.get("path", "")
+        root_path = scope.get("root_path", "")
+        if root_path and path.startswith(root_path):
+            # uvicorn folds root_path into scope["path"], so behind a
+            # path-prefixing proxy the exemptions would stop matching (and
+            # /docs would break) without this strip.
+            path = path[len(root_path) :]
+        # Segment-aware: an exemption for /docs must not silently cover a
+        # future /docs-archive route — a prefix typo must never *remove* the
+        # backstop from a page that should have it.
+        if any(path == p or path.startswith(p + "/") for p in self.exempt_prefixes):
             await self.app(scope, receive, send)
             return
 
         async def send_with_headers(message: Message) -> None:
             if message["type"] == "http.response.start":
-                existing = {k for k, _v in message.setdefault("headers", [])}
+                # Header names are case-insensitive (ASGI only *recommends*
+                # lower-case): a route's own CSP must be seen however it was
+                # cased, or the response ends up with two policies and the
+                # browser enforces the intersection.
+                existing = {k.lower() for k, _v in message.setdefault("headers", [])}
                 added = [
                     (name.encode("latin-1"), value.encode("latin-1"))
                     for name, value in self.headers.items()

--- a/src/clm/infrastructure/web_security.py
+++ b/src/clm/infrastructure/web_security.py
@@ -25,6 +25,13 @@ Hence the two middlewares here, which are meant to be installed together:
 - :class:`OriginGuardMiddleware` — a *mutating* request must come from this
   app's own origin, judged by ``Sec-Fetch-Site`` first and ``Origin`` second.
 
+A third middleware lives here but installs separately
+(:func:`install_security_headers`): :class:`SecurityHeadersMiddleware` sets a
+Content-Security-Policy that makes injected markup unable to execute — the
+backstop for every HTML-sanitizing layer above it. It is separate because it
+is only safe to apply to an app whose pages run no inline script, which the
+recordings dashboard currently does (its base template embeds one).
+
 Both are deliberately zero-friction: no token, no per-form nonce, nothing for
 the user to configure in the common case. That is the point — a protection
 that costs the single-user local workflow something would be turned off.
@@ -54,12 +61,12 @@ not acceptable.
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from urllib.parse import urlsplit
 
 from starlette.datastructures import Headers
 from starlette.responses import PlainTextResponse
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +75,34 @@ logger = logging.getLogger(__name__)
 #: answerable — a rejected preflight tells the browser nothing useful, and the
 #: actual request behind it is still checked.
 SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
+
+#: The Content-Security-Policy :class:`SecurityHeadersMiddleware` installs.
+#: ``script-src 'self'`` is the load-bearing directive — every page these apps
+#: serve loads its JavaScript from static files, so inline script and event
+#: handlers (the two things injected markup needs) never run. ``connect-src
+#: 'self'`` confines fetch/XHR/WebSocket to this origin, closing the exfil
+#: channel for the Studio's non-expiring bearer token; CSP3 browsers match
+#: ``'self'`` to a same-origin ``ws:``/``wss:``, which ``/ws`` needs. The two
+#: relaxations — ``style-src 'unsafe-inline'`` and ``img-src … https:`` — are
+#: deliberate; see the middleware's docstring.
+CONTENT_SECURITY_POLICY = (
+    "default-src 'self'; "
+    "script-src 'self'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' data: https:; "
+    "connect-src 'self'; "
+    "object-src 'none'; "
+    "base-uri 'none'; "
+    "frame-ancestors 'none'; "
+    "form-action 'none'"
+)
+
+#: The full header set. Names are lower-case, as ASGI requires.
+SECURITY_HEADERS: dict[str, str] = {
+    "content-security-policy": CONTENT_SECURITY_POLICY,
+    "x-content-type-options": "nosniff",
+    "referrer-policy": "no-referrer",
+}
 
 #: Host names that always name this machine.
 LOOPBACK_HOSTS: tuple[str, ...] = ("localhost", "127.0.0.1", "::1")
@@ -504,6 +539,84 @@ async def _reject(
         return
     response = PlainTextResponse(detail, status_code=status_code)
     await response(scope, receive, send)
+
+
+class SecurityHeadersMiddleware:
+    """Set a Content-Security-Policy and friends on every HTML-serving response.
+
+    This is the backstop that keeps a bug in any content-sanitizing layer
+    above it from being fatal. The Studio page holds a non-expiring bearer
+    token in ``localStorage`` and injects server-sanitized HTML (the tier-2
+    preview, issue #697); without a CSP, every sanitizer miss is script
+    execution with the token in reach. With ``script-src 'self'`` the same
+    miss is a defacement bug — the injected markup cannot run, and
+    ``connect-src 'self'`` closes the exfil channel for anything that tries.
+
+    Two deliberate properties of :data:`CONTENT_SECURITY_POLICY`:
+
+    * ``style-src`` keeps ``'unsafe-inline'`` — the Studio shell has an inline
+      ``<style>`` block, and the tier-2 sanitizer *deliberately* keeps
+      ``style`` attributes (CSS policy is the sanitizer's job; the CSP's job
+      is script execution and exfiltration).
+    * ``img-src`` allows ``https:`` — the documented tier-1-parity decision
+      that an off-origin image is acceptable (a beacon, not a takeover).
+
+    A response that already carries a ``Content-Security-Policy`` keeps it:
+    a route that sets one deliberately has the last word.
+
+    Pure ASGI like the two guards above — ``BaseHTTPMiddleware`` wraps
+    streaming responses badly, and headers cost nothing to add by hand.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        headers: Mapping[str, str] | None = None,
+        exempt_prefixes: Sequence[str] = ("/docs", "/redoc"),
+    ) -> None:
+        self.app = app
+        self.headers = headers if headers is not None else SECURITY_HEADERS
+        # FastAPI's /docs and /redoc pull JS/CSS from a CDN and run an inline
+        # script, so a strict CSP breaks them; they are static, trusted pages
+        # (no user content), which makes the exemption free. openapi.json is
+        # not exempt — CSP only governs documents, so its header is inert.
+        self.exempt_prefixes = tuple(exempt_prefixes)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or scope.get("path", "").startswith(self.exempt_prefixes):
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                existing = {k for k, _v in message.setdefault("headers", [])}
+                added = [
+                    (name.encode("latin-1"), value.encode("latin-1"))
+                    for name, value in self.headers.items()
+                    if name.encode("latin-1") not in existing
+                ]
+                message["headers"] = [*message["headers"], *added]
+            await send(message)
+
+        await self.app(scope, receive, send_with_headers)
+
+
+def install_security_headers(
+    app,
+    *,
+    headers: Mapping[str, str] | None = None,
+    exempt_prefixes: Sequence[str] = ("/docs", "/redoc"),
+) -> None:
+    """Install :class:`SecurityHeadersMiddleware` on ``app``.
+
+    Kept out of :func:`install_web_security` on purpose: the recordings
+    dashboard — that function's other caller — has a large inline ``<script>``
+    in its base template by design, so a ``script-src 'self'`` policy would
+    break it until that script moves to a static file. ``clm serve`` (the
+    dashboard + Studio) installs it from :func:`clm.web.app.create_app`.
+    """
+    app.add_middleware(SecurityHeadersMiddleware, headers=headers, exempt_prefixes=exempt_prefixes)
 
 
 def install_web_security(

--- a/src/clm/infrastructure/web_security.py
+++ b/src/clm/infrastructure/web_security.py
@@ -590,7 +590,10 @@ class SecurityHeadersMiddleware:
         # script, so a strict CSP breaks them; they are static, trusted pages
         # (no user content), which makes the exemption free. openapi.json is
         # not exempt — CSP only governs documents, so its header is inert.
-        self.exempt_prefixes = tuple(exempt_prefixes)
+        # Falsy prefixes are dropped: an empty entry would otherwise exempt
+        # *every* path (any path starts with "" + "/"), silently disabling
+        # the whole middleware.
+        self.exempt_prefixes = tuple(p for p in exempt_prefixes if p)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
@@ -598,10 +601,11 @@ class SecurityHeadersMiddleware:
             return
         path = scope.get("path", "")
         root_path = scope.get("root_path", "")
-        if root_path and path.startswith(root_path):
+        if root_path not in ("", "/") and path.startswith(root_path):
             # uvicorn folds root_path into scope["path"], so behind a
             # path-prefixing proxy the exemptions would stop matching (and
-            # /docs would break) without this strip.
+            # /docs would break) without this strip. "/" itself is not a
+            # prefix to strip — that would turn "/docs" into "docs".
             path = path[len(root_path) :]
         # Segment-aware: an exemption for /docs must not silently cover a
         # future /docs-archive route — a prefix typo must never *remove* the

--- a/src/clm/web/app.py
+++ b/src/clm/web/app.py
@@ -23,7 +23,11 @@ from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
 from clm.__version__ import __version__
-from clm.infrastructure.web_security import install_web_security, normalize_origin
+from clm.infrastructure.web_security import (
+    install_security_headers,
+    install_web_security,
+    normalize_origin,
+)
 from clm.web.api.routes import router as api_router
 from clm.web.api.websocket import websocket_endpoint
 from clm.web.services.monitor_service import MonitorService
@@ -224,6 +228,13 @@ def create_app(
         allowed_hosts=allowed_hosts,
         allowed_origins=guard_origins,
     )
+    # The content-injection backstop (issue #705): the Studio page holds a
+    # non-expiring bearer token and injects sanitized HTML, so a CSP that
+    # forbids inline script turns any sanitizer miss from token theft into
+    # defacement. Installed here rather than inside install_web_security
+    # because the recordings dashboard — that function's other caller — runs
+    # an inline <script> by design and would break.
+    install_security_headers(app)
     logger.debug("Dashboard accepts Host values: %s", effective_hosts)
     app.state.allowed_hosts = effective_hosts
 

--- a/tests/infrastructure/test_web_security.py
+++ b/tests/infrastructure/test_web_security.py
@@ -23,6 +23,7 @@ from clm.infrastructure.web_security import (
     default_allowed_hosts,
     extract_host,
     host_is_allowed,
+    install_security_headers,
     install_web_security,
     normalize_origin,
     remote_access_warning,
@@ -421,3 +422,90 @@ class TestGuardsAreIndependentlyUsable:
         client = TestClient(app, base_url="http://127.0.0.1:8008")
         assert client.post("/write").status_code == 200
         assert client.post("/write", headers={"Origin": "https://evil.example"}).status_code == 403
+
+
+def _headers_app() -> Starlette:
+    """A small app behind the security-headers middleware, for end-to-end tests."""
+
+    async def read(request):
+        return PlainTextResponse("ok")
+
+    async def docs(request):
+        return PlainTextResponse("swagger-ish")
+
+    async def own_csp(request):
+        return PlainTextResponse("ok", headers={"Content-Security-Policy": "script-src 'none'"})
+
+    async def socket(websocket):
+        await websocket.accept()
+        await websocket.send_text("ws ok")
+        await websocket.close()
+
+    app = Starlette(
+        routes=[
+            Route("/read", read, methods=["GET"]),
+            Route("/docs", docs, methods=["GET"]),
+            Route("/own-csp", own_csp, methods=["GET"]),
+            WebSocketRoute("/ws", socket),
+        ]
+    )
+    install_security_headers(app)
+    return app
+
+
+class TestSecurityHeaders:
+    """The CSP is the backstop that keeps a sanitizer miss from being fatal.
+
+    The Studio page holds a non-expiring bearer token in ``localStorage`` and
+    injects server-sanitized HTML; without a CSP every sanitizing bug is
+    immediately script execution. These tests pin the *content* of the policy,
+    not just its presence — a header that permits inline script protects
+    nothing.
+    """
+
+    def test_security_headers_are_set_on_an_ordinary_response(self):
+        r = TestClient(_headers_app()).get("/read")
+        assert "content-security-policy" in r.headers
+        assert r.headers["x-content-type-options"] == "nosniff"
+        assert r.headers["referrer-policy"] == "no-referrer"
+
+    def test_the_policy_forbids_what_makes_xss_fatal(self):
+        r = TestClient(_headers_app()).get("/read")
+        directives = dict(
+            d.strip().split(" ", 1) for d in r.headers["content-security-policy"].split(";")
+        )
+        # Inline script and event handlers are what an injected tag needs.
+        assert directives["script-src"] == "'self'"
+        # Token exfil goes through fetch/XHR/WebSocket — same-origin only.
+        assert directives["connect-src"] == "'self'"
+        assert directives["object-src"] == "'none'"
+        assert directives["base-uri"] == "'none'"
+        assert directives["frame-ancestors"] == "'none'"
+        # The Studio logo is a data: URI; off-origin images are the documented
+        # tier-1-parity decision.
+        assert "data:" in directives["img-src"]
+        assert "https:" in directives["img-src"]
+        # Inline styles must stay: the Studio shell has an inline <style> block
+        # and the tier-2 sanitizer deliberately keeps style attributes (CSS
+        # policy is the sanitizer's job, not the CSP's).
+        assert "'unsafe-inline'" in directives["style-src"]
+
+    def test_swagger_pages_are_exempt(self):
+        """FastAPI's /docs + /redoc pull JS/CSS from a CDN and run inline script.
+
+        A strict CSP breaks them; they are static, trusted pages, so the
+        exemption costs nothing. (openapi.json needs no exemption — CSP only
+        governs documents.)
+        """
+        r = TestClient(_headers_app()).get("/docs")
+        assert "content-security-policy" not in r.headers
+
+    def test_a_routes_own_csp_is_not_overwritten(self):
+        """A route that sets a policy deliberately keeps the last word."""
+        r = TestClient(_headers_app()).get("/own-csp")
+        assert r.headers["content-security-policy"] == "script-src 'none'"
+
+    def test_websocket_scope_is_untouched(self):
+        client = TestClient(_headers_app())
+        with client.websocket_connect("/ws") as ws:
+            assert ws.receive_text() == "ws ok"

--- a/tests/infrastructure/test_web_security.py
+++ b/tests/infrastructure/test_web_security.py
@@ -18,6 +18,7 @@ from starlette.testclient import TestClient
 
 from clm.infrastructure.web_security import (
     OriginGuardMiddleware,
+    SecurityHeadersMiddleware,
     TrustedHostMiddleware,
     check_request_origin,
     default_allowed_hosts,
@@ -509,3 +510,82 @@ class TestSecurityHeaders:
         client = TestClient(_headers_app())
         with client.websocket_connect("/ws") as ws:
             assert ws.receive_text() == "ws ok"
+
+
+def _raw_scope_probe(app, path: str, root_path: str = "") -> list[dict]:
+    """Drive ``SecurityHeadersMiddleware`` around a raw ASGI ``app``.
+
+    Needed where Starlette gets in the way of what is being tested: uvicorn's
+    root_path-into-``scope["path"]`` composition, and a non-Starlette app that
+    emits a mixed-case header name (Starlette lowercases everything).
+    """
+    import asyncio
+
+    async def _run() -> list[dict]:
+        messages: list[dict] = []
+        scope = {
+            "type": "http",
+            "path": path,
+            "root_path": root_path,
+            "method": "GET",
+            "headers": [],
+        }
+
+        async def receive():
+            return {"type": "http.request", "body": b""}
+
+        async def send(message):
+            messages.append(message)
+
+        await SecurityHeadersMiddleware(app)(scope, receive, send)
+        return messages
+
+    return asyncio.run(_run())
+
+
+async def _ok_app(scope, receive, send):
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b"ok"})
+
+
+class TestExemptionMatching:
+    """The exemption must name pages, never a prefix that can grow."""
+
+    def test_docs_subpaths_are_exempt(self):
+        messages = _raw_scope_probe(_ok_app, "/docs/oauth2-redirect")
+        assert all(k != b"content-security-policy" for k, _ in messages[0]["headers"])
+
+    def test_a_path_that_merely_begins_with_docs_is_not_exempt(self):
+        """A future /docs-archive route must not silently lose the backstop."""
+        messages = _raw_scope_probe(_ok_app, "/docs-archive")
+        assert any(k == b"content-security-policy" for k, _ in messages[0]["headers"])
+
+    def test_docs_stays_exempt_behind_a_root_path_proxy(self):
+        """uvicorn folds ``root_path`` into ``scope["path"]``; strip it first."""
+        messages = _raw_scope_probe(_ok_app, "/clm/docs", root_path="/clm")
+        assert all(k != b"content-security-policy" for k, _ in messages[0]["headers"])
+
+    def test_root_path_does_not_exempt_unrelated_pages(self):
+        messages = _raw_scope_probe(_ok_app, "/clm/read", root_path="/clm")
+        assert any(k == b"content-security-policy" for k, _ in messages[0]["headers"])
+
+
+class TestExistingHeaderCasing:
+    def test_a_mixed_case_route_csp_is_not_duplicated(self):
+        """ASGI only *recommends* lower-case names; two CSPs = intersection."""
+
+        async def mixed_case_app(scope, receive, send):
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 200,
+                    "headers": [(b"Content-Security-Policy", b"script-src 'none'")],
+                }
+            )
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        messages = _raw_scope_probe(mixed_case_app, "/read")
+        csp_headers = [
+            v for k, v in messages[0]["headers"] if k.lower() == b"content-security-policy"
+        ]
+        assert csp_headers == [b"script-src 'none'"]

--- a/tests/infrastructure/test_web_security.py
+++ b/tests/infrastructure/test_web_security.py
@@ -589,3 +589,27 @@ class TestExistingHeaderCasing:
             v for k, v in messages[0]["headers"] if k.lower() == b"content-security-policy"
         ]
         assert csp_headers == [b"script-src 'none'"]
+
+
+class TestExemptionEdgeCases:
+    """Round-2 review findings, pinned."""
+
+    def test_root_path_slash_alone_is_not_stripped(self):
+        """``root_path="/"`` must not turn ``/docs`` into ``docs``."""
+        messages = _raw_scope_probe(_ok_app, "/docs", root_path="/")
+        assert all(k != b"content-security-policy" for k, _ in messages[0]["headers"])
+
+    def test_an_empty_prefix_entry_does_not_exempt_everything(self):
+        """``"" + "/"`` is ``"/"``, which every path starts with — drop it."""
+
+        async def app(scope, receive, send):
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b"ok"})
+
+        messages = _raw_scope_probe(app, "/read")
+        assert any(k == b"content-security-policy" for k, _ in messages[0]["headers"])
+
+        # And with the empty entry present alongside a real one, the real one
+        # still works.
+        mw = SecurityHeadersMiddleware(app, exempt_prefixes=("", "/docs"))
+        assert mw.exempt_prefixes == ("/docs",)

--- a/tests/web/studio/test_render_pwa.py
+++ b/tests/web/studio/test_render_pwa.py
@@ -101,3 +101,31 @@ class TestPwaAssets:
     def test_app_shell_served(self, client: TestClient):
         assert client.get("/studio/app.js").status_code == 200
         assert client.get("/studio/").status_code == 200
+
+
+class TestStudioShellSecurityHeaders:
+    """The token-holding page is the entire point of #705 — pin the wiring.
+
+    ``/api/health`` keeping its CSP while ``/studio/`` loses it (an accidental
+    ``exempt_prefixes`` addition, a middleware-ordering change) fails no other
+    test, so the shell asserts its own.
+    """
+
+    @pytest.fixture()
+    def client(self, course: Course) -> TestClient:
+        app = make_app(course.spec_path, course.slides_dir.parent / "jobs.db", TOKEN)
+        return TestClient(app)
+
+    def test_the_shell_carries_the_csp(self, client: TestClient) -> None:
+        r = client.get("/studio/")
+        assert r.status_code == 200
+        csp = r.headers["content-security-policy"]
+        assert "script-src 'self'" in csp
+        assert "connect-src 'self'" in csp
+
+    def test_the_service_worker_keeps_its_own_headers_and_gains_csp(
+        self, client: TestClient
+    ) -> None:
+        r = client.get("/studio/sw.js")
+        assert r.headers["Service-Worker-Allowed"] == "/"
+        assert "content-security-policy" in r.headers

--- a/tests/web/test_serve_security.py
+++ b/tests/web/test_serve_security.py
@@ -299,3 +299,21 @@ class TestNoStudioNoToken:
         client = TestClient(app)
         with client.websocket_connect("/ws", subprotocols=[offered]) as ws:
             assert ws.accepted_subprotocol == offered
+
+
+class TestSecurityHeadersOnServe:
+    """``clm serve`` sends the CSP that backstops the Studio's sanitizer (#705)."""
+
+    def test_api_responses_carry_the_policy(self, app):
+        r = TestClient(app).get("/api/health")
+        assert r.status_code == 200
+        csp = r.headers["content-security-policy"]
+        assert "script-src 'self'" in csp
+        assert "connect-src 'self'" in csp
+        assert r.headers["x-content-type-options"] == "nosniff"
+
+    def test_swagger_ui_is_exempt(self, app):
+        """FastAPI's /docs needs CDN assets and inline script; it is static."""
+        r = TestClient(app).get("/docs")
+        assert r.status_code == 200
+        assert "content-security-policy" not in r.headers


### PR DESCRIPTION
Closes #705. Draft pending the adversarial review round (per the next-issue workflow).

## Why

The third adversarial pass on #704 found the structural gap behind two rounds of sanitizer bugs: the Studio page holds a **non-expiring bearer token in `localStorage`** and injects sanitized HTML, and the app sent **no CSP anywhere** — so every sanitizer miss was immediately script execution with the token in reach. This PR adds the backstop: with `script-src 'self'` the same miss is a defacement bug, and `connect-src 'self'` closes the exfil channel.

## What

- **`SecurityHeadersMiddleware`** (`clm/infrastructure/web_security.py`, pure ASGI like the D4 guards — `BaseHTTPMiddleware` wraps streaming responses badly): sets `Content-Security-Policy`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer` on every response. A route that sets its own CSP keeps the last word.
- **Policy**: `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'none'`. The two relaxations are deliberate and documented: inline styles (the Studio shell has an inline `<style>` block and the tier-2 sanitizer keeps `style` attributes — CSS policy is the sanitizer's job) and off-origin images (the documented tier-1-parity decision). `connect-src 'self'` covers `/ws` — CSP3 browsers match `'self'` to same-origin `ws:`/`wss:`.
- **Exemptions**: `/docs` + `/redoc` (FastAPI's Swagger/ReDoc pull JS/CSS from a CDN and run inline script; they are static, trusted pages).
- **Scope decision**: installed from `clm.web.app.create_app`, *not* inside the shared `install_web_security` — its other caller, the recordings dashboard, embeds a large inline `<script>` in its base template by design and would break. Documented in both places. (Fixing that = extract the script to a static file; out of scope here.)
- **Feasibility verified**: `app.js` is external with no inline handlers; the only inline-script pages in the app are the exempted Swagger ones.

## Deferred (recorded, not silently dropped)

- Token lifecycle (short-lived pairing tokens instead of persistent-until-`--rotate-token`): recorded as an accepted risk in `docs/claude/design/mobile-deck-studio.md` (the CSP decision bullet).

## Checks

- `tests/infrastructure/test_web_security.py` + `tests/web/test_serve_security.py`: **97 passed** — 7 new, including policy-content assertions (not just header presence), the Swagger exemption, route-set-CSP precedence, and WS scope untouched.
- `pytest tests/web tests/infrastructure`: **1954 passed**.
- `ruff check`, `ruff format --check`, `mypy`: clean.
- Docs: changelog fragment (`security`), design-doc decision bullet. Info topics n/a (no CLI/spec/migration change).

## Assumptions

- The unbuilt React dashboard ( dormant `static/index.html` branch) is assumed to load its JS from static files, as React builds do; if a future build inlines a bootstrap script it will hit `script-src 'self'` and need a hash/nonce exception.