### PR TITLE
fix(sync): name the one-sided slide-tag refusal instead of duplicate_id (#653)

### DIFF
--- a/changelog.d/653-anchor-shape-refusal.fixed.md
+++ b/changelog.d/653-anchor-shape-refusal.fixed.md
@@ -1,0 +1,13 @@
+- `clm slides sync report` no longer reports a one-sided `slide` tag change as
+  `duplicate_id`. Removing (or adding) `tags=["slide"]` on one half of a split
+  deck makes the same id a slide start on one side and a continuation cell on
+  the other; the parse used to refuse the whole deck with
+  `duplicate_id: member key id:X resolves to 2 distinct members` — a message
+  about parsing ambiguity whose `rename-id` hint renames *both* halves and so
+  cannot fix it. The cause is now named by its own code,
+  `anchor_shape_divergence`, which locates both halves, says which side carries
+  the tag, and hints the edit that repairs it (#653).
+- A parse refusal whose reasons are all codes `normalize` cannot repair no
+  longer opens with "run `clm slides normalize --stamp-ids` first" — that
+  command reports nothing to do for a duplicate id or a one-sided slide tag.
+  The header names `normalize` only when at least one id-less reason is present.

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -108,6 +108,26 @@ carries **no** answers: reconcile by editing, minting ids, then re-report),
 and the normalize-refusal deck item (run `clm slides normalize`, then
 re-report).
 
+### Parse refusals: read the code, not the header
+
+A refusal blocks the **whole deck** and frames zero items, so its code is the
+only routing information you get. Only the id-less codes (`idless_anchor`,
+`idless_localized`, `idless_narrative`) are repaired by
+`clm slides normalize --stamp-ids` — and the refusal header names that command
+only when at least one such reason is present. The others carry their own
+`hint:` line:
+
+| Code | What it means | Fix |
+|---|---|---|
+| `duplicate_id` | one `slide_id` names two cells on one side | `clm slides rename-id DECK OLD NEW` |
+| `anchor_shape_divergence` | one id'd cell is a slide start on one half and a continuation cell on the other — the `slide` / `subslide` tag differs between halves | align the tag on the named side, then re-report |
+| `legacy_title_companion` | pre-#242 `slide_id="title"` with no `for_slide` | give the cell `for_slide="title"` and its own `slide_id` |
+
+`anchor_shape_divergence` names both halves and both line numbers. It is the
+one-sided-retag shape of #653; until the engine frames it as a mechanical tag
+row, mirroring the tag by hand is the sanctioned repair — the refusal tells
+you which side carries it.
+
 ## Tag parity (tags are language-independent)
 
 Cell tags mirror across the twins — a tag set is never per-language. The

--- a/src/clm/slides/bilingual_doc.py
+++ b/src/clm/slides/bilingual_doc.py
@@ -228,12 +228,20 @@ class Observation:
 class RefusalReason:
     """One reason a bundle failed the §3.4 normalize precondition."""
 
-    # duplicate_id | idless_anchor | idless_localized | idless_narrative
-    # | legacy_title_companion
+    # anchor_shape_divergence | duplicate_id | idless_anchor | idless_localized
+    # | idless_narrative | legacy_title_companion
     code: str
     detail: str
     member: MemberKey | None = None
 
+
+#: The refusal codes ``normalize --stamp-ids`` actually repairs — the ones
+#: that exist because a cell has no id. Every other code needs its own remedy
+#: (:data:`REFUSAL_HINTS`), and telling the author to run `normalize` for one
+#: of those sends them down a dead end (#653).
+NORMALIZE_FIXABLE: frozenset[str] = frozenset(
+    {"idless_anchor", "idless_localized", "idless_narrative"}
+)
 
 #: Remediation hints per refusal code, appended to the rendered refusal.
 #: The header line's remedy (`normalize --stamp-ids`) covers the id-less
@@ -245,21 +253,37 @@ REFUSAL_HINTS: dict[str, str] = {
         "(rewrites both halves and migrates the sync-ledger key; `normalize` "
         "cannot fix duplicates)"
     ),
+    "anchor_shape_divergence": (
+        "align the slide/subslide tag across the halves — add it to the "
+        "continuation side, or remove it from the slide side — so the cell is "
+        "a slide start on both, then re-report (`rename-id` renames both "
+        "halves and `normalize` cannot fix a tag difference)"
+    ),
 }
 
 
 @define
 class NormalizeRefusal:
-    """A framed "run normalize first" refusal for a whole deck (design §3.2).
+    """A framed parse refusal for a whole deck (design §3.2).
 
     Every offending condition is enumerated (never first-error-only), so one
-    normalize pass can fix them all.
+    repair pass can fix them all. The header line names `normalize` only when
+    at least one reason is actually a :data:`NORMALIZE_FIXABLE` id-less shape;
+    a refusal made purely of codes normalize cannot touch (a duplicate id, a
+    one-sided slide tag) says so instead of sending the author to a command
+    that will report nothing to do (#653).
     """
 
     reasons: list[RefusalReason] = field(factory=list)
 
     def render(self) -> str:
-        lines = ["deck is not normalized — run `clm slides normalize --stamp-ids` first:"]
+        head = (
+            "deck is not normalized — run `clm slides normalize --stamp-ids` first:"
+            if any(r.code in NORMALIZE_FIXABLE for r in self.reasons)
+            else "deck cannot be parsed as a split pair — repair the conditions below, "
+            "then re-report:"
+        )
+        lines = [head]
         lines += [f"  - [{r.code}] {r.detail}" for r in self.reasons]
         for code in dict.fromkeys(r.code for r in self.reasons):
             hint = REFUSAL_HINTS.get(code)

--- a/src/clm/slides/doc_lenses.py
+++ b/src/clm/slides/doc_lenses.py
@@ -427,6 +427,53 @@ class _Parser:
                         f"(deck.{lang} line {cell.line_number})",
                     )
 
+    def _anchor_shapes(self, lang: Lang) -> dict[str, tuple[bool, int]]:
+        """Per id on one deck half: ``(is a slide start, header line)``."""
+        source = self._source(lang, "deck")
+        if source is None:  # pragma: no cover - both halves always exist
+            return {}
+        shapes: dict[str, tuple[bool, int]] = {}
+        for i, cell in enumerate(source.cells):
+            bare = _bare(cell.slide_id)
+            if bare is not None:
+                shapes[bare] = (self._is_anchor(source.raw[i]), cell.line_number)
+        return shapes
+
+    def check_anchor_shape(self) -> None:
+        """Refuse ids whose *slide-hood* differs between the halves (#653).
+
+        Anchor-hood is tag-derived and anchors pair by group rather than by id
+        (:meth:`pair_by_id`), so a one-sided `slide` retag — a routine layout
+        edit — builds **two** members under one key and the deck used to die
+        in :meth:`_check_key_uniqueness` with a `duplicate_id` whose message
+        described a parsing ambiguity and whose hint (`rename-id`, which
+        rewrites *both* halves) could not fix it.
+
+        Naming the cause here instead: the refusal is still whole-deck, but it
+        is enumerated in phase 1 alongside the other keying preconditions, it
+        says which half carries the tag, and its hint is the edit that repairs
+        it. Framing this transition as a mechanical tag row — so it never
+        refuses at all — is the engine change designed in
+        ``docs/claude/design/sync-slide-hood-is-presentation.md``.
+        """
+        de_shapes = self._anchor_shapes("de")
+        en_shapes = self._anchor_shapes("en")
+        for bare in sorted(de_shapes.keys() & en_shapes.keys()):
+            de_anchor, de_line = de_shapes[bare]
+            en_anchor, en_line = en_shapes[bare]
+            if de_anchor == en_anchor:
+                continue
+            anchor_side, plain_side = ("de", "en") if de_anchor else ("en", "de")
+            anchor_line, plain_line = (de_line, en_line) if de_anchor else (en_line, de_line)
+            self.refuse(
+                "anchor_shape_divergence",
+                f'slide_id "{bare}" is a slide start on the {anchor_side} side '
+                f"(deck.{anchor_side} line {anchor_line}) but a continuation cell "
+                f"on the {plain_side} side (deck.{plain_side} line {plain_line}) — "
+                f"the slide/subslide tag differs between the halves",
+                member=MemberKey.for_id(bare),
+            )
+
     # -- phase 2: pairing --------------------------------------------------------
 
     def pair_by_id(self) -> None:
@@ -735,6 +782,7 @@ class _Parser:
 
     def run(self) -> ParseOutcome:
         self.check_keying()
+        self.check_anchor_shape()
         if self.refusals:
             return ParseOutcome(refusal=NormalizeRefusal(reasons=self.refusals))
 

--- a/tests/slides/test_bilingual_doc.py
+++ b/tests/slides/test_bilingual_doc.py
@@ -123,6 +123,24 @@ class TestNormalizeRefusal:
         )
         assert refusal.render().count("clm slides rename-id") == 1
 
+    def test_render_names_normalize_only_when_it_can_fix_a_reason(self):
+        # #653: a refusal made purely of codes normalize cannot touch used to
+        # open with "run `normalize --stamp-ids` first", which reports nothing
+        # to do — the author's first move was wasted on the wrong command.
+        unfixable = NormalizeRefusal(
+            reasons=[RefusalReason(code="anchor_shape_divergence", detail="id x, one side")]
+        )
+        assert "normalize --stamp-ids" not in unfixable.render()
+        assert "repair the conditions below" in unfixable.render()
+
+        mixed = NormalizeRefusal(
+            reasons=[
+                RefusalReason(code="anchor_shape_divergence", detail="id x, one side"),
+                RefusalReason(code="idless_localized", detail="line 7"),
+            ]
+        )
+        assert "normalize --stamp-ids" in mixed.render()
+
     def test_render_no_hint_for_codes_normalize_fixes(self):
         refusal = NormalizeRefusal(
             reasons=[RefusalReason(code="idless_localized", detail="line 7")]

--- a/tests/slides/test_doc_lens_corpus.py
+++ b/tests/slides/test_doc_lens_corpus.py
@@ -47,6 +47,9 @@ _BUNDLED_CORPUS = Path(__file__).parent.parent / "data" / "doc_corpus"
 _REAL_REFUSAL_CEILING = 70
 _REAL_PARSED_FLOOR = 620
 _EXPECTED_REFUSAL_CODES = {
+    # not a new refusal class: #653 split the anchor↔non-anchor cause out of
+    # duplicate_id (which was already pinned) so the message names the tag.
+    "anchor_shape_divergence",
     "duplicate_id",
     "idless_localized",
     "idless_narrative",

--- a/tests/slides/test_doc_lenses.py
+++ b/tests/slides/test_doc_lenses.py
@@ -377,6 +377,57 @@ class TestRefusals:
         assert outcome.refusal is not None
         assert {r.code for r in outcome.refusal.reasons} == {"duplicate_id"}
 
+    def test_one_sided_slide_tag_refuses_with_the_anchor_shape_code(self):
+        # #653: removing tags=["slide"] from an id'd cell on ONE half made the
+        # same id an anchor on one side and a plain member on the other. The
+        # lens built two members under one key and the deck died with
+        # `duplicate_id` ("resolves to 2 distinct members") — a message about
+        # parsing, whose `rename-id` hint renames both halves and so cannot fix
+        # it. The cause is named instead, in phase 1, with both sides located.
+        de = _strip_final_blank(
+            HEADER_DE + _slide("a", "de", "A") + _localized("a-explain", "de", "Fortsetzung")
+        )
+        en = _strip_final_blank(
+            HEADER_EN + _slide("a", "en", "A") + _slide("a-explain", "en", "Continued")
+        )
+        outcome = parse_bundle(de, en)
+        assert not outcome.ok
+        assert outcome.refusal is not None
+        assert {r.code for r in outcome.refusal.reasons} == {"anchor_shape_divergence"}
+        (reason,) = outcome.refusal.reasons
+        assert reason.member == MemberKey.for_id("a-explain")
+        # both halves located, and which one carries the tag
+        assert "en side" in reason.detail
+        assert "de side" in reason.detail
+        assert "slide start" in reason.detail and "continuation" in reason.detail
+        text = outcome.refusal.render()
+        assert "normalize --stamp-ids" not in text  # it cannot fix a tag shape
+        assert "align the slide/subslide tag" in text
+
+    def test_anchor_shape_divergence_fires_in_both_directions(self):
+        # The retag is symmetric: the tag may go missing on either half.
+        de = _strip_final_blank(
+            HEADER_DE + _slide("a", "de", "A") + _slide("a-explain", "de", "Fortsetzung")
+        )
+        en = _strip_final_blank(
+            HEADER_EN + _slide("a", "en", "A") + _localized("a-explain", "en", "Continued")
+        )
+        outcome = parse_bundle(de, en)
+        assert outcome.refusal is not None
+        assert {r.code for r in outcome.refusal.reasons} == {"anchor_shape_divergence"}
+
+    def test_slide_to_subslide_retag_does_not_refuse(self):
+        # is_slide_start = slide OR subslide, so this retag keeps anchor-hood:
+        # a tag row, never a refusal. Pins the boundary of the check above.
+        de = _strip_final_blank(
+            HEADER_DE
+            + _slide("a", "de", "A")
+            + '# %% [markdown] lang="de" tags=["subslide"] slide_id="b"\n#\n# # B\n\n'
+        )
+        en = _strip_final_blank(HEADER_EN + _slide("a", "en", "A") + _slide("b", "en", "B"))
+        outcome = parse_bundle(de, en)
+        assert outcome.ok, outcome.refusal.render() if outcome.refusal else ""
+
     def test_idless_anchor_refuses(self):
         de = _strip_final_blank(HEADER_DE + '# %% [markdown] lang="de" tags=["slide"]\n# # A\n\n')
         en = _strip_final_blank(HEADER_EN + '# %% [markdown] lang="en" tags=["slide"]\n# # A\n\n')


### PR DESCRIPTION
The messaging half of #653 — **653a** in the sequencing of `docs/claude/design/sync-slide-hood-is-presentation.md` (merged in #751). Independent of the engine change, and useful whatever that lands as. **Does not close #653.**

## The bug

Removing `tags=["slide"]` from an id'd cell on one half of a split deck makes the same id a slide start on one side and a continuation cell on the other. Anchors are excluded from by-id pairing (`doc_lenses.py:447-448`) and pair via group co-location instead, so the lens builds **two members under one key** and `_check_key_uniqueness` refuses the whole deck:

```
duplicate_id: member key id:signal-and-noise-explain resolves to 2 distinct members
```

Zero items framed, so there is nothing to answer. And both pieces of routing information the refusal offers are wrong:

- the `duplicate_id` hint says `rename-id`, which rewrites **both** halves — the anchor/non-anchor split survives the rename verbatim (circular);
- the header says `normalize --stamp-ids`, but the cells already have ids, so normalize reports nothing to do.

Each occurrence cost a manual investigation to discover that the trigger was a tag line.

## The change

- Detect the divergence in **phase 1**, alongside the other keying preconditions, under its own code **`anchor_shape_divergence`**. The detail names both halves and both line numbers and says which side carries the tag; the hint is the edit that repairs it.
- A refusal made purely of codes `normalize` cannot repair no longer opens by recommending `normalize`. The header names it only when at least one `NORMALIZE_FIXABLE` id-less reason is present.
- `clm info sync-agents` gains a short parse-refusal table — code → meaning → fix — since a refusal frames zero items and its code is the only routing an agent gets.

## Verification

- New regression tests fail before the change with `assert {'duplicate_id'} == {'anchor_shape_divergence'}`, in both retag directions.
- **Boundary pinned**: `slide` ↔ `subslide` retags keep anchor-hood (`is_slide_start = is_slide or is_subslide`) and must never reach the new check — that test passes before and after.
- `tests/slides`: 1770 passed, 5 skipped.
- Measured against the real corpus (PythonCourses, 730 deck bundles): **zero refusals**, so no committed content changes verdict. The corpus gate's pinned code set gains `anchor_shape_divergence` with a comment — it is a split-out of `duplicate_id`, which was already pinned, not a new refusal class.

## Still open on #653

The transition should frame as a mechanical `mirror_tags` row and not refuse at all. That is the engine change in the merged design note, gated on its own adversarial pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm9cCFzyYG61oQLb7Zmho8