### PR TITLE
test(git): recovery test drives _init_create_new_repo; seal the ssh prompt vector (#686 follow-up)

### DIFF
--- a/src/clm/cli/commands/git.py
+++ b/src/clm/cli/commands/git.py
@@ -200,6 +200,9 @@ def _read_only_dry_run_env() -> dict[str, str]:
     env = os.environ.copy()
     env["GIT_TERMINAL_PROMPT"] = "0"
     env["GCM_INTERACTIVE"] = "never"
+    # SSH ignores the vars above — batch mode seals the passphrase/host-key
+    # prompt vector for ssh-form remotes too.
+    env.setdefault("GIT_SSH_COMMAND", "ssh -oBatchMode=yes")
     return env
 
 

--- a/tests/cli/test_git_ops.py
+++ b/tests/cli/test_git_ops.py
@@ -1672,10 +1672,14 @@ class TestInitDryRunRecovery:
     stub state — a spurious hard error under the no-changes banner."""
 
     def test_init_dry_run_previews_recovery_without_mutating(self, tmp_path: Path, capsys):
-        from clm.cli.commands.git import init_repo_from_remote
+        from clm.cli.commands.git import _init_create_new_repo
 
+        # Explicit: setup must run for real (a leaked dry-run context would
+        # stub the scaffolding and pass vacuously).
+        _dry_run_mode.set(False)
         # A local bare remote with one commit — remote_exists and
-        # remote_has_commits are both True, no network involved.
+        # remote_has_commits are both True, no network involved, so
+        # _init_create_new_repo genuinely routes into recovery mode.
         remote = tmp_path / "remote.git"
         seed = tmp_path / "seed"
         seed.mkdir()
@@ -1691,11 +1695,11 @@ class TestInitDryRunRecovery:
 
         _dry_run_mode.set(True)
         try:
-            ok = init_repo_from_remote(repo, "next")
+            _init_create_new_repo(repo, "next")
         finally:
             _dry_run_mode.set(False)
         captured = capsys.readouterr()
-        assert ok is True
         assert "Would clone the remote and restore .git" in captured.out
         assert "Error" not in captured.out
+        assert "Error" not in captured.err  # the round-1 symptom used err=True
         assert not (out_dir / ".git").exists()  # nothing mutated


### PR DESCRIPTION
Follow-up to PR #741 (merged before this landed — armed auto-merge won the race). The round-2 review's non-blocking nits:

- The `init --dry-run` recovery regression now drives `_init_create_new_repo` (the real routing — the bare-remote scaffolding is load-bearing), asserts stderr where the round-1 symptom actually lived (`err=True`), and pins dry-run off during setup so a leaked context can't make it pass vacuously.
- Dry-run read-only git also gets `GIT_SSH_COMMAND=ssh -oBatchMode=yes` — ssh ignores `GIT_TERMINAL_PROMPT`, so an ssh-form remote with a passphrase key could still hang a preview.

Checks: `tests/cli/test_git_ops.py` + `test_git_release_channels.py` — 137 passed; ruff + mypy green; fast suite on pre-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh
