### PR TITLE
fix(build): cached partial renders the localized answer stub — fresh-path parity (#737)

### DIFF
--- a/changelog.d/737-answer-stub-parity.fixed.md
+++ b/changelog.d/737-answer-stub-parity.fixed.md
@@ -1,0 +1,4 @@
+- `clm build`: cache-hit partial HTML renders blanked in-workshop `answer`
+  markdown as the localized `*Answer:*` / `*Antwort:*` stub, matching a
+  fresh partial build (#737) — previously the cached path emitted an empty
+  cell where the fresh path showed the stub.

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -444,6 +444,18 @@ def _strip_lines_to_next_cell(cells: Iterable[Cell]) -> None:
             metadata.pop("lines_to_next_cell", None)
 
 
+def _answer_stub(language: str) -> str:
+    """The localized stub a blanked ``answer`` markdown cell renders as.
+
+    One definition for BOTH render sites — the fresh path's markdown
+    processing and the cached-partial filter (#737): the two regaining
+    byte-parity depends on them agreeing, so divergence must be
+    structurally impossible.
+    """
+    answer_text = "Answer" if language == "en" else "Antwort"
+    return f"*{answer_text}:* "
+
+
 def _drop_start_cells(cells: Iterable[Cell]) -> list[Cell]:
     """Drop ``start``-tagged cells from an export view of the cached notebook.
 
@@ -1100,8 +1112,7 @@ class NotebookProcessor:
                         # an empty cell. The cached cell already carries the
                         # stub prefix (Recording's processing added it) —
                         # keep the prefix, drop the answer text.
-                        answer_text = "Answer" if self.output_spec.language == "en" else "Antwort"
-                        cell["source"] = f"*{answer_text}:* "
+                        cell["source"] = _answer_stub(self.output_spec.language)
 
             new_cells.append(cell)
 
@@ -1411,8 +1422,7 @@ class NotebookProcessor:
                 "<div style='background: #FFEEBA; color: black;'>\n" + contents + "\n</div>"
             )
         if is_answer_cell(cell):
-            answer_text = "Answer" if self.output_spec.language == "en" else "Antwort"
-            prefix = f"*{answer_text}:* "
+            prefix = _answer_stub(self.output_spec.language)
             if self.output_spec.is_cell_contents_included(cell):
                 cell["source"] = prefix + cell["source"]
             else:

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -1095,7 +1095,13 @@ class NotebookProcessor:
                         cell["execution_count"] = None
                 elif is_markdown_cell(cell):
                     if post_blank_markdown.intersection(tags):
-                        cell["source"] = ""
+                        # Fresh-partial parity (#737): the fresh path renders
+                        # a blanked answer cell as the localized stub, not as
+                        # an empty cell. The cached cell already carries the
+                        # stub prefix (Recording's processing added it) —
+                        # keep the prefix, drop the answer text.
+                        answer_text = "Answer" if self.output_spec.language == "en" else "Antwort"
+                        cell["source"] = f"*{answer_text}:* "
 
             new_cells.append(cell)
 

--- a/tests/workers/notebook/test_cache_equivalence.py
+++ b/tests/workers/notebook/test_cache_equivalence.py
@@ -533,7 +533,9 @@ class TestPartialCacheFilter:
         for cell in filtered.cells:
             assert "alt" not in cell.get("metadata", {}).get("tags", [])
 
-    def test_post_workshop_answer_markdown_blanked(self, processor, cached_speaker_nb):
+    def test_post_workshop_answer_markdown_blanked_to_stub(self, processor, cached_speaker_nb):
+        """The blanked answer renders as the localized stub, matching the
+        fresh partial path (#737) — not as an empty cell."""
         filtered = processor._filter_cached_notebook_for_partial(cached_speaker_nb)
         answer_cell = next(
             c
@@ -541,7 +543,7 @@ class TestPartialCacheFilter:
             if c.get("cell_type") == "markdown"
             and "answer" in c.get("metadata", {}).get("tags", [])
         )
-        assert answer_cell["source"] == ""
+        assert answer_cell["source"] == "*Answer:* "
 
     def test_no_workshop_heading_matches_completed_filter(self, processor):
         """Without a workshop heading, Partial's filter degenerates to the

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -3372,3 +3372,45 @@ class TestTrainerCacheReuseKeepsNotes:
         assert "read this aloud" not in sources
         assert "# TODO" not in sources
         assert "x = 1" in sources
+
+
+class TestCachedPartialAnswerStub:
+    """Issue #737: in-range `answer` markdown renders as the localized
+    `*Answer:* ` stub on the fresh partial path but rendered as an empty
+    cell on the cached path — align the cached filter on the stub."""
+
+    @pytest.mark.asyncio
+    async def test_cached_partial_renders_the_answer_stub(self):
+        notebook = make_notebook_node(
+            [
+                make_cell("markdown", "# Workshop", tags=["slide", "workshop"]),
+                make_cell("markdown", "The answer is 42", tags=["answer"]),
+            ]
+        )
+        recording = NotebookProcessor(RecordingOutput(format="html"))
+        payload = make_payload("", kind="speaker", format_="html")
+        cached_nb = await recording._process_notebook_node(notebook, payload)
+
+        partial = NotebookProcessor(PartialOutput(format="html"))
+        filtered = partial._filter_cached_notebook_for_partial(cached_nb)
+        answer_cells = [c for c in filtered["cells"] if "answer" in c["metadata"]["tags"]]
+        assert len(answer_cells) == 1
+        assert answer_cells[0]["source"] == "*Answer:* "
+        assert "42" not in answer_cells[0]["source"]
+
+    @pytest.mark.asyncio
+    async def test_cached_partial_answer_stub_is_localized(self):
+        notebook = make_notebook_node(
+            [
+                make_cell("markdown", "# Workshop", tags=["slide", "workshop"]),
+                make_cell("markdown", "Die Antwort ist 42", tags=["answer"]),
+            ]
+        )
+        recording = NotebookProcessor(RecordingOutput(format="html", language="de"))
+        payload = make_payload("", kind="speaker", format_="html", language="de")
+        cached_nb = await recording._process_notebook_node(notebook, payload)
+
+        partial = NotebookProcessor(PartialOutput(format="html", language="de"))
+        filtered = partial._filter_cached_notebook_for_partial(cached_nb)
+        answer_cells = [c for c in filtered["cells"] if "answer" in c["metadata"]["tags"]]
+        assert answer_cells[0]["source"] == "*Antwort:* "


### PR DESCRIPTION
Closes #737.

The last of the fresh-vs-cached partial divergences from the #732/#734/#736 review arc, and the smallest: in-workshop `answer` markdown rendered as the localized `*Answer:* ` / `*Antwort:* ` stub on the fresh path but as an empty cell on the cache-hit path.

## Change

`_filter_cached_notebook_for_partial` blanks the answer cell to the localized stub (same language source as the fresh path's `_process_markdown_cell_contents`). The pre-existing cache-equivalence test that pinned the empty-cell behavior now pins the stub; two new tests cover the EN and DE stubs end-to-end through Recording processing → cached-partial filtering.

## Checks

Full `tests/workers/notebook`: 665 passed. ruff + mypy green; fast suite green on pre-push. No cache schema bump (read-side only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh
