### PR TITLE
fix(build): cache-hit partial HTML keeps workshop starters — cache retains unexecuted start cells (#734)

### DIFF
--- a/changelog.d/734-cached-partial-starters.fixed.md
+++ b/changelog.d/734-cached-partial-starters.fixed.md
@@ -1,0 +1,11 @@
+- `clm build`: cache-hit partial HTML no longer loses workshop starter
+  cells (#734). Recording deleted `start` cells before caching its executed
+  notebook, so the cached-partial path — unlike a fresh partial build —
+  emitted workshops without their scaffolding. The cached artifact now
+  retains the starters **unexecuted** (they are often deliberately
+  incomplete and are skipped at execution); the cached-partial view keeps
+  them in-range exactly like a fresh build, and every other view
+  (Recording's own HTML, completed/trainer-from-cache, pre-workshop
+  partial) drops them at its boundary as before. The notebook cache schema
+  version was bumped again — the first build after upgrading re-executes
+  once instead of replaying starter-less artifacts.

--- a/src/clm/infrastructure/messaging/notebook_classes.py
+++ b/src/clm/infrastructure/messaging/notebook_classes.py
@@ -15,7 +15,11 @@ from clm.infrastructure.messaging.base_classes import Payload, ProcessingError, 
 # cell metadata (the cached-partial path recomputes workshop ranges and must
 # see the slide_id opener form); pre-v3 artifacts lack it and would silently
 # keep the tag-only range detection.
-CACHE_HASH_SCHEMA_VERSION = 3
+# v4 (#734): cached executed notebooks additionally retain unexecuted
+# ``start`` cells (the cached-partial path keeps them in-range; every other
+# view drops them at its boundary); pre-v4 artifacts lack the starters and
+# would silently keep emitting scaffolding-less partial HTML.
+CACHE_HASH_SCHEMA_VERSION = 4
 
 
 def notebook_metadata(kind, prog_lang, language, output_format) -> str:

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -443,6 +443,18 @@ def _strip_lines_to_next_cell(cells: Iterable[Cell]) -> None:
             metadata.pop("lines_to_next_cell", None)
 
 
+def _drop_start_cells(cells: Iterable[Cell]) -> list[Cell]:
+    """Drop ``start``-tagged cells from an export view of the cached notebook.
+
+    The caching spec retains starters in the cached artifact for the
+    cached-partial path (#734); every non-partial export view (Recording's
+    own HTML, completed/trainer-from-cache) drops them here — the same
+    output those views produced when the spec's delete set removed the
+    cells before caching.
+    """
+    return [cell for cell in cells if "start" not in get_tags(cell)]
+
+
 def _strip_internal_cell_metadata(cells: Iterable[Cell]) -> None:
     """Strip ``slide_id``/``for_slide`` and the synthetic post-workshop tag.
 
@@ -716,6 +728,17 @@ class TrackingExecutePreprocessor(ExecutePreprocessor):
         Returns:
             Tuple of (processed cell, resources)
         """
+        # #734: starter cells ride along in the caching spec's notebook so
+        # the cached-partial path can keep them in-range — but starters are
+        # often deliberately incomplete (the student fills them in), so they
+        # must NEVER execute. The non-caching pipeline deletes them before
+        # execution; the caching pipeline skips them here instead.
+        if (
+            cell.get("cell_type") == "code"
+            and "start" in cell.get("metadata", {}).get("tags", [])
+            and self.processor.output_spec.should_cache_execution
+        ):
+            return cell, resources
         # Set the current cell context before execution
         self.processor._current_cell = CellContext(
             cell_index=cell_index,
@@ -1004,7 +1027,10 @@ class NotebookProcessor:
         filtered_nb.cells = [
             cell
             for cell in filtered_nb.get("cells", [])
-            if not {"notes", "voiceover"}.intersection(get_tags(cell))
+            # ``start`` joined the drop set with #734: the cached notebook
+            # now retains starters (for the cached-partial path); this view
+            # mirrors Completed/Trainer, whose delete sets drop them.
+            if not {"notes", "voiceover", "start"}.intersection(get_tags(cell))
         ]
         # The cached notebook retains slide_id/for_slide (#732) — never let
         # them reach the exported HTML.
@@ -1033,7 +1059,11 @@ class NotebookProcessor:
         # strip below runs only after the ranges are fixed.
         ranges = find_workshop_ranges(cells)
 
-        pre_drop = {"notes", "voiceover"}
+        # Pre-workshop mirrors Completed, which drops ``start`` — the cached
+        # notebook retains starters since #734 precisely so the IN-RANGE
+        # branch below can keep them (fresh-partial parity: scaffolding
+        # shown, outputs cleared).
+        pre_drop = {"notes", "voiceover", "start"}
         post_drop = {"alt", "completed", "del", "notes", "voiceover"}
         post_retain_code = {"keep", "start"}
         post_blank_markdown = {"answer"}
@@ -1229,10 +1259,15 @@ class NotebookProcessor:
     ) -> NotebookNode:
         source_cells = nb.get("cells", [])
         self.output_spec.annotate_cells(source_cells)
+        # The caching spec (Recording HTML) retains ``start`` cells the spec
+        # itself would delete (#734): the cached-partial path needs them
+        # in-range, and every export view drops or blanks them at its own
+        # boundary. They are excluded from execution in preprocess_cell.
+        keep_start = self.output_spec.should_cache_execution
         new_cells = [
             await self._process_cell(cell, index, payload)
             for index, cell in enumerate(source_cells)
-            if self.output_spec.is_cell_included(cell)
+            if self.output_spec.is_cell_included(cell) or (keep_start and "start" in get_tags(cell))
         ]
         # Strip slide_id/for_slide (internal CLM metadata that must never
         # appear in output) and the synthetic _post_workshop tag attached by
@@ -1990,7 +2025,11 @@ class NotebookProcessor:
                     self._cache_executed_notebook(processed_nb, payload)
         # The caching spec kept slide_id/for_slide through the cache write
         # (#732) — strip them at the export boundary. Idempotent for every
-        # other spec (already stripped during processing).
+        # other spec (already stripped during processing). It also kept the
+        # ``start`` cells its own delete set excludes (#734) — drop them
+        # here so Recording's HTML is unchanged.
+        if self.output_spec.should_cache_execution:
+            processed_nb.cells = _drop_start_cells(processed_nb.get("cells", []))
         _strip_internal_cell_metadata(processed_nb.get("cells", []))
         html_exporter = HTMLExporter(template_name="classic")
         (body, _resources) = html_exporter.from_notebook_node(processed_nb)

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -85,6 +85,7 @@ from .utils.jupyter_utils import (
     get_slide_tag,
     get_tags,
     is_answer_cell,
+    is_cell_included_for_language,
     is_code_cell,
     is_markdown_cell,
 )
@@ -1267,7 +1268,15 @@ class NotebookProcessor:
         new_cells = [
             await self._process_cell(cell, index, payload)
             for index, cell in enumerate(source_cells)
-            if self.output_spec.is_cell_included(cell) or (keep_start and "start" in get_tags(cell))
+            if self.output_spec.is_cell_included(cell)
+            or (
+                keep_start
+                and "start" in get_tags(cell)
+                # The retention overrides only the spec's TAG delete set —
+                # the language filter still applies (a DE-only starter must
+                # not leak into an EN build's cached artifact).
+                and is_cell_included_for_language(cell, self.output_spec.language)
+            )
         ]
         # Strip slide_id/for_slide (internal CLM metadata that must never
         # appear in output) and the synthetic _post_workshop tag attached by

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -3236,3 +3236,84 @@ class TestCachedPartialSlideIdOpener:
         filtered = completed._filter_notes_cells_from_cached(cached_nb)
         assert all("slide_id" not in c["metadata"] for c in filtered["cells"])
         assert len(filtered["cells"]) == 1  # notes dropped
+
+
+class TestCachedPartialStarters:
+    """Issue #734: the cached artifact retains unexecuted ``start`` cells so
+    cache-hit partial HTML keeps workshop scaffolding — Recording used to
+    delete them before caching, so the cache-hit and fresh partial paths
+    diverged on exactly the cells the workshop exists for."""
+
+    def _workshop_nb(self) -> NotebookNode:
+        return make_notebook_node(
+            [
+                make_cell("markdown", "# Workshop", tags=["slide", "workshop"]),
+                make_cell("code", "# TODO", tags=["start"]),
+                make_cell("code", "answer = 42", tags=["completed"]),
+                make_cell("code", "check = 1"),
+            ]
+        )
+
+    @pytest.mark.asyncio
+    async def test_cached_partial_keeps_the_in_range_starter(self):
+        recording = NotebookProcessor(RecordingOutput(format="html"))
+        payload = make_payload("", kind="speaker", format_="html")
+        cached_nb = await recording._process_notebook_node(self._workshop_nb(), payload)
+        starters = [c for c in cached_nb["cells"] if "start" in c["metadata"]["tags"]]
+        assert len(starters) == 1  # retained in the cached artifact...
+        assert starters[0].get("outputs", []) == []  # ...unexecuted
+
+        partial = NotebookProcessor(PartialOutput(format="html"))
+        filtered = partial._filter_cached_notebook_for_partial(cached_nb)
+        sources = [c["source"] for c in filtered["cells"]]
+        assert "# TODO" in sources  # fresh-partial parity: scaffolding shown
+        assert "answer = 42" not in sources
+
+    @pytest.mark.asyncio
+    async def test_cached_completed_view_still_drops_starters(self):
+        recording = NotebookProcessor(RecordingOutput(format="html"))
+        payload = make_payload("", kind="speaker", format_="html")
+        cached_nb = await recording._process_notebook_node(self._workshop_nb(), payload)
+        completed = NotebookProcessor(CompletedOutput(format="html"))
+        filtered = completed._filter_notes_cells_from_cached(cached_nb)
+        assert all("start" not in c["metadata"]["tags"] for c in filtered["cells"])
+
+    @pytest.mark.asyncio
+    async def test_pre_workshop_starter_still_dropped_on_cached_partial(self):
+        notebook = make_notebook_node(
+            [
+                make_cell("code", "# TODO pre", tags=["start"]),
+                make_cell("markdown", "# Workshop", tags=["slide", "workshop"]),
+                make_cell("code", "# TODO in", tags=["start"]),
+            ]
+        )
+        recording = NotebookProcessor(RecordingOutput(format="html"))
+        payload = make_payload("", kind="speaker", format_="html")
+        cached_nb = await recording._process_notebook_node(notebook, payload)
+        partial = NotebookProcessor(PartialOutput(format="html"))
+        filtered = partial._filter_cached_notebook_for_partial(cached_nb)
+        sources = [c["source"] for c in filtered["cells"]]
+        assert "# TODO pre" not in sources  # pre-range mirrors Completed
+        assert "# TODO in" in sources
+
+    def test_recording_export_view_drops_starters(self):
+        from clm.workers.notebook.notebook_processor import _drop_start_cells
+
+        cells = [
+            make_cell("code", "# TODO", tags=["start"]),
+            make_cell("code", "x = 1", tags=["keep"]),
+        ]
+        kept = _drop_start_cells(cells)
+        assert [c["source"] for c in kept] == ["x = 1"]
+
+    def test_start_cells_skip_execution_under_the_caching_spec(self):
+        """The starters ride along UNEXECUTED: they are often deliberately
+        incomplete, so preprocess_cell must return them untouched (no
+        kernel interaction — this test has no kernel and would error on
+        any execution attempt)."""
+        processor = NotebookProcessor(RecordingOutput(format="html"))
+        tep = TrackingExecutePreprocessor(processor)
+        cell = make_cell("code", "value = ", tags=["start"])
+        result_cell, _resources = tep.preprocess_cell(cell, {}, 0)
+        assert result_cell is cell
+        assert cell.get("outputs", []) == []

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -3317,3 +3317,21 @@ class TestCachedPartialStarters:
         result_cell, _resources = tep.preprocess_cell(cell, {}, 0)
         assert result_cell is cell
         assert cell.get("outputs", []) == []
+
+    @pytest.mark.asyncio
+    async def test_start_retention_still_respects_language_filtering(self):
+        """The retention overrides only the tag delete set — a DE-only
+        starter must not leak into an EN build's cached artifact."""
+        notebook = make_notebook_node(
+            [
+                make_cell("markdown", "# Workshop", tags=["slide", "workshop"]),
+                make_cell("code", "# TODO de", tags=["start"], lang="de"),
+                make_cell("code", "# TODO en", tags=["start"], lang="en"),
+            ]
+        )
+        recording = NotebookProcessor(RecordingOutput(format="html", language="en"))
+        payload = make_payload("", kind="speaker", format_="html", language="en")
+        cached_nb = await recording._process_notebook_node(notebook, payload)
+        sources = [c["source"] for c in cached_nb["cells"]]
+        assert "# TODO en" in sources
+        assert "# TODO de" not in sources


### PR DESCRIPTION
Closes #734.

The second cache-path divergence uncovered by the #732 review work: Recording deleted `start` cells before caching its executed notebook, so **cache-hit partial HTML emitted workshops without their scaffolding** while a fresh partial build kept it — and cache hits are the normal path.

## Design

The starters must ride along in the cached artifact **without ever executing** (they are often deliberately incomplete — `value = ` — and would break the Recording build):

- `_process_notebook_node` retains `start` cells for the caching spec (extending #732's internal-metadata retention).
- `TrackingExecutePreprocessor.preprocess_cell` skips `start`-tagged code cells under the caching spec — the pinning test runs with **no kernel**, so any execution attempt would error.
- Every non-partial view drops them at its boundary, keeping all existing outputs byte-identical: Recording's own HTML export (`_drop_start_cells`), the completed/trainer-from-cache filter, and the cached-partial **pre-range** branch (Completed parity). The **in-range** branch keeps them with cleared outputs — fresh-partial parity, the point of the fix.
- `CACHE_HASH_SCHEMA_VERSION` 3 → 4: pre-v4 artifacts lack the starters and would silently keep emitting scaffolding-less partial HTML; the bump forces one visible re-execution.

## Checks

- 5 regression tests (`TestCachedPartialStarters`), 4 verified **failing before**: in-range starter kept unexecuted, completed-from-cache unchanged, pre-range starter still dropped, the export-view drop, and the no-kernel execution skip.
- Full `tests/workers/notebook` + `tests/slides` + `tests/cli` + `tests/infrastructure`: 5824 passed (includes the cache-equivalence suite). ruff + mypy green; fast suite green on the pre-push hook.

## Assumptions

- Starters carry no outputs in any view (fresh partial clears in-range outputs anyway), so caching them unexecuted loses nothing.
- Non-HTML Recording outputs (`notebook`/`code` formats) are not caching specs (`should_cache_execution` requires HTML) and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh
