### PR TITLE
docs(sync): close out adversarial-review Phase 0; document the anchor-adjacency refusal

### DIFF
--- a/docs/claude/sync-v3-adversarial-review.md
+++ b/docs/claude/sync-v3-adversarial-review.md
@@ -453,6 +453,19 @@ urgency).**
    offenders degrade to cold) (C6).
 5. `copy_new` lang-attribute swap on `treat_as_new`/`keep` paths (M9).
 
+*Status: **complete 2026-07-29** — issues #716–#720, PRs #721–#725, merged
+sequentially, each with failing-before regression tests, a §13 amendments
+row in the design note, and a changelog fragment (item 1 → #716, item 2 →
+#720, item 3 → #719, item 4 → #718, item 5 → #717). Two documented
+deviations from the prescriptions above: item 4 shipped as an extended
+`rename_group_scopes` (all four reference classes: pos keys, order-scope
+keys, owner refs, member-order `id:` handles) plus a save-time
+`prune_dangling_refs` sweep, rather than `migrate_ledger_key` — stale
+handles are dropped and a dangling owner degrades to `None`, not cold; item
+5's severity was corrected to defense-in-depth on the issue (the e2e probes
+showed the suspect shapes route to `fork_pending_twin` before reaching
+`copy_new`). See the design note's §13 rows for the shipped mechanisms.*
+
 **Phase 1 — make order first-class (the #615 treatment).** Frame
 `order_decision` from *current* cross-side evidence even with no/thin base
 (the executor already resolves `de`/`en` from current state); keep

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -247,6 +247,14 @@ a warning in `sync verify` output, but it **blocks** `record` and `apply`'s
 ledger save: reorder one half so the twins mirror (`clm validate` names the
 diverging sequences too), then re-run.
 
+The same divergence has a write-path guard: minting a slide's missing twin
+(`copy_new_shared` / `translate_new` on a slide or subslide cell) **fails
+that one item** when the computed insert position would separate the slide
+from its group's existing cells on the other half — the reason reads
+"cannot mint the … twin … the halves' group order diverges". This is not a
+whole-pass abort: all other items still land. The remedy is the same as for
+`order-parity` — reorder one half so the twins mirror, then re-apply.
+
 ## Cold members and `record`
 
 A brand-new checkout, a never-synced deck, or a deck whose ledger entries


### PR DESCRIPTION
Follow-up documentation for the Phase 0 remediation push (issues #716-#720, PRs #721-#725).

## Changes

- **`docs/claude/sync-v3-adversarial-review.md` §8**: annotate Phase 0 as **complete 2026-07-29** with the item → issue/PR mapping, so a reader of the remediation program doesn't need session memory to know it shipped. Records the two documented deviations from the §8 prescriptions: item 4 shipped as an extended `rename_group_scopes` (all four reference classes) plus a save-time `prune_dangling_refs` sweep rather than `migrate_ledger_key`, and item 5's severity was corrected to defense-in-depth on the issue.
- **`src/clm/cli/info_topics/sync-agents.md`**: name the #720 write-path guard right next to the `order-parity` violation it mirrors — minting an anchor twin that would land away from its group's existing cells fails that one item (not the whole pass) with a reorder-first reason. Agents hitting this in course repos now find the remedy in `clm info sync-agents`.

No code changes; no changelog fragment (the behavior itself is covered by the existing #719/#720 fragments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh
