### PR TITLE
fix(tests): restore worker-global logging/config state after every test (#694)

### DIFF
--- a/changelog.d/694-logging-isolation.fixed.md
+++ b/changelog.d/694-logging-isolation.fixed.md
@@ -1,0 +1,12 @@
+- Fixed the nightly flake in `test_cache_miss_falls_back_to_direct_execution`
+  (#694): a three-hop cross-test poisoning chain — a config test reloaded the
+  process-global `ClmConfig` singleton under a monkeypatched
+  `CLM_LOGGING__LOG_LEVEL=ERROR` (monkeypatch reverts the env var, not the
+  singleton), a later in-process `clm build` applied the poisoned level via
+  `setup_logging` → `getLogger("clm").setLevel(ERROR)`, and every later
+  `clm.*` WARNING on that xdist worker was silently swallowed. Added an
+  autouse `_restore_worker_global_state` fixture in `tests/conftest.py` that
+  snapshots/restores the clm logger chain and the config singleton around
+  every test (pinned by `tests/test_global_state_isolation.py`), and guarded
+  the three caplog-asserting tests that lacked a `caplog.set_level` guard
+  (the other 35 caplog-using files already had one).

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -243,6 +243,36 @@ xdist load, so the suite relaxes it in one place instead of every heartbeat
 test re-patching the constant. Never raise the **production** default — relax it
 only in tests, via this env var.
 
+### Worker-global state is restored after every test (#694)
+
+Under xdist, every test in a worker shares one Python process, so a test that
+mutates process-global state without restoring it poisons its successors —
+possibly hundreds of tests later, which makes the flake nearly impossible to
+connect to its cause from the failure alone. The 2026-07-26 nightly failed on
+exactly that: a config test reloaded the global `ClmConfig` singleton under a
+monkeypatched `CLM_LOGGING__LOG_LEVEL=ERROR` (monkeypatch reverts the env var,
+**not** the singleton), a later in-process `clm build` applied the poisoned
+level via `setup_logging` → `getLogger("clm").setLevel(ERROR)`, and a
+`caplog`-based assertion ~300 tests downstream lost its WARNING and failed.
+
+The autouse `_restore_worker_global_state` fixture in `tests/conftest.py`
+snapshots the clm logger chain (level/disabled/propagate) and the config
+singleton before each test and restores both after it.
+`tests/test_global_state_isolation.py` pins the property: one test pollutes
+on purpose, the next proves the pollution cannot cross the boundary.
+
+Two takeaways when writing tests:
+
+- **Never mutate process-global state without restore.** `monkeypatch` covers
+  env vars and attributes, but not cached singletons — if a test reloads
+  `get_config()`, that is exactly the case the fixture now guards, but new
+  globals need the same discipline.
+- **Guard `caplog` assertions with `caplog.set_level(level, logger=...)`.**
+  A bare `caplog.records` assertion inherits whatever effective level the
+  logger happens to have; nearly all caplog-using files in this suite set the
+  level explicitly, and the fixture is the second line of defense, not a
+  license to skip the guard.
+
 ### Per-test timeout
 
 `[tool.pytest.ini_options] timeout` (pyproject) defaults to **120s** — the same

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -869,6 +869,50 @@ def auto_configure_logging_for_marked_tests(request):
 
 
 @pytest.fixture(scope="function", autouse=True)
+def _restore_worker_global_state():
+    """Restore worker-global logging/config state mutated by a test (#694).
+
+    The 2026-07-26 nightly flaked on a three-hop chain across one xdist
+    worker: a test reloaded the process-global ``ClmConfig`` singleton under
+    a monkeypatched ``CLM_LOGGING__LOG_LEVEL=ERROR`` (monkeypatch reverts the
+    env var, not the singleton); a later in-process ``clm build`` resolved
+    the poisoned value and applied it via ``setup_logging`` →
+    ``getLogger("clm").setLevel(ERROR)``; every later ``clm.*`` WARNING on
+    that worker died at the gate and a ``caplog`` assertion 300 tests
+    downstream failed. Snapshot the clm logger chain (level/disabled/
+    propagate) and the config singleton before each test and restore both
+    after it, so no test can poison its successors. Pinned by
+    ``tests/test_global_state_isolation.py``.
+    """
+    import clm.infrastructure.config as config_module
+
+    chain = (
+        "clm",
+        "clm_cli",
+        "clm_common",
+        "clm_faststream_backend",
+        "clm.workers",
+        "clm.workers.notebook",
+        "clm.workers.notebook.notebook_processor",
+        "clm.infrastructure",
+        "clm.infrastructure.database",
+        "clm.infrastructure.database.executed_notebook_cache",
+        "clm.release",
+    )
+    loggers = [logging.getLogger(name) for name in chain]
+    snapshot = [(lg.level, lg.disabled, lg.propagate) for lg in loggers]
+    previous_config = config_module._config
+    try:
+        yield
+    finally:
+        for lg, (level, disabled, propagate) in zip(loggers, snapshot, strict=True):
+            lg.setLevel(level)
+            lg.disabled = disabled
+            lg.propagate = propagate
+        config_module._config = previous_config
+
+
+@pytest.fixture(scope="function", autouse=True)
 def _neutralise_pool_size_cap(monkeypatch, request):
     """Pin the Fix 4 pool-size cap helpers to effectively-unlimited values.
 

--- a/tests/infrastructure/database/test_executed_notebook_cache.py
+++ b/tests/infrastructure/database/test_executed_notebook_cache.py
@@ -1,6 +1,7 @@
 """Tests for the ExecutedNotebookCache class."""
 
 import json
+import logging
 import pickle
 import sqlite3
 import tempfile
@@ -210,6 +211,10 @@ class TestExecutedNotebookCache:
 
     def test_without_context_manager_warns(self, temp_db_path, sample_notebook, caplog):
         """Test that using cache without context manager logs warning."""
+        # Guard against worker-global logger pollution (#694).
+        caplog.set_level(
+            logging.WARNING, logger="clm.infrastructure.database.executed_notebook_cache"
+        )
         cache = ExecutedNotebookCache(temp_db_path)
         # conn is None without __enter__
 

--- a/tests/release/test_sync.py
+++ b/tests/release/test_sync.py
@@ -1,6 +1,7 @@
 """Tests for the release sync/promote algorithm (issue #208, step 2)."""
 
 import hashlib
+import logging
 
 from clm.release.frozen_manifest import FrozenManifest, FrozenRecord
 from clm.release.sync import (
@@ -207,6 +208,8 @@ def test_sync_refuses_vcs_paths_from_a_polluted_manifest(tmp_path, caplog):
     """Defense in depth (issue #302): a manifest from an older build that
     walked a stray ``.git`` into the skeleton must never overwrite the
     destination repo's own ``.git``."""
+    # Guard against worker-global logger pollution (#694).
+    caplog.set_level(logging.WARNING, logger="clm.release.sync")
     manifest = _manifest()
     manifest["files"] += [
         {

--- a/tests/test_global_state_isolation.py
+++ b/tests/test_global_state_isolation.py
@@ -28,7 +28,6 @@ import logging
 
 import pytest
 
-import clm.infrastructure.config as config_module
 from clm.infrastructure.config import get_config
 
 
@@ -54,11 +53,3 @@ class TestGlobalStateIsolation:
             "boundary — the autouse _restore_worker_global_state fixture in "
             "tests/conftest.py is broken"
         )
-
-    def test_c_singleton_identity_is_restored(self) -> None:
-        """The fixture restores the *previous* singleton object, not a reset."""
-        # No test before this one in the group reloaded the singleton, so the
-        # object here is the one the worker started with (or None lazily) —
-        # the point is that test_a's reloaded instance is gone.
-        assert get_config() is not None
-        assert config_module._config is not None  # noqa: SLF001 - asserting the fixture's subject

--- a/tests/test_global_state_isolation.py
+++ b/tests/test_global_state_isolation.py
@@ -1,0 +1,64 @@
+"""Isolation guarantees for worker-global logging/config state (#694).
+
+The 2026-07-26 nightly flaked because three tests on one xdist worker formed
+a poisoning chain:
+
+1. ``tests/infrastructure/test_config.py`` reloaded the process-global
+   ``ClmConfig`` singleton under a monkeypatched ``CLM_LOGGING__LOG_LEVEL
+   =ERROR``; monkeypatch reverted the env var, but the singleton kept the
+   poisoned value.
+2. A later in-process ``clm build`` (``tests/snapshot/test_build_cli.py``)
+   resolved that poisoned value and applied it globally via
+   ``setup_logging`` → ``logging.getLogger("clm").setLevel(ERROR)``, never
+   restored.
+3. Hundreds of tests later, ``test_cache_miss_falls_back_to_direct_execution``
+   lost its ``cache miss`` WARNING to the ERROR gate and its ``caplog``
+   assertion failed — while the unrelated traitlets logger kept capturing,
+   which is exactly what the CI log showed.
+
+The autouse ``_restore_worker_global_state`` fixture in ``tests/conftest.py``
+is the class fix: it snapshots and restores the clm logger chain and the
+config singleton around every test. These two tests pin the property: the
+first pollutes on purpose, the second proves the pollution cannot cross the
+test boundary. They must run in one worker in order, hence the shared
+``xdist_group``.
+"""
+
+import logging
+
+import pytest
+
+import clm.infrastructure.config as config_module
+from clm.infrastructure.config import get_config
+
+
+@pytest.mark.xdist_group("global_state_isolation")
+class TestGlobalStateIsolation:
+    def test_a_deliberately_pollutes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Reproduce the #694 poisoning: poisoned singleton + raised clm level."""
+        monkeypatch.setenv("CLM_LOGGING__LOG_LEVEL", "ERROR")
+        get_config(reload=True)
+        logging.getLogger("clm").setLevel(logging.CRITICAL)
+        # Both mutations took effect *within* this test...
+        assert get_config().logging.log_level == "ERROR"
+        assert logging.getLogger("clm").level == logging.CRITICAL
+
+    def test_b_sees_clean_state(self) -> None:
+        """...and neither survives the test boundary, thanks to the fixture."""
+        assert logging.getLogger("clm").level != logging.CRITICAL, (
+            "clm logger level leaked across a test boundary — the autouse "
+            "_restore_worker_global_state fixture in tests/conftest.py is broken"
+        )
+        assert get_config().logging.log_level == "INFO", (
+            "config singleton kept a monkeypatched value across a test "
+            "boundary — the autouse _restore_worker_global_state fixture in "
+            "tests/conftest.py is broken"
+        )
+
+    def test_c_singleton_identity_is_restored(self) -> None:
+        """The fixture restores the *previous* singleton object, not a reset."""
+        # No test before this one in the group reloaded the singleton, so the
+        # object here is the one the worker started with (or None lazily) —
+        # the point is that test_a's reloaded instance is gone.
+        assert get_config() is not None
+        assert config_module._config is not None  # noqa: SLF001 - asserting the fixture's subject

--- a/tests/workers/notebook/test_cache_equivalence.py
+++ b/tests/workers/notebook/test_cache_equivalence.py
@@ -5,6 +5,7 @@ compared to direct execution, validating that the Speaker→Completed cache
 reuse strategy is correct.
 """
 
+import logging
 import tempfile
 from pathlib import Path
 
@@ -211,6 +212,9 @@ class TestCacheEquivalence:
     @pytest.mark.asyncio
     async def test_cache_miss_falls_back_to_direct_execution(self, temp_cache_db, caplog):
         """Verify that cache miss falls back to direct execution with warning."""
+        # Guard against worker-global logger pollution: an earlier test on the
+        # same xdist worker may have raised the clm logger's level (#694).
+        caplog.set_level(logging.WARNING, logger="clm.workers.notebook.notebook_processor")
         payload = NotebookPayload(
             data="# Simple notebook\nprint('hello')",
             input_file="/test/nonexistent.py",


### PR DESCRIPTION
## Why

The 2026-07-26 nightly failed 1/8776 tests: `test_cache_miss_falls_back_to_direct_execution` lost its `cache miss` WARNING to `caplog` while traitlets DEBUG records kept being captured. Diagnosis (full writeup in https://github.com/hoelzl/clm/issues/694#issuecomment-5085597624): a three-hop cross-test poisoning chain inside one xdist worker —

1. `tests/infrastructure/test_config.py` reloaded the process-global `ClmConfig` singleton under `monkeypatch.setenv("CLM_LOGGING__LOG_LEVEL", "ERROR")`; monkeypatch reverts the env var, **not** the singleton.
2. A later in-process `clm build` (`tests/snapshot/test_build_cli.py`) resolved the poisoned value and applied it via `setup_logging` → `getLogger("clm").setLevel(ERROR)`, never restored.
3. ~300 tests later the victim's WARNING died at the ERROR gate.

Proven empirically: a per-test logger-chain snapshotter (pytest hooks diffing level/disabled/propagate around every test) ran on the **real nightly workflow** via a temporary debug branch; it caught the 20→40 transition live at the snapshot-CLI test, and the flake then reproduced on the same worker with full chain diagnostics (`clm=40`, children inheriting). The debug branch was deleted after the hunt. Windows/32-worker local runs never reproduce — the trio must share a worker in order, far more likely with CI's 4 workers.

## What

- **Class fix**: autouse `_restore_worker_global_state` fixture in `tests/conftest.py` snapshots the clm logger chain (level/disabled/propagate) and the `ClmConfig` singleton before each test, restores both after. No test can poison its successors anymore.
- **Pinned**: `tests/test_global_state_isolation.py` — one test pollutes deliberately, the next proves the pollution cannot cross the boundary (RED before the fixture, GREEN after; shared `xdist_group` keeps them on one worker).
- **Victim hardening**: the only three `caplog`-asserting test files (of 38) without a `caplog.set_level`/`at_level` guard get one, matching the suite's established convention.
- Docs: new "Worker-global state is restored after every test" section in `docs/developer-guide/testing.md` + changelog fragment.

## Verification

- `tests/test_global_state_isolation.py`: RED without the fixture (`clm` still CRITICAL in test B), GREEN with it.
- Full suite (`-m "not docker"`, 9338 tests): **4 consecutive clean runs** with the fixture (one earlier run showed 2 transient failures from the repo's known CPU-starvation flake families; passed in isolation and in all subsequent full runs).
- ruff check + format clean.

Closes #694