### PR TITLE
fix(build): cache keys follow the effective worker image for all three worker types (#744)

### DIFF
--- a/changelog.d/690-worker-image-flags.added.md
+++ b/changelog.d/690-worker-image-flags.added.md
@@ -5,7 +5,6 @@
   `docker.io/mhoelzl/clm-drawio-converter:test`). Previously only the
   notebook image was reachable from the command line; the diagram workers
   required deriving `CLM_WORKER_MANAGEMENT__*__IMAGE` env-var spellings.
-  The env-var route keeps working. Caveat (#744): the build caches do not
-  yet key on the worker image — pass `--ignore-cache` when testing a
-  rebuilt image against unchanged sources, and stop lingering reused
-  workers first (reuse is image-blind).
+  The env-var route keeps working. Caveat: worker reuse is image-blind —
+  stop lingering reused workers when switching images (cache keys follow
+  the image since #744).

--- a/changelog.d/744-image-cache-identity.fixed.md
+++ b/changelog.d/744-image-cache-identity.fixed.md
@@ -1,0 +1,12 @@
+- `clm build`: the caches now key on the **effective worker image** for all
+  three worker types (#744). Diagram (PlantUML/Draw.io) results previously
+  cached on the source bytes alone — a rebuilt converter image silently
+  replayed the old image's output for every unchanged diagram; their cache
+  keys now fold in the worker-image identity, the output format, and a
+  schema version (one-time diagram re-render on upgrade). The notebook
+  image identity now sees CLI overrides too: `--notebook-image X` used to
+  execute on `X` but key the cache as the configured default, replaying
+  stale outputs — `clm build` records the post-override identities and
+  payload construction reads them. Residual limits: mutable tags
+  (`:latest`) re-pulled to a new image do not change keys, and worker
+  reuse remains image-blind.

--- a/changelog.d/744-image-cache-identity.fixed.md
+++ b/changelog.d/744-image-cache-identity.fixed.md
@@ -2,8 +2,8 @@
   three worker types (#744). Diagram (PlantUML/Draw.io) results previously
   cached on the source bytes alone — a rebuilt converter image silently
   replayed the old image's output for every unchanged diagram; their cache
-  keys now fold in the worker-image identity, the output format, and a
-  schema version (one-time diagram re-render on upgrade). The notebook
+  keys now fold in the worker-image identity and a schema version
+  (one-time diagram re-render on upgrade). The notebook
   image identity now sees CLI overrides too: `--notebook-image X` used to
   execute on `X` but key the cache as the configured default, replaying
   stale outputs — `clm build` records the post-override identities and

--- a/docs/developer-guide/caching.md
+++ b/docs/developer-guide/caching.md
@@ -149,9 +149,10 @@ Diagram results replay from the jobs DB keyed on `(output_file,
 content_hash)`. Since issue #744 the `ImagePayload.content_hash` folds in,
 besides the diagram source: the `IMAGE_CACHE_HASH_SCHEMA_VERSION`, the
 **effective worker-image identity** of the rendering worker type
-(`"direct"` / `"docker:<image>"`), and the output format — so a rebuilt
-converter image re-renders unchanged sources instead of replaying the old
-image's bytes. CLI image overrides (`--notebook-image` /
+(`"direct"` / `"docker:<image>"`), and the payload's `output_format` field
+(constant in current production — the actual format is discriminated by
+the `output_file` half of the cache key) — so a rebuilt converter image
+re-renders unchanged sources instead of replaying the old image's bytes. CLI image overrides (`--notebook-image` /
 `--plantuml-image` / `--drawio-image`) are visible to every cache key:
 `clm build` records the post-override identities
 (`clm.infrastructure.workers.image_identity.set_effective_worker_identities`)

--- a/docs/developer-guide/caching.md
+++ b/docs/developer-guide/caching.md
@@ -143,6 +143,23 @@ invalidation* (clm upgrade, worker-image/mode switch, CRLF drift, a
 `CACHE_HASH_SCHEMA_VERSION` bump), **not** eviction by retention. Confirm with
 `clm cache explain`.
 
+### Diagram (PlantUML / Draw.io) cache keys
+
+Diagram results replay from the jobs DB keyed on `(output_file,
+content_hash)`. Since issue #744 the `ImagePayload.content_hash` folds in,
+besides the diagram source: the `IMAGE_CACHE_HASH_SCHEMA_VERSION`, the
+**effective worker-image identity** of the rendering worker type
+(`"direct"` / `"docker:<image>"`), and the output format — so a rebuilt
+converter image re-renders unchanged sources instead of replaying the old
+image's bytes. CLI image overrides (`--notebook-image` /
+`--plantuml-image` / `--drawio-image`) are visible to every cache key:
+`clm build` records the post-override identities
+(`clm.infrastructure.workers.image_identity.set_effective_worker_identities`)
+and payload construction reads them — previously the identity read the
+global config singleton, which the CLI overrides never touch (they apply to
+the deliberate #223 config copy). The mutable-tag limitation applies here
+too: re-pulling `:latest` does not change the key.
+
 ## Where each cache is consulted during a build
 
 `execute_operation` (`infrastructure/backends/sqlite_backend.py`) is the choke

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -965,7 +965,15 @@ def configure_workers(config: BuildConfig):
     if config.drawio_image is not None:
         cli_overrides["drawio_image"] = config.drawio_image
 
-    return load_worker_config(cli_overrides)
+    worker_config = load_worker_config(cli_overrides)
+    # The cache keys must see the images that will actually execute (issue
+    # #744): record the post-override identity per worker type — the
+    # override lives only in this config copy, never in the singleton the
+    # identity fallback reads.
+    from clm.infrastructure.workers.image_identity import set_effective_worker_identities
+
+    set_effective_worker_identities(worker_config)
+    return worker_config
 
 
 def enable_jupyterlite_workers_if_needed(course, worker_config) -> None:
@@ -2335,23 +2343,25 @@ async def main_build(
 @click.option(
     "--notebook-image",
     type=str,
-    help="Docker image for notebook workers. Can be full image name or just a tag (e.g., 'lite', 'full'). Default is :latest which uses the lite variant. Only used with --workers=docker. Caches do not key on the image — pass --force-execute/--ignore-cache when testing a new image (issue #744).",
+    help="Docker image for notebook workers. Can be full image name or just a tag (e.g., 'lite', 'full'). Default is :latest which uses the lite variant. Only used with --workers=docker. Cache keys follow the image (issue #744); lingering reused workers do not — stop them when switching images.",
 )
 @click.option(
     "--plantuml-image",
     type=str,
     help="Docker image for PlantUML workers. Full image name or just a tag "
     "(expands to docker.io/mhoelzl/clm-plantuml-converter:<tag>). Only used "
-    "with --workers=docker (issue #690). Caches do not key on the image — "
-    "pass --ignore-cache when testing a new image (issue #744).",
+    "with --workers=docker (issue #690). Cache keys follow the image "
+    "(issue #744); lingering reused workers do not — stop them when "
+    "switching images.",
 )
 @click.option(
     "--drawio-image",
     type=str,
     help="Docker image for Draw.io workers. Full image name or just a tag "
     "(expands to docker.io/mhoelzl/clm-drawio-converter:<tag>). Only used "
-    "with --workers=docker (issue #690). Caches do not key on the image — "
-    "pass --ignore-cache when testing a new image (issue #744).",
+    "with --workers=docker (issue #690). Cache keys follow the image "
+    "(issue #744); lingering reused workers do not — stop them when "
+    "switching images.",
 )
 @click.option(
     "--output-mode",

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -78,12 +78,14 @@ Key options:
 | `--fail-on-missing-xref / --no-fail-on-missing-xref` | Exit with non-zero status when a `clm:` cross-reference points at a topic not included in the build (issue #17). Defaults to **on** under `--http-replay=replay` (incl. CI) and **off** under all other replay modes (a missing target is then a warning and the link is dropped). Override via `CLM_FAIL_ON_MISSING_XREF={1,true,yes,0,false,no}`. See `clm info spec-files` → "Cross-references". |
 | `--provenance-manifest / --no-provenance-manifest` | Write a `.clm-manifest.json` provenance index into each output root, mapping every output file to its source commit and owning section/topic (issue #208 — needed by the per-topic solution-release workflow). **On by default since CLM {version}**; `clm git` excludes it from every distributed repo. Pass `--no-provenance-manifest` to skip it. Always suppressed under `--snapshot` / `--verify-against` (it embeds a timestamp + commit, so it must not enter a byte-reproducibility baseline). |
 
-**Image-override caveats (#744).** The build caches do not yet key on the
-worker image: when testing a rebuilt/pinned image against unchanged sources,
-pass `--ignore-cache` (or `--force-execute` for notebooks) or cached results
-from the previous image are replayed as hits. Worker *reuse* is also
-image-blind — a still-running worker pool from an earlier build keeps its
-old image, so stop lingering workers first when switching images.
+**Image-override caveats.** Since CLM {version} the build caches key on the
+effective worker image for all three worker types (#744): switching images
+re-renders cached notebooks *and* diagrams without `--ignore-cache`. Two
+residual caveats: a **mutable tag** (`:latest`) re-pulled to a new image
+does not change the key — pin versioned tags/digests for exact
+invalidation; and worker *reuse* is image-blind — a still-running worker
+pool from an earlier build keeps its old image, so stop lingering workers
+first when switching images.
 
 Examples:
 

--- a/src/clm/core/operations/convert_drawio_file.py
+++ b/src/clm/core/operations/convert_drawio_file.py
@@ -24,9 +24,14 @@ class ConvertDrawIoFileOperation(ConvertSourceOutputFileOperation):
     async def payload(self) -> DrawioPayload:
         data = self.input_file.source_path.read_text(encoding="utf-8")
         correlation_id = await new_correlation_id()
+        from clm.infrastructure.workers.image_identity import (
+            effective_worker_image_identity,
+        )
+
         payload = DrawioPayload(
             data=data,
             correlation_id=correlation_id,
+            worker_image_identity=effective_worker_image_identity("drawio"),
             input_file=str(self.input_file.path),
             input_file_name=self.input_file.path.name,
             output_file=str(self.output_file),

--- a/src/clm/core/operations/convert_plantuml_file.py
+++ b/src/clm/core/operations/convert_plantuml_file.py
@@ -24,9 +24,14 @@ class ConvertPlantUmlFileOperation(ConvertSourceOutputFileOperation):
     async def payload(self) -> PlantUmlPayload:
         data = self.input_file.source_path.read_text(encoding="utf-8")
         correlation_id = await new_correlation_id()
+        from clm.infrastructure.workers.image_identity import (
+            effective_worker_image_identity,
+        )
+
         payload = PlantUmlPayload(
             data=data,
             correlation_id=correlation_id,
+            worker_image_identity=effective_worker_image_identity("plantuml"),
             input_file=str(self.input_file.path),
             input_file_name=self.input_file.path.name,
             output_file=str(self.output_file),

--- a/src/clm/core/operations/process_notebook.py
+++ b/src/clm/core/operations/process_notebook.py
@@ -26,6 +26,13 @@ from clm.infrastructure.utils.path_utils import (
     relative_path_to_course_img,
 )
 
+# Re-exported for existing callers/tests; the canonical home is the
+# infrastructure module so the diagram operations and the build's
+# effective-identity registry share one implementation (issue #744).
+from clm.infrastructure.workers.image_identity import (
+    worker_image_identity_for,  # noqa: F401
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -103,28 +110,6 @@ def compute_template_fingerprint(prog_lang: str) -> str:
     return _hash_template_dir(prog_lang, template_dir)
 
 
-def worker_image_identity_for(execution_mode: str, image: str | None) -> str:
-    """Resolve the execution-environment identity string for the cache key.
-
-    Pure resolution logic, separated from the global-config read in
-    :func:`compute_worker_image_identity` so it is directly testable.
-
-    - ``direct`` mode → ``"direct"``: the worker runs the host's own
-      environment, whose version/template content is already covered by
-      ``compute_template_fingerprint``.
-    - ``docker`` mode → ``"docker:<image>"`` with the same effective-image
-      resolution the pool starter uses (per-type override, else the bundled
-      default) — the key must describe the image that actually executes.
-    """
-    if execution_mode != "docker":
-        return "direct"
-    from clm.infrastructure.config import DEFAULT_WORKER_IMAGES
-
-    effective = image or DEFAULT_WORKER_IMAGES.get("notebook", "")
-    return f"docker:{effective}"
-
-
-@cache
 def compute_worker_image_identity() -> str:
     """Identity of the execution environment notebook jobs will run in.
 
@@ -135,32 +120,18 @@ def compute_worker_image_identity() -> str:
     fingerprint cannot see: a Docker worker image carries its own clm
     version, templates, and kernel (xeus-cpp etc.), so a cache populated
     under one image must not be replayed under another (issue #321 class 5,
-    the xeus-cling → xeus-cpp incident). The image reference is host-known
-    configuration, so every cache layer can compute the key identically
-    without asking the worker.
+    the xeus-cling → xeus-cpp incident).
 
-    Limitation: this is the configured image *reference*, not a content
-    digest. A mutable tag (``:latest``) that is re-pulled to point at a new
-    image does NOT change the key — pin worker images to versioned tags or
-    ``@sha256:...`` digests for the invalidation to be exact. (Resolving the
-    local digest at payload time would require a Docker API call per build
-    and a running daemon; not worth it host-side.)
-
-    Defensive ``""`` on any config error: a payload must never fail to
-    build because worker config is unreadable; an empty identity merely
-    reverts that build to the pre-#321 keying for this component.
+    Since #744 this resolves through
+    :mod:`clm.infrastructure.workers.image_identity`, so a build's CLI
+    image override (``--notebook-image``) is visible to the cache key —
+    previously the singleton config was read and the override was not.
+    See that module for the mutable-tag limitation and the defensive
+    empty-identity contract.
     """
-    try:
-        from clm.infrastructure.config import get_config
+    from clm.infrastructure.workers.image_identity import effective_worker_image_identity
 
-        worker_management = get_config().worker_management
-        execution_mode = (
-            worker_management.notebook.execution_mode or worker_management.default_execution_mode
-        )
-        return worker_image_identity_for(execution_mode, worker_management.notebook.image)
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.warning(f"Could not resolve worker image identity for cache key: {exc}")
-        return ""
+    return effective_worker_image_identity("notebook")
 
 
 def _resolve_trace_dir_for_payload() -> str:

--- a/src/clm/infrastructure/messaging/base_classes.py
+++ b/src/clm/infrastructure/messaging/base_classes.py
@@ -95,8 +95,30 @@ class Payload(TransferModel):
         return "default"
 
 
+#: Version tag folded into every diagram cache hash. Bump whenever the
+#: composition of ``ImagePayload.content_hash()`` changes so stale entries
+#: keyed under the old schema can never replay as hits (the notebook caches
+#: have their own ``CACHE_HASH_SCHEMA_VERSION`` with the same contract).
+IMAGE_CACHE_HASH_SCHEMA_VERSION = 1
+
+
 class ImagePayload(Payload):
     output_format: str = "png"
+    #: Identity of the worker environment that renders this image —
+    #: ``"direct"`` or ``"docker:<image>"`` (issue #744). Folded into
+    #: ``content_hash`` so a diagram cache populated under one converter
+    #: image is never replayed under another; host-known, computed at
+    #: payload construction like ``NotebookPayload.worker_image_identity``.
+    #: Default ``""`` keeps pre-#744 callers constructible (identity-less
+    #: keying for that payload only).
+    worker_image_identity: str = ""
+
+    def content_hash(self) -> str:
+        key = (
+            f"{IMAGE_CACHE_HASH_SCHEMA_VERSION}:{self.worker_image_identity}:"
+            f"{self.output_format}:{self.data}"
+        )
+        return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
     def output_metadata(self) -> str:
         return self.output_format

--- a/src/clm/infrastructure/workers/image_identity.py
+++ b/src/clm/infrastructure/workers/image_identity.py
@@ -1,0 +1,108 @@
+"""Effective worker-image identity for cache keys (issue #744).
+
+The cache key must describe the environment that actually executes a job
+(issue #321 class 5). Two things used to break that for images:
+
+- **CLI overrides were invisible**: ``load_worker_config`` applies
+  ``--notebook-image``/``--plantuml-image``/``--drawio-image`` to a deep
+  *copy* of the config (the deliberate #223 copy), while the identity
+  computation read the untouched global singleton — a build executing on
+  the override image keyed its cache as the default image.
+- **Diagram payloads had no image component at all** — a rebuilt converter
+  image replayed the old image's bytes for every unchanged source.
+
+``clm build`` records the post-override identities here
+(:func:`set_effective_worker_identities`); the per-type accessor falls back
+to the global singleton for callers outside a build (tests, tools), which
+matches the pre-#744 behavior when no override exists.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from clm.infrastructure.config import WorkersManagementConfig
+
+logger = logging.getLogger(__name__)
+
+_WORKER_TYPES = ("notebook", "plantuml", "drawio")
+
+#: Post-override identity per worker type, recorded by ``clm build``.
+_effective: dict[str, str] = {}
+
+
+def worker_image_identity_for(
+    execution_mode: str, image: str | None, worker_type: str = "notebook"
+) -> str:
+    """The environment identity string for one worker type.
+
+    - ``direct`` mode → ``"direct"``: the worker runs the host's own
+      environment (for notebooks its version/template content is already
+      covered by ``compute_template_fingerprint``; the diagram binaries'
+      versions are honest residue of the direct mode).
+    - ``docker`` mode → ``"docker:<image>"`` with the same effective-image
+      resolution the pool starter uses (per-type override, else the bundled
+      default) — the key must describe the image that actually executes.
+    """
+    if execution_mode != "docker":
+        return "direct"
+    from clm.infrastructure.config import DEFAULT_WORKER_IMAGES
+
+    effective = image or DEFAULT_WORKER_IMAGES.get(worker_type, "")
+    return f"docker:{effective}"
+
+
+def set_effective_worker_identities(worker_config: WorkersManagementConfig) -> None:
+    """Record the post-override execution identity of every worker type.
+
+    Called by ``clm build`` right after ``load_worker_config`` resolved the
+    CLI overrides into its config copy — from here on the cache keys see
+    the images that will actually execute, not the singleton's view.
+    Wholesale replacement: one build, one set of identities.
+    """
+    for worker_type in _WORKER_TYPES:
+        type_config = getattr(worker_config, worker_type)
+        execution_mode = type_config.execution_mode or worker_config.default_execution_mode
+        _effective[worker_type] = worker_image_identity_for(
+            execution_mode, type_config.image, worker_type
+        )
+    logger.debug(f"Effective worker image identities: {_effective}")
+
+
+def reset_effective_worker_identities() -> None:
+    """Drop recorded identities (tests) — accessors fall back to the singleton."""
+    _effective.clear()
+
+
+def effective_worker_image_identity(worker_type: str) -> str:
+    """Identity of the environment ``worker_type`` jobs will run in.
+
+    Computed HOST-side at payload construction and folded into the cache
+    keys. Prefers the identities a build recorded via
+    :func:`set_effective_worker_identities`; falls back to the global
+    config singleton otherwise.
+
+    Limitation: this is the configured image *reference*, not a content
+    digest — a mutable tag (``:latest``) re-pulled to a new image does NOT
+    change the key; pin worker images to versioned tags or digests for the
+    invalidation to be exact.
+
+    Defensive ``""`` on any config error: a payload must never fail to
+    build because worker config is unreadable; an empty identity merely
+    reverts that build to identity-less keying for this component.
+    """
+    recorded = _effective.get(worker_type)
+    if recorded is not None:
+        return recorded
+    try:
+        from clm.infrastructure.config import get_config
+
+        worker_management = get_config().worker_management
+        type_config = getattr(worker_management, worker_type)
+        execution_mode = type_config.execution_mode or worker_management.default_execution_mode
+        return worker_image_identity_for(execution_mode, type_config.image, worker_type)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(f"Could not resolve worker image identity for cache key: {exc}")
+        return ""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,6 +211,25 @@ def _isolate_db_path_env():
 
 
 @pytest.fixture(autouse=True)
+def _reset_effective_worker_identities():
+    """Keep the #744 image-identity registry hermetic per test.
+
+    ``configure_workers`` records the effective worker-image identities in
+    a module-level registry; any test driving it (build-command tests, the
+    config-loader tests) would otherwise leak the recording process-wide
+    and change what later tests observe from the singleton-fallback path —
+    same reasoning as ``_isolate_db_path_env``.
+    """
+    from clm.infrastructure.workers.image_identity import (
+        reset_effective_worker_identities,
+    )
+
+    reset_effective_worker_identities()
+    yield
+    reset_effective_worker_identities()
+
+
+@pytest.fixture(autouse=True)
 def _worker_api_env(request):
     """Isolate the Worker API env vars, and give each Docker test its own port.
 

--- a/tests/core/operations/test_process_notebook.py
+++ b/tests/core/operations/test_process_notebook.py
@@ -117,10 +117,29 @@ class TestWorkerImageIdentity:
         assert old != new
 
     def test_compute_from_global_config_is_stable_and_nonempty(self):
-        """The cached global-config wrapper returns a stable, non-empty
-        identity (cache-key components must not flap within a process)."""
-        compute_worker_image_identity.cache_clear()
+        """The global-config wrapper returns a stable, non-empty identity
+        (cache-key components must not flap within a process). Since #744
+        it resolves through the effective-identity registry; with nothing
+        recorded it falls back to the singleton, as before."""
+        from clm.infrastructure.workers.image_identity import (
+            reset_effective_worker_identities,
+        )
+
+        reset_effective_worker_identities()
         first = compute_worker_image_identity()
         second = compute_worker_image_identity()
         assert first == second
         assert first.startswith(("direct", "docker:"))
+
+    def test_effective_registry_overrides_the_singleton(self):
+        """#744 hole (b): the CLI override lives only in the config COPY —
+        the identity must prefer what the build recorded over the
+        singleton's stale view."""
+        from clm.infrastructure.workers import image_identity as ii
+
+        ii.reset_effective_worker_identities()
+        try:
+            ii._effective["notebook"] = "docker:ghcr.io/me/override:1"
+            assert compute_worker_image_identity() == "docker:ghcr.io/me/override:1"
+        finally:
+            ii.reset_effective_worker_identities()

--- a/tests/infrastructure/workers/test_image_identity.py
+++ b/tests/infrastructure/workers/test_image_identity.py
@@ -1,0 +1,103 @@
+"""Tests for :mod:`clm.infrastructure.workers.image_identity` (issue #744)."""
+
+import pytest
+
+from clm.infrastructure.config import DEFAULT_WORKER_IMAGES
+from clm.infrastructure.messaging.drawio_classes import DrawioPayload
+from clm.infrastructure.messaging.plantuml_classes import PlantUmlPayload
+from clm.infrastructure.workers.image_identity import (
+    effective_worker_image_identity,
+    reset_effective_worker_identities,
+    set_effective_worker_identities,
+    worker_image_identity_for,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    reset_effective_worker_identities()
+    yield
+    reset_effective_worker_identities()
+
+
+class TestPerTypeIdentity:
+    def test_bare_defaults_resolve_per_service(self):
+        """The docker default expands against each service's OWN repo."""
+        assert worker_image_identity_for("docker", None, "plantuml") == (
+            f"docker:{DEFAULT_WORKER_IMAGES['plantuml']}"
+        )
+        assert worker_image_identity_for("docker", None, "drawio") == (
+            f"docker:{DEFAULT_WORKER_IMAGES['drawio']}"
+        )
+
+    def test_direct_mode_per_type(self):
+        assert worker_image_identity_for("direct", "ignored:1", "drawio") == "direct"
+
+
+class TestEffectiveRegistry:
+    def test_set_records_post_override_identities(self):
+        """The #744 wiring: a build's resolved config (with CLI overrides
+        applied to the copy) is what the cache keys must see."""
+        from clm.infrastructure.workers.config_loader import load_worker_config
+
+        worker_config = load_worker_config(
+            {
+                "workers": "docker",
+                "plantuml_image": "test",
+                "drawio_image": "candidate:1.2",
+            }
+        )
+        set_effective_worker_identities(worker_config)
+        assert effective_worker_image_identity("plantuml") == (
+            "docker:docker.io/mhoelzl/clm-plantuml-converter:test"
+        )
+        assert effective_worker_image_identity("drawio") == "docker:candidate:1.2"
+
+    def test_fallback_without_recording_matches_singleton_path(self):
+        ident = effective_worker_image_identity("plantuml")
+        assert ident == "" or ident.startswith(("direct", "docker:"))
+
+
+class TestDiagramPayloadIdentity:
+    """Issue #744 hole (a): the diagram caches key on the payload
+    content_hash — a different converter image must be a cache MISS for
+    the same source."""
+
+    def _payload(self, cls, identity: str):
+        return cls(
+            data="@startuml\nA -> B\n@enduml",
+            correlation_id="c1",
+            input_file="a/x.puml",
+            input_file_name="x.puml",
+            output_file="out/x.png",
+            output_file_name="x.png",
+            worker_image_identity=identity,
+        )
+
+    def test_same_source_different_image_is_a_miss(self):
+        old = self._payload(PlantUmlPayload, "docker:conv:1.0").content_hash()
+        new = self._payload(PlantUmlPayload, "docker:conv:2.0").content_hash()
+        assert old != new
+
+    def test_same_source_same_image_is_stable(self):
+        a = self._payload(DrawioPayload, "docker:conv:1.0").content_hash()
+        b = self._payload(DrawioPayload, "docker:conv:1.0").content_hash()
+        assert a == b
+
+    def test_output_format_is_part_of_the_key(self):
+        png = self._payload(PlantUmlPayload, "direct")
+        svg = self._payload(PlantUmlPayload, "direct").model_copy(update={"output_format": "svg"})
+        assert png.content_hash() != svg.content_hash()
+
+    def test_identityless_payload_still_hashes(self):
+        """Pre-#744 constructors (default identity) stay valid — degraded
+        keying for that payload only."""
+        p = PlantUmlPayload(
+            data="@startuml\nA -> B\n@enduml",
+            correlation_id="c1",
+            input_file="a/x.puml",
+            input_file_name="x.puml",
+            output_file="out/x.png",
+            output_file_name="x.png",
+        )
+        assert p.content_hash()


### PR DESCRIPTION
Closes #744.

Both holes the #743 review identified, fixed at the root:

## (a) Diagram caches gain an image component

`ImagePayload` gains `worker_image_identity`, folded into `content_hash()` with a new `IMAGE_CACHE_HASH_SCHEMA_VERSION` and the output format. Old diagram cache entries can never replay under the new keys — a one-time diagram re-render on upgrade, exactly like the notebook schema bumps. The worker side needs **no change** (it stores the host-computed hash from the job row), and pydantic ignores the new field on older worker images, so there is no payload-compat break.

## (b) CLI overrides become visible to every cache key

New `clm.infrastructure.workers.image_identity` module: `worker_image_identity_for` generalized per worker type (moved from `process_notebook`, re-exported for existing callers); `set_effective_worker_identities` is called by `clm build` right after `load_worker_config` resolves the CLI overrides into its config copy; `effective_worker_image_identity(worker_type)` prefers the recorded identities and falls back to the global singleton (the pre-#744 path) for callers outside a build. `compute_worker_image_identity` keeps its name/signature but resolves through the registry (its `@cache` dropped so the recording is visible; the one test using `cache_clear()` updated).

Diagram payload construction (`convert_plantuml_file` / `convert_drawio_file`) passes the per-type identity.

## Docs

`caching.md` gains the diagram cache-key section; the #690 caveat texts (commands.md block, all three help texts, the unreleased #690 fragment) now state the fixed behavior with the two residual limits (mutable tags; image-blind worker reuse).

## Checks

- Regression tests (`tests/infrastructure/workers/test_image_identity.py` + extended `test_process_notebook.py`): same source + different image → different diagram hash; the registry-beats-singleton CLI-override hole; per-service default resolution; output format in the key; identity-less payloads still construct. Pre-fix the new module does not exist (loud failing-before).
- Full `tests/infrastructure` + `tests/core` + `tests/cli`: 4280 passed. ruff + mypy green; fast suite green on pre-push.

## Deliberately out of scope

Image-aware worker **reuse** (the lifecycle manager counts workers by type+mode+session only) — documented as a residual caveat; a reuse-key change deserves its own issue if it bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh
