### PR TITLE
feat(studio): tier-2 preview renders in a killable subprocess under a wall-clock budget (#698)

### DIFF
--- a/changelog.d/698-preview-subprocess.security.md
+++ b/changelog.d/698-preview-subprocess.security.md
@@ -1,0 +1,11 @@
+- `clm serve` Studio: the tier-2 cell preview's Jinja expansion runs in a
+  **killable subprocess under a wall-clock budget** (#698). The in-process
+  sandbox and value caps bound memory but could not bound CPU — a nested
+  `range()` loop burned hours producing two characters, and the old
+  worker-thread route let 40 slow renders occupy the shared threadpool that
+  also serves the `/studio/` app shell. A timed-out render now degrades to
+  the tier-1 client-side fallback like every other preview failure, the
+  route holds no threadpool token while waiting, and the child carries a
+  POSIX address-space rlimit as a belt. Reachable only by a Studio
+  bearer-token holder (the trust boundary, decision D4) — defense in depth,
+  not a new exposure.

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -4466,7 +4466,11 @@ authenticate with `Authorization: Bearer` only; `?token=` is **not** accepted
 (it was, until CLM {version}). The server-side `is_j2` cell preview renders in
 a Jinja sandbox: it expands the bundled header macros without a kernel, and a
 template cannot walk Python attributes (`__class__` and friends) out of the
-template namespace, nor repeat a sequence into a memory bomb. The sandbox does
+template namespace, nor repeat a sequence into a memory bomb. Since CLM
+{version} the expansion also runs in a **killable subprocess under a
+wall-clock budget** (#698), so a CPU-burning template (nested `range()`
+loops) times out into the tier-1 fallback instead of stalling the server.
+The sandbox does
 not restrict the template *loader*, so `{% include %}` can still read files.
 Traversal out of the deck's directory is refused, but the reach is that
 directory **and its whole subtree, dotfiles included** — so anything parked

--- a/src/clm/web/studio/__init__.py
+++ b/src/clm/web/studio/__init__.py
@@ -16,6 +16,15 @@ lightweight vanilla-JS surface; the no-build Preact + CodeMirror PWA is
 deferred to P2+ where in-cell editing ergonomics start to pay off.
 """
 
-from clm.web.studio.service import StudioService
-
 __all__ = ["StudioService"]
+
+
+def __getattr__(name: str):
+    # Lazy: the preview render child (#698) imports this package on every
+    # spawn and must not pay for StudioService's pydantic/service imports
+    # (~262 ms of a ~400 ms cold start, measured in the #698 review).
+    if name == "StudioService":
+        from clm.web.studio.service import StudioService
+
+        return StudioService
+    raise AttributeError(name)

--- a/src/clm/web/studio/models.py
+++ b/src/clm/web/studio/models.py
@@ -242,7 +242,12 @@ class RenderCellRequest(BaseModel):
     """Tier-2 (kernel-free) render request for one ``is_j2`` cell (P4)."""
 
     deck_id: str = Field(description="Slides-dir-relative deck path (for prog-lang + includes).")
-    body: str = Field(description="Raw cell body (comment-prefixed, with the j2 lines).")
+    body: str = Field(
+        max_length=2_000_000,
+        description="Raw cell body (comment-prefixed, with the j2 lines). "
+        "Capped (#698): a body above the render output limit cannot produce "
+        "a legal preview anyway, and the subprocess protocol copies it.",
+    )
     is_j2: bool = Field(default=False, description="Only is_j2 cells are server-rendered.")
     lang: str | None = Field(default=None, description='"de"/"en" Jinja global for the macros.')
 

--- a/src/clm/web/studio/render.py
+++ b/src/clm/web/studio/render.py
@@ -44,10 +44,14 @@ routes them differently:
 ``{% for %}`` over ``range()`` burns hours producing two characters — so
 the request path renders in a **killable subprocess** under a wall-clock
 budget (:func:`render_j2_cell_in_subprocess`, one child per request,
-:data:`PREVIEW_TIMEOUT_SECONDS`), with a POSIX ``RLIMIT_AS`` belt in the
-child. The old thread-occupancy vector is gone with it: the route awaits
-the child on the event loop instead of holding one of the 40 shared
-threadpool tokens. The in-process value caps above stay as the memory
+:data:`PREVIEW_TIMEOUT_SECONDS`, at most
+:data:`MAX_CONCURRENT_PREVIEW_RENDERS` at once), and the child
+self-limits (watchdog + POSIX rlimits) so no parent-side failure can
+leave a burner behind. The old thread-occupancy vector shrinks with it:
+the route awaits the child on the event loop instead of holding one of
+the 40 shared threadpool tokens for the whole render — only the
+deterministic post-render tail (~90 ms worst case, size-capped input)
+briefly uses a worker thread. The in-process value caps above stay as the memory
 bound inside the child, and :func:`render_j2_cell` remains the in-process
 core for tests and non-request callers.
 
@@ -337,13 +341,76 @@ def _to_preview_html(text: str, comment_token: str) -> str:
 #: for interpreter start-up on a cold spawn.
 PREVIEW_TIMEOUT_SECONDS = 10.0
 
+#: Concurrent preview children (review MEDIUM-3). Real decks carry a median
+#: of ONE ``is_j2`` cell, so legitimate load is 1-2; without a cap, N
+#: concurrent requests saturate N cores for ``timeout`` seconds each — the
+#: only concurrency bound the old threadpool route had was its 40 tokens.
+#: Saturation degrades to tier-1 IMMEDIATELY (no queueing — a queue would
+#: recreate head-of-line blocking).
+MAX_CONCURRENT_PREVIEW_RENDERS = 4
+
+#: Longest child-supplied error string returned to the client (review
+#: LOW-4): Jinja syntax errors embed template source, so an uncapped error
+#: is O(body).
+_MAX_ERROR_CHARS = 2_000
+
+_render_semaphore = None
+
+
+def _get_render_semaphore():
+    """Lazily create the semaphore on the running loop (module import must
+    not require one)."""
+    global _render_semaphore
+    import asyncio
+
+    if _render_semaphore is None:
+        _render_semaphore = asyncio.Semaphore(MAX_CONCURRENT_PREVIEW_RENDERS)
+    return _render_semaphore
+
+
+#: Interpreter flags for the child (review LOW-1): ``-I`` keeps the
+#: server's cwd — normally a course repo, which can plausibly hold a
+#: ``json.py`` teaching example — off the child's ``sys.path``, and ignores
+#: ``PYTHON*`` env influence.
+_CHILD_ARGS = ("-I", "-m", "clm.web.studio.render_child")
+
+
+def _child_env() -> dict[str, str]:
+    """A minimal environment for the child (review LOW-2).
+
+    The child executes client-supplied Jinja; the server's environment can
+    carry credentials (LLM keys etc.) that a sandbox escape should not
+    find. Keep only what the interpreter and imports need.
+    """
+    import os
+
+    keep = (
+        "SYSTEMROOT",
+        "SYSTEMDRIVE",
+        "PATH",
+        "PATHEXT",
+        "TEMP",
+        "TMP",
+        "TMPDIR",
+        "HOME",
+        "USERPROFILE",
+        "LOCALAPPDATA",
+        "APPDATA",
+        "COMSPEC",
+        "LANG",
+        "LC_ALL",
+    )
+    env = {key: value for key, value in os.environ.items() if key.upper() in keep}
+    env["PYTHONUTF8"] = "1"
+    return env
+
 
 async def render_j2_cell_in_subprocess(
     deck_path: Path,
     body: str,
     lang: str | None,
     *,
-    timeout: float = PREVIEW_TIMEOUT_SECONDS,
+    timeout: float | None = None,
 ) -> tuple[bool, str | None, str]:
     """:func:`render_j2_cell`, in a killable subprocess (issue #698).
 
@@ -352,55 +419,101 @@ async def render_j2_cell_in_subprocess(
     hours producing two characters. One child process per request (see
     :mod:`clm.web.studio.render_child`), a wall-clock ``timeout``, and a
     kill: the failure mode is the preview's ordinary tier-1 degradation.
-    Runs on the event loop — no threadpool token is held while waiting, so
-    slow renders cannot occupy the shared pool either (the second half of
-    #698).
+    No threadpool token is held while waiting.
 
-    Same return contract as :func:`render_j2_cell`; never raises.
+    Defense in depth, both directions (#698 review): the parent NEVER
+    leaves this function with a live child (``finally`` kill + bounded
+    ``wait()`` reap — ``communicate()`` would hang if a kill only reached
+    a venv launcher trampoline whose grandchild still holds the pipe; on
+    this repo's uv venvs ``sys.executable`` IS such a trampoline, and the
+    kill covers the tree only via the launcher's job object). And the
+    child self-limits with a watchdog + POSIX rlimits, so even a path the
+    parent cannot cover — cancellation mid-await, a hard server crash —
+    cannot leave an unbounded burner behind.
+
+    Same return contract as :func:`render_j2_cell`; never raises (a
+    saturated concurrency cap degrades to tier-1 immediately).
     """
     import asyncio
     import json as json_module
     import sys
 
-    request = json_module.dumps({"deck_path": str(deck_path), "body": body, "lang": lang}).encode(
-        "utf-8"
-    )
+    # Resolved at call time so tests (and future config) can adjust the
+    # module constant; a def-time default would freeze it.
+    if timeout is None:
+        timeout = PREVIEW_TIMEOUT_SECONDS
+    semaphore = _get_render_semaphore()
+    if semaphore.locked():
+        return False, "preview busy (concurrent render cap) — showing raw cell", body
+
+    request = json_module.dumps(
+        {"deck_path": str(deck_path), "body": body, "lang": lang, "budget": timeout}
+    ).encode("utf-8")
     proc = None
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            sys.executable,
-            "-m",
-            "clm.web.studio.render_child",
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.DEVNULL,
-        )
-        stdout, _ = await asyncio.wait_for(proc.communicate(request), timeout=timeout)
-        if proc.returncode != 0:
-            return False, f"preview render failed (exit {proc.returncode})", body
-        response = json_module.loads(stdout.decode("utf-8"))
-        ok = bool(response.get("ok"))
-        text = response.get("text")
-        if not isinstance(text, str):
-            return False, "preview render returned no text", body
-        if len(text) > MAX_OUTPUT_CHARS:
-            # Belt: the child enforces this too, but the parent must never
-            # trust a child that was killed mid-write or misbehaved.
-            return False, f"preview output too large ({len(text)} chars)", body
-        error = response.get("error")
-        return ok, error if error is None or isinstance(error, str) else str(error), text
-    except TimeoutError:
-        if proc is not None:
-            proc.kill()
-            # Reap: an unawaited killed child leaks a zombie/handle.
-            await proc.communicate()
-        return False, f"preview timed out after {timeout:g}s", body
-    except Exception as exc:  # noqa: BLE001 - preview must never crash the request
-        logger.debug("Studio subprocess render failed for %s: %s", deck_path, exc)
-        if proc is not None and proc.returncode is None:
-            proc.kill()
-            await proc.communicate()
-        return False, str(exc), body
+    stderr_data = b""
+    async with semaphore:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                sys.executable,
+                *_CHILD_ARGS,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=_child_env(),
+            )
+            stdout, stderr_data = await asyncio.wait_for(proc.communicate(request), timeout=timeout)
+            if proc.returncode != 0:
+                # Systematic child failure must not be invisible (LOW-3).
+                logger.warning(
+                    "Studio preview child exited %s for %s: %s",
+                    proc.returncode,
+                    deck_path,
+                    stderr_data[-500:].decode("utf-8", "replace"),
+                )
+                return False, f"preview render failed (exit {proc.returncode})", body
+            response = json_module.loads(stdout.decode("utf-8"))
+            ok = bool(response.get("ok"))
+            text = response.get("text")
+            if not isinstance(text, str):
+                return False, "preview render returned no text", body
+            if len(text) > MAX_OUTPUT_CHARS:
+                # Belt: the child enforces this too, but the parent must never
+                # trust a child that was killed mid-write or misbehaved.
+                return False, f"preview output too large ({len(text)} chars)", body
+            error = response.get("error")
+            if error is not None and not isinstance(error, str):
+                error = str(error)
+            if error is not None and len(error) > _MAX_ERROR_CHARS:
+                error = error[:_MAX_ERROR_CHARS] + "…"
+            return ok, error, text
+        except TimeoutError:
+            return False, f"preview timed out after {timeout:g}s", body
+        except Exception as exc:  # noqa: BLE001 - preview must never crash the request
+            logger.debug("Studio subprocess render failed for %s: %s", deck_path, exc)
+            return False, str(exc), body
+        finally:
+            # The single kill/reap point (review HIGH-1/HIGH-2/MEDIUM-1):
+            # runs on success, timeout, error, AND cancellation, guarded so
+            # it can never raise out of the return paths.
+            if proc is not None and proc.returncode is None:
+                try:
+                    proc.kill()
+                except ProcessLookupError:
+                    pass
+                try:
+                    # wait() waits on the process handle — unlike
+                    # communicate(), it cannot hang on a pipe a surviving
+                    # grandchild still holds.
+                    await asyncio.wait_for(proc.wait(), timeout=5)
+                except (TimeoutError, Exception):  # noqa: BLE001
+                    pass
+                except BaseException:
+                    # Cancellation arrived while reaping: don't block the
+                    # cancel, but don't abandon the reap either — the child
+                    # was already killed; a background wait releases the
+                    # transport. The child's own watchdog is the backstop.
+                    asyncio.get_running_loop().create_task(proc.wait())
+                    raise
 
 
 def render_j2_cell_html(
@@ -432,19 +545,23 @@ async def render_j2_cell_html_in_subprocess(
     body: str,
     lang: str | None,
     *,
-    timeout: float = PREVIEW_TIMEOUT_SECONDS,
+    timeout: float | None = None,
 ) -> tuple[bool, str | None, str | None]:
     """:func:`render_j2_cell_html` with the expansion in a killable subprocess.
 
     The untrusted part — executing the client-supplied Jinja — runs in the
     child under the wall-clock budget; the deterministic tail (delimiter
-    drop, de-prefix, logo rewrite, sanitize) runs in-process on the child's
-    size-capped output.
+    drop, de-prefix, logo rewrite, sanitize) runs in a worker thread — it
+    is pure CPU on the child's size-capped output and measures ~50-90 ms
+    at the output cap (#698 review MEDIUM-2), which must not block the
+    event loop.
     """
+    import asyncio
+
     ok, error, text = await render_j2_cell_in_subprocess(deck_path, body, lang, timeout=timeout)
     if not ok:
         return False, error, None
-    return _finish_preview_html(deck_path, text)
+    return await asyncio.to_thread(_finish_preview_html, deck_path, text)
 
 
 def _finish_preview_html(deck_path: Path, text: str) -> tuple[bool, str | None, str | None]:

--- a/src/clm/web/studio/render.py
+++ b/src/clm/web/studio/render.py
@@ -40,13 +40,16 @@ routes them differently:
   ``{% set s = "A" * 100000 %}{% set s = s ~ s %}…`` went from ~1.2 GB to
   5.2 MB.
 
-**Still unbounded: CPU.** Nothing limits iteration, so nested ``{% for %}``
-over ``range()`` burns time without allocating, and ``run_in_threadpool``
-gives a client 40 shared threads to occupy. A token holder can still stall
-this process. That is accepted rather than fixed — the token is the trust
-boundary (decision D4) and the same client can already rewrite any deck —
-and doing it properly means rendering under a wall-clock limit in a
-subprocess, which is issue #698.
+**CPU (issue #698).** Nothing in-process limits iteration — nested
+``{% for %}`` over ``range()`` burns hours producing two characters — so
+the request path renders in a **killable subprocess** under a wall-clock
+budget (:func:`render_j2_cell_in_subprocess`, one child per request,
+:data:`PREVIEW_TIMEOUT_SECONDS`), with a POSIX ``RLIMIT_AS`` belt in the
+child. The old thread-occupancy vector is gone with it: the route awaits
+the child on the event loop instead of holding one of the 40 shared
+threadpool tokens. The in-process value caps above stay as the memory
+bound inside the child, and :func:`render_j2_cell` remains the in-process
+core for tests and non-request callers.
 
 **The loader.** The sandbox constrains the *template*, not the
 ``FileSystemLoader`` under it, so ``{% include %}`` still reads files. Jinja
@@ -329,6 +332,77 @@ def _to_preview_html(text: str, comment_token: str) -> str:
     return deprefix("\n".join(kept), comment_token).strip("\n")
 
 
+#: Wall-clock budget for one subprocess preview render (issue #698). A
+#: legitimate preview expands in well under a second; the budget mostly pays
+#: for interpreter start-up on a cold spawn.
+PREVIEW_TIMEOUT_SECONDS = 10.0
+
+
+async def render_j2_cell_in_subprocess(
+    deck_path: Path,
+    body: str,
+    lang: str | None,
+    *,
+    timeout: float = PREVIEW_TIMEOUT_SECONDS,
+) -> tuple[bool, str | None, str]:
+    """:func:`render_j2_cell`, in a killable subprocess (issue #698).
+
+    The in-process value caps bound every way of growing *memory*, but
+    nothing in-process can bound *CPU* — nested ``range()`` loops burn two
+    hours producing two characters. One child process per request (see
+    :mod:`clm.web.studio.render_child`), a wall-clock ``timeout``, and a
+    kill: the failure mode is the preview's ordinary tier-1 degradation.
+    Runs on the event loop — no threadpool token is held while waiting, so
+    slow renders cannot occupy the shared pool either (the second half of
+    #698).
+
+    Same return contract as :func:`render_j2_cell`; never raises.
+    """
+    import asyncio
+    import json as json_module
+    import sys
+
+    request = json_module.dumps({"deck_path": str(deck_path), "body": body, "lang": lang}).encode(
+        "utf-8"
+    )
+    proc = None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-m",
+            "clm.web.studio.render_child",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        stdout, _ = await asyncio.wait_for(proc.communicate(request), timeout=timeout)
+        if proc.returncode != 0:
+            return False, f"preview render failed (exit {proc.returncode})", body
+        response = json_module.loads(stdout.decode("utf-8"))
+        ok = bool(response.get("ok"))
+        text = response.get("text")
+        if not isinstance(text, str):
+            return False, "preview render returned no text", body
+        if len(text) > MAX_OUTPUT_CHARS:
+            # Belt: the child enforces this too, but the parent must never
+            # trust a child that was killed mid-write or misbehaved.
+            return False, f"preview output too large ({len(text)} chars)", body
+        error = response.get("error")
+        return ok, error if error is None or isinstance(error, str) else str(error), text
+    except TimeoutError:
+        if proc is not None:
+            proc.kill()
+            # Reap: an unawaited killed child leaks a zombie/handle.
+            await proc.communicate()
+        return False, f"preview timed out after {timeout:g}s", body
+    except Exception as exc:  # noqa: BLE001 - preview must never crash the request
+        logger.debug("Studio subprocess render failed for %s: %s", deck_path, exc)
+        if proc is not None and proc.returncode is None:
+            proc.kill()
+            await proc.communicate()
+        return False, str(exc), body
+
+
 def render_j2_cell_html(
     deck_path: Path, body: str, lang: str | None
 ) -> tuple[bool, str | None, str | None]:
@@ -342,10 +416,39 @@ def render_j2_cell_html(
 
     Fails closed when the sanitizer is missing: no HTML leaves this function
     unless it went through :func:`sanitize_preview_html`.
+
+    In-process variant — the request path uses
+    :func:`render_j2_cell_html_in_subprocess` (issue #698); this one stays
+    for tests and non-request callers.
     """
     ok, error, text = render_j2_cell(deck_path, body, lang)
     if not ok:
         return False, error, None
+    return _finish_preview_html(deck_path, text)
+
+
+async def render_j2_cell_html_in_subprocess(
+    deck_path: Path,
+    body: str,
+    lang: str | None,
+    *,
+    timeout: float = PREVIEW_TIMEOUT_SECONDS,
+) -> tuple[bool, str | None, str | None]:
+    """:func:`render_j2_cell_html` with the expansion in a killable subprocess.
+
+    The untrusted part — executing the client-supplied Jinja — runs in the
+    child under the wall-clock budget; the deterministic tail (delimiter
+    drop, de-prefix, logo rewrite, sanitize) runs in-process on the child's
+    size-capped output.
+    """
+    ok, error, text = await render_j2_cell_in_subprocess(deck_path, body, lang, timeout=timeout)
+    if not ok:
+        return False, error, None
+    return _finish_preview_html(deck_path, text)
+
+
+def _finish_preview_html(deck_path: Path, text: str) -> tuple[bool, str | None, str | None]:
+    """The deterministic HTML tail shared by both render variants."""
     try:
         from clm.infrastructure.utils.path_utils import path_to_prog_lang
         from clm.workers.notebook.utils.prog_lang_utils import line_comment_for

--- a/src/clm/web/studio/render_child.py
+++ b/src/clm/web/studio/render_child.py
@@ -1,38 +1,66 @@
 """Subprocess entry for the Studio tier-2 preview render (issue #698).
 
 The parent (:func:`clm.web.studio.render.render_j2_cell_in_subprocess`)
-spawns ``python -m clm.web.studio.render_child``, writes one JSON request to
-stdin (``{"deck_path": …, "body": …, "lang": …}``), and reads one JSON
-response from stdout (``{"ok": …, "error": …, "text": …}``). The render
-itself is the ordinary in-process :func:`~clm.web.studio.render.render_j2_cell`
-with all its value-size caps — the subprocess adds what those caps cannot:
-a wall-clock bound enforced by the parent killing this process, and (POSIX)
-an address-space rlimit, so CPU burn like nested ``range()`` loops ends with
-the process instead of stalling the server.
+spawns ``python -I -m clm.web.studio.render_child``, writes one JSON request
+to stdin (``{"deck_path": …, "body": …, "lang": …, "budget": …}``), and
+reads one JSON response from stdout (``{"ok": …, "error": …, "text": …}``).
+The render itself is the ordinary in-process
+:func:`~clm.web.studio.render.render_j2_cell` with all its value-size caps —
+the subprocess adds what those caps cannot: a wall-clock bound, so CPU burn
+like nested ``range()`` loops ends with the process instead of stalling the
+server.
+
+**The child is self-limiting** (#698 review HIGH-1): the parent's kill is
+the fast path, but no parent-side code path may be load-bearing for the
+bound — a cancelled request, a crashed server, or a kill that only reaches
+a venv launcher trampoline (uv's ``python.exe`` re-launches the real
+interpreter as a *child*; ``TerminateProcess`` does not kill trees) must
+not leave an unbounded burner behind. So the child arms its own limits
+before rendering: a daemon watchdog timer that hard-exits at the budget
+plus grace (works everywhere, immune to what the template does), and on
+POSIX ``RLIMIT_CPU``/``RLIMIT_AS`` belts.
 
 Protocol notes:
 
 - Exactly one request per process — no reuse, so a wedged render never
   poisons a later one and the kill path stays trivial.
-- Any crash, malformed output, or nonzero exit degrades the preview to
-  tier-1 in the parent; nothing here needs to be defensive about its own
-  failure mode.
-- stdout carries ONLY the JSON response (logging is forced to stderr), so
-  the parent can parse unconditionally.
+- Pipes are **explicit UTF-8 binary** (#698 review MINOR-2): text-mode
+  stdio uses the locale encoding, which round-trips today only because
+  ``json.dumps`` defaults to ``ensure_ascii=True`` — an undeclared,
+  load-bearing invariant this removes.
+- Any crash, malformed output, nonzero exit, or watchdog exit degrades the
+  preview to tier-1 in the parent; nothing here needs to be defensive
+  about its own failure mode.
+- stdout carries ONLY the JSON response (logging is forced to stderr,
+  which the parent drains and logs on failure).
 """
 
 from __future__ import annotations
 
 import json
+import os
 import sys
+import threading
 
-#: Address-space cap for the child (POSIX only — Windows has no rlimits; the
-#: wall-clock kill is the bound there). Generous: the in-process value caps
-#: keep legitimate previews far below this.
+#: Address-space cap for the child (POSIX only). Generous: the in-process
+#: value caps keep legitimate previews far below this.
 _ADDRESS_SPACE_LIMIT_BYTES = 1_024 * 1_024 * 1_024  # 1 GiB
 
+#: Fallback wall-clock budget when the request carries none, and the grace
+#: added on top of the parent's budget — the parent's kill is the fast
+#: path; the watchdog only has to catch the parent *failing* to kill.
+_DEFAULT_BUDGET_SECONDS = 30.0
+_WATCHDOG_GRACE_SECONDS = 5.0
 
-def _apply_posix_rlimit() -> None:
+#: Watchdog exit code, distinguishable from render crashes in the parent.
+WATCHDOG_EXIT_CODE = 3
+
+
+def _apply_limits(budget: float) -> None:
+    """Arm the self-limits: watchdog everywhere, rlimits on POSIX."""
+    timer = threading.Timer(budget + _WATCHDOG_GRACE_SECONDS, lambda: os._exit(WATCHDOG_EXIT_CODE))
+    timer.daemon = True
+    timer.start()
     try:
         import resource  # POSIX-only module
 
@@ -42,7 +70,12 @@ def _apply_posix_rlimit() -> None:
             resource.RLIMIT_AS,  # type: ignore[attr-defined,unused-ignore]
             (_ADDRESS_SPACE_LIMIT_BYTES, _ADDRESS_SPACE_LIMIT_BYTES),
         )
-    except Exception:  # noqa: BLE001 - belt only; the wall clock is the bound
+        cpu_seconds = max(1, int(budget + _WATCHDOG_GRACE_SECONDS))
+        resource.setrlimit(  # type: ignore[attr-defined,unused-ignore]
+            resource.RLIMIT_CPU,  # type: ignore[attr-defined,unused-ignore]
+            (cpu_seconds, cpu_seconds),
+        )
+    except Exception:  # noqa: BLE001 - belts only; the watchdog is the bound
         pass
 
 
@@ -51,17 +84,21 @@ def main() -> int:
     from pathlib import Path
 
     logging.basicConfig(stream=sys.stderr, level=logging.WARNING)
-    _apply_posix_rlimit()
 
-    request = json.loads(sys.stdin.read())
+    request = json.loads(sys.stdin.buffer.read().decode("utf-8"))
+    try:
+        budget = float(request.get("budget") or _DEFAULT_BUDGET_SECONDS)
+    except (TypeError, ValueError):
+        budget = _DEFAULT_BUDGET_SECONDS
+    _apply_limits(budget)
 
     from clm.web.studio.render import render_j2_cell
 
     ok, error, text = render_j2_cell(
         Path(request["deck_path"]), request["body"], request.get("lang")
     )
-    sys.stdout.write(json.dumps({"ok": ok, "error": error, "text": text}))
-    sys.stdout.flush()
+    sys.stdout.buffer.write(json.dumps({"ok": ok, "error": error, "text": text}).encode("utf-8"))
+    sys.stdout.buffer.flush()
     return 0
 
 

--- a/src/clm/web/studio/render_child.py
+++ b/src/clm/web/studio/render_child.py
@@ -1,0 +1,69 @@
+"""Subprocess entry for the Studio tier-2 preview render (issue #698).
+
+The parent (:func:`clm.web.studio.render.render_j2_cell_in_subprocess`)
+spawns ``python -m clm.web.studio.render_child``, writes one JSON request to
+stdin (``{"deck_path": …, "body": …, "lang": …}``), and reads one JSON
+response from stdout (``{"ok": …, "error": …, "text": …}``). The render
+itself is the ordinary in-process :func:`~clm.web.studio.render.render_j2_cell`
+with all its value-size caps — the subprocess adds what those caps cannot:
+a wall-clock bound enforced by the parent killing this process, and (POSIX)
+an address-space rlimit, so CPU burn like nested ``range()`` loops ends with
+the process instead of stalling the server.
+
+Protocol notes:
+
+- Exactly one request per process — no reuse, so a wedged render never
+  poisons a later one and the kill path stays trivial.
+- Any crash, malformed output, or nonzero exit degrades the preview to
+  tier-1 in the parent; nothing here needs to be defensive about its own
+  failure mode.
+- stdout carries ONLY the JSON response (logging is forced to stderr), so
+  the parent can parse unconditionally.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+#: Address-space cap for the child (POSIX only — Windows has no rlimits; the
+#: wall-clock kill is the bound there). Generous: the in-process value caps
+#: keep legitimate previews far below this.
+_ADDRESS_SPACE_LIMIT_BYTES = 1_024 * 1_024 * 1_024  # 1 GiB
+
+
+def _apply_posix_rlimit() -> None:
+    try:
+        import resource  # POSIX-only module
+
+        # The paired unused-ignore keeps POSIX mypy green too — Windows
+        # mypy cannot see these attrs (the transcribe.py pattern).
+        resource.setrlimit(  # type: ignore[attr-defined,unused-ignore]
+            resource.RLIMIT_AS,  # type: ignore[attr-defined,unused-ignore]
+            (_ADDRESS_SPACE_LIMIT_BYTES, _ADDRESS_SPACE_LIMIT_BYTES),
+        )
+    except Exception:  # noqa: BLE001 - belt only; the wall clock is the bound
+        pass
+
+
+def main() -> int:
+    import logging
+    from pathlib import Path
+
+    logging.basicConfig(stream=sys.stderr, level=logging.WARNING)
+    _apply_posix_rlimit()
+
+    request = json.loads(sys.stdin.read())
+
+    from clm.web.studio.render import render_j2_cell
+
+    ok, error, text = render_j2_cell(
+        Path(request["deck_path"]), request["body"], request.get("lang")
+    )
+    sys.stdout.write(json.dumps({"ok": ok, "error": error, "text": text}))
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/clm/web/studio/routes.py
+++ b/src/clm/web/studio/routes.py
@@ -18,7 +18,6 @@ from collections.abc import Callable
 from typing import cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from starlette.concurrency import run_in_threadpool
 from starlette.responses import Response
 
 from clm.web.studio import sync_runner
@@ -265,14 +264,17 @@ async def render_cell(request: Request, req: RenderCellRequest) -> RenderCellRes
     a missing sanitizer) return ``rendered=False`` with ``html=None`` so the phone
     falls back to tier-1.
 
-    Runs in a worker thread: Jinja rendering is CPU-bound and the body is
-    client-supplied, so doing it inline would let one request hold the event
-    loop and stall every other request plus the disk watcher.
+    The Jinja expansion runs in a **killable subprocess** under a wall-clock
+    budget (issue #698): the body is client-supplied and CPU-unboundable
+    in-process (nested ``range()`` loops), and the old worker-thread route
+    let 40 slow renders occupy the shared threadpool that also serves the
+    ``/studio/`` static shell. A timed-out render degrades to tier-1 like
+    every other preview failure; no threadpool token is held while waiting.
     """
     service = get_service(request)
     try:
-        rendered, error, html = await run_in_threadpool(
-            service.render_cell, req.deck_id, req.body, is_j2=req.is_j2, lang=req.lang
+        rendered, error, html = await service.render_cell_async(
+            req.deck_id, req.body, is_j2=req.is_j2, lang=req.lang
         )
     except InvalidDeckIdError as e:
         raise HTTPException(status_code=400, detail=f"Invalid deck id: {e}") from e

--- a/src/clm/web/studio/service.py
+++ b/src/clm/web/studio/service.py
@@ -459,6 +459,20 @@ class StudioService:
         path = self._resolve_deck_id(deck_id)
         return render_j2_cell_html(path, body, lang)
 
+    async def render_cell_async(
+        self, deck_id: str, body: str, *, is_j2: bool, lang: str | None = None
+    ) -> tuple[bool, str | None, str | None]:
+        """:meth:`render_cell`, with the Jinja expansion in a killable
+        subprocess under a wall-clock budget (issue #698) — the request
+        path's variant. Same contract; never raises except
+        ``InvalidDeckIdError`` from deck-id resolution."""
+        if not is_j2:
+            return False, None, None
+        from clm.web.studio.render import render_j2_cell_html_in_subprocess
+
+        path = self._resolve_deck_id(deck_id)
+        return await render_j2_cell_html_in_subprocess(path, body, lang)
+
     def try_begin_sync(self, key: str) -> bool:
         """Claim the in-flight slot for ``key`` (the DE deck id). False if taken."""
         if key in self._sync_inflight:

--- a/src/clm/web/studio/service.py
+++ b/src/clm/web/studio/service.py
@@ -441,10 +441,14 @@ class StudioService:
 
     # ------------------------------------------------------- tier-2 render (P4)
 
-    def render_cell(
+    def render_cell_in_process(
         self, deck_id: str, body: str, *, is_j2: bool, lang: str | None = None
     ) -> tuple[bool, str | None, str | None]:
-        """Tier-2 (kernel-free) render of one cell. Returns ``(rendered, error, html)``.
+        """Tier-2 render, IN-PROCESS — tests and non-request callers only.
+
+        The request path is :meth:`render_cell_async` (#698): this variant
+        has no CPU bound, so a route must never reach for it. Returns
+        ``(rendered, error, html)``.
 
         Only ``is_j2`` cells are expanded server-side (through the build's bundled
         macros); a plain cell returns ``html=None`` for the client to render as

--- a/tests/web/studio/test_render_pwa.py
+++ b/tests/web/studio/test_render_pwa.py
@@ -36,7 +36,7 @@ class TestTier2Render:
     def test_service_skips_non_j2(self, service: StudioService, course: Course):
         # Since #697 the third element is the sanitized HTML, so "no render" is
         # `None` — the client keeps the tier-1 markdown it already drew.
-        ok, error, html = service.render_cell(course.deck_id, "# plain", is_j2=False)
+        ok, error, html = service.render_cell_in_process(course.deck_id, "# plain", is_j2=False)
         assert ok is False and html is None and error is None
 
 
@@ -129,3 +129,34 @@ class TestStudioShellSecurityHeaders:
         r = client.get("/studio/sw.js")
         assert r.headers["Service-Worker-Allowed"] == "/"
         assert "content-security-policy" in r.headers
+
+
+@pytest.mark.slow
+class TestRenderEndpointTimeout:
+    """#698 claimed-wired: a timed-out render degrades to tier-1 THROUGH
+    the route — rendered=False, html None, error says timed out, and the
+    request survives (no 500 from the never-raises contract)."""
+
+    @pytest.fixture()
+    def client(self, course: Course) -> TestClient:
+        app = make_app(course.spec_path, course.slides_dir.parent / "jobs.db", TOKEN)
+        return TestClient(app)
+
+    def test_cpu_bomb_times_out_into_tier1(
+        self, client: TestClient, course: Course, monkeypatch: pytest.MonkeyPatch
+    ):
+        from clm.web.studio import render as render_module
+
+        monkeypatch.setattr(render_module, "PREVIEW_TIMEOUT_SECONDS", 3.0)
+        bomb = "{% for a in range(100000) %}{% for b in range(100000) %}{% endfor %}{% endfor %}ok"
+        r = client.post(
+            "/api/studio/deck/render-cell",
+            headers=AUTH,
+            json={"deck_id": course.deck_id, "body": bomb, "is_j2": True, "lang": "de"},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["rendered"] is False
+        assert data["html"] is None
+        assert "timed out" in (data["error"] or "")
+        assert data["body"] == bomb  # tier-1 fallback keeps the original

--- a/tests/web/studio/test_render_subprocess.py
+++ b/tests/web/studio/test_render_subprocess.py
@@ -167,7 +167,11 @@ class TestChildLifetime:
             assert proc.poll() is not None, "watchdog did not fire"
             from clm.web.studio.render_child import WATCHDOG_EXIT_CODE
 
-            assert proc.returncode == WATCHDOG_EXIT_CODE
+            # Windows: the watchdog timer exits with its marker code. POSIX:
+            # RLIMIT_CPU's hard limit can beat the timer and kill with
+            # SIGKILL (-9) or SIGXCPU (-24) — that is the self-limit
+            # working too, via the other belt.
+            assert proc.returncode in (WATCHDOG_EXIT_CODE, -9, -24), proc.returncode
         finally:
             if proc.poll() is None:
                 proc.kill()

--- a/tests/web/studio/test_render_subprocess.py
+++ b/tests/web/studio/test_render_subprocess.py
@@ -72,3 +72,134 @@ class TestSubprocessRender:
         assert html is not None
         assert "3" in html
         assert "<script>" not in html
+
+
+def _live_render_children():
+    """Pids of live render_child processes (whole tree, launcher included)."""
+    import psutil
+
+    found = []
+    for proc in psutil.process_iter(["cmdline"]):
+        try:
+            cmdline = proc.info["cmdline"] or []
+        except Exception:  # noqa: BLE001 - processes vanish mid-iteration
+            continue
+        if any("clm.web.studio.render_child" in part for part in cmdline):
+            found.append(proc)
+    return found
+
+
+def _assert_no_live_children(deadline: float = 10.0) -> None:
+    """The whole child tree must be gone — on Windows the venv launcher is a
+    trampoline whose grandchild does the rendering (#698 review MEDIUM-1)."""
+    import time as time_module
+
+    end = time_module.monotonic() + deadline
+    while time_module.monotonic() < end:
+        if not _live_render_children():
+            return
+        time_module.sleep(0.2)
+    raise AssertionError(f"live render children: {_live_render_children()}")
+
+
+@pytest.mark.slow
+@pytest.mark.serial
+class TestChildLifetime:
+    """#698 review HIGH-1: no code path may leave a live child behind —
+    the kill/reap is in a finally, and the child self-limits."""
+
+    def test_timeout_kills_the_whole_child_tree(self, tmp_path: Path):
+        ok, _error, _text = asyncio.run(
+            render_j2_cell_in_subprocess(tmp_path / DECK, CPU_BOMB, "de", timeout=3.0)
+        )
+        assert ok is False
+        _assert_no_live_children()
+
+    def test_cancellation_kills_the_child(self, tmp_path: Path):
+        """Cancelling the awaiting task (timeout middleware, teardown) must
+        not orphan a burning child — the finally + the child watchdog."""
+
+        async def scenario():
+            task = asyncio.create_task(
+                render_j2_cell_in_subprocess(tmp_path / DECK, CPU_BOMB, "de", timeout=60.0)
+            )
+            await asyncio.sleep(2.0)  # let the child spawn and start burning
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            # Give the finally's bounded reap a moment.
+            await asyncio.sleep(0.5)
+
+        asyncio.run(scenario())
+        _assert_no_live_children()
+
+    def test_child_watchdog_self_limits_without_a_parent_kill(self, tmp_path: Path):
+        """The parent-death shape (#698 review HIGH-1 case 2): even with no
+        parent-side kill at all, the child's own watchdog exits it. Spawn
+        the child directly and never kill it."""
+        import json
+        import subprocess
+        import sys
+        import time as time_module
+
+        request = json.dumps(
+            {
+                "deck_path": str(tmp_path / DECK),
+                "body": CPU_BOMB,
+                "lang": "de",
+                "budget": 2.0,  # watchdog fires at budget + 5s grace
+            }
+        ).encode("utf-8")
+        proc = subprocess.Popen(
+            [sys.executable, "-I", "-m", "clm.web.studio.render_child"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        try:
+            proc.stdin.write(request)
+            proc.stdin.close()
+            deadline = time_module.monotonic() + 30
+            while proc.poll() is None and time_module.monotonic() < deadline:
+                time_module.sleep(0.5)
+            assert proc.poll() is not None, "watchdog did not fire"
+            from clm.web.studio.render_child import WATCHDOG_EXIT_CODE
+
+            assert proc.returncode == WATCHDOG_EXIT_CODE
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+
+
+@pytest.mark.slow
+class TestParentBranches:
+    """The parent's degradation branches, driven by a stubbed child."""
+
+    def _run_with_child(self, monkeypatch, tmp_path: Path, child_args: tuple):
+        from clm.web.studio import render as render_module
+
+        monkeypatch.setattr(render_module, "_CHILD_ARGS", child_args)
+        return asyncio.run(
+            render_j2_cell_in_subprocess(tmp_path / DECK, "{{ 1 }}", "de", timeout=5.0)
+        )
+
+    def test_nonzero_exit_degrades(self, monkeypatch, tmp_path: Path):
+        ok, error, text = self._run_with_child(
+            monkeypatch, tmp_path, ("-c", "import sys; sys.exit(7)")
+        )
+        assert ok is False and "exit 7" in error and text == "{{ 1 }}"
+
+    def test_malformed_stdout_degrades(self, monkeypatch, tmp_path: Path):
+        ok, error, text = self._run_with_child(monkeypatch, tmp_path, ("-c", "print('not json')"))
+        assert ok is False and error and text == "{{ 1 }}"
+
+    def test_oversized_child_output_is_refused(self, monkeypatch, tmp_path: Path):
+        child = (
+            "-c",
+            "import json,sys;"
+            "sys.stdout.write(json.dumps({'ok': True, 'error': None, 'text': 'A'*2000000}))",
+        )
+        ok, error, text = self._run_with_child(monkeypatch, tmp_path, child)
+        assert ok is False and "too large" in error and text == "{{ 1 }}"

--- a/tests/web/studio/test_render_subprocess.py
+++ b/tests/web/studio/test_render_subprocess.py
@@ -1,0 +1,74 @@
+"""Tests for the subprocess preview render (issue #698).
+
+The in-process value caps bound memory; the subprocess bounds CPU via a
+wall-clock kill and removes the thread-occupancy vector (the route awaits
+the child on the event loop). One child per request; every failure mode
+degrades to tier-1.
+"""
+
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+
+from clm.web.studio.render import (
+    render_j2_cell_html_in_subprocess,
+    render_j2_cell_in_subprocess,
+)
+
+DECK = "slides_x.de.py"
+
+#: 10^10 iterations producing two characters — the issue's CPU-bomb shape,
+#: measured at roughly two hours in-process.
+CPU_BOMB = "{% for a in range(100000) %}{% for b in range(100000) %}{% endfor %}{% endfor %}ok"
+
+
+@pytest.mark.slow
+class TestSubprocessRender:
+    def test_normal_body_renders(self, tmp_path: Path):
+        ok, error, text = asyncio.run(
+            render_j2_cell_in_subprocess(tmp_path / DECK, "{{ 1 + 2 }}", "de")
+        )
+        assert ok, error
+        assert text == "3"
+
+    def test_cpu_bomb_is_killed_within_the_budget(self, tmp_path: Path):
+        """The #698 regression: in-process this runs for hours; the
+        subprocess is killed at the wall-clock budget and the preview
+        degrades to tier-1 with the body unchanged."""
+        started = time.monotonic()
+        ok, error, text = asyncio.run(
+            render_j2_cell_in_subprocess(tmp_path / DECK, CPU_BOMB, "de", timeout=3.0)
+        )
+        elapsed = time.monotonic() - started
+        assert ok is False
+        assert error is not None and "timed out" in error
+        assert text == CPU_BOMB  # tier-1 fallback gets the original body
+        assert elapsed < 30, f"kill took {elapsed:.1f}s"
+
+    def test_render_errors_degrade_like_in_process(self, tmp_path: Path):
+        ok, error, text = asyncio.run(
+            render_j2_cell_in_subprocess(tmp_path / DECK, "{% include 'missing.j2' %}", "de")
+        )
+        assert ok is False
+        assert error
+        assert text == "{% include 'missing.j2' %}"
+
+    def test_value_caps_hold_inside_the_child(self, tmp_path: Path):
+        ok, error, _text = asyncio.run(
+            render_j2_cell_in_subprocess(tmp_path / DECK, '{{ "A" * 200000000 }}', "de")
+        )
+        assert ok is False
+        assert error
+
+    def test_html_variant_sanitizes_the_child_output(self, tmp_path: Path):
+        ok, error, html = asyncio.run(
+            render_j2_cell_html_in_subprocess(
+                tmp_path / DECK, "# {{ 1 + 2 }} <script>alert(1)</script>", "de"
+            )
+        )
+        assert ok, error
+        assert html is not None
+        assert "3" in html
+        assert "<script>" not in html


### PR DESCRIPTION
Closes #698.

The issue's proposed fix, in full: the Studio cell preview's Jinja expansion — a client-supplied body — runs in a **one-request-per-process subprocess** with a wall-clock timeout, closing both remaining vectors (CPU burn; thread occupancy).

## Design

- **`clm.web.studio.render_child`**: reads one JSON request from stdin, runs the ordinary `render_j2_cell` (the whole S7 sandbox + value-cap arsenal stays intact as the in-child memory bound), writes one JSON response to stdout. POSIX `RLIMIT_AS` belt applied in-child (Windows: the wall-clock kill is the bound). Logging forced to stderr so stdout is pure protocol. One request per process — a wedged render can never poison a later one.
- **`render_j2_cell_in_subprocess`**: spawn → `wait_for(communicate, timeout)` → kill + reap on timeout → tier-1 degradation (the preview's existing failure mode) on every failure path. The parent re-checks the output-size cap — never trust a child killed mid-write.
- **`render_j2_cell_html_in_subprocess`**: subprocess expansion + the deterministic in-process tail (delimiter drop, de-prefix, logo rewrite, **sanitize**) factored into `_finish_preview_html`, shared with the in-process variant (kept for tests and non-request callers).
- **The route awaits the child on the event loop** — no threadpool token held, so slow renders can no longer starve the `/studio/` static shell (`abandon_on_cancel` becomes irrelevant).
- Loader reconstruction in the child is free: the child calls the same `render_j2_cell`, which builds its own `PackageLoader`/`FileSystemLoader` from the deck path. No warm pool (the issue calls it "mitigable" — cold spawn fits inside the 10 s default budget with a wide margin).

## Checks

- 5 tests (`test_render_subprocess.py`, marked `slow` — PR CI runs the slow suite): normal round-trip, **the issue's exact CPU bomb killed within budget with the tier-1 fallback carrying the original body**, error degradation, value caps holding inside the child, sanitize on the html variant. Failing-before: the module does not exist pre-PR.
- Full `tests/web` (incl. slow): 503 passed. ruff + mypy green (the POSIX `resource` attrs use the repo's paired cross-platform ignore pattern); fast suite on pre-push.
- Docs: module docstring's "Still unbounded: CPU" section replaced with the bounded reality; route docstring; `commands.md`'s serve/Studio section; `security`-typed changelog fragment (bearer-token holders only — defense in depth per decision D4, not a new exposure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh
