### PR TITLE
feat(web): serve the studio logo as an asset; drop data: everywhere

### DIFF
--- a/changelog.d/706-logo-asset.security.md
+++ b/changelog.d/706-logo-asset.security.md
@@ -1,0 +1,13 @@
+- **Studio tier-2 preview: the course logo is now a same-origin asset, and
+  `data:` is gone from the sanitizer entirely.** The bundled header macros
+  still embed the logo as a `data:` URI for self-contained student notebooks,
+  but the Studio's render-cell endpoint rewrites the *bundled* logo's URI to
+  `GET /api/studio/asset/logo/<prog_lang>` (a new route serving the packaged
+  logo files) **before** sanitizing. `ALLOWED_URL_SCHEMES` drops `data`, and
+  the `<img src>`-only confinement rule — the sanitizer's most complex
+  hand-rolled piece and the site of the first bypass found in the #704
+  adversarial rounds — is deleted rather than hardened. The `clm serve` CSP
+  (`#705`) no longer needs a `data:` exception in `img-src` and loses it too.
+  A course author's own `data:` images in custom macros no longer render in
+  the phone's tier-2 preview (they are refused like any other unlisted
+  scheme); student-facing slides and notebooks are unaffected.

--- a/docs/claude/design/mobile-deck-studio.md
+++ b/docs/claude/design/mobile-deck-studio.md
@@ -460,6 +460,19 @@ taken while building, several resolving open calls left by §9.1–§9.5:
   now:** the token itself has no lifecycle (persistent until
   `--rotate-token`); short-lived pairing tokens would shrink the window a
   future content-injection bug could exploit.
+  - **Logo as asset, `data:` deleted (#706, 2026-07-26):** the bundled logo's
+  `data:` URI is rewritten to `/api/studio/asset/logo/<prog_lang>` *before*
+  sanitizing (`clm.web.studio.logo`; the route serves the packaged logo
+  files and is deliberately not token-gated — an `<img>` fetch cannot carry
+  the header). `data` left `ALLOWED_URL_SCHEMES` and the `<img src>`
+  confinement rule — the sanitizer's most complex hand-rolled piece and the
+  site of the first #704 bypass — was deleted rather than hardened;
+  `img-src` in the CSP lost its `data:` exception too. Maintainer decision
+  in session: bundled-logo-only, not a generic content-addressed store —
+  the store would re-introduce the surface (decoded attacker bytes served
+  same-origin) this change exists to remove. Cost, accepted: a course
+  author's own `data:` images in custom macros drop out of the phone
+  preview (preview ≠ parity; student deliverables are untouched).
 - **Reuse (§9.3):** only `qr.py` was lifted from the closed #394 branch (with
   the `[edit]`→`[web]` adaptation); the byte-exact "untouched cells unchanged"
   test pattern was re-authored against `FileState`. `DeckFile`, routes, and

--- a/src/clm/infrastructure/web_security.py
+++ b/src/clm/infrastructure/web_security.py
@@ -87,12 +87,14 @@ SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
 #: (disk-change banner, sync progress); REST is unaffected, and the policy is
 #: deliberately not widened for it. The two relaxations — ``style-src
 #: 'unsafe-inline'`` and ``img-src … https:`` — are deliberate; see the
-#: middleware's docstring.
+#: middleware's docstring. (``img-src`` carries no ``data:`` exception since
+#: #706: the Studio logo is a same-origin asset now, and the tier-1 renderer
+#: has no image syntax that could produce one.)
 CONTENT_SECURITY_POLICY = (
     "default-src 'self'; "
     "script-src 'self'; "
     "style-src 'self' 'unsafe-inline'; "
-    "img-src 'self' data: https:; "
+    "img-src 'self' https:; "
     "connect-src 'self'; "
     "object-src 'none'; "
     "base-uri 'none'; "
@@ -563,6 +565,8 @@ class SecurityHeadersMiddleware:
       is script execution and exfiltration).
     * ``img-src`` allows ``https:`` — the documented tier-1-parity decision
       that an off-origin image is acceptable (a beacon, not a takeover).
+      No ``data:`` exception: the Studio logo is a same-origin asset since
+      #706, and tier-1 markdown has no image syntax that could produce one.
 
     A response that already carries a ``Content-Security-Policy`` keeps it:
     a route that sets one deliberately has the last word.

--- a/src/clm/web/static/studio/app.js
+++ b/src/clm/web/static/studio/app.js
@@ -153,11 +153,12 @@ function needsServerRender(cell) {
 }
 
 // The server returns HTML it has already sanitized against an allowlist
-// (clm/web/studio/sanitize.py — the header macros emit `<div>`, `<br>` and a
-// data: logo, so escaping here would delete the feature). Inject it verbatim:
-// only the exact bytes the server checked are safe, so this must not
-// post-process them. If anything fails, the tier-1 markdown already in the
-// element stays — a preview is best-effort by design.
+// (clm/web/studio/sanitize.py — the header macros emit `<div>`, `<br>` and the
+// course logo, which the server rewrites to a same-origin asset URL before
+// sanitizing; see clm/web/studio/logo.py), so escaping here would delete the
+// feature. Inject it verbatim: only the exact bytes the server checked are
+// safe, so this must not post-process them. If anything fails, the tier-1
+// markdown already in the element stays — a preview is best-effort by design.
 async function renderJ2(cell, bodyEl) {
   // Captured before the await so a reply can never be attributed to whatever
   // deck is open when it lands, and so the staleness check below has something

--- a/src/clm/web/studio/logo.py
+++ b/src/clm/web/studio/logo.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import re
 from functools import cache
 from importlib import resources
-from pathlib import Path
 
 #: prog_lang → (base64 include the macro embeds, packaged image to serve,
 #: media type the macro declares). The asset route serves the *source* file;
@@ -42,9 +41,13 @@ _LOGOS: dict[str, tuple[str, str, str]] = {
     "typescript": ("typescript-logo.svg.base64", "typescript_logo.svg", "image/svg+xml"),
 }
 
-#: An ``<img src="data:image/…">`` in expanded text. The bundled ``*.base64``
-#: includes are line-wrapped, so the attribute value spans newlines.
-_IMG_DATA_SRC = re.compile(r'(<img\b[^>]*?\bsrc=")(data:image/[^"]+)(")', re.DOTALL)
+#: Guard that a ``<img`` hit is really a tag start (``<imgfoo`` is not).
+_IMG_TAG_START = re.compile(r"<img\b")
+
+#: A ``src="data:image/…"`` attribute inside one already-delimited tag, so the
+#: value scan is bounded by the tag. The bundled ``*.base64`` includes are
+#: line-wrapped, so the attribute value spans newlines.
+_IMG_DATA_SRC = re.compile(r'\bsrc="(data:image/[^"]+)"', re.DOTALL)
 
 
 def _templates_dir(prog_lang: str) -> resources.abc.Traversable:
@@ -72,8 +75,15 @@ def _bundled_data_uri(prog_lang: str) -> str | None:
 
 
 @cache
-def logo_file(prog_lang: str) -> tuple[Path, str] | None:
-    """The packaged logo file for ``prog_lang`` and its media type, or ``None``."""
+def logo_file(prog_lang: str) -> tuple[resources.abc.Traversable, str] | None:
+    """The packaged logo resource for ``prog_lang`` and its media type, or ``None``.
+
+    Returns the :class:`~importlib.resources.abc.Traversable` itself rather
+    than a :class:`pathlib.Path`: ``Path(str(traversable))`` points *inside
+    the archive* on a zipped install, where ``FileResponse`` would 500 while
+    the rewrite side (which uses ``read_text``) keeps working — an asymmetric
+    failure found by the #709 review round. The route serves ``read_bytes()``.
+    """
     entry = _LOGOS.get(prog_lang)
     if entry is None:
         return None
@@ -84,9 +94,7 @@ def logo_file(prog_lang: str) -> tuple[Path, str] | None:
         return None
     if not source.is_file():
         return None
-    # importlib.resources.files on an installed (non-zipped) package yields
-    # real paths; clm is always installed unpacked.
-    return Path(str(source)), media_type
+    return source, media_type
 
 
 def rewrite_bundled_logo(html: str, prog_lang: str) -> str:
@@ -97,6 +105,13 @@ def rewrite_bundled_logo(html: str, prog_lang: str) -> str:
     is not byte-recognizable as the bundled logo (after whitespace
     normalization) is left alone, and the sanitizer then refuses it:
     ``data:`` is no longer an allowed scheme at all.
+
+    The scan is a manual ``str.find`` loop, **not** one big regex: this runs
+    on request-controlled bytes, and any pattern that looks for a tag end or
+    ``src="`` from each ``<img`` start is quadratic — ``"<img a" * 40000``
+    never terminates the scan, so every start position rewalks the tail (an
+    authenticated threadpool DoS found by the #709 review round). ``find``
+    rewinds nothing: an unterminated ``<img`` ends the loop in one pass.
     """
     bundled = _bundled_data_uri(prog_lang)
     if bundled is None:
@@ -104,10 +119,26 @@ def rewrite_bundled_logo(html: str, prog_lang: str) -> str:
 
     asset_url = f"/api/studio/asset/logo/{prog_lang}"
 
-    def _replace(match: re.Match[str]) -> str:
-        candidate = "".join(match.group(2).split())
+    def _replace_src(match: re.Match[str]) -> str:
+        candidate = "".join(match.group(1).split())
         if candidate == bundled:
-            return f"{match.group(1)}{asset_url}{match.group(3)}"
+            return f'src="{asset_url}"'
         return match.group(0)
 
-    return _IMG_DATA_SRC.sub(_replace, html)
+    parts: list[str] = []
+    pos = 0
+    while (start := html.find("<img", pos)) != -1:
+        end = html.find(">", start)
+        if end == -1:
+            break  # no complete tag remains — the rest passes through verbatim
+        tag = html[start : end + 1]
+        parts.append(html[pos:start])
+        if _IMG_TAG_START.match(tag):
+            # Only the first src: nh3 keeps the first of duplicate attributes,
+            # so rewriting a later one would change what the client sees.
+            parts.append(_IMG_DATA_SRC.sub(_replace_src, tag, count=1))
+        else:
+            parts.append(tag)
+        pos = end + 1
+    parts.append(html[pos:])
+    return "".join(parts)

--- a/src/clm/web/studio/logo.py
+++ b/src/clm/web/studio/logo.py
@@ -1,0 +1,113 @@
+"""The bundled course logo as a same-origin asset for the tier-2 preview (#706).
+
+The header macros embed the logo as a ``data:`` URI because *notebooks* need
+self-contained HTML — and the build pipeline keeps it exactly that way;
+nothing here touches student deliverables. The Studio's tier-2 preview is
+different: it is a page on a server, so the logo can be a URL. This module
+rewrites the **bundled** logo's ``data:`` URI to
+``/api/studio/asset/logo/<prog_lang>`` *before* sanitizing (preserving the
+rule that the client injects exactly what was sanitized), which lets
+:mod:`clm.web.studio.sanitize` drop ``data`` from its URL schemes entirely —
+the confinement rule that was its most complex hand-rolled piece, and the
+site of the first bypass the #704 adversarial rounds found, is deleted
+rather than hardened.
+
+**Only the bundled logos are rewritten.** A course author's own ``data:``
+images in custom macros are refused by the sanitizer like any other
+unlisted-scheme content — the preview is documented as "preview, not
+parity", and the alternative (a generic content-addressed store serving
+decoded request bytes from this origin) was rejected precisely because it
+re-introduces a hand-rolled security surface to save an edge case.
+"""
+
+from __future__ import annotations
+
+import re
+from functools import cache
+from importlib import resources
+from pathlib import Path
+
+#: prog_lang → (base64 include the macro embeds, packaged image to serve,
+#: media type the macro declares). The asset route serves the *source* file;
+#: the base64 resource is only needed to recognize the URI in expanded text.
+_LOGOS: dict[str, tuple[str, str, str]] = {
+    "python": (
+        "python-logo-no-text-optimized.base64",
+        "python-logo-no-text-optimized.svg",
+        "image/svg+xml",
+    ),
+    "cpp": ("cpp-logo.base64", "cpp-logo-64x64.png", "image/png"),
+    "csharp": ("csharp-logo.base64", "c-sharp-c-seeklogo.png", "image/png"),
+    "java": ("java-logo.svg.base64", "java-logo.svg", "image/svg+xml"),
+    "typescript": ("typescript-logo.svg.base64", "typescript_logo.svg", "image/svg+xml"),
+}
+
+#: An ``<img src="data:image/…">`` in expanded text. The bundled ``*.base64``
+#: includes are line-wrapped, so the attribute value spans newlines.
+_IMG_DATA_SRC = re.compile(r'(<img\b[^>]*?\bsrc=")(data:image/[^"]+)(")', re.DOTALL)
+
+
+def _templates_dir(prog_lang: str) -> resources.abc.Traversable:
+    return resources.files("clm.workers.notebook").joinpath(f"templates_{prog_lang}")
+
+
+@cache
+def _bundled_data_uri(prog_lang: str) -> str | None:
+    """The bundled logo's ``data:`` URI, whitespace-normalized, or ``None``.
+
+    Normalization is whitespace-stripping and nothing else: the macro
+    inserts the ``*.base64`` file verbatim (line-wrapped, maybe a trailing
+    newline), so equality after removing all whitespace is exact recognition
+    without parsing base64.
+    """
+    entry = _LOGOS.get(prog_lang)
+    if entry is None:
+        return None
+    base64_name, _source_name, media_type = entry
+    try:
+        payload = _templates_dir(prog_lang).joinpath(base64_name).read_text(encoding="ascii")
+    except (FileNotFoundError, ModuleNotFoundError):
+        return None
+    return f"data:{media_type};base64,{''.join(payload.split())}"
+
+
+@cache
+def logo_file(prog_lang: str) -> tuple[Path, str] | None:
+    """The packaged logo file for ``prog_lang`` and its media type, or ``None``."""
+    entry = _LOGOS.get(prog_lang)
+    if entry is None:
+        return None
+    _base64_name, source_name, media_type = entry
+    try:
+        source = _templates_dir(prog_lang).joinpath(source_name)
+    except ModuleNotFoundError:
+        return None
+    if not source.is_file():
+        return None
+    # importlib.resources.files on an installed (non-zipped) package yields
+    # real paths; clm is always installed unpacked.
+    return Path(str(source)), media_type
+
+
+def rewrite_bundled_logo(html: str, prog_lang: str) -> str:
+    """Replace the bundled logo's ``data:`` URI in ``html`` with its asset URL.
+
+    Runs **before** sanitizing — the client injects the sanitizer's output
+    verbatim, so the rewrite must be part of what gets checked. Anything that
+    is not byte-recognizable as the bundled logo (after whitespace
+    normalization) is left alone, and the sanitizer then refuses it:
+    ``data:`` is no longer an allowed scheme at all.
+    """
+    bundled = _bundled_data_uri(prog_lang)
+    if bundled is None:
+        return html
+
+    asset_url = f"/api/studio/asset/logo/{prog_lang}"
+
+    def _replace(match: re.Match[str]) -> str:
+        candidate = "".join(match.group(2).split())
+        if candidate == bundled:
+            return f"{match.group(1)}{asset_url}{match.group(3)}"
+        return match.group(0)
+
+    return _IMG_DATA_SRC.sub(_replace, html)

--- a/src/clm/web/studio/qr.py
+++ b/src/clm/web/studio/qr.py
@@ -51,6 +51,11 @@ def svg_data_uri(url: str, *, scale: int = 6) -> str:
     """Return ``url`` as an inline-SVG ``data:`` URI for an ``<img>`` tag.
 
     ``scale`` is pixels-per-module; 6 renders comfortably on a phone camera.
+
+    Note: the ``clm serve`` CSP carries no ``data:`` exception in ``img-src``
+    (#706 — images come from same-origin asset routes there). A served page
+    that wants to display this should get an SVG asset route instead; this
+    helper is for contexts without that CSP.
     """
     segno = _require_segno()
     qr = segno.make(url, error="m")

--- a/src/clm/web/studio/render.py
+++ b/src/clm/web/studio/render.py
@@ -87,6 +87,7 @@ import logging
 import re
 from pathlib import Path
 
+from clm.web.studio.logo import rewrite_bundled_logo
 from clm.web.studio.sanitize import SanitizerUnavailableError, sanitize_preview_html
 
 logger = logging.getLogger(__name__)
@@ -358,7 +359,11 @@ def render_j2_cell_html(
         return False, f"render unavailable: {exc}", None
 
     try:
-        return True, None, sanitize_preview_html(_to_preview_html(text, comment_token))
+        # The bundled logo's data: URI becomes a same-origin asset URL *before*
+        # sanitizing (#706) — the client injects exactly what was sanitized,
+        # and a relative URL needs no data: exception in the allowlist.
+        preview_html = rewrite_bundled_logo(_to_preview_html(text, comment_token), prog_lang)
+        return True, None, sanitize_preview_html(preview_html)
     except SanitizerUnavailableError as exc:
         return False, str(exc), None
     except Exception as exc:  # noqa: BLE001 - preview must never crash the request

--- a/src/clm/web/studio/routes.py
+++ b/src/clm/web/studio/routes.py
@@ -19,7 +19,7 @@ from typing import cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from starlette.concurrency import run_in_threadpool
-from starlette.responses import FileResponse
+from starlette.responses import Response
 
 from clm.web.studio import sync_runner
 from clm.web.studio.auth import token_matches
@@ -280,27 +280,34 @@ async def render_cell(request: Request, req: RenderCellRequest) -> RenderCellRes
 
 
 @router.get("/asset/logo/{prog_lang}")
-async def logo_asset(prog_lang: str) -> FileResponse:
+async def logo_asset(prog_lang: str) -> Response:
     """The bundled course logo, for the tier-2 preview's rewritten ``<img>`` (#706).
 
     Deliberately **not** token-gated: an ``<img src>`` fetch cannot carry the
     ``Authorization`` header, and there is nothing here to protect — the route
     serves only the packaged logo files, with ``prog_lang`` selecting a fixed
-    mapping entry (never a path). ``script-src 'none'`` is set in case the SVG
-    is ever opened as a document rather than an image subresource; the global
-    security-headers middleware keeps a route's own CSP (route has the last
-    word), so this overrides ``script-src 'self'`` for exactly this response.
+    mapping entry (never a path). The response carries its own restrictive CSP
+    in case the SVG is ever opened as a *document* rather than an image
+    subresource — and because the global security-headers middleware keeps a
+    route's own CSP (route has the last word), that policy is self-contained
+    (``default-src 'none'``), not just ``script-src 'none'``.
     """
     found = logo_file(prog_lang)
     if found is None:
         raise HTTPException(status_code=404, detail=f"No bundled logo for {prog_lang!r}")
-    path, media_type = found
-    return FileResponse(
-        path,
+    source, media_type = found
+    return Response(
+        content=source.read_bytes(),
         media_type=media_type,
         headers={
             # Packaged with clm; changes only across installs/upgrades.
             "Cache-Control": "max-age=3600",
-            "Content-Security-Policy": "script-src 'none'",
+            # The global CSP middleware lets a route's own policy *replace* the
+            # app-wide one, so this must be self-contained — not just
+            # "script-src 'none'" — or an SVG opened as a same-origin document
+            # would lose default-src/object-src/base-uri with it.
+            "Content-Security-Policy": (
+                "default-src 'none'; script-src 'none'; style-src 'unsafe-inline'"
+            ),
         },
     )

--- a/src/clm/web/studio/routes.py
+++ b/src/clm/web/studio/routes.py
@@ -19,9 +19,11 @@ from typing import cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from starlette.concurrency import run_in_threadpool
+from starlette.responses import FileResponse
 
 from clm.web.studio import sync_runner
 from clm.web.studio.auth import token_matches
+from clm.web.studio.logo import logo_file
 from clm.web.studio.models import (
     DeckTree,
     DeckView,
@@ -275,3 +277,30 @@ async def render_cell(request: Request, req: RenderCellRequest) -> RenderCellRes
     except InvalidDeckIdError as e:
         raise HTTPException(status_code=400, detail=f"Invalid deck id: {e}") from e
     return RenderCellResult(rendered=rendered, body=req.body, html=html, error=error)
+
+
+@router.get("/asset/logo/{prog_lang}")
+async def logo_asset(prog_lang: str) -> FileResponse:
+    """The bundled course logo, for the tier-2 preview's rewritten ``<img>`` (#706).
+
+    Deliberately **not** token-gated: an ``<img src>`` fetch cannot carry the
+    ``Authorization`` header, and there is nothing here to protect — the route
+    serves only the packaged logo files, with ``prog_lang`` selecting a fixed
+    mapping entry (never a path). ``script-src 'none'`` is set in case the SVG
+    is ever opened as a document rather than an image subresource; the global
+    security-headers middleware keeps a route's own CSP (route has the last
+    word), so this overrides ``script-src 'self'`` for exactly this response.
+    """
+    found = logo_file(prog_lang)
+    if found is None:
+        raise HTTPException(status_code=404, detail=f"No bundled logo for {prog_lang!r}")
+    path, media_type = found
+    return FileResponse(
+        path,
+        media_type=media_type,
+        headers={
+            # Packaged with clm; changes only across installs/upgrades.
+            "Cache-Control": "max-age=3600",
+            "Content-Security-Policy": "script-src 'none'",
+        },
+    )

--- a/src/clm/web/studio/sanitize.py
+++ b/src/clm/web/studio/sanitize.py
@@ -3,9 +3,9 @@ r"""Server-side HTML sanitizing for the Studio's tier-2 cell preview (issue #697
 The tier-2 preview expands a cell's Jinja server-side so the phone sees a
 rendered header instead of raw ``{{ header_de("…") }}``. The expansion is
 **deliberately HTML** — the bundled ``macros.j2`` header macros emit
-``<div style="text-align:center">``, a ``<br/>``, and the course logo as an
-``<img src="data:image/…;base64,…">`` — so the client cannot escape its way out
-of the problem: escaping the output *is* removing the feature.
+``<div style="text-align:center">``, a ``<br/>``, and the course logo — so the
+client cannot escape its way out of the problem: escaping the output *is*
+removing the feature.
 
 The decision (maintainer, 2026-07-26; D13 in the adversarial-review handover)
 is to **sanitize on the server** and keep the client's ``innerHTML``
@@ -13,19 +13,22 @@ assignment. Two consequences worth stating plainly:
 
 * The client injects this output **verbatim**. So everything that changes the
   bytes — dropping the ``%% [markdown]`` delimiter line the macro emits,
-  stripping the per-language comment prefix — happens *before* the sanitizer
-  runs, never after. Sanitize exactly what gets injected.
+  stripping the per-language comment prefix, and (since #706) rewriting the
+  bundled logo's ``data:`` URI to a same-origin asset URL — happens *before*
+  the sanitizer runs, never after. Sanitize exactly what gets injected.
 * If :mod:`nh3` is missing (an install without the ``[web]`` extra), the
   preview **fails closed**: :func:`sanitize_preview_html` raises and the caller
   degrades to tier-1 client-side markdown. There is no unsanitized fallback.
 
-**The ``data:`` question, measured rather than assumed.** The logo is a
-``data:`` URI, so the scheme has to be allowed; but with ``data`` merely added
-to nh3's ``url_schemes``, ``<a href="data:text/html,<script>…">`` survives too
-(verified — it is a navigation vector, not a decoration). So the working
-combination is: allow ``data`` globally, then have
-:func:`_attribute_filter` refuse it everywhere except an ``<img src>`` that is
-specifically ``data:image/``.
+**The ``data:`` question is gone (measured, then removed).** The logo used to
+be a ``data:`` URI, which forced ``data`` into the scheme allowlist plus a
+confinement rule limiting it to ``<img src="data:image/…">`` — the most
+complex hand-rolled rule in this module, and the site of the first bypass the
+#704 adversarial rounds found. Since #706 the logo is served as a same-origin
+asset (:mod:`clm.web.studio.logo`) and rewritten to that URL *before*
+sanitizing, so ``data:`` is refused everywhere like any other unlisted
+scheme. The rule was deleted rather than hardened — see the #706 changelog
+fragment for why a generic asset store was rejected.
 
 **And the filter may only reject, never rewrite.** nh3 checks its scheme
 allowlist against the *incoming* value and then writes whatever the filter
@@ -61,10 +64,9 @@ parity rule above. Preview content is *content*; the guarantee here is "no
 script, no fixed-position impersonation of the app chrome", not "cannot look
 inviting".
 
-**URL rules, and why they are here rather than left to nh3.** Two decisions
-nh3's declarative config cannot express, both in :func:`_attribute_filter`:
+**URL rules, and why they are here rather than left to nh3.** One decision
+nh3's declarative config cannot express, in :func:`_attribute_filter`:
 
-* ``data:`` is confined to an ``<img src>`` that is ``data:image/…`` (the logo).
 * an **authority-relative** target (``//host``, and the ``\\`` / ``/\`` / ``\/``
   spellings WHATWG parsing treats identically) is refused, matching the client's
   ``safeUrl()`` for tier-1 markdown links. Both tiers render into the same page,
@@ -74,8 +76,9 @@ nh3's declarative config cannot express, both in :func:`_attribute_filter`:
   an off-origin image. What the rule removes is the *scheme-less* form, which
   reads as a path and is easy to miss in review.
 
-Both decisions depend on normalizing a URL the way ammonia and the browser do,
-which is **not** Python's ``\s`` — see :data:`_URL_INSIGNIFICANT` for the
+The scheme allowlist itself is applied over *this* module's normalization
+rather than deferring to nh3's — normalizing a URL the way ammonia and the
+browser do is **not** Python's ``\s``; see :data:`_URL_INSIGNIFICANT` for the
 control-character gap that made this a real bypass.
 """
 
@@ -163,9 +166,14 @@ ALLOWED_ATTRIBUTES: dict[str, set[str]] = {
     "*": {"style", "align"},
 }
 
-#: Link schemes a preview may point at. ``data`` is here **only** so the logo
-#: image works; :func:`_attribute_filter` is what confines it to ``<img src>``.
-ALLOWED_URL_SCHEMES: frozenset[str] = frozenset({"http", "https", "mailto", "data"})
+#: Link schemes a preview may point at. ``data`` is deliberately **absent**:
+#: the bundled logo used to force it in (with a confinement rule limiting it
+#: to ``<img src="data:image/…">`` — the most complex hand-rolled rule here,
+#: and the site of the first bypass the #704 adversarial rounds found). Since
+#: #706 the logo reaches the preview as a same-origin asset URL, rewritten by
+#: :mod:`clm.web.studio.logo` *before* sanitizing, so ``data:`` is simply
+#: refused everywhere like any other unlisted scheme.
+ALLOWED_URL_SCHEMES: frozenset[str] = frozenset({"http", "https", "mailto"})
 
 #: CSS properties kept inside a surviving ``style`` attribute. The first five
 #: are what the bundled header macros use; the rest are inert text formatting.
@@ -261,10 +269,12 @@ def _attribute_filter(tag: str, attribute: str, value: str) -> str | None:
     ``None``. :func:`_filter_style` is the one exception, and it is not a URL —
     it can only ever *remove* declarations.
 
-    Three rules: CSS is filtered; ``data:`` is confined to an ``<img src>`` that
-    is an image; and an **authority-relative** target is refused, matching the
-    client's ``safeUrl()`` for tier-1 links (both land in the same token-holding
-    page, so both get the same rule).
+    Two rules: CSS is filtered, and an **authority-relative** target is
+    refused, matching the client's ``safeUrl()`` for tier-1 links (both land
+    in the same token-holding page, so both get the same rule). Everything
+    scheme-related is the allowlist itself, applied below over this module's
+    own normalization — ``data:`` included, which is simply unlisted since
+    #706 (the logo arrives as a same-origin asset URL instead).
     """
     if attribute == "style":
         return _filter_style(value)
@@ -274,11 +284,6 @@ def _attribute_filter(tag: str, attribute: str, value: str) -> str | None:
     if normalized.startswith(_AUTHORITY_RELATIVE):
         return None
     scheme = _scheme_of(normalized)
-    if scheme == "data":
-        # The one legitimate use is the logo the header macros embed.
-        if tag == "img" and attribute == "src" and normalized.startswith("data:image/"):
-            return value
-        return None
     if scheme and scheme not in ALLOWED_URL_SCHEMES:
         # The scheme allowlist, applied over *this* module's normalization rather
         # than deferring to nh3's. They do not agree: measured, ammonia reads

--- a/tests/infrastructure/test_web_security.py
+++ b/tests/infrastructure/test_web_security.py
@@ -482,9 +482,9 @@ class TestSecurityHeaders:
         assert directives["object-src"] == "'none'"
         assert directives["base-uri"] == "'none'"
         assert directives["frame-ancestors"] == "'none'"
-        # The Studio logo is a data: URI; off-origin images are the documented
-        # tier-1-parity decision.
-        assert "data:" in directives["img-src"]
+        # The Studio logo is a same-origin asset since #706; off-origin images
+        # are the documented tier-1-parity decision.
+        assert "data:" not in directives["img-src"]
         assert "https:" in directives["img-src"]
         # Inline styles must stay: the Studio shell has an inline <style> block
         # and the tier-2 sanitizer deliberately keeps style attributes (CSS

--- a/tests/web/studio/test_logo_asset.py
+++ b/tests/web/studio/test_logo_asset.py
@@ -1,0 +1,130 @@
+"""The bundled logo as a same-origin asset, and the pre-sanitize rewrite (#706).
+
+The point of the issue is deletion: the ``data:`` confinement rule was the
+tier-2 sanitizer's most complex hand-rolled piece and the site of the first
+bypass the #704 adversarial rounds found. These tests pin what replaced it:
+
+* the rewrite recognizes the **bundled** logo (whitespace-normalized equality
+  against the packaged ``*.base64`` include — nothing else qualifies),
+* the asset route serves the **packaged** logo file (a fixed mapping, never a
+  request-derived path) and does so without the token, because an ``<img>``
+  fetch cannot carry one,
+* and the packaged ``*.base64`` resources actually decode to the packaged
+  image files — otherwise the rewrite and the route disagree about what the
+  logo is, silently.
+"""
+
+from __future__ import annotations
+
+import base64
+from importlib import resources
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from clm.web.studio.logo import _LOGOS, logo_file, rewrite_bundled_logo
+from tests.web.studio.conftest import Course, make_app
+
+TOKEN = "test-token-706"
+
+
+def _packaged_base64(prog_lang: str) -> str:
+    base64_name = _LOGOS[prog_lang][0]
+    return (
+        resources.files("clm.workers.notebook")
+        .joinpath(f"templates_{prog_lang}/{base64_name}")
+        .read_text(encoding="ascii")
+    )
+
+
+def _logo_data_uri(prog_lang: str) -> str:
+    """The URI as the macro emits it: verbatim (line-wrapped) include output."""
+    media_type = _LOGOS[prog_lang][2]
+    return f"data:{media_type};base64,{_packaged_base64(prog_lang)}"
+
+
+class TestRewriteBundledLogo:
+    @pytest.mark.parametrize("prog_lang", sorted(_LOGOS))
+    def test_the_bundled_logo_becomes_an_asset_url(self, prog_lang: str) -> None:
+        html = f'<div><img src="{_logo_data_uri(prog_lang)}" width="24"></div>'
+        rewritten = rewrite_bundled_logo(html, prog_lang)
+        assert f'<img src="/api/studio/asset/logo/{prog_lang}"' in rewritten
+        assert "data:" not in rewritten
+
+    def test_wrapping_spelling_does_not_matter(self) -> None:
+        """Recognition normalizes whitespace, so re-wrapped base64 still matches."""
+        compact = "".join(_packaged_base64("python").split())
+        html = f'<img src="data:image/svg+xml;base64,{compact}">'
+        assert "/api/studio/asset/logo/python" in rewrite_bundled_logo(html, "python")
+
+    def test_a_foreign_data_uri_is_left_for_the_sanitizer(self) -> None:
+        """Not byte-equal to the bundled logo → untouched here, refused there."""
+        html = '<img src="data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=">'
+        assert rewrite_bundled_logo(html, "python") == html
+
+    def test_the_cpp_logo_is_not_confused_with_the_python_one(self) -> None:
+        """Recognition is per-language: the png payload is not the svg one."""
+        html = f'<img src="{_logo_data_uri("cpp")}">'
+        assert rewrite_bundled_logo(html, "python") == html
+
+    def test_an_unknown_language_rewrites_nothing(self) -> None:
+        html = f'<img src="{_logo_data_uri("python")}">'
+        assert rewrite_bundled_logo(html, "rust") == html
+
+    def test_the_rewrite_is_idempotent(self) -> None:
+        """The client re-renders cells; a second pass must be a no-op."""
+        html = f'<img src="{_logo_data_uri("python")}">'
+        once = rewrite_bundled_logo(html, "python")
+        assert rewrite_bundled_logo(once, "python") == once
+
+    def test_other_tags_with_data_urls_are_not_touched(self) -> None:
+        """Only ``<img src>`` is rewritten — a link never becomes an asset URL."""
+        html = f'<a href="{_logo_data_uri("python")}">x</a>'
+        assert rewrite_bundled_logo(html, "python") == html
+
+
+class TestPackagedLogoConsistency:
+    @pytest.mark.parametrize("prog_lang", sorted(_LOGOS))
+    def test_the_base64_include_decodes_to_the_served_file(self, prog_lang: str) -> None:
+        """If these drift apart the preview shows a different logo than the build."""
+        found = logo_file(prog_lang)
+        assert found is not None
+        path, _media_type = found
+        decoded = base64.b64decode("".join(_packaged_base64(prog_lang).split()))
+        assert decoded == path.read_bytes()
+
+    def test_an_unknown_language_has_no_logo(self) -> None:
+        assert logo_file("rust") is None
+
+
+class TestLogoAssetRoute:
+    @pytest.fixture()
+    def client(self, course: Course) -> TestClient:
+        app = make_app(course.spec_path, course.slides_dir.parent / "jobs.db", TOKEN)
+        return TestClient(app)
+
+    @pytest.mark.parametrize("prog_lang", sorted(_LOGOS))
+    def test_the_logo_is_served_without_a_token(self, client: TestClient, prog_lang: str) -> None:
+        """An ``<img>`` fetch cannot carry ``Authorization`` — by design."""
+        r = client.get(f"/api/studio/asset/logo/{prog_lang}")
+        assert r.status_code == 200
+        assert r.headers["content-type"].startswith(_LOGOS[prog_lang][2])
+        found = logo_file(prog_lang)
+        assert found is not None
+        assert r.content == found[0].read_bytes()
+
+    def test_the_response_disables_script_for_document_loads(self, client: TestClient) -> None:
+        """An SVG opened as a *document* must not run — its own CSP says so."""
+        r = client.get("/api/studio/asset/logo/python")
+        assert r.headers["content-security-policy"] == "script-src 'none'"
+
+    def test_an_unknown_language_is_a_404(self, client: TestClient) -> None:
+        assert client.get("/api/studio/asset/logo/rust").status_code == 404
+
+    def test_a_path_traversal_spelling_cannot_escape(self, client: TestClient) -> None:
+        """``prog_lang`` selects a mapping entry; it is never a path fragment."""
+        assert client.get("/api/studio/asset/logo/..%2F..%2Fpyproject").status_code in (
+            404,
+            422,
+        )

--- a/tests/web/studio/test_logo_asset.py
+++ b/tests/web/studio/test_logo_asset.py
@@ -115,9 +115,16 @@ class TestLogoAssetRoute:
         assert r.content == found[0].read_bytes()
 
     def test_the_response_disables_script_for_document_loads(self, client: TestClient) -> None:
-        """An SVG opened as a *document* must not run — its own CSP says so."""
+        """An SVG opened as a *document* gets a self-contained lockdown CSP.
+
+        The global middleware lets a route's CSP *replace* the app-wide one,
+        so this must carry ``default-src 'none'`` itself — ``script-src
+        'none'`` alone would silently drop every other directive.
+        """
         r = client.get("/api/studio/asset/logo/python")
-        assert r.headers["content-security-policy"] == "script-src 'none'"
+        assert r.headers["content-security-policy"] == (
+            "default-src 'none'; script-src 'none'; style-src 'unsafe-inline'"
+        )
 
     def test_an_unknown_language_is_a_404(self, client: TestClient) -> None:
         assert client.get("/api/studio/asset/logo/rust").status_code == 404
@@ -128,3 +135,32 @@ class TestLogoAssetRoute:
             404,
             422,
         )
+
+
+class TestRewritePerformance:
+    """The regex runs on request-controlled bytes, so it must be linear.
+
+    The first version matched ``src="`` in the same pattern as ``<img``, and
+    every ``<img`` start rescanned the rest of the input: ``"<img a" * N``
+    cost O(N²) — 34 s at N=20000, an authenticated threadpool DoS found by
+    the #709 review round. The ``str.find`` loop rewinds nothing — an
+    unterminated ``<img`` ends the scan in one pass; the threshold is generous
+    so slow CI can't flake, while the old shape would exceed it by an order
+    of magnitude.
+    """
+
+    def test_many_img_starts_do_not_go_quadratic(self) -> None:
+        import time
+
+        payload = "<img a " * 20000  # no complete tag, the old quadratic case
+        start = time.monotonic()
+        assert rewrite_bundled_logo(payload, "python") == payload
+        assert time.monotonic() - start < 5.0
+
+    def test_many_complete_img_tags_are_linear_too(self) -> None:
+        import time
+
+        payload = '<img src="data:image/png;base64,AAAA">' * 20000
+        start = time.monotonic()
+        assert rewrite_bundled_logo(payload, "python") == payload
+        assert time.monotonic() - start < 5.0

--- a/tests/web/studio/test_tier2_preview.py
+++ b/tests/web/studio/test_tier2_preview.py
@@ -11,11 +11,12 @@ Two failures met here, and they are different in kind:
   original bug: the predicate can be right about a contract that changed, and
   the contract can be right with nobody consulting it.
 * **The consumer was a raw ``innerHTML`` sink.** The expansion is deliberately
-  HTML (the header macros emit ``<div>``, ``<br>`` and a ``data:`` logo), so
+  HTML (the header macros emit ``<div>``, ``<br>`` and the course logo), so
   escaping it deletes the feature. Decision D13: sanitize **server-side**
-  against an allowlist. These tests are the allowlist's teeth — including the
-  case that made ``data:`` awkward, since the logo needs it and a link must not
-  have it.
+  against an allowlist. These tests are the allowlist's teeth. Since #706 the
+  logo reaches the sanitizer as a same-origin asset URL (rewritten
+  pre-sanitize — see tests/web/studio/test_logo_asset.py), so ``data:`` is
+  refused here like any other unlisted scheme.
 """
 
 from __future__ import annotations
@@ -131,16 +132,22 @@ class TestSanitizer:
         assert "text-align:center" in cleaned
         assert "<br>" in cleaned
 
-    def test_the_data_uri_logo_survives(self) -> None:
+    def test_a_data_uri_image_no_longer_survives(self) -> None:
+        """``data:`` is unlisted since #706 — the logo arrives as an asset URL.
+
+        What reaches the sanitizer is *post-rewrite* HTML, so a ``data:``
+        image here is by definition not the bundled logo and must be refused.
+        """
         cleaned = sanitize_preview_html(
             '<img src="data:image/svg+xml;base64,PHN2Zy8+" style="display:block;width:5%">'
         )
-        assert 'src="data:image/svg+xml;base64,PHN2Zy8+"' in cleaned
+        assert "data:" not in cleaned
+        assert "display:block" in cleaned  # the style policy is unaffected
 
-    def test_a_line_wrapped_data_uri_survives(self) -> None:
-        """The bundled ``*.base64`` includes are wrapped, so the URI has newlines."""
+    def test_a_line_wrapped_data_uri_is_refused_too(self) -> None:
+        """Newlines inside the URI must not resurrect the scheme."""
         cleaned = sanitize_preview_html('<img src="data:image/svg+xml;base64,PHN2\nZy8+\nAA">')
-        assert "data:image/svg+xml;base64," in cleaned
+        assert "data:" not in cleaned.replace("\n", "")
 
     @pytest.mark.parametrize(
         "html",
@@ -171,7 +178,7 @@ class TestSanitizer:
         ],
     )
     def test_a_link_can_never_carry_data_or_script_schemes(self, html: str) -> None:
-        """``data:`` is allowed for the logo, so a link must be refused explicitly."""
+        """``data:`` is unlisted like any other non-web scheme — refused on links."""
         cleaned = sanitize_preview_html(html)
         assert "href" not in cleaned
 
@@ -210,15 +217,21 @@ class TestSanitizer:
     @pytest.mark.parametrize(
         "html",
         [
+            '<img src="data:image/png;base64,AAAA">',
             '<img src="data:text/html,<b>x</b>">',
             '<img src="&#1;data:text/html,x">',
             '<img src="&#14;data:application/javascript,x">',
         ],
     )
-    def test_a_non_image_data_uri_is_refused_even_on_img(self, html: str) -> None:
-        """Cases 2–3 are the control-prefix bypass: the confinement to
-        ``data:image/`` has to normalize the same way nh3's scheme check does, or
-        the prefix defeats one check and not the other."""
+    def test_a_data_uri_is_refused_even_on_img(self, html: str) -> None:
+        """No ``data:`` at all since #706 — not even ``data:image/`` on ``<img>``.
+
+        Cases 2–4 are the old control-prefix bypass: the scheme check has to
+        normalize the same way nh3's does, or the prefix defeats one check and
+        not the other. Case 1 is the #706 change itself: the bundled logo is
+        rewritten to an asset URL *before* this runs, so a ``data:`` image
+        reaching the sanitizer is never legitimate.
+        """
         cleaned = sanitize_preview_html(html)
         assert "data:" not in cleaned
 
@@ -232,8 +245,8 @@ class TestSanitizer:
         parser resolves ``\x7fjavascript:…`` as a same-origin path — so leaving it
         alone is both safer and simpler.
         """
-        cleaned = sanitize_preview_html('<img src="&#8;data:image/svg+xml;base64,AAaaBB">')
-        assert "\x08data:image/svg+xml;base64,AAaaBB" in cleaned
+        cleaned = sanitize_preview_html('<img src="&#8;https://ok.example/x.png">')
+        assert "\x08https://ok.example/x.png" in cleaned
 
     @pytest.mark.parametrize(
         "url",
@@ -386,6 +399,10 @@ class TestRenderJ2CellHtml:
         assert "\n# <" not in html  # and so is the comment prefix
         assert "<div" in html  # the macro's markup survived
         assert "<script" not in html
+        # The bundled logo arrives as a same-origin asset URL, not a data: URI
+        # (#706 — the rewrite happens before sanitizing).
+        assert '<img src="/api/studio/asset/logo/python"' in html
+        assert "data:" not in html
 
     def test_a_body_smuggling_script_is_sanitized_not_reflected(self, tmp_path: Path) -> None:
         """The body is a *request* body — a token holder can put anything in it."""


### PR DESCRIPTION
Closes #706. Draft pending the adversarial review round (per the next-issue loop).

## Why

The tier-2 sanitizer's `data:` confinement rule (`data:` allowed globally, then hand-restricted to `<img src="data:image/…">`) was its most complex hand-rolled piece and the site of the **first bypass the #704 adversarial rounds found** (the `\s` vs C0 normalization desync). #706's premise: the rule exists solely for the bundled header logo, and the preview is a page on a server — so serve the logo as a URL and **delete the rule** instead of hardening it.

## What changed

- **`clm.web.studio.logo`** (new): `rewrite_bundled_logo(html, prog_lang)` replaces the bundled logo's `data:` URI with `/api/studio/asset/logo/<prog_lang>` — recognition is whitespace-normalized equality against the packaged `*.base64` include, nothing else qualifies. Runs in `render_j2_cell_html` **before** sanitizing, preserving "the client injects exactly what was sanitized".
- **New route** `GET /api/studio/asset/logo/<prog_lang>` serves the packaged logo files (a fixed five-entry mapping — `prog_lang` selects an entry, never a path). **Deliberately not token-gated**: an `<img>` fetch cannot carry `Authorization`, and there is nothing to protect beyond what pip installed. Responds with `Content-Security-Policy: script-src 'none'` (composes with #708's route-wins CSP semantics) so an SVG opened as a *document* cannot execute.
- **`sanitize.py`**: `data` leaves `ALLOWED_URL_SCHEMES`; the confinement branch is deleted; the docstring's "data: question" section now records why the question is gone.
- **CSP tightening** (`web_security.py`): `img-src` loses its `data:` exception — the one in-app producer is now same-origin. Verified `qr.svg_data_uri` has **no served-page caller** (the QR pairing goes to the terminal); it got a docstring note instead of a CSP exception.
- **Design decision (maintainer, in session): bundled-logo-only, not a generic content-addressed store.** A store would serve decoded attacker bytes same-origin — re-introducing exactly the hand-rolled surface this change exists to remove. Accepted cost: a course author's own `data:` images in custom macros drop out of the phone preview (documented; "preview, not parity" was already the tier's stance). **Student-facing slides/notebooks are untouched** — the build pipeline never goes near the sanitizer.

## Tests

- `tests/web/studio/test_logo_asset.py` (new): per-language recognition for all five template languages, wrap-spelling invariance, foreign-URI passthrough, idempotence, `<a href>` never rewritten, **base64-include vs served-file consistency** (they can't silently drift), route behavior incl. no-token access, per-language content-type, `script-src 'none'`, 404, traversal spelling.
- `test_tier2_preview.py` updated: `data:` is now refused everywhere (incl. `data:image/` on `<img>`, line-wrapped spellings); the end-to-end real-header test asserts the asset URL appears and no `data:` remains.
- `test_web_security.py`: the CSP test now asserts **no** `data:` in `img-src`.

`pytest tests/web tests/infrastructure` → 1989 passed; ruff/mypy clean.