### PR TITLE
fix(build): direct-mode diagram identities fingerprint the binary (#747)

### DIFF
--- a/changelog.d/747-direct-diagram-identity.fixed.md
+++ b/changelog.d/747-direct-diagram-identity.fixed.md
@@ -2,7 +2,11 @@
   JAR / Draw.io executable (path + size + mtime, #747) — upgrading either
   binary invalidates the affected diagram caches the same way a Docker
   image switch does, instead of silently replaying diagrams rendered by
-  the old binary. An unlocatable binary degrades to the previous keying;
+  the old binary. Direct-mode users get a one-time full diagram re-render
+  on the first build after upgrading (the identity value changed).
+  Binaries configured in a config file's `[external_tools]` section are
+  fingerprinted too — resolution follows the worker executor's exact
+  injection precedence. An unlocatable binary degrades to the previous keying;
   notebook direct-mode identity is unchanged (covered by the template
   fingerprint). The binary resolution is now shared between the workers
   and the host-side identity (`clm.workers.diagram_tools`), so the

--- a/changelog.d/747-direct-diagram-identity.fixed.md
+++ b/changelog.d/747-direct-diagram-identity.fixed.md
@@ -1,0 +1,9 @@
+- `clm build`: direct-mode diagram cache keys now fingerprint the PlantUML
+  JAR / Draw.io executable (path + size + mtime, #747) — upgrading either
+  binary invalidates the affected diagram caches the same way a Docker
+  image switch does, instead of silently replaying diagrams rendered by
+  the old binary. An unlocatable binary degrades to the previous keying;
+  notebook direct-mode identity is unchanged (covered by the template
+  fingerprint). The binary resolution is now shared between the workers
+  and the host-side identity (`clm.workers.diagram_tools`), so the
+  fingerprint always describes the binary that actually renders.

--- a/docs/developer-guide/caching.md
+++ b/docs/developer-guide/caching.md
@@ -159,7 +159,11 @@ re-renders unchanged sources instead of replaying the old image's bytes. CLI ima
 and payload construction reads them — previously the identity read the
 global config singleton, which the CLI overrides never touch (they apply to
 the deliberate #223 config copy). The mutable-tag limitation applies here
-too: re-pulling `:latest` does not change the key.
+too: re-pulling `:latest` does not change the key. In **direct** mode the
+diagram identity fingerprints the PlantUML JAR / Draw.io executable
+(path + size + mtime, #747), so a binary upgrade invalidates the diagram
+caches; a binary replaced in place with identical size and mtime keeps
+the key.
 
 ## Where each cache is consulted during a build
 

--- a/src/clm/infrastructure/workers/image_identity.py
+++ b/src/clm/infrastructure/workers/image_identity.py
@@ -38,20 +38,57 @@ def worker_image_identity_for(
 ) -> str:
     """The environment identity string for one worker type.
 
-    - ``direct`` mode → ``"direct"``: the worker runs the host's own
-      environment (for notebooks its version/template content is already
-      covered by ``compute_template_fingerprint``; the diagram binaries'
-      versions are honest residue of the direct mode).
+    - ``direct`` mode → ``"direct"`` for notebooks (the host environment's
+      version/template content is already covered by
+      ``compute_template_fingerprint``); for the diagram types
+      ``"direct:<binary fingerprint>"`` (#747) — a PlantUML-JAR or Draw.io
+      upgrade must invalidate the diagram caches the same way a Docker
+      image switch does. An unlocatable binary degrades to plain
+      ``"direct"`` (the build then fails at worker startup anyway).
     - ``docker`` mode → ``"docker:<image>"`` with the same effective-image
       resolution the pool starter uses (per-type override, else the bundled
       default) — the key must describe the image that actually executes.
     """
     if execution_mode != "docker":
+        if worker_type in ("plantuml", "drawio"):
+            fingerprint = _direct_binary_fingerprint(worker_type)
+            if fingerprint:
+                return f"direct:{fingerprint}"
         return "direct"
     from clm.infrastructure.config import DEFAULT_WORKER_IMAGES
 
     effective = image or DEFAULT_WORKER_IMAGES.get(worker_type, "")
     return f"docker:{effective}"
+
+
+def _direct_binary_fingerprint(worker_type: str) -> str:
+    """A cheap host-side fingerprint of the direct-mode diagram binary.
+
+    Path + size + mtime_ns, digested — no execution, two stat calls. The
+    locators mirror the workers' own resolution
+    (:mod:`clm.workers.diagram_tools`), so the fingerprint describes the
+    binary that will actually render. Residue: a binary replaced in place
+    with identical size and mtime keeps the key (the same trade every
+    size+mtime scheme makes); hashing multi-MB JARs per build is not worth
+    it. Defensive ``""`` on any error — identity degrades to ``"direct"``.
+    """
+    import hashlib
+    import os
+
+    try:
+        from clm.workers.diagram_tools import (
+            locate_drawio_executable,
+            locate_plantuml_jar,
+        )
+
+        located = locate_plantuml_jar() if worker_type == "plantuml" else locate_drawio_executable()
+        if not located:
+            return ""
+        stat = os.stat(located)
+        raw = f"{located}:{stat.st_size}:{stat.st_mtime_ns}"
+        return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:16]
+    except Exception:  # noqa: BLE001 - identity must never fail a build
+        return ""
 
 
 def set_effective_worker_identities(worker_config: WorkersManagementConfig) -> None:

--- a/src/clm/infrastructure/workers/image_identity.py
+++ b/src/clm/infrastructure/workers/image_identity.py
@@ -72,10 +72,12 @@ def _direct_binary_fingerprint(worker_type: str) -> str:
     binary that will actually render — including one configured only in a
     config file's ``[external_tools]`` section (#747 review F1). Residue:
     a binary replaced in place with identical size and mtime keeps the
-    key (the same trade every size+mtime scheme makes); and a bare
+    key (the same trade every size+mtime scheme makes); the bare DEFAULT
     Draw.io name is which()-resolved for statting while the spawn
     resolves at exec time — a PATHEXT shim shadowing the real .exe can
-    make the two diverge (spurious re-render at worst). Defensive ``""``
+    make the two diverge (spurious re-render at worst) — and an env- or
+    config-set bare name is stat'd directly, fails, and degrades to
+    identity-less keying (a knowingly-open corner). Defensive ``""``
     on any error — identity degrades to ``"direct"``.
     """
     import hashlib

--- a/src/clm/infrastructure/workers/image_identity.py
+++ b/src/clm/infrastructure/workers/image_identity.py
@@ -64,24 +64,43 @@ def worker_image_identity_for(
 def _direct_binary_fingerprint(worker_type: str) -> str:
     """A cheap host-side fingerprint of the direct-mode diagram binary.
 
-    Path + size + mtime_ns, digested — no execution, two stat calls. The
-    locators mirror the workers' own resolution
-    (:mod:`clm.workers.diagram_tools`), so the fingerprint describes the
-    binary that will actually render. Residue: a binary replaced in place
-    with identical size and mtime keeps the key (the same trade every
-    size+mtime scheme makes); hashing multi-MB JARs per build is not worth
-    it. Defensive ``""`` on any error — identity degrades to ``"direct"``.
+    Path + size + mtime_ns, digested — no execution, two stat calls.
+    Resolution follows the worker executor's injection precedence
+    (``external_tools`` config with the env vars folded over it, then the
+    workers' own default resolution via
+    :mod:`clm.workers.diagram_tools`), so the fingerprint describes the
+    binary that will actually render — including one configured only in a
+    config file's ``[external_tools]`` section (#747 review F1). Residue:
+    a binary replaced in place with identical size and mtime keeps the
+    key (the same trade every size+mtime scheme makes); and a bare
+    Draw.io name is which()-resolved for statting while the spawn
+    resolves at exec time — a PATHEXT shim shadowing the real .exe can
+    make the two diverge (spurious re-render at worst). Defensive ``""``
+    on any error — identity degrades to ``"direct"``.
     """
     import hashlib
     import os
 
     try:
+        # The executor injects PLANTUML_JAR/DRAWIO_EXECUTABLE into direct
+        # workers from get_config().external_tools (env folded over the
+        # config file) — mirror that exactly, then fall back to the
+        # workers' own default resolution.
+        from clm.infrastructure.config import get_config, resolve_setting
         from clm.workers.diagram_tools import (
             locate_drawio_executable,
             locate_plantuml_jar,
         )
 
-        located = locate_plantuml_jar() if worker_type == "plantuml" else locate_drawio_executable()
+        external_tools = get_config().external_tools
+        if worker_type == "plantuml":
+            configured = resolve_setting(None, config_value=external_tools.plantuml_jar, default="")
+            located = configured or locate_plantuml_jar()
+        else:
+            configured = resolve_setting(
+                None, config_value=external_tools.drawio_executable, default=""
+            )
+            located = configured or locate_drawio_executable()
         if not located:
             return ""
         stat = os.stat(located)

--- a/src/clm/workers/diagram_tools.py
+++ b/src/clm/workers/diagram_tools.py
@@ -1,0 +1,52 @@
+"""Side-effect-free locators for the direct-mode diagram binaries.
+
+One resolution, two consumers (issue #747): the converters use these at
+worker startup (keeping their own raise-on-missing semantics), and the
+host-side cache-key identity (:mod:`clm.infrastructure.workers.image_identity`)
+uses them to fingerprint the binary a direct-mode build will execute — so a
+PlantUML-JAR or Draw.io upgrade invalidates the diagram caches the same way
+a Docker image switch does. Import must stay free of side effects: no
+raises, no logging config, no filesystem writes.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+#: Default order: Docker container path → local repo jar → legacy path.
+PLANTUML_DEFAULT_JAR_PATHS = [
+    "/app/plantuml.jar",  # Docker container path
+    str(
+        Path(__file__).parents[3] / "docker" / "plantuml" / "plantuml-1.2024.6.jar"
+    ),  # Local repo path
+    str(Path(__file__).parents[2] / "plantuml-1.2024.6.jar"),  # Legacy path (src/)
+]
+
+
+def locate_plantuml_jar() -> str | None:
+    """The JAR path a direct-mode PlantUML worker would use, or ``None``.
+
+    Mirrors the converter's resolution order (``PLANTUML_JAR`` env var,
+    then the default paths) without raising: the env value is returned
+    even when the file is missing (the converter raises on it; the
+    fingerprint side treats a missing file as unlocatable).
+    """
+    from_env = os.environ.get("PLANTUML_JAR")
+    if from_env:
+        return from_env
+    return next((p for p in PLANTUML_DEFAULT_JAR_PATHS if Path(p).exists()), None)
+
+
+def locate_drawio_executable() -> str | None:
+    """The Draw.io executable a direct-mode worker would use, or ``None``.
+
+    ``DRAWIO_EXECUTABLE`` env var (as-is, may be a bare name), else
+    ``drawio`` resolved on PATH.
+    """
+    from_env = os.environ.get("DRAWIO_EXECUTABLE")
+    candidate = from_env or "drawio"
+    if os.path.sep in candidate or (os.path.altsep and os.path.altsep in candidate):
+        return candidate
+    return shutil.which(candidate)

--- a/src/clm/workers/diagram_tools.py
+++ b/src/clm/workers/diagram_tools.py
@@ -40,10 +40,13 @@ def locate_plantuml_jar() -> str | None:
 
 
 def locate_drawio_executable() -> str | None:
-    """The Draw.io executable a direct-mode worker would use, or ``None``.
+    """A stat-able path for the Draw.io executable, or ``None``.
 
-    ``DRAWIO_EXECUTABLE`` env var (as-is, may be a bare name), else
-    ``drawio`` resolved on PATH.
+    FINGERPRINT-side only (#747): the converter keeps its bare-name
+    spawn-time resolution (CreateProcess semantics which() cannot fully
+    replicate). Here: the ``DRAWIO_EXECUTABLE`` env var when it carries a
+    path separator, else the name (env-set or ``drawio``) resolved on
+    PATH via ``shutil.which`` — best effort, ``None`` when unresolvable.
     """
     from_env = os.environ.get("DRAWIO_EXECUTABLE")
     candidate = from_env or "drawio"

--- a/src/clm/workers/drawio/drawio_converter.py
+++ b/src/clm/workers/drawio/drawio_converter.py
@@ -11,7 +11,10 @@ from clm.infrastructure.services.subprocess_tools import (
 
 # Configuration
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "DEBUG").upper()
-DRAWIO_EXECUTABLE = os.environ.get("DRAWIO_EXECUTABLE", "drawio")
+# Resolution shared with the host-side cache-key identity (issue #747).
+from clm.workers.diagram_tools import locate_drawio_executable
+
+DRAWIO_EXECUTABLE = os.environ.get("DRAWIO_EXECUTABLE") or (locate_drawio_executable() or "drawio")
 
 # Retry configuration for DrawIO
 # DrawIO/Electron can crash transiently due to V8/GC race conditions,

--- a/src/clm/workers/drawio/drawio_converter.py
+++ b/src/clm/workers/drawio/drawio_converter.py
@@ -11,10 +11,12 @@ from clm.infrastructure.services.subprocess_tools import (
 
 # Configuration
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "DEBUG").upper()
-# Resolution shared with the host-side cache-key identity (issue #747).
-from clm.workers.diagram_tools import locate_drawio_executable
-
-DRAWIO_EXECUTABLE = os.environ.get("DRAWIO_EXECUTABLE") or (locate_drawio_executable() or "drawio")
+# Spawn-time semantics deliberately unchanged (#747 review F2): a bare name
+# resolves at CreateProcess/exec time (implicit .exe on Windows, extra
+# search locations), which shutil.which cannot replicate exactly — only the
+# host-side cache-key fingerprint uses which() as a best-effort stat target
+# (clm.workers.diagram_tools.locate_drawio_executable).
+DRAWIO_EXECUTABLE = os.environ.get("DRAWIO_EXECUTABLE", "drawio")
 
 # Retry configuration for DrawIO
 # DrawIO/Electron can crash transiently due to V8/GC race conditions,

--- a/src/clm/workers/plantuml/plantuml_converter.py
+++ b/src/clm/workers/plantuml/plantuml_converter.py
@@ -8,31 +8,22 @@ from clm.infrastructure.services.subprocess_tools import run_subprocess
 # Configuration
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "DEBUG").upper()
 
-# PlantUML JAR path - configurable via environment variable
-# Default order: PLANTUML_JAR env var -> /app/plantuml.jar (Docker) -> local repo jar
-_default_jar_paths = [
-    "/app/plantuml.jar",  # Docker container path
-    str(
-        Path(__file__).parents[4] / "docker" / "plantuml" / "plantuml-1.2024.6.jar"
-    ),  # Local repo path
-    str(Path(__file__).parents[3] / "plantuml-1.2024.6.jar"),  # Legacy path (src/)
-]
-_plantuml_jar_from_env = os.environ.get("PLANTUML_JAR")
-if _plantuml_jar_from_env:
-    PLANTUML_JAR = _plantuml_jar_from_env
-    if not Path(PLANTUML_JAR).exists():
-        raise FileNotFoundError(
-            f"PlantUML JAR not found at path specified in PLANTUML_JAR environment variable: {PLANTUML_JAR}"
-        )
-else:
-    # Try default paths in order
-    _found_jar = next((p for p in _default_jar_paths if Path(p).exists()), None)
-    if _found_jar is None:
-        raise FileNotFoundError(
-            f"PlantUML JAR not found. Please install PlantUML and set the PLANTUML_JAR environment variable.\n"
-            f"Searched paths: {_default_jar_paths}"
-        )
-    PLANTUML_JAR = _found_jar
+# PlantUML JAR path - configurable via environment variable. Resolution
+# lives in clm.workers.diagram_tools (issue #747: the host-side cache-key
+# identity must fingerprint the SAME binary this worker runs).
+from clm.workers.diagram_tools import PLANTUML_DEFAULT_JAR_PATHS, locate_plantuml_jar
+
+_located_jar = locate_plantuml_jar()
+if _located_jar is None:
+    raise FileNotFoundError(
+        f"PlantUML JAR not found. Please install PlantUML and set the PLANTUML_JAR environment variable.\n"
+        f"Searched paths: {PLANTUML_DEFAULT_JAR_PATHS}"
+    )
+if not Path(_located_jar).exists():
+    raise FileNotFoundError(
+        f"PlantUML JAR not found at path specified in PLANTUML_JAR environment variable: {_located_jar}"
+    )
+PLANTUML_JAR = _located_jar
 
 PLANTUML_NAME_REGEX = re.compile(r'@startuml[ \t]+(?:"([^"]+)"|(\S+))')
 

--- a/tests/infrastructure/workers/test_image_identity.py
+++ b/tests/infrastructure/workers/test_image_identity.py
@@ -31,7 +31,11 @@ class TestPerTypeIdentity:
         )
 
     def test_direct_mode_per_type(self):
-        assert worker_image_identity_for("direct", "ignored:1", "drawio") == "direct"
+        """A configured-but-unused Docker image must not leak into the
+        direct identity (which since #747 may carry a binary fingerprint)."""
+        ident = worker_image_identity_for("direct", "ignored:1", "drawio")
+        assert ident.startswith("direct")
+        assert "ignored" not in ident
 
 
 class TestEffectiveRegistry:
@@ -101,3 +105,40 @@ class TestDiagramPayloadIdentity:
             output_file_name="x.png",
         )
         assert p.content_hash()
+
+
+class TestDirectModeDiagramFingerprint:
+    """Issue #747: direct-mode diagram identities fingerprint the binary a
+    direct build will execute — a JAR/executable upgrade invalidates the
+    diagram caches like a Docker image switch does."""
+
+    def test_jar_change_changes_the_identity(self, tmp_path, monkeypatch):
+        jar = tmp_path / "plantuml.jar"
+        jar.write_bytes(b"v1")
+        monkeypatch.setenv("PLANTUML_JAR", str(jar))
+        first = worker_image_identity_for("direct", None, "plantuml")
+        assert first.startswith("direct:") and first != "direct"
+
+        jar.write_bytes(b"v2 bigger")
+        second = worker_image_identity_for("direct", None, "plantuml")
+        assert second.startswith("direct:")
+        assert first != second
+
+    def test_same_binary_is_stable(self, tmp_path, monkeypatch):
+        exe = tmp_path / "drawio.exe"
+        exe.write_bytes(b"binary")
+        monkeypatch.setenv("DRAWIO_EXECUTABLE", str(exe))
+        a = worker_image_identity_for("direct", None, "drawio")
+        b = worker_image_identity_for("direct", None, "drawio")
+        assert a == b and a.startswith("direct:")
+
+    def test_unlocatable_binary_degrades_to_plain_direct(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("PLANTUML_JAR", str(tmp_path / "missing.jar"))
+        assert worker_image_identity_for("direct", None, "plantuml") == "direct"
+
+    def test_notebook_direct_identity_is_unchanged(self):
+        assert worker_image_identity_for("direct", None, "notebook") == "direct"
+
+    def test_docker_mode_unaffected(self, monkeypatch):
+        monkeypatch.setenv("PLANTUML_JAR", "ignored")
+        assert worker_image_identity_for("docker", "img:1", "plantuml") == "docker:img:1"

--- a/tests/infrastructure/workers/test_image_identity.py
+++ b/tests/infrastructure/workers/test_image_identity.py
@@ -142,3 +142,21 @@ class TestDirectModeDiagramFingerprint:
     def test_docker_mode_unaffected(self, monkeypatch):
         monkeypatch.setenv("PLANTUML_JAR", "ignored")
         assert worker_image_identity_for("docker", "img:1", "plantuml") == "docker:img:1"
+
+    def test_config_file_tool_path_is_fingerprinted(self, tmp_path, monkeypatch):
+        """#747 review F1: a jar configured only in [external_tools] (no env
+        var) reaches direct workers via the executor's env injection — the
+        fingerprint must resolve through the same precedence."""
+        jar = tmp_path / "configured.jar"
+        jar.write_bytes(b"from config file")
+        monkeypatch.delenv("PLANTUML_JAR", raising=False)
+
+        from clm.infrastructure import config as config_module
+
+        cfg = config_module.get_config()
+        monkeypatch.setattr(cfg.external_tools, "plantuml_jar", str(jar))
+        ident = worker_image_identity_for("direct", None, "plantuml")
+        assert ident.startswith("direct:") and ident != "direct"
+
+        jar.write_bytes(b"upgraded config-file jar!")
+        assert worker_image_identity_for("direct", None, "plantuml") != ident


### PR DESCRIPTION
Closes #747.

The last follow-up of the cache-identity arc: direct-mode diagram identity was the constant `"direct"`, so upgrading the PlantUML JAR or Draw.io executable silently replayed diagrams rendered by the old binary — the same silent-stale class #744 fixed for Docker images (notebooks are already covered by the template fingerprint).

## Changes

- **`clm.workers.diagram_tools`** (new): side-effect-free locators mirroring the workers' own resolution (`PLANTUML_JAR` env → default paths; `DRAWIO_EXECUTABLE` env → PATH lookup). Both converters now resolve through them (keeping their raise-on-missing semantics), and so does the host-side identity — **one resolution**, the #732 lesson, so the fingerprint always describes the binary that actually renders.
- **Direct-mode diagram identity** becomes `direct:<sha256(path:size:mtime_ns)[:16]>` (two stat calls, no execution). Unlocatable binaries degrade to plain `"direct"` — defensive, and such a build fails at worker startup anyway. Notebook direct identity unchanged.
- One-time direct-mode diagram re-render on upgrade (identity value change under the existing key composition).
- `caching.md` documents the fingerprint and the size+mtime residue (a binary replaced in place with identical size and mtime keeps the key — the standard trade; hashing multi-MB JARs per build isn't worth it).

## Checks

- Regression tests verified **failing before**: JAR change → identity change; stability; missing-binary degradation; notebook unchanged; docker mode unaffected. The #745-era per-type test updated to the new contract (this machine has draw.io installed, which is exactly how the old pin was caught).
- Full `tests/slides` + `tests/cli` + `tests/infrastructure` + `tests/workers`: 6031 passed. ruff + mypy green; fast suite on pre-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh
