### PR TITLE
docs(release): evergreen freshness is fixed at build time (#657)

### DIFF
--- a/changelog.d/657-evergreen-freshness-note.fixed.md
+++ b/changelog.d/657-evergreen-freshness-note.fixed.md
@@ -1,0 +1,5 @@
+- `clm info releases` and `clm release sync --help` now state that evergreen
+  freshness is fixed at **build** time (#657): regenerate the sources of
+  evergreen files (exported outlines, schedules — often a spec-declared
+  task) before `clm build`, or the sync truthfully reports `up-to-date` for
+  the stale content the build baked in and ships it to the cohort.

--- a/src/clm/cli/commands/release.py
+++ b/src/clm/cli/commands/release.py
@@ -842,7 +842,10 @@ def sync_cmd(
     Skeleton files matching an evergreen pattern (the channel's ``<evergreen>``
     declarations plus any ``--evergreen`` options) are exempt from the
     skeleton freeze: each sync re-copies a matching file whose built content
-    differs from the cohort's copy.
+    differs from the cohort's copy. Evergreen freshness is fixed at build
+    time — regenerate the sources of evergreen files (exported outlines,
+    schedules) before ``clm build``, or the sync reports ``up-to-date`` for
+    the stale content the build baked in (issue #657).
     """
     if channels or all_channels:
         if spec_file is None:

--- a/src/clm/cli/info_topics/releases.md
+++ b/src/clm/cli/info_topics/releases.md
@@ -191,7 +191,14 @@ Skeleton (global files) is copied once on first sync and then frozen —
 **except evergreen files**: skeleton files matching the channel's
 `<evergreen>` patterns (or `--evergreen` options) plan `refresh` whenever the
 built content differs from the cohort's copy, and `up-to-date` otherwise.
-Evergreen is skeleton-only; patterns matching topic-owned files are warned
+**Evergreen freshness is fixed at build time**: the sync compares the
+cohort's copy against the *built* content, so regenerate the sources of
+evergreen files (e.g. exported outlines or schedules, often produced by a
+spec-declared task via `clm export outline` / `clm calendar generate`)
+**before** `clm build` — otherwise the sync truthfully reports
+`up-to-date` for the stale content the build baked in, and a `refresh` you
+expect never appears. Evergreen is skeleton-only; patterns matching
+topic-owned files are warned
 about and ignored (topic content changes only via `--refreeze`). The
 comparison is stateless (destination hash vs. manifest hash), so nothing is
 recorded in the frozen manifest and re-runs are idempotent.

--- a/src/clm/cli/info_topics/releases.md
+++ b/src/clm/cli/info_topics/releases.md
@@ -191,18 +191,19 @@ Skeleton (global files) is copied once on first sync and then frozen —
 **except evergreen files**: skeleton files matching the channel's
 `<evergreen>` patterns (or `--evergreen` options) plan `refresh` whenever the
 built content differs from the cohort's copy, and `up-to-date` otherwise.
-**Evergreen freshness is fixed at build time**: the sync compares the
-cohort's copy against the *built* content, so regenerate the sources of
-evergreen files (e.g. exported outlines or schedules, often produced by a
-spec-declared task via `clm export outline` / `clm calendar generate`)
-**before** `clm build` — otherwise the sync truthfully reports
-`up-to-date` for the stale content the build baked in, and a `refresh` you
-expect never appears. Evergreen is skeleton-only; patterns matching
-topic-owned files are warned
+Evergreen is skeleton-only; patterns matching topic-owned files are warned
 about and ignored (topic content changes only via `--refreeze`). The
 comparison is stateless (destination hash vs. manifest hash), so nothing is
 recorded in the frozen manifest and re-runs are idempotent.
 `--push` chains `clm git commit` + `clm git push` after promotion.
+
+**Evergreen freshness is fixed at build time**: the sync compares the
+cohort's copy against the *built* content, so regenerate the sources of
+evergreen files (e.g. exported outlines or schedules, often produced by a
+spec-declared task via `clm export outline` / `clm calendar generate`)
+**before** `clm build` — otherwise the sync truthfully reports `up-to-date`
+for the stale content the build baked in, and a `refresh` you expect never
+appears.
 
 ### Shared destination: several streams, one cohort repo
 


### PR DESCRIPTION
Closes #657.

Adds the missing when-is-freshness-decided warning to the evergreen documentation, per the issue's suggested wording:

- **`clm info releases`** (the evergreen paragraph): evergreen freshness is fixed at build time — regenerate the sources of evergreen files (exported outlines/schedules, often a spec-declared task) **before** `clm build`, or the sync truthfully reports `up-to-date` for the stale content the build baked in.
- **`clm release sync --help`**: one-sentence version of the same warning in the docstring's evergreen paragraph.
- Changelog fragment.

Docs-only; no behavior change. The field incident: a dry run showed `evergreen: 7 file(s) up-to-date`, the build was started, and only afterwards was it clear the outline/schedule sources had never been regenerated — the sync would have shipped stale overview content to students while reporting up-to-date.

## Checks

ruff + mypy green (pre-commit); fast suite green (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh
