### PR TITLE
fix(build): trainer cache hits keep speaker notes — project through the consuming spec's delete set (#736)

### DIFF
--- a/changelog.d/736-trainer-cache-notes.fixed.md
+++ b/changelog.d/736-trainer-cache-notes.fixed.md
@@ -1,0 +1,7 @@
+- `clm build`: trainer HTML no longer loses speaker notes on an
+  execution-cache hit (#736). The cache-reuse path filtered every
+  non-partial kind through a hard-coded notes/voiceover drop; it now
+  projects the cached notebook through the consuming output kind's own
+  delete set, so trainer keeps its notes exactly as a cache-miss build
+  does (completed output is unchanged; the #734 starters stay dropped in
+  every non-partial view).

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -1028,6 +1028,13 @@ class NotebookProcessor:
         cached artifact retains unexecuted starters solely for the
         cached-partial path (#734), and no non-partial view may show them.
         """
+        # This projection drops cells but never blanks contents — a spec
+        # that blanks (code-along style) must not reuse the cache through
+        # it, or full solution code would ship into its HTML.
+        assert not self.output_spec.blanks_code_cells, (
+            "cache projection does not blank cell contents — this spec must "
+            "not take the non-partial reuse path"
+        )
         # Make a deep copy to avoid modifying the cached notebook
         filtered_nb = copy.deepcopy(nb)
         drop = set(self.output_spec.tags_to_delete_cell) | {"start"}

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -997,14 +997,16 @@ class NotebookProcessor:
 
         logger.info(f"{cid}:Cache hit - reusing executed notebook for '{payload.input_file_name}'")
 
-        # Translate the cached Speaker notebook into the consuming kind.
-        # Completed drops notes/voiceover; Partial additionally blanks and
-        # clears outputs for every cell at or after the workshop boundary so
-        # no workshop code is ever executed under the Partial kind.
+        # Translate the cached Recording notebook into the consuming kind.
+        # Non-partial kinds project through their own delete set (issue
+        # #736: a hard-coded notes/voiceover drop silently lost the notes
+        # Trainer keeps on a cache miss); Partial additionally blanks and
+        # clears outputs for every cell inside a workshop range so no
+        # workshop code is ever presented as executed.
         if isinstance(self.output_spec, PartialOutput):
             filtered_nb = self._filter_cached_notebook_for_partial(cached_nb)
         else:
-            filtered_nb = self._filter_notes_cells_from_cached(cached_nb)
+            filtered_nb = self._filter_cached_notebook_for_spec(cached_nb)
 
         # Export to HTML (no execution needed)
         traitlets_logger = traitlets.log.get_logger()
@@ -1016,22 +1018,21 @@ class NotebookProcessor:
         logger.debug(f"{cid}:Successfully reused cached execution for '{payload.input_file_name}'")
         return body
 
-    def _filter_notes_cells_from_cached(self, nb: NotebookNode) -> NotebookNode:
-        """Filter out notes and voiceover cells from a cached executed notebook.
+    def _filter_cached_notebook_for_spec(self, nb: NotebookNode) -> NotebookNode:
+        """Project Recording's cached executed notebook onto this spec's view.
 
-        This is used when reusing Speaker's executed notebook for Completed HTML.
-        Notes and voiceover cells are markdown cells that should not appear in
-        Completed output.
+        Drops the cells the consuming spec's own delete set would have
+        removed during processing — issue #736: a hard-coded
+        notes/voiceover drop here silently lost the ``notes`` cells that
+        Trainer keeps on a cache miss. ``start`` is always dropped: the
+        cached artifact retains unexecuted starters solely for the
+        cached-partial path (#734), and no non-partial view may show them.
         """
         # Make a deep copy to avoid modifying the cached notebook
         filtered_nb = copy.deepcopy(nb)
+        drop = set(self.output_spec.tags_to_delete_cell) | {"start"}
         filtered_nb.cells = [
-            cell
-            for cell in filtered_nb.get("cells", [])
-            # ``start`` joined the drop set with #734: the cached notebook
-            # now retains starters (for the cached-partial path); this view
-            # mirrors Completed/Trainer, whose delete sets drop them.
-            if not {"notes", "voiceover", "start"}.intersection(get_tags(cell))
+            cell for cell in filtered_nb.get("cells", []) if not drop.intersection(get_tags(cell))
         ]
         # The cached notebook retains slide_id/for_slide (#732) — never let
         # them reach the exported HTML.

--- a/src/clm/workers/notebook/output_spec.py
+++ b/src/clm/workers/notebook/output_spec.py
@@ -10,7 +10,6 @@ output that should be generated.
 - `TrainerOutput`: Private output for trainers — keeps speaker notes, strips voiceover.
 - `RecordingOutput`: Private output for video recording — keeps both notes and voiceover.
 - `SpeakerOutput`: Deprecated alias for ``RecordingOutput`` (removed in CLM 1.8).
-- `EditScriptOutput`: Output type that generates an edit script to update from codealong to completed notebook.
 """
 
 import logging

--- a/tests/workers/notebook/test_cache_equivalence.py
+++ b/tests/workers/notebook/test_cache_equivalence.py
@@ -197,7 +197,7 @@ class TestCacheEquivalence:
             # Use processor's filter method
             completed_spec = CompletedOutput(format="html", language="en", prog_lang="python")
             processor = NotebookProcessor(completed_spec, cache=cache)
-            filtered_nb = processor._filter_notes_cells_from_cached(cached_nb)
+            filtered_nb = processor._filter_cached_notebook_for_spec(cached_nb)
 
             # Verify notes cells are removed
             filtered_notes_count = sum(

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -3233,7 +3233,7 @@ class TestCachedPartialSlideIdOpener:
         assert cached_nb["cells"][0]["metadata"].get("slide_id") == "some-slide"
 
         completed = NotebookProcessor(CompletedOutput(format="html"))
-        filtered = completed._filter_notes_cells_from_cached(cached_nb)
+        filtered = completed._filter_cached_notebook_for_spec(cached_nb)
         assert all("slide_id" not in c["metadata"] for c in filtered["cells"])
         assert len(filtered["cells"]) == 1  # notes dropped
 
@@ -3275,7 +3275,7 @@ class TestCachedPartialStarters:
         payload = make_payload("", kind="speaker", format_="html")
         cached_nb = await recording._process_notebook_node(self._workshop_nb(), payload)
         completed = NotebookProcessor(CompletedOutput(format="html"))
-        filtered = completed._filter_notes_cells_from_cached(cached_nb)
+        filtered = completed._filter_cached_notebook_for_spec(cached_nb)
         assert all("start" not in c["metadata"]["tags"] for c in filtered["cells"])
 
     @pytest.mark.asyncio
@@ -3335,3 +3335,40 @@ class TestCachedPartialStarters:
         sources = [c["source"] for c in cached_nb["cells"]]
         assert "# TODO en" in sources
         assert "# TODO de" not in sources
+
+
+class TestTrainerCacheReuseKeepsNotes:
+    """Issue #736: the non-partial cache-reuse view projects through the
+    CONSUMING spec's delete set — the hard-coded notes/voiceover drop lost
+    the notes Trainer keeps on a cache miss."""
+
+    def _cached_nb(self):
+        return make_notebook_node(
+            [
+                make_cell("markdown", "# Title", tags=["slide"]),
+                make_cell("markdown", "- speaker hint", tags=["notes"]),
+                make_cell("markdown", "read this aloud", tags=["voiceover"]),
+                make_cell("code", "# TODO", tags=["start"]),
+                make_cell("code", "x = 1", tags=["keep"]),
+            ]
+        )
+
+    def test_trainer_view_keeps_notes_drops_voiceover_and_starters(self):
+        from clm.workers.notebook.output_spec import TrainerOutput
+
+        trainer = NotebookProcessor(TrainerOutput(format="html"))
+        filtered = trainer._filter_cached_notebook_for_spec(self._cached_nb())
+        sources = [c["source"] for c in filtered["cells"]]
+        assert "- speaker hint" in sources  # the #736 regression
+        assert "read this aloud" not in sources
+        assert "# TODO" not in sources
+        assert "x = 1" in sources
+
+    def test_completed_view_unchanged(self):
+        completed = NotebookProcessor(CompletedOutput(format="html"))
+        filtered = completed._filter_cached_notebook_for_spec(self._cached_nb())
+        sources = [c["source"] for c in filtered["cells"]]
+        assert "- speaker hint" not in sources
+        assert "read this aloud" not in sources
+        assert "# TODO" not in sources
+        assert "x = 1" in sources


### PR DESCRIPTION
Closes #736.

Third and smallest of the fresh-vs-cached divergences uncovered by the #732/#734 review arc: `_try_reuse_cached_execution` filtered every non-partial kind through a hard-coded notes/voiceover drop, so **trainer HTML silently lost speaker notes on a cache hit** while keeping them on a cache miss (`TrainerOutput` keeps `notes`; its `can_reuse_execution` is True for HTML).

## Change

`_filter_notes_cells_from_cached` → `_filter_cached_notebook_for_spec`: the cached Recording notebook is projected through the **consuming spec's own `tags_to_delete_cell`**, plus the #734 starters (which no non-partial view may show), plus the #732 internal-metadata strip. Trainer keeps notes and drops voiceover/starters; completed output is byte-identical to before.

## Checks

- 2 regression tests (`TestTrainerCacheReuseKeepsNotes`), both verified **failing before** (the trainer one for the real reason; the completed one pins byte-parity of the old behavior).
- Full `tests/workers` + `tests/slides` + `tests/cli`: 4486 passed (includes the cache-equivalence suite). ruff + mypy green; fast suite green on pre-push.

## Assumptions

- No cache schema bump: the cached-artifact **shape** is unchanged (this fixes only the read-side projection); stale caches produce the corrected trainer view immediately.
- #737 (answer-stub cosmetic parity on the partial path) is deliberately not bundled — separate issue, separate view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh
