### PR TITLE
fix(cache): explain accepts the build's worker/image flags (#746)

### DIFF
--- a/changelog.d/746-cache-explain-image-flags.fixed.md
+++ b/changelog.d/746-cache-explain-image-flags.fixed.md
@@ -1,0 +1,6 @@
+- `clm cache explain` gains `--workers` and the three image-override flags
+  (#746): the cache keys follow the effective worker image since #744, so
+  explain must be given the same flags as the build it explains — it used
+  to read the config singleton (which CLI overrides never touch) and
+  misattributed the resulting miss. With no flags it matches a no-flag
+  build, as before.

--- a/src/clm/cli/commands/cache.py
+++ b/src/clm/cli/commands/cache.py
@@ -249,6 +249,33 @@ def _unwrap_operations(op) -> list:
 )
 @click.option("--kind", "kinds", multiple=True, help="Limit to output kind(s).")
 @click.option("--format", "formats", multiple=True, help="Limit to output format(s).")
+@click.option(
+    "--workers",
+    type=click.Choice(["direct", "docker"]),
+    default=None,
+    help="Match the build's --workers mode, so the explained keys use the "
+    "same worker-image identity (issue #746). Default: the configured mode.",
+)
+@click.option(
+    "--notebook-image",
+    type=str,
+    default=None,
+    help="Match the build's --notebook-image: the cache keys follow the "
+    "effective image (#744), so explain must be given the same override or "
+    "it misattributes the miss (issue #746).",
+)
+@click.option(
+    "--plantuml-image",
+    type=str,
+    default=None,
+    help="Match the build's --plantuml-image (see --notebook-image).",
+)
+@click.option(
+    "--drawio-image",
+    type=str,
+    default=None,
+    help="Match the build's --drawio-image (see --notebook-image).",
+)
 @click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
 @click.pass_context
 def explain_cmd(
@@ -260,6 +287,10 @@ def explain_cmd(
     languages: tuple[str, ...],
     kinds: tuple[str, ...],
     formats: tuple[str, ...],
+    workers: str | None,
+    notebook_image: str | None,
+    plantuml_image: str | None,
+    drawio_image: str | None,
     as_json: bool,
 ):
     """Explain the cache keys and cache state for one slide source file.
@@ -324,6 +355,26 @@ def explain_cmd(
             f"'{source_file}' is a {type(course_file).__name__}, not a notebook "
             f"slide file — only notebook execution is cached with explained keys."
         )
+
+    # Mirror the build's effective-identity recording (issues #744/#746):
+    # the cache keys follow the effective worker image, so explain must
+    # resolve identities the same way a build with these flags would —
+    # including the no-flag case (the recording then equals the config
+    # fallback, keeping no-flag explain aligned with a no-flag build).
+    from clm.infrastructure.workers.config_loader import load_worker_config
+    from clm.infrastructure.workers.image_identity import set_effective_worker_identities
+
+    identity_overrides: dict[str, object] = {}
+    if workers:
+        identity_overrides["workers"] = workers
+    for override_key, override_value in (
+        ("notebook_image", notebook_image),
+        ("plantuml_image", plantuml_image),
+        ("drawio_image", drawio_image),
+    ):
+        if override_value:
+            identity_overrides[override_key] = override_value
+    set_effective_worker_identities(load_worker_config(identity_overrides))
 
     async def _payloads():
         operations = []

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -2993,11 +2993,14 @@ shown but marked excluded (its bytes are deliberately not part of the key).
 | `-L, --lang LANG` | Limit to output language(s) |
 | `--kind KIND` | Limit to output kind(s) |
 | `--format FORMAT` | Limit to output format(s) |
+| `--workers direct\|docker` | Match the build's worker mode for the image identity (CLM {version}, #746) |
+| `--notebook-image` / `--plantuml-image` / `--drawio-image` | Match the build's image overrides — the cache keys follow the effective image (#744), so explain must be given the same flags as the build it explains, or it misattributes the miss |
 | `--json` | Output as JSON |
 
 Run it with the same global `--cache-db-path` / `--jobs-db-path` as your
-builds, or the lookups miss spuriously. Entirely read-only: databases are
-opened in read-only mode and no output directories are created.
+builds — **and the same `--workers` / image flags** — or the lookups miss
+spuriously. Entirely read-only: databases are opened in read-only mode and
+no output directories are created.
 
 ```bash
 clm cache explain slides/.../slides_shared_ptr.cpp --spec cpp-einsteiger.xml

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -2999,8 +2999,11 @@ shown but marked excluded (its bytes are deliberately not part of the key).
 
 Run it with the same global `--cache-db-path` / `--jobs-db-path` as your
 builds — **and the same `--workers` / image flags** — or the lookups miss
-spuriously. Entirely read-only: databases are opened in read-only mode and
-no output directories are created.
+spuriously. One residual gap: explain does not auto-load the course
+`.env` (the build does), so `CLM_WORKER_MANAGEMENT__*` vars set only
+there must be exported in the shell for explain to see them. Entirely
+read-only: databases are opened in read-only mode and no output
+directories are created.
 
 ```bash
 clm cache explain slides/.../slides_shared_ptr.cpp --spec cpp-einsteiger.xml

--- a/tests/cli/test_cache_explain.py
+++ b/tests/cli/test_cache_explain.py
@@ -258,5 +258,13 @@ class TestExplainImageOverrides:
         assert data["components"]["worker_image_identity"] == "docker:candidate:9"
 
     def test_no_flags_matches_the_config_fallback(self, tmp_path):
+        """The no-flag contract pinned exactly: explain's recording equals
+        the singleton-derived identity, not arbitrary recorded state."""
+        from clm.infrastructure.config import get_config
+        from clm.infrastructure.workers.image_identity import worker_image_identity_for
+
+        wm = get_config().worker_management
+        mode = wm.notebook.execution_mode or wm.default_execution_mode
+        expected = worker_image_identity_for(mode, wm.notebook.image, "notebook")
         data = _explain_json(tmp_path)
-        assert data["components"]["worker_image_identity"].startswith(("direct", "docker:"))
+        assert data["components"]["worker_image_identity"] == expected

--- a/tests/cli/test_cache_explain.py
+++ b/tests/cli/test_cache_explain.py
@@ -237,3 +237,26 @@ class TestCacheExplainSeeded:
             assert "skips execution" in hit["verdict"]
         else:
             assert "output file is missing" in hit["verdict"]
+
+
+class TestExplainImageOverrides:
+    """Issue #746: explain must compute the same keys a build with the same
+    image flags would — it used to read the config singleton, which CLI
+    overrides never touch, and misattributed the resulting miss."""
+
+    def test_image_flags_reach_the_identity(self, tmp_path):
+        result = _explain(
+            tmp_path,
+            "--json",
+            "--workers",
+            "docker",
+            "--notebook-image",
+            "candidate:9",
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output[result.output.index("{") :])
+        assert data["components"]["worker_image_identity"] == "docker:candidate:9"
+
+    def test_no_flags_matches_the_config_fallback(self, tmp_path):
+        data = _explain_json(tmp_path)
+        assert data["components"]["worker_image_identity"].startswith(("direct", "docker:"))


### PR DESCRIPTION
Closes #746.

Since #744 the cache keys follow the effective worker image — but `clm cache explain` constructed its payloads with the identity registry empty, reported the config singleton's identity, and misattributed the miss a `--notebook-image` build produces. AGENTS.md's rebuild-troubleshooting flow leans on explain, so it must speak the build's language.

## Change

`cache explain` gains `--workers` + `--notebook-image` / `--plantuml-image` / `--drawio-image` and records the effective identities through the exact path the build uses (`load_worker_config` → `set_effective_worker_identities`) before payload construction. Bare-tag shorthand and per-service expansion come along for free. With no flags the recording equals the config fallback, so no-flag explain matches a no-flag build — unchanged behavior.

## Checks

- Regression test verified **failing before** (`--workers docker --notebook-image candidate:9` → `worker_image_identity == "docker:candidate:9"`); the no-flag fallback pinned.
- Full `tests/cli`: 1882 passed. ruff + mypy green; fast suite on pre-push. Info topic updated ("run it with the same `--workers`/image flags as your builds").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh
