### PR TITLE
fix(cache): kill cross-install cache thrash + cached-phase hotspots (#711)

### DIFF
--- a/changelog.d/711-executed-notebook-cache-migration-gate.fixed.md
+++ b/changelog.d/711-executed-notebook-cache-migration-gate.fixed.md
@@ -1,0 +1,7 @@
+- Sped up cached builds: `ExecutedNotebookCache` ran its legacy-payload
+  migration (a full-scan `DELETE` + commit) on *every* connection open — and
+  the recording/speaker replay gate opens a fresh connection per HTML op,
+  several hundred times per build (measured: 15% of host time in the cached
+  phase of a large-course build, #711). The migration now runs once per
+  database file, gated on `PRAGMA user_version`; steady-state opens cost only
+  the `CREATE IF NOT EXISTS` schema checks.

--- a/changelog.d/711-template-fingerprint-crlf.fixed.md
+++ b/changelog.d/711-template-fingerprint-crlf.fixed.md
@@ -1,0 +1,10 @@
+- Fixed cross-install cache thrash from line-ending drift:
+  `compute_template_fingerprint` hashed raw template bytes, so an editable
+  install on Windows (CRLF working tree, `core.autocrlf=true`) and a
+  wheel/sdist install (LF) of the *same* clm version produced different
+  fingerprints — and therefore different content hashes for every notebook —
+  invalidating the whole cache whenever a build switched between installs
+  (#711). Template bytes are now newline-normalized (CRLF → LF) before
+  hashing. Note: this changes the fingerprint value for CRLF installs once,
+  causing a one-time cache refresh on their next build (same effect as a
+  template change).

--- a/changelog.d/711-worker-liveness-psutil-scan.fixed.md
+++ b/changelog.d/711-worker-liveness-psutil-scan.fixed.md
@@ -1,0 +1,10 @@
+- Sped up worker health monitoring on Windows: when a worker was not in the
+  executor's local process table, `is_worker_running` fell back to a
+  system-wide `psutil.process_iter(["pid", "environ"])` sweep that read every
+  process's environment block (a PEB read per process — seconds per scan
+  under load), once per worker per 10 s monitor cycle; profiling showed it
+  consuming ~57% of all host-process samples during a build (#711). The scan
+  now reads process names first and only pays the `environ()` call for
+  Python interpreters (the only processes that can be clm workers), caches
+  the WORKER_ID → PID map for 5 s so a monitor cycle scans at most once, and
+  re-verifies liveness per call with `psutil.pid_exists`.

--- a/src/clm/core/operations/process_notebook.py
+++ b/src/clm/core/operations/process_notebook.py
@@ -3,6 +3,7 @@ import logging
 from base64 import b64encode
 from functools import cache
 from importlib.resources import files as package_files
+from importlib.resources.abc import Traversable
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +27,39 @@ from clm.infrastructure.utils.path_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_template_bytes(data: bytes) -> bytes:
+    """Collapse CRLF to LF before hashing.
+
+    The same clm version can legitimately carry either line ending: an
+    editable install reads the working tree (CRLF on Windows with
+    ``core.autocrlf=true``), while a wheel/sdist copy is LF-normalized.
+    Hashing raw bytes made two installs of one version disagree on the
+    fingerprint — and therefore on every notebook content hash — so
+    alternating installs thrashed each other's cache (issue #711). The
+    templates are Jinja text; their line endings do not affect rendered
+    output semantics for cache-key purposes.
+    """
+    return data.replace(b"\r\n", b"\n")
+
+
+def _hash_template_dir(prog_lang: str, template_dir: Traversable) -> str:
+    """Digest of *prog_lang* plus the (newline-normalized) files in *template_dir*.
+
+    Split from :func:`compute_template_fingerprint` so tests can point it at
+    synthetic directories (CRLF vs LF twins) instead of the bundled package.
+    """
+    from clm import __version__
+
+    hasher = hashlib.sha256()
+    hasher.update(f"{__version__}:{prog_lang}".encode())
+    if template_dir.is_dir():
+        entries = sorted((entry.name, entry) for entry in template_dir.iterdir() if entry.is_file())
+        for name, entry in entries:
+            hasher.update(f"\n{name}:".encode())
+            hasher.update(_normalize_template_bytes(entry.read_bytes()))
+    return hasher.hexdigest()
 
 
 @cache
@@ -59,18 +93,14 @@ def compute_template_fingerprint(prog_lang: str) -> str:
 
     ``cache`` makes this a one-time cost per prog_lang per process; the
     template directories are a handful of small files.
-    """
-    from clm import __version__
 
-    hasher = hashlib.sha256()
-    hasher.update(f"{__version__}:{prog_lang}".encode())
+    Template bytes are newline-normalized (CRLF → LF) before hashing: an
+    editable install on Windows reads CRLF working-tree files while a wheel
+    install carries LF, and the two must not disagree on the cache key for
+    the same clm version (issue #711).
+    """
     template_dir = package_files("clm") / "workers" / "notebook" / f"templates_{prog_lang}"
-    if template_dir.is_dir():
-        entries = sorted((entry.name, entry) for entry in template_dir.iterdir() if entry.is_file())
-        for name, entry in entries:
-            hasher.update(f"\n{name}:".encode())
-            hasher.update(entry.read_bytes())
-    return hasher.hexdigest()
+    return _hash_template_dir(prog_lang, template_dir)
 
 
 def worker_image_identity_for(execution_mode: str, image: str | None) -> str:

--- a/src/clm/infrastructure/database/executed_notebook_cache.py
+++ b/src/clm/infrastructure/database/executed_notebook_cache.py
@@ -41,6 +41,15 @@ logger = logging.getLogger(__name__)
 #: Anything else is from a version that stored pickles and is unreadable here.
 PAYLOAD_FORMAT = "nbformat-json"
 
+# Value for ``PRAGMA user_version`` marking that the legacy-payload migration
+# (the full-scan DELETE below) has already run for this database file.
+# 0/absent = unmigrated (may contain pickle-era rows); 1 = JSON-only.
+# The marker travels with the DB file, so every process that opens it —
+# backend, workers, CLI — pays the scan at most once per database, instead
+# of on every connection open (issue #711: the per-op opens in the
+# recording/speaker replay gate made this 15% of cached-phase host time).
+_USER_VERSION_JSON_ONLY = 1
+
 
 class ExecutedNotebookCache:
     """Manages caching of executed notebooks for reuse across HTML variants.
@@ -91,7 +100,14 @@ class ExecutedNotebookCache:
         deletes every row this version cannot read. The delete is deliberate
         and not recoverable — a pickle payload is exactly what we refuse to
         deserialize, and this is a cache: the entries regenerate on the next
-        build.
+        build. Any legacy row that slips past (e.g. written by an older clm
+        after migration) is still safe: readers treat unparsable payloads as
+        cache misses.
+
+        The migration runs once per database file, gated on
+        ``PRAGMA user_version`` — not on every connection open. Steady-state
+        opens (several hundred per build via the recording/speaker replay
+        gate) then cost only the CREATE IF NOT EXISTS schema checks.
         """
         assert self.conn is not None, "Connection not initialized"
         cursor = self.conn.cursor()
@@ -123,15 +139,18 @@ class ExecutedNotebookCache:
                 "payload_format TEXT NOT NULL DEFAULT 'pickle'"
             )
 
-        cursor.execute(
-            "DELETE FROM executed_notebooks WHERE payload_format != ?",
-            (PAYLOAD_FORMAT,),
-        )
-        if cursor.rowcount > 0:
-            logger.info(
-                f"Discarded {cursor.rowcount} executed-notebook cache entries in the "
-                f"legacy pickle format; they will be re-executed and re-cached."
+        (user_version,) = cursor.execute("PRAGMA user_version").fetchone()
+        if user_version < _USER_VERSION_JSON_ONLY:
+            cursor.execute(
+                "DELETE FROM executed_notebooks WHERE payload_format != ?",
+                (PAYLOAD_FORMAT,),
             )
+            if cursor.rowcount > 0:
+                logger.info(
+                    f"Discarded {cursor.rowcount} executed-notebook cache entries in the "
+                    f"legacy pickle format; they will be re-executed and re-cached."
+                )
+            cursor.execute(f"PRAGMA user_version = {_USER_VERSION_JSON_ONLY}")
 
         assert self.conn is not None  # Already checked above, but reassure mypy
         self.conn.commit()

--- a/src/clm/infrastructure/workers/worker_executor.py
+++ b/src/clm/infrastructure/workers/worker_executor.py
@@ -9,6 +9,7 @@ import os
 import signal
 import subprocess
 import sys
+import time
 import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -623,6 +624,8 @@ class DirectWorkerExecutor(WorkerExecutor):
         self.notebook_kernel_python = notebook_kernel_python
         self.processes: dict[str, subprocess.Popen] = {}
         self.worker_info: dict[str, dict] = {}  # worker_id -> {type, index, etc.}
+        # TTL cache for the system-wide WORKER_ID scan, see _scan_worker_processes.
+        self._liveness_scan_cache: tuple[float, dict[str, int]] | None = None
 
         # Provision the course kernelspec once (idempotent) so every notebook
         # worker this executor starts shares one JUPYTER_PATH root. Fails fast
@@ -906,16 +909,49 @@ class DirectWorkerExecutor(WorkerExecutor):
 
         # If not in our dict, check if process exists system-wide via psutil.
         # This handles the case where a different executor instance started it.
-        for proc in psutil.process_iter(["pid", "environ"]):
+        pid = self._scan_worker_processes().get(worker_id)
+        if pid is None:
+            return False
+        # The map is TTL-cached; re-verify the PID is actually alive so a
+        # worker that crashed mid-cycle is still detected promptly.
+        return bool(psutil.pid_exists(pid))
+
+    # How long a system-wide WORKER_ID → PID scan stays valid. The health
+    # monitor checks every worker once per cycle, so calls cluster: one scan
+    # serves the whole cycle instead of one scan per worker.
+    _LIVENESS_SCAN_TTL_SECONDS = 5.0
+
+    def _scan_worker_processes(self) -> dict[str, int]:
+        """Map WORKER_ID → PID for clm worker processes, system-wide (TTL-cached).
+
+        Reading a process's environment on Windows is an OpenProcess + PEB
+        read *per process*, so the previous
+        ``process_iter(["pid", "environ"])`` + ``environ()`` sweep over every
+        process on the system cost seconds per scan under load — and the
+        health monitor ran it per worker per cycle (measured: ~57% of all
+        host-process samples during a build, issue #711). Process names are
+        cheap to read, so only Python interpreters (the only processes that
+        can be clm workers) pay the ``environ()`` call, and the result is
+        cached for a few seconds so a monitor cycle scans at most once.
+        """
+        now = time.monotonic()
+        if self._liveness_scan_cache is not None:
+            ts, cached = self._liveness_scan_cache
+            if now - ts < self._LIVENESS_SCAN_TTL_SECONDS:
+                return cached
+        workers: dict[str, int] = {}
+        for proc in psutil.process_iter(["pid", "name"]):
             try:
+                if "python" not in (proc.info.get("name") or "").lower():
+                    continue
                 env = proc.environ()
-                if env.get("WORKER_ID") == worker_id:
-                    return bool(proc.is_running())
+                worker_id = env.get("WORKER_ID")
+                if worker_id:
+                    workers[worker_id] = proc.info["pid"]
             except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
                 continue
-
-        # Could not verify - assume not running
-        return False
+        self._liveness_scan_cache = (now, workers)
+        return workers
 
     def get_worker_stats(self, worker_id: str) -> dict | None:
         """Get resource usage statistics for a direct process worker.

--- a/tests/core/operations/test_process_notebook.py
+++ b/tests/core/operations/test_process_notebook.py
@@ -8,6 +8,7 @@ directory, shipped via ``NotebookPayload.template_fingerprint``) and
 """
 
 from clm.core.operations.process_notebook import (
+    _hash_template_dir,
     compute_template_fingerprint,
     compute_worker_image_identity,
     worker_image_identity_for,
@@ -50,6 +51,37 @@ class TestComputeTemplateFingerprint:
         compute_template_fingerprint.cache_clear()
         second = compute_template_fingerprint("cpp")
         assert first == second
+
+    def test_crlf_and_lf_templates_hash_identically(self, tmp_path):
+        """A CRLF working tree (Windows editable install, autocrlf=true) and
+        an LF-normalized copy (wheel/sdist install) of the SAME templates
+        must yield the same fingerprint — raw-byte hashing made two installs
+        of one clm version disagree on every notebook cache key and thrash
+        each other's cache (issue #711)."""
+        lf_dir = tmp_path / "lf"
+        crlf_dir = tmp_path / "crlf"
+        lf_dir.mkdir()
+        crlf_dir.mkdir()
+        (lf_dir / "macros.j2").write_bytes(b"{% macro a() %}\nbody\n{% endmacro %}\n")
+        (crlf_dir / "macros.j2").write_bytes(b"{% macro a() %}\r\nbody\r\n{% endmacro %}\r\n")
+        assert _hash_template_dir("python", lf_dir) == _hash_template_dir("python", crlf_dir)
+
+    def test_content_difference_still_changes_fingerprint(self, tmp_path):
+        """Newline normalization must not blunt real content sensitivity:
+        actually different template text still produces a different key."""
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        (dir_a / "macros.j2").write_bytes(b"version A\n")
+        (dir_b / "macros.j2").write_bytes(b"version B\n")
+        assert _hash_template_dir("python", dir_a) != _hash_template_dir("python", dir_b)
+
+    def test_missing_dir_hashes_version_and_lang_only(self, tmp_path):
+        """A nonexistent template dir must not crash and must still vary by
+        prog_lang (mirrors the unknown-language behavior of the public API)."""
+        missing = tmp_path / "no-such-dir"
+        assert _hash_template_dir("python", missing) != _hash_template_dir("cpp", missing)
 
 
 class TestWorkerImageIdentity:

--- a/tests/infrastructure/database/test_executed_notebook_cache.py
+++ b/tests/infrastructure/database/test_executed_notebook_cache.py
@@ -11,6 +11,7 @@ import pytest
 from nbformat.v4 import new_code_cell, new_markdown_cell, new_notebook
 
 from clm.infrastructure.database.executed_notebook_cache import (
+    _USER_VERSION_JSON_ONLY,
     PAYLOAD_FORMAT,
     ExecutedNotebookCache,
 )
@@ -331,3 +332,53 @@ class TestPickleEradication:
             cache.conn.commit()
 
             assert cache.get("/path/nb.py", "hash1", "en", "python") is None
+
+    def test_marks_database_migrated_via_user_version(self, temp_db_path):
+        """Opening stamps ``PRAGMA user_version`` so later opens can skip the
+        migration scan (issue #711 — the per-op opens in the replay gate made
+        the full-scan DELETE 15% of cached-phase host time)."""
+        with ExecutedNotebookCache(temp_db_path):
+            pass
+        conn = sqlite3.connect(str(temp_db_path))
+        (user_version,) = conn.execute("PRAGMA user_version").fetchone()
+        conn.close()
+        assert user_version == _USER_VERSION_JSON_ONLY
+
+    def test_migration_runs_once_not_on_every_open(self, temp_db_path, sample_notebook):
+        """After migration, reopening must NOT rerun the full-scan DELETE.
+
+        A legacy-format row written *after* migration (e.g. by an older clm
+        sharing the cache DB) surviving a reopen proves the scan was gated
+        off. The row is still harmless: readers treat it as a cache miss.
+        """
+        with ExecutedNotebookCache(temp_db_path) as cache:
+            cache.store("/path/nb.py", "hash-json", "en", "python", sample_notebook)
+
+        # Simulate an older clm writing a pickle row into the migrated DB.
+        conn = sqlite3.connect(str(temp_db_path))
+        conn.execute(
+            "INSERT INTO executed_notebooks "
+            "(input_file, content_hash, language, prog_lang, executed_notebook, payload_format) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "/path/old.py",
+                "hash-legacy",
+                "en",
+                "python",
+                pickle.dumps(sample_notebook),
+                "pickle",
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        with ExecutedNotebookCache(temp_db_path) as cache:
+            rows = cache.conn.execute(
+                "SELECT COUNT(*) FROM executed_notebooks WHERE payload_format != ?",
+                (PAYLOAD_FORMAT,),
+            ).fetchone()[0]
+            assert rows == 1  # not purged again — the DELETE did not rerun
+            # ...but it still cannot be read back as a hit.
+            assert cache.get("/path/old.py", "hash-legacy", "en", "python") is None
+            # And the JSON row written before is unaffected.
+            assert cache.get("/path/nb.py", "hash-json", "en", "python") is not None

--- a/tests/infrastructure/workers/test_worker_executor.py
+++ b/tests/infrastructure/workers/test_worker_executor.py
@@ -478,6 +478,127 @@ class TestDirectWorkerExecutor:
             assert mock_killpg.call_count == 2
 
 
+class TestLivenessScan:
+    """System-wide WORKER_ID scan used when the worker is not in the local
+    process dict (worker started by a different executor instance).
+
+    The scan must stay cheap on Windows: reading a process environment is a
+    PEB read per process, so only Python interpreters may pay it, and a
+    monitor cycle (one call per worker) must share a single scan (#711).
+    """
+
+    @staticmethod
+    def _fake_proc(pid, name, env=None, environ_raises=None):
+        proc = MagicMock()
+        proc.info = {"pid": pid, "name": name}
+        if environ_raises is not None:
+            proc.environ.side_effect = environ_raises
+        else:
+            proc.environ.return_value = env or {}
+        return proc
+
+    def test_scan_reads_environ_only_for_python_processes(self, db_path, workspace_path):
+        executor = DirectWorkerExecutor(db_path=db_path, workspace_path=workspace_path)
+        worker = self._fake_proc(101, "python.exe", {"WORKER_ID": "direct-notebook-0-aaa"})
+        system_proc = self._fake_proc(
+            102, "svchost.exe", environ_raises=AssertionError("must not read environ")
+        )
+        other = self._fake_proc(
+            103, "chrome.exe", environ_raises=AssertionError("must not read environ")
+        )
+
+        with (
+            patch(
+                "clm.infrastructure.workers.worker_executor.psutil.process_iter",
+                return_value=[system_proc, worker, other],
+            ),
+            patch(
+                "clm.infrastructure.workers.worker_executor.psutil.pid_exists", return_value=True
+            ),
+        ):
+            assert executor.is_worker_running("direct-notebook-0-aaa") is True
+
+    def test_scan_unknown_worker_returns_false(self, db_path, workspace_path):
+        executor = DirectWorkerExecutor(db_path=db_path, workspace_path=workspace_path)
+        worker = self._fake_proc(101, "python.exe", {"WORKER_ID": "direct-notebook-0-aaa"})
+
+        with patch(
+            "clm.infrastructure.workers.worker_executor.psutil.process_iter", return_value=[worker]
+        ):
+            assert executor.is_worker_running("direct-notebook-1-bbb") is False
+
+    def test_scan_is_cached_across_calls_within_ttl(self, db_path, workspace_path):
+        executor = DirectWorkerExecutor(db_path=db_path, workspace_path=workspace_path)
+        procs = [
+            self._fake_proc(101, "python.exe", {"WORKER_ID": "w-a"}),
+            self._fake_proc(102, "python.exe", {"WORKER_ID": "w-b"}),
+        ]
+
+        with (
+            patch(
+                "clm.infrastructure.workers.worker_executor.psutil.process_iter", return_value=procs
+            ) as mock_iter,
+            patch(
+                "clm.infrastructure.workers.worker_executor.psutil.pid_exists", return_value=True
+            ),
+        ):
+            assert executor.is_worker_running("w-a") is True
+            assert executor.is_worker_running("w-b") is True
+            assert mock_iter.call_count == 1  # one scan served both lookups
+
+    def test_scan_cache_expires_after_ttl(self, db_path, workspace_path):
+        executor = DirectWorkerExecutor(db_path=db_path, workspace_path=workspace_path)
+        procs = [self._fake_proc(101, "python.exe", {"WORKER_ID": "w-a"})]
+
+        with (
+            patch(
+                "clm.infrastructure.workers.worker_executor.psutil.process_iter", return_value=procs
+            ) as mock_iter,
+            patch(
+                "clm.infrastructure.workers.worker_executor.psutil.pid_exists", return_value=True
+            ),
+        ):
+            assert executor.is_worker_running("w-a") is True
+            # Force the cache to expire.
+            ts, cached = executor._liveness_scan_cache
+            executor._liveness_scan_cache = (ts - executor._LIVENESS_SCAN_TTL_SECONDS - 1, cached)
+            assert executor.is_worker_running("w-a") is True
+            assert mock_iter.call_count == 2
+
+    def test_scan_tolerates_access_denied(self, db_path, workspace_path):
+        import psutil
+
+        executor = DirectWorkerExecutor(db_path=db_path, workspace_path=workspace_path)
+        denied = self._fake_proc(100, "python.exe", environ_raises=psutil.AccessDenied(pid=100))
+        worker = self._fake_proc(101, "python.exe", {"WORKER_ID": "w-a"})
+
+        with (
+            patch(
+                "clm.infrastructure.workers.worker_executor.psutil.process_iter",
+                return_value=[denied, worker],
+            ),
+            patch(
+                "clm.infrastructure.workers.worker_executor.psutil.pid_exists", return_value=True
+            ),
+        ):
+            assert executor.is_worker_running("w-a") is True
+
+    def test_crash_after_scan_detected_via_pid_exists(self, db_path, workspace_path):
+        """The TTL-cached map must not mask a crash: pid_exists re-verifies."""
+        executor = DirectWorkerExecutor(db_path=db_path, workspace_path=workspace_path)
+        procs = [self._fake_proc(101, "python.exe", {"WORKER_ID": "w-a"})]
+
+        with (
+            patch(
+                "clm.infrastructure.workers.worker_executor.psutil.process_iter", return_value=procs
+            ),
+            patch(
+                "clm.infrastructure.workers.worker_executor.psutil.pid_exists", return_value=False
+            ),
+        ):
+            assert executor.is_worker_running("w-a") is False
+
+
 class TestDockerWorkerExecutor:
     """Tests for DockerWorkerExecutor."""
 


### PR DESCRIPTION
Implements the top three optimization candidates from the #711 investigation (recorded in `docs/claude/cache-performance-investigation.md`, merged via #712). All measured on a real AZAV 2026-04 build profile.

## Commits

**1. `fix(cache)`: newline-normalize the template fingerprint** — the root cause of the mass `content hash changed` storms. `compute_template_fingerprint` hashed raw template bytes; a Windows editable install (`core.autocrlf=true`, CRLF working tree) and a wheel/sdist install (LF) of the *same* clm version produced different fingerprints → different content hash for every notebook → total cache invalidation whenever builds alternated installs (measured: ~3000/5800 ops rebuilt on a single switch; same deck flipped hashes within one build session with unchanged sources). Template bytes are now CRLF→LF normalized before hashing. One-time fingerprint change for CRLF installs (their next build refreshes once, as with any template change). Core digest split into `_hash_template_dir` so tests point it at synthetic CRLF/LF twin directories.

**2. `perf(cache)`: run the executed-notebook migration once per DB, not per open.** `ExecutedNotebookCache._init_table` ran a full-scan legacy-purge `DELETE` + commit on *every* connection open, and `_can_replay_from_cache` opens a fresh connection per recording/speaker HTML op — several hundred opens per build. py-spy: **15% of MainThread time in the cached phase**. Now gated on `PRAGMA user_version` (marker travels with the DB file; backend, workers, and CLI each pay the scan at most once). Safety: a legacy row written by an older clm after migration still degrades to a cache miss at read time (pinned by tests).

**3. `perf(workers)`: cheap worker-liveness scan for the health monitor.** `is_worker_running`'s fallback read *every* process's environment block (`process_iter(["pid","environ"])` — OpenProcess + PEB read per process, seconds per scan on Windows), once per worker per 10 s monitor cycle. py-spy: **~57% of all host-process samples**. Now: name-first filtering (only Python interpreters pay `environ()`), a 5 s TTL cache on the WORKER_ID→PID map (one scan per monitor cycle, not per worker), and `psutil.pid_exists` re-verification per call so mid-cycle crashes are still caught promptly.

## Tests

- 9 new tests total: CRLF/LF twin-dir fingerprint equality + sensitivity, migration-once gating + `user_version` stamping + post-migration legacy-row behavior, scan narrowing/TTL/expiry/AccessDenied/crash-detection.
- Full fast suite: **9192 passed, 7 skipped, 1 xfailed** (was green before push via pre-push hook too).

Refs #711. Not closing it — remaining candidates there: notebook-worker default for large courses, the 1200 s notebook hangs, per-file dependency hashing.