### PR TITLE
fix(build): one canonical workshop range detector for validator, export, and partial builds (#732)

### DIFF
--- a/changelog.d/732-workshop-detector-unify.fixed.md
+++ b/changelog.d/732-workshop-detector-unify.fixed.md
@@ -2,9 +2,13 @@
   opener forms (#732). The build carried a tag-only duplicate of the range
   detector, so a workshop opened only by the sanctioned `workshop-…`
   slide_id form passed `clm validate` but its partial build detected no
-  range — the starter cell was deleted and the full solution shipped
-  unblanked. One canonical detector (`clm.slides.workshop_scope`) now backs
-  the validator, `clm export`, and the build. The validator's
-  orphan-`end-workshop` warning uses the same opener predicate, so a
-  slide_id-opened workshop's closer no longer warns "the tag has no
+  range — the full solution shipped unblanked. One canonical detector
+  (`clm.slides.workshop_scope`) now backs the validator, `clm export`, and
+  the build — including the cached-HTML partial path: the cached executed
+  notebook now retains `slide_id`/`for_slide` metadata (stripped at the
+  export boundaries instead of before the cache write), and the notebook
+  cache schema version was bumped, so the first build after upgrading
+  re-executes once instead of replaying stale slide_id-less artifacts. The
+  validator's orphan-`end-workshop` warning uses the same opener predicate,
+  so a slide_id-opened workshop's closer no longer warns "the tag has no
   effect".

--- a/changelog.d/732-workshop-detector-unify.fixed.md
+++ b/changelog.d/732-workshop-detector-unify.fixed.md
@@ -1,0 +1,10 @@
+- `clm build`: the `partial` output kind now recognizes **both** workshop
+  opener forms (#732). The build carried a tag-only duplicate of the range
+  detector, so a workshop opened only by the sanctioned `workshop-…`
+  slide_id form passed `clm validate` but its partial build detected no
+  range — the starter cell was deleted and the full solution shipped
+  unblanked. One canonical detector (`clm.slides.workshop_scope`) now backs
+  the validator, `clm export`, and the build. The validator's
+  orphan-`end-workshop` warning uses the same opener predicate, so a
+  slide_id-opened workshop's closer no longer warns "the tag has no
+  effect".

--- a/src/clm/cli/info_topics/slide-format.md
+++ b/src/clm/cli/info_topics/slide-format.md
@@ -101,11 +101,10 @@ A workshop **opens** at either
   `workshop-` — the deck-level convention when the announcement slide is a
   regular slide. Voiceover/notes cells sharing that slide's id do not
   open or fragment a scope, and neither opener form counts on a code cell.
-  **Caveat (issue #732)**: the notebook build's `partial` output currently
-  recognizes only the **tag** form — a deck relying on the slide_id form
-  alone passes validation but its partial build detects no range (starter
-  deleted, solution emitted in full). Until #732 lands, also tag the
-  opening cell with `workshop`.
+  Both opener forms are honored everywhere — the validator, `clm export`,
+  and the notebook build's `partial` output share one detector (since
+  {version}, issue #732; older versions' partial builds recognized only
+  the tag form).
 
 It **closes** (exclusively — the closing cell is *outside* the workshop) at
 the first of:

--- a/src/clm/infrastructure/messaging/notebook_classes.py
+++ b/src/clm/infrastructure/messaging/notebook_classes.py
@@ -5,12 +5,17 @@ from typing import Any, Literal
 from clm.infrastructure.messaging.base_classes import Payload, ProcessingError, Result
 
 # Version tag folded into every notebook cache hash. Bump whenever the
-# *composition* of ``content_hash()`` / ``execution_cache_hash()`` changes so
-# that stale cache entries produced under the old key schema can never be
-# replayed as hits under the new one. Bumping invalidates all existing
-# notebook caches (one full re-execution on the next build) — deliberate and
-# visible, instead of an accidental partial overlap between key schemas.
-CACHE_HASH_SCHEMA_VERSION = 2
+# *composition* of ``content_hash()`` / ``execution_cache_hash()`` changes —
+# or the *shape of the cached artifact* itself changes — so that stale cache
+# entries produced under the old schema can never be replayed as hits under
+# the new one. Bumping invalidates all existing notebook caches (one full
+# re-execution on the next build) — deliberate and visible, instead of an
+# accidental partial overlap between key schemas.
+# v3 (#732): cached executed notebooks now retain ``slide_id``/``for_slide``
+# cell metadata (the cached-partial path recomputes workshop ranges and must
+# see the slide_id opener form); pre-v3 artifacts lack it and would silently
+# keep the tag-only range detection.
+CACHE_HASH_SCHEMA_VERSION = 3
 
 
 def notebook_metadata(kind, prog_lang, language, output_format) -> str:

--- a/src/clm/slides/validator.py
+++ b/src/clm/slides/validator.py
@@ -42,7 +42,7 @@ from clm.slides.slug import (
 )
 from clm.slides.split import _is_shared
 from clm.slides.tags import ALL_VALID_TAGS, EXPECTED_CODE_TAGS, EXPECTED_MARKDOWN_TAGS
-from clm.slides.workshop_scope import find_workshop_ranges, is_in_workshop
+from clm.slides.workshop_scope import find_workshop_ranges, is_in_workshop, is_workshop_opener
 
 # ---------------------------------------------------------------------------
 # Result types
@@ -418,13 +418,15 @@ def _check_tags(cells: list[Cell], file_path: str) -> list[Finding]:
     pending_starts: dict[str | None, Cell] = {}
 
     # Flag orphan ``end-workshop`` cells (any cell type — issue #362 allows
-    # the tag on code cells too) that appear BEFORE any ``workshop`` heading
+    # the tag on code cells too) that appear BEFORE any workshop opener
     # in the file — those have no effect on the partition and almost always
-    # indicate a typo. Only markdown cells open a workshop, so only they set
-    # ``seen_workshop``. After at least one workshop has been opened,
-    # additional ``end-workshop`` markers are tolerated: bilingual slide
-    # pairs typically carry the tag on both the DE and EN heading cells, and
-    # the second one (after the first has already closed the workshop) is
+    # indicate a typo. ``seen_workshop`` uses the canonical opener predicate
+    # (issue #732): a workshop opened by the ``workshop-…`` slide_id form
+    # used to trip this warning although the scope machinery honors its
+    # closer. After at least one workshop has been opened, additional
+    # ``end-workshop`` markers are tolerated: bilingual slide pairs
+    # typically carry the tag on both the DE and EN heading cells, and the
+    # second one (after the first has already closed the workshop) is
     # harmless.
     seen_workshop = False
     for cell in cells:
@@ -432,7 +434,7 @@ def _check_tags(cells: list[Cell], file_path: str) -> list[Finding]:
         if meta.is_j2:
             continue
         cell_tags = meta.tags
-        if meta.cell_type == "markdown" and "workshop" in cell_tags:
+        if is_workshop_opener(cell):
             seen_workshop = True
         elif "end-workshop" in cell_tags and not seen_workshop:
             findings.append(
@@ -442,12 +444,13 @@ def _check_tags(cells: list[Cell], file_path: str) -> list[Finding]:
                     file=file_path,
                     line=cell.line_number,
                     message=(
-                        "'end-workshop' tag with no preceding 'workshop' heading "
+                        "'end-workshop' tag with no preceding workshop opener "
                         "— the tag has no effect"
                     ),
                     suggestion=(
-                        "Remove 'end-workshop' or add a 'workshop'-tagged "
-                        "markdown cell earlier in the file"
+                        "Remove 'end-workshop', or open a workshop earlier in "
+                        "the file (a 'workshop'-tagged markdown cell, or a "
+                        "slide-start cell whose slide_id begins 'workshop-')"
                     ),
                 )
             )

--- a/src/clm/slides/workshop_scope.py
+++ b/src/clm/slides/workshop_scope.py
@@ -48,12 +48,14 @@ class _CellLike(Protocol):
     def slide_id(self) -> str | None: ...
 
 
-def _is_workshop_opener(cell: _CellLike) -> bool:
+def is_workshop_opener(cell: _CellLike) -> bool:
     """Detect either the ``workshop`` tag or a ``workshop-…`` slide_id opener.
 
     The slide_id form only counts on slide-start cells (``slide`` /
     ``subslide``) so that voiceover or notes cells inheriting the same
     slide_id from the announcement slide do not re-trigger a new range.
+    Public since #732: the validator's orphan-``end-workshop`` check and
+    the notebook build must recognize the same openers this module does.
     """
     if cell.cell_type != "markdown":
         return False
@@ -76,7 +78,7 @@ def find_workshop_ranges(cells: Sequence[_CellLike]) -> list[tuple[int, int]]:
     ranges: list[tuple[int, int]] = []
     open_start: int | None = None
     for i, cell in enumerate(cells):
-        if _is_workshop_opener(cell):
+        if is_workshop_opener(cell):
             if open_start is not None:
                 ranges.append((open_start, i))
             open_start = i

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -443,6 +443,27 @@ def _strip_lines_to_next_cell(cells: Iterable[Cell]) -> None:
             metadata.pop("lines_to_next_cell", None)
 
 
+def _strip_internal_cell_metadata(cells: Iterable[Cell]) -> None:
+    """Strip ``slide_id``/``for_slide`` and the synthetic post-workshop tag.
+
+    Internal CLM metadata that must never appear in an output artifact. Runs
+    at the export boundaries: inside ``_process_notebook_node`` for
+    non-caching specs, right before the HTML export for the caching spec
+    (whose *cached* notebook deliberately retains ``slide_id`` so the
+    cached-partial path can recompute workshop ranges — issue #732), and in
+    the cached-reuse filters after their range computation.
+    """
+    for cell in cells:
+        metadata = cell.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        metadata.pop("slide_id", None)
+        metadata.pop("for_slide", None)
+        tags = metadata.get("tags")
+        if tags and POST_WORKSHOP_TAG in tags:
+            metadata["tags"] = [t for t in tags if t != POST_WORKSHOP_TAG]
+
+
 # Regex pattern to match img and video tags with src="img/..." paths
 # Captures: prefix (before img/), filename (after img/), suffix (rest of tag)
 MEDIA_SRC_PATTERN = re.compile(r'(<(?:img|video)\s+[^>]*src=["\'])img/([^"\']+)(["\'][^>]*>)')
@@ -985,6 +1006,9 @@ class NotebookProcessor:
             for cell in filtered_nb.get("cells", [])
             if not {"notes", "voiceover"}.intersection(get_tags(cell))
         ]
+        # The cached notebook retains slide_id/for_slide (#732) — never let
+        # them reach the exported HTML.
+        _strip_internal_cell_metadata(filtered_nb.cells)
         return filtered_nb
 
     def _filter_cached_notebook_for_partial(self, nb: NotebookNode) -> NotebookNode:
@@ -1004,6 +1028,9 @@ class NotebookProcessor:
         """
         filtered_nb = copy.deepcopy(nb)
         cells = filtered_nb.get("cells", [])
+        # The cached notebook retains slide_id metadata precisely so this
+        # range computation can see the slide_id opener form (#732) — the
+        # strip below runs only after the ranges are fixed.
         ranges = find_workshop_ranges(cells)
 
         pre_drop = {"notes", "voiceover"}
@@ -1034,6 +1061,9 @@ class NotebookProcessor:
             new_cells.append(cell)
 
         filtered_nb.cells = new_cells
+        # Ranges are computed — the internal metadata must not reach the
+        # exported HTML (#732).
+        _strip_internal_cell_metadata(new_cells)
         return filtered_nb
 
     async def load_and_expand_jinja_template(
@@ -1204,16 +1234,16 @@ class NotebookProcessor:
             for index, cell in enumerate(source_cells)
             if self.output_spec.is_cell_included(cell)
         ]
-        # Strip slide_id and for_slide from cell metadata — these are
-        # internal CLM metadata and must never appear in output.
-        # Also strip the synthetic _post_workshop tag attached by
-        # PartialOutput.annotate_cells.
-        for cell in new_cells:
-            cell["metadata"].pop("slide_id", None)
-            cell["metadata"].pop("for_slide", None)
-            tags = cell["metadata"].get("tags")
-            if tags and POST_WORKSHOP_TAG in tags:
-                cell["metadata"]["tags"] = [t for t in tags if t != POST_WORKSHOP_TAG]
+        # Strip slide_id/for_slide (internal CLM metadata that must never
+        # appear in output) and the synthetic _post_workshop tag attached by
+        # PartialOutput.annotate_cells. A CACHING spec (Recording HTML) keeps
+        # the internal metadata through the cache write — the cached-partial
+        # path recomputes workshop ranges from the cached notebook and must
+        # still see the slide_id opener form (#732); its own HTML export
+        # strips at the export boundary instead, as do the cached-reuse
+        # filters.
+        if not self.output_spec.should_cache_execution:
+            _strip_internal_cell_metadata(new_cells)
         # Drop jupytext's ``lines_to_next_cell`` layout artifact so that split
         # and bilingual builds produce byte-equivalent output (issue #133).
         _strip_lines_to_next_cell(new_cells)
@@ -1958,6 +1988,10 @@ class NotebookProcessor:
                 # The "executed" notebook is just the processed notebook in this case
                 if self.output_spec.should_cache_execution and self.cache is not None:
                     self._cache_executed_notebook(processed_nb, payload)
+        # The caching spec kept slide_id/for_slide through the cache write
+        # (#732) — strip them at the export boundary. Idempotent for every
+        # other spec (already stripped during processing).
+        _strip_internal_cell_metadata(processed_nb.get("cells", []))
         html_exporter = HTMLExporter(template_name="classic")
         (body, _resources) = html_exporter.from_notebook_node(processed_nb)
         return body

--- a/src/clm/workers/notebook/output_spec.py
+++ b/src/clm/workers/notebook/output_spec.py
@@ -78,9 +78,12 @@ def find_workshop_ranges(cells: Iterable[Cell]) -> list[tuple[int, int]]:
     markdown-only rules are documented there and in
     ``clm info slide-format``. Shared between the per-cell filter path
     (``PartialOutput.annotate_cells``) and the Partial HTML cache-reuse
-    post-processor in the notebook processor; security-relevant coverage:
-    ``TestPartialOutput.test_slide_id_opener_blanks_the_range`` in
-    ``tests/workers/notebook/test_output_spec.py``.
+    post-processor in the notebook processor; solution-leak coverage:
+    ``TestSlideIdWorkshopOpener.test_slide_id_opener_blanks_the_range``
+    (``tests/workers/notebook/test_output_spec.py``, the annotate path) and
+    ``TestCachedPartialSlideIdOpener`` (``test_notebook_processor.py``, the
+    cache-hit path — which additionally requires the cached notebook to
+    retain ``slide_id``).
     """
     from clm.slides.workshop_scope import find_workshop_ranges as _canonical
 

--- a/src/clm/workers/notebook/output_spec.py
+++ b/src/clm/workers/notebook/output_spec.py
@@ -36,32 +36,55 @@ from .utils.prog_lang_utils import jupytext_format_for, suffix_for
 POST_WORKSHOP_TAG = "_post_workshop"
 
 
+class _NotebookCellView:
+    """Adapt an nbformat cell dict to the workshop-scope cell protocol.
+
+    ``slide_id`` reads the cell metadata CLM's slide pipeline carries
+    through the build (it is stripped from the *output* only at the very
+    end of processing, so it is present when ranges are computed).
+    """
+
+    __slots__ = ("_cell",)
+
+    def __init__(self, cell: Cell) -> None:
+        self._cell = cell
+
+    @property
+    def cell_type(self) -> str:
+        return str(self._cell.get("cell_type", ""))
+
+    @property
+    def tags(self) -> list[str]:
+        tags = self._cell.get("metadata", {}).get("tags", [])
+        return list(tags) if tags else []
+
+    @property
+    def slide_id(self) -> str | None:
+        slide_id = self._cell.get("metadata", {}).get("slide_id")
+        return str(slide_id) if slide_id is not None else None
+
+
 def find_workshop_ranges(cells: Iterable[Cell]) -> list[tuple[int, int]]:
     """Return ``[(start_inclusive, end_exclusive), ...]`` for each workshop.
 
-    A workshop starts at a markdown cell tagged ``workshop`` and ends —
-    exclusively — at the next cell of *any* type tagged ``end-workshop``
-    (issue #362: many workshops end with a code cell), the next ``workshop``
-    markdown cell, or end-of-notebook. Only markdown cells open a range;
-    the cell carrying ``end-workshop`` is itself outside the workshop.
-    Shared between the per-cell filter path (``PartialOutput.annotate_cells``)
-    and the Partial HTML cache-reuse post-processor in the notebook processor.
+    A thin adapter over the canonical detector in
+    :mod:`clm.slides.workshop_scope` — one implementation for the
+    validator, ``clm export``, AND the build (issue #732: this used to be
+    a tag-only duplicate, so a workshop opened by the sanctioned
+    ``workshop-…`` slide_id form passed validation but the partial build
+    detected no range, deleted the starter, and emitted the full
+    solution). Both opener forms, the three closers (``end-workshop`` cell
+    outside the range, next opener, end-of-notebook), and the
+    markdown-only rules are documented there and in
+    ``clm info slide-format``. Shared between the per-cell filter path
+    (``PartialOutput.annotate_cells``) and the Partial HTML cache-reuse
+    post-processor in the notebook processor; security-relevant coverage:
+    ``TestPartialOutput.test_slide_id_opener_blanks_the_range`` in
+    ``tests/workers/notebook/test_output_spec.py``.
     """
-    cells_list = list(cells)
-    ranges: list[tuple[int, int]] = []
-    open_start: int | None = None
-    for i, cell in enumerate(cells_list):
-        tags = cell.get("metadata", {}).get("tags", [])
-        if cell.get("cell_type") == "markdown" and "workshop" in tags:
-            if open_start is not None:
-                ranges.append((open_start, i))
-            open_start = i
-        elif "end-workshop" in tags and open_start is not None:
-            ranges.append((open_start, i))
-            open_start = None
-    if open_start is not None:
-        ranges.append((open_start, len(cells_list)))
-    return ranges
+    from clm.slides.workshop_scope import find_workshop_ranges as _canonical
+
+    return _canonical([_NotebookCellView(cell) for cell in cells])
 
 
 def _is_in_workshop(idx: int, ranges: Iterable[tuple[int, int]]) -> bool:

--- a/tests/slides/test_validator.py
+++ b/tests/slides/test_validator.py
@@ -407,6 +407,29 @@ class TestCheckTags:
         ]
         assert len(warnings) == 1
 
+    def test_slide_id_opened_workshop_closer_is_not_an_orphan(self, tmp_path):
+        """Issue #732: a workshop opened by the ``workshop-…`` slide_id form
+        used to trip the orphan-``end-workshop`` warning although the scope
+        machinery honors the closer — the sub-check was tag-only."""
+        p = _write_slide(
+            tmp_path,
+            "slides_slideid_opener.py",
+            """\
+            # %% [markdown] lang="de" tags=["slide"] slide_id="workshop-prompting"
+            # ## Workshop: Prompting
+
+            # %% tags=["keep"]
+            x = 1
+
+            # %% [markdown] lang="de" tags=["subslide", "end-workshop"] slide_id="next-section"
+            # ## Weiter
+            """,
+        )
+        result = validate_file(p, checks=["tags"])
+        assert [
+            w for w in result.findings if w.severity == "warning" and "end-workshop" in w.message
+        ] == [], [f.message for f in result.findings]
+
     def test_end_workshop_tag_recognized(self, tmp_path):
         """``end-workshop`` is a valid markdown tag — no unrecognized-tag error."""
         p = _write_slide(

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -36,6 +36,7 @@ from clm.workers.notebook.output_spec import (
     CodeAlongOutput,
     CompletedOutput,
     PartialOutput,
+    RecordingOutput,
     SpeakerOutput,
     create_output_spec,
 )
@@ -3152,3 +3153,86 @@ class TestEffectiveCellTimeout:
             patch.object(notebook_processor_module, "_HTTP_REPLAY_DEFAULT_CELL_TIMEOUT", None),
         ):
             assert _effective_cell_timeout(self._payload("once")) is None
+
+
+class TestCachedPartialSlideIdOpener:
+    """Issue #732, cached-HTML path: the cached executed notebook must retain
+    ``slide_id`` so ``_filter_cached_notebook_for_partial`` can recompute
+    workshop ranges with BOTH opener forms. Before the fix the caching spec
+    stripped slide_id before the cache write, so the cache-hit partial —
+    the path partial HTML normally takes — was blind to the slide_id opener
+    and shipped the full solution unblanked."""
+
+    def _slide_id_cell(self, source: str, tags: list[str], slide_id: str) -> NotebookNode:
+        cell = make_cell("markdown", source, tags=tags)
+        cell["metadata"]["slide_id"] = slide_id
+        return cell
+
+    @pytest.mark.asyncio
+    async def test_caching_spec_retains_slide_id_through_processing(self):
+        notebook = make_notebook_node(
+            [
+                self._slide_id_cell("# Workshop: Prompting", ["slide"], "workshop-prompting"),
+                make_cell("code", "# TODO", tags=["start"]),
+                make_cell("code", "answer = 42", tags=["completed"]),
+            ]
+        )
+        spec = RecordingOutput(format="html")
+        processor = NotebookProcessor(spec)
+        payload = make_payload("", kind="speaker", format_="html")
+        result = await processor._process_notebook_node(notebook, payload)
+        assert result["cells"][0]["metadata"].get("slide_id") == "workshop-prompting"
+
+    @pytest.mark.asyncio
+    async def test_non_caching_spec_still_strips_slide_id(self):
+        notebook = make_notebook_node([self._slide_id_cell("# Title", ["slide"], "some-slide")])
+        spec = CompletedOutput(format="notebook")
+        processor = NotebookProcessor(spec)
+        payload = make_payload("", kind="completed", format_="notebook")
+        result = await processor._process_notebook_node(notebook, payload)
+        assert "slide_id" not in result["cells"][0]["metadata"]
+
+    @pytest.mark.asyncio
+    async def test_cached_partial_blanks_slide_id_opened_workshop(self):
+        """The end-to-end cache-hit shape: Recording processes (retaining
+        slide_id), the partial filter recomputes ranges from the cached
+        notebook and must blank the workshop — no solution leak."""
+        notebook = make_notebook_node(
+            [
+                self._slide_id_cell("# Workshop: Prompting", ["slide"], "workshop-prompting"),
+                make_cell("code", "# TODO", tags=["start"]),
+                make_cell("code", "prompt = 'THE FULL SOLUTION'", tags=["completed"]),
+                make_cell("code", "check = 1"),
+            ]
+        )
+        recording = NotebookProcessor(RecordingOutput(format="html"))
+        payload = make_payload("", kind="speaker", format_="html")
+        cached_nb = await recording._process_notebook_node(notebook, payload)
+
+        partial = NotebookProcessor(PartialOutput(format="html"))
+        filtered = partial._filter_cached_notebook_for_partial(cached_nb)
+        sources = [c["source"] for c in filtered["cells"]]
+        assert "prompt = 'THE FULL SOLUTION'" not in sources  # completed dropped
+        assert "" in sources  # untagged in-range code blanked — range detected
+        # (The starter is absent from EVERY cached-partial output — Recording
+        # deletes `start` cells before caching; pre-existing, issue #734.)
+        # The internal metadata never reaches the exported notebook.
+        assert all("slide_id" not in c["metadata"] for c in filtered["cells"])
+
+    @pytest.mark.asyncio
+    async def test_cached_completed_filter_strips_slide_id(self):
+        notebook = make_notebook_node(
+            [
+                self._slide_id_cell("# Title", ["slide"], "some-slide"),
+                make_cell("markdown", "- hint", tags=["notes"]),
+            ]
+        )
+        recording = NotebookProcessor(RecordingOutput(format="html"))
+        payload = make_payload("", kind="speaker", format_="html")
+        cached_nb = await recording._process_notebook_node(notebook, payload)
+        assert cached_nb["cells"][0]["metadata"].get("slide_id") == "some-slide"
+
+        completed = NotebookProcessor(CompletedOutput(format="html"))
+        filtered = completed._filter_notes_cells_from_cached(cached_nb)
+        assert all("slide_id" not in c["metadata"] for c in filtered["cells"])
+        assert len(filtered["cells"]) == 1  # notes dropped

--- a/tests/workers/notebook/test_output_spec.py
+++ b/tests/workers/notebook/test_output_spec.py
@@ -24,6 +24,7 @@ from clm.workers.notebook.output_spec import (
     TrainerOutput,
     create_output_spec,
     create_output_specs,
+    find_workshop_ranges,
 )
 
 
@@ -964,3 +965,59 @@ class TestEdgeCases:
             PartialOutput().get_target_subdir_fragment(),
         }
         assert len(fragments) == 5, "All canonical subdir fragments should be unique"
+
+
+class TestSlideIdWorkshopOpener:
+    """Issue #732: the build must recognize BOTH workshop opener forms.
+
+    The build side used to carry a tag-only duplicate of the range
+    detector — a workshop opened by the sanctioned ``workshop-…`` slide_id
+    form passed validation but the partial build detected no range,
+    deleted the ``start`` cell, and emitted the full ``completed``
+    solution. One canonical detector now backs the validator, exports,
+    and the build."""
+
+    def _slide_id_cell(self, make_cell, tags, source, slide_id):
+        cell = make_cell("markdown", tags, source)
+        cell["metadata"]["slide_id"] = slide_id
+        return cell
+
+    def test_slide_id_opener_is_detected(self, make_cell):
+        cells = [
+            make_cell("markdown", ["slide"], "# Intro"),
+            self._slide_id_cell(
+                make_cell, ["slide"], "# Workshop: Prompting", "workshop-basic-prompting"
+            ),
+            make_cell("code", ["start"], "# TODO"),
+            make_cell("code", ["completed"], "answer = 42"),
+        ]
+        assert find_workshop_ranges(cells) == [(1, 4)]
+
+    def test_slide_id_opener_blanks_the_range(self, make_cell):
+        """The #732 solution leak: without the fix, no range is detected —
+        the start cell is deleted (Completed rules) and the completed
+        solution ships in full."""
+        cells = [
+            self._slide_id_cell(
+                make_cell, ["slide"], "# Workshop: Prompting", "workshop-basic-prompting"
+            ),
+            make_cell("code", ["start"], "# TODO"),
+            make_cell("code", ["completed"], "answer = 42"),
+        ]
+        spec = PartialOutput()
+        spec.annotate_cells(cells)
+        assert all(POST_WORKSHOP_TAG in c["metadata"]["tags"] for c in cells)
+        # CodeAlong rules inside the range: starter kept with content,
+        # solution deleted.
+        assert spec.is_cell_included(cells[1]) is True
+        assert spec.is_cell_contents_included(cells[1]) is True
+        assert spec.is_cell_included(cells[2]) is False
+
+    def test_slide_id_on_non_slide_cell_does_not_open(self, make_cell):
+        """Voiceover/notes cells sharing the announcement slide's id must
+        not open or fragment a range (the canonical rule)."""
+        cells = [
+            self._slide_id_cell(make_cell, ["notes"], "- speaker hint", "workshop-basic-prompting"),
+            make_cell("code", [], "x = 1"),
+        ]
+        assert find_workshop_ranges(cells) == []


### PR DESCRIPTION
Closes #732.

The solution-leak divergence found (probe-verified) during the adversarial review of PR #731.

## Root cause

Two `find_workshop_ranges` implementations: the canonical one in `clm.slides.workshop_scope` (both opener forms — `workshop` tag, and the `workshop-…` slide_id on a slide-start markdown cell) backing the validator and `clm export`, and a **tag-only duplicate** in `output_spec.py` backing the `partial` build (`PartialOutput.annotate_cells` + the cached-partial post-processor). A deck whose workshop was opened only by the sanctioned slide_id form passed `clm validate`, but its partial build detected no range: the `start` cell was deleted (pre-workshop mirrors Completed) and the full `completed` solution shipped unblanked.

## Changes

- `output_spec.find_workshop_ranges` is now a thin adapter over the canonical detector: `_NotebookCellView` exposes `cell_type`/`tags`/`slide_id` from nbformat cell metadata (slide_id is stripped from the *output* only at the very end of processing, so it is present when ranges are computed). The duplicate range logic is deleted; both build call sites keep their signature.
- `workshop_scope`'s opener predicate is now public (`is_workshop_opener`); the validator's orphan-`end-workshop` sub-check uses it — a slide_id-opened workshop's closer no longer warns "the tag has no effect" (the second divergence named in #732). Message/suggestion mention both opener forms.
- `clm info slide-format`: the #732 caveat added by PR #731 replaced with the fixed state (one detector everywhere since {version}; older partial builds recognized only the tag form).
- Changelog fragment.

## Checks

- 4 new tests, 3 verified **failing before**: build-side slide_id-opener detection, the solution-leak shape blanking correctly under `PartialOutput` (the claimed-wired regression the adapter docstring cites, per AGENTS.md), and the validator closer test. The 4th pins that voiceover/notes cells sharing the announcement slide's id never open a range.
- Full `tests/slides` + `tests/cli` + `tests/workers/notebook`: 4292 passed. ruff + mypy green; fast suite green on the pre-push hook.

## Assumptions

- Import direction workers → `clm.slides` follows existing precedent (`notebook_processor` imports `clm.slides.cpp_code_emitter`; `jupyter_utils` imports `clm.slides.tags`). The import is lazy inside the function, matching the repo's lazy-import pattern for cross-module hops.
- Behavior for tag-opened workshops is byte-identical (the canonical detector's tag path is the same algorithm); the only behavior change is the slide_id form now being honored by the build and the orphan check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh
