### PR TITLE
feat(sync): schema 4 — report_id freshness token and already_applied (#649)

### DIFF
--- a/changelog.d/649-report-id-already-applied.added.md
+++ b/changelog.d/649-report-id-already-applied.added.md
@@ -1,0 +1,24 @@
+- **Sync wire schema 4.** `report` / `apply` / `record` payloads now announce
+  `"schema": 4`, and every report pair payload carries the deck's identity and
+  a freshness token:
+  - `report_id` — a hash of the bundle bytes plus this deck's ledger section.
+    Echo it at the top level of the decision document
+    (`{"schema": 4, "report_id": "…", "decisions": [...]}`) and `apply` will
+    refuse the **whole** document — exit 2, nothing written — when the deck or
+    its ledger moved on since that report. Documents without the token are
+    still accepted, with a warning naming the field; that grace ends in a
+    future release (#649).
+  - `deck_key` and `ledger` — the deck's trust identity, so it is visible that
+    a deck half and its `voiceover_*` companion are one deck with one ledger
+    section. Pointing `sync` at a companion now says on stderr that it is
+    reconciling the deck.
+- `apply` distinguishes **`already_applied`** from `rejected`: an answer whose
+  member frames nothing in the current report is redundant, not wrong — the
+  state it asks for already holds — and no longer blocks exit 0. Only a handle
+  naming no member of the deck is a stale-handle rejection. This is the
+  verdict half of #649, where apply reported "rejected" for decisions whose
+  writes had demonstrably landed.
+- `report` and `apply` embed `exit_code` in their `--json` envelopes, decision
+  parse/freshness refusals emit a JSON envelope instead of an empty stdout, and
+  the rejection block is printed to stderr **before** the payload so a merged
+  stream still ends in valid JSON.

--- a/src/clm/cli/commands/slides/sync.py
+++ b/src/clm/cli/commands/slides/sync.py
@@ -140,6 +140,17 @@ def _resolve_single_path(de_path: Path, en_path: Path | None) -> tuple[Path, Pat
                 # Issue #501: pointing sync at a companion reconciles its *deck* pair.
                 deck = _deck_for_companion(de_path)
                 if deck is not None:
+                    # Say so (#649 / finding C7): the redirect used to be
+                    # silent, so `voiceover_x` and `slides_x` looked like two
+                    # decks while being one deck with one ledger section —
+                    # two "independent" passes then raced, and the second
+                    # found its decisions already satisfied.
+                    click.echo(
+                        f"note: {de_path.name} is a voiceover companion — reconciling "
+                        f"its deck {deck.name} (the deck halves and their companions "
+                        f"are one member table with one ledger section)",
+                        err=True,
+                    )
                     return _resolve_single_path(deck, None)
                 raise click.UsageError(
                     f"{de_path.name} is a voiceover companion, but its slide deck could "

--- a/src/clm/cli/commands/slides/sync_v3.py
+++ b/src/clm/cli/commands/slides/sync_v3.py
@@ -7,7 +7,7 @@ paths (``sync_verify``) is loaded lazily inside the functions that need it.
 
 Verbs (design §8):
 
-* ``report`` — read-only, ledger-trusted; schema-3 envelope with the stable
+* ``report`` — read-only, ledger-trusted; schema-4 envelope with the stable
   ``is_clean`` / ``needs_model`` / ``needs_agent`` booleans; framed items
   carry their decision vocabulary so an agent can answer in one document.
 * ``apply``  — per-item: every mechanical row plus validated decisions; the
@@ -32,12 +32,14 @@ from clm.slides.doc_report import (
     diff_bundle,
     diff_bundle_at_ref,
     pair_payload,
+    report_id_for,
 )
 from clm.slides.pairing import (
     find_split_slide_files_recursive,
     iter_split_pairs,
 )
 from clm.slides.sync_diff import DeckDiff
+from clm.slides.sync_wire import REQUIRE_REPORT_ID, WIRE_SCHEMA
 
 __all__ = ["run_apply_v3", "run_record_v3", "run_report_v3"]
 
@@ -144,12 +146,14 @@ def run_report_v3(
                     payload["base_refusal"] = base_refusal
             payloads.append(payload)
         if not de_path.is_dir() and len(payloads) == 1 and not errors:
+            payloads[0]["exit_code"] = 0 if clean else 1
             _echo_json(payloads[0])
         else:
             _echo_json(
                 {
-                    "schema": 3,
+                    "schema": WIRE_SCHEMA,
                     "engine": "v3",
+                    "exit_code": 0 if clean else 1,
                     "is_clean": clean,
                     "needs_model": any(d.needs_model for _, d, _r in results),
                     "needs_agent": any(d.needs_agent for _, d, _r in results) or bool(errors),
@@ -208,17 +212,46 @@ def run_apply_v3(
             )
         except OSError as exc:
             raise click.UsageError(f"cannot read the decision document: {exc}") from exc
-        decisions, decision_errors = doc_apply.load_decisions_text(text)
+        document, decision_errors = doc_apply.load_decision_document(text)
+        if not decision_errors:
+            decision_errors = _report_id_errors(bundle, document)
         if decision_errors:
             for error in decision_errors:
                 click.echo(f"decision error: {error}", err=True)
+            if as_json:
+                # M14: the refusal paths must not differ in shape. A parse or
+                # freshness refusal used to exit 2 with an EMPTY stdout while
+                # the apply-refusal path emitted an envelope, so a --json
+                # consumer saw "no output" and could not tell a crash from a
+                # rejection.
+                _echo_json(
+                    {
+                        "schema": WIRE_SCHEMA,
+                        "engine": "v3",
+                        "exit_code": 2,
+                        "error": "; ".join(decision_errors),
+                        "decision_errors": decision_errors,
+                        "wrote": False,
+                        "items": [],
+                    }
+                )
             return 2
+        decisions = document.decisions
 
     diff = diff_bundle(bundle)
     if diff.refusal is not None:
         message = diff.refusal.render()
         if as_json:
-            _echo_json({"schema": 3, "engine": "v3", "error": message, "items": []})
+            _echo_json(
+                {
+                    "schema": WIRE_SCHEMA,
+                    "engine": "v3",
+                    "exit_code": 2,
+                    "error": message,
+                    "wrote": False,
+                    "items": [],
+                }
+            )
         else:
             click.echo(message, err=True)
         return 2
@@ -258,45 +291,99 @@ def run_apply_v3(
         if not verify_violations:
             doc_ledger.save(ledger, ledger_path)
 
+    rejected = [r for r in outcome.results if r.status == "rejected"]
+    exit_code = (
+        2
+        if outcome.error is not None
+        else (0 if outcome.all_applied and not verify_violations else 1)
+    )
     if as_json:
+        # M14/C7: the rejection block goes to stderr BEFORE the payload. It
+        # used to print after, so a consumer merging the two streams got JSON
+        # with prose appended — unparseable exactly when something went wrong.
+        _echo_rejections(rejected)
         payload = outcome.to_payload()
+        payload["exit_code"] = exit_code
+        payload["deck_key"] = doc_ledger.deck_key_for(bundle.de_path)
+        payload["ledger"] = str(ledger_path)
         payload["ledger_recorded"] = outcome.ledger_changed and not verify_violations
         payload["verify_violations"] = verify_violations
         _echo_json(payload)
-    else:
-        for result in outcome.results:
-            click.echo(f"  {result.status:8s} {result.action} {result.key}  {result.reason}")
-        if outcome.error:
-            click.echo(f"ERROR: {outcome.error}", err=True)
-        elif outcome.wrote:
-            names = ", ".join(p.name for p in outcome.written_paths)
-            click.echo(f"wrote {names}" + (" (dry run)" if dry_run else ""))
-        elif dry_run:
-            click.echo("dry run — nothing written")
-        for violation in verify_violations:
-            click.echo(f"verify: {violation}", err=True)
-        if verify_violations:
-            click.echo(
-                "structural verify failed — applied changes were written but NOT "
-                "recorded into the ledger; fix the pair, then `sync record`. If the "
-                "divergence is in a voiceover companion and is intentional, "
-                "`--allow-diverged-companion` records it anyway (logged)",
-                err=True,
-            )
-    rejected = [r for r in outcome.results if r.status == "rejected"]
-    if rejected:
-        # Stderr in both modes: agents parsing --json counts alone provably
-        # committed with rejections unnoticed. Keep it one line per item.
+        return exit_code
+
+    for result in outcome.results:
+        click.echo(f"  {result.status:8s} {result.action} {result.key}  {result.reason}")
+    if outcome.error:
+        click.echo(f"ERROR: {outcome.error}", err=True)
+    elif outcome.wrote:
+        names = ", ".join(p.name for p in outcome.written_paths)
+        click.echo(f"wrote {names}" + (" (dry run)" if dry_run else ""))
+    elif dry_run:
+        click.echo("dry run — nothing written")
+    for violation in verify_violations:
+        click.echo(f"verify: {violation}", err=True)
+    if verify_violations:
         click.echo(
-            f"{len(rejected)} decision(s) rejected — each item's accepted answers "
-            "come from report --json (its `answers` list); see `clm info sync-agents`:",
+            "structural verify failed — applied changes were written but NOT "
+            "recorded into the ledger; fix the pair, then `sync record`. If the "
+            "divergence is in a voiceover companion and is intentional, "
+            "`--allow-diverged-companion` records it anyway (logged)",
             err=True,
         )
-        for result in rejected:
-            click.echo(f"  {result.key} ({result.action}): {result.reason}", err=True)
-    if outcome.error is not None:
-        return 2
-    return 0 if outcome.all_applied and not verify_violations else 1
+    _echo_rejections(rejected)
+    return exit_code
+
+
+def _echo_rejections(rejected: list[doc_apply.ItemResult]) -> None:
+    """The per-item rejection block — stderr in both modes.
+
+    Agents parsing ``--json`` counts alone provably committed with rejections
+    unnoticed, so this is never silent.
+    """
+    if not rejected:
+        return
+    click.echo(
+        f"{len(rejected)} decision(s) rejected — each item's accepted answers "
+        "come from report --json (its `answers` list); see `clm info sync-agents`:",
+        err=True,
+    )
+    for result in rejected:
+        click.echo(f"  {result.key} ({result.action}): {result.reason}", err=True)
+
+
+def _report_id_errors(bundle: LoadedBundle, document: doc_apply.DecisionDocument) -> list[str]:
+    """Refuse a decision document written against a report that has expired.
+
+    Wholesale, before anything is written (Q2): a stale document's *other*
+    answers are as suspect as the one that no longer matches, and the old
+    per-handle rejection let the first apply's writes stand while telling the
+    second one its decisions were stale (#649).
+
+    A document with no token is accepted with a warning — schema 3 predates
+    the field, and the drivers that emit those documents are still in flight.
+    :data:`~clm.slides.sync_wire.REQUIRE_REPORT_ID` flips that in the release
+    that drops schema 3.
+    """
+    if document.report_id is None:
+        message = (
+            "decision document carries no `report_id` — copy it from the report "
+            "envelope so apply can refuse a document answering a report that no "
+            "longer describes this deck"
+        )
+        if REQUIRE_REPORT_ID:
+            return [message]
+        click.echo(f"warning: {message} (accepted for now)", err=True)
+        return []
+    current = report_id_for(bundle)
+    if document.report_id == current:
+        return []
+    return [
+        f"decision document was written against report_id {document.report_id!r}, "
+        f"but this deck is now {current!r} — the bundle or its ledger section "
+        "changed since that report (an edit, a sibling apply, or the companion "
+        "spelling of the same deck). Nothing was written: re-run "
+        "`clm slides sync report DECK --json` and answer the fresh items"
+    ]
 
 
 def _head_commit(path: Path) -> str | None:
@@ -353,7 +440,7 @@ def run_record_v3(
     if as_json:
         _echo_json(
             {
-                "schema": 3,
+                "schema": WIRE_SCHEMA,
                 "engine": "v3",
                 "recorded": sum(r.get("recorded", 0) for r in rows),
                 "unchanged": sum(

--- a/src/clm/cli/commands/slides/sync_v3.py
+++ b/src/clm/cli/commands/slides/sync_v3.py
@@ -31,6 +31,7 @@ from clm.slides.doc_report import (
     cold_sweep_hint,
     diff_bundle,
     diff_bundle_at_ref,
+    diff_bundle_with_ledger,
     pair_payload,
     report_id_for,
 )
@@ -120,7 +121,7 @@ def run_report_v3(
     this window"), never a trust change: the ledger is neither consulted nor
     written, and nothing else about the verb differs.
     """
-    results: list[tuple[LoadedBundle, DeckDiff, list[str]]] = []
+    results: list[tuple[LoadedBundle, DeckDiff, list[str], doc_ledger.TopicLedger | None]] = []
     errors: list[str] = []
     pairs, solos = _scope_pairs(de_path, en_path)
     _warn_solos(solos)
@@ -130,16 +131,17 @@ def run_report_v3(
         except DocLensError as exc:
             errors.append(str(exc))
             continue
+        ledger: doc_ledger.TopicLedger | None = None
         if since_ref is not None:
             diff, base_refusal = diff_bundle_at_ref(bundle, since_ref)
         else:
-            diff, base_refusal = diff_bundle(bundle), []
-        results.append((bundle, diff, base_refusal))
-    clean = all(diff.is_clean for _, diff, _refusal in results) and not errors
+            (diff, ledger), base_refusal = diff_bundle_with_ledger(bundle), []
+        results.append((bundle, diff, base_refusal, ledger))
+    clean = all(diff.is_clean for _, diff, _refusal, _l in results) and not errors
     if as_json:
         payloads = []
-        for bundle, diff, base_refusal in results:
-            payload = pair_payload(bundle, diff)
+        for bundle, diff, base_refusal, ledger in results:
+            payload = pair_payload(bundle, diff, ledger=ledger)
             if since_ref is not None:
                 payload["baseline"] = f"since:{since_ref}"
                 if base_refusal:
@@ -155,15 +157,15 @@ def run_report_v3(
                     "engine": "v3",
                     "exit_code": 0 if clean else 1,
                     "is_clean": clean,
-                    "needs_model": any(d.needs_model for _, d, _r in results),
-                    "needs_agent": any(d.needs_agent for _, d, _r in results) or bool(errors),
+                    "needs_model": any(d.needs_model for _, d, _r, _l in results),
+                    "needs_agent": any(d.needs_agent for _, d, _r, _l in results) or bool(errors),
                     "errors": errors,
                     "skipped_solos": [str(p) for p in solos],
                     "pairs": payloads,
                 }
             )
     else:
-        for bundle, diff, base_refusal in results:
+        for bundle, diff, base_refusal, _ledger in results:
             click.echo(_render_pair(bundle, diff))
             if base_refusal:
                 click.echo(

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1971,7 +1971,7 @@ the languages, is **refused** with a normalize hint — never silently guessed.
 
 Read-only. Prints one `outcome/action` row per non-in-sync member; exit `0`
 clean / `1` work pending / `2` error. The JSON envelope is self-describing
-(`"schema": 3, "engine": "v3"`) and carries the stable booleans:
+(`"schema": 4, "engine": "v3"`) and carries the stable booleans:
 
 - `is_clean` — nothing to do (also false, with an `observations` entry, when
   the halves' group order visibly diverges — even if no item is framed);
@@ -1979,6 +1979,14 @@ clean / `1` work pending / `2` error. The JSON envelope is self-describing
   `translate_new`) exists;
 - `needs_agent` — judgment beyond translation is required (a conflict, a cold
   member, a normalize refusal).
+
+Schema 4 (CLM {version}) adds the deck's identity and a freshness token to
+every pair payload: `deck_key`, `ledger` (the trust store's path), and
+`report_id` — a hash of the bundle bytes plus this deck's ledger section.
+Echo `report_id` at the top level of the decision document; `apply` refuses
+the whole document with exit 2, writing nothing, when the deck has moved on
+since the report. Documents without the token are still accepted, with a
+warning. See `clm info sync-agents`.
 
 Order divergence frames from the **current** cross-side state whether or not
 the ledger carries recorded order trust (CLM {version}): with trust, a

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -87,6 +87,12 @@ A document with no `report_id` is still accepted, with a warning naming the
 field — schema 3 predates it. That grace ends in a future release; emit the
 token now.
 
+**Your own `apply` invalidates the token** — it records into the ledger, which
+is half of the token's input. That is deliberate: one report, one apply, then
+re-report. If you are applying a report in stages (`--member` at a time), take
+a fresh report between passes rather than reusing the document; the second
+pass is answering a deck that has already moved.
+
 **Mechanical actions** (no decision needed — `apply` executes them):
 `propagate_shared_edit`, `copy_new_shared`, `mirror_remove`, `mirror_tags`,
 `mirror_order`, `mirror_layout`, the `record_*` acknowledgements, and the

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -43,7 +43,7 @@ writes**. The default is "tell me what is necessary", not "do it".
 
 ## Reading the report
 
-`report --json` emits a schema-3 envelope (`"schema": 3, "engine": "v3"`).
+`report --json` emits a schema-4 envelope (`"schema": 4, "engine": "v3"`).
 Branch on the stable booleans rather than scanning the lists:
 
 - `is_clean` — nothing to do; **stop**. One non-item state suppresses it:
@@ -66,6 +66,26 @@ answer — `apply` executes it). Note the `de`/`en` excerpts **include** the
 `# %%` header line; a `body` answer must **not** (see below). A report whose
 items are *all* `verify_cold` also carries a top-level `hint` — that is the
 seeding case; use `record`, not a confirm-all document (see "Cold members").
+
+### The freshness token (`report_id`) — copy it into your answers
+
+Every pair payload carries three identity fields:
+
+- **`report_id`** — a token over the bundle bytes **plus** this deck's ledger
+  section. Put it at the top level of your decision document
+  (`{"schema": 4, "report_id": "…", "decisions": [...]}`). `apply` recomputes
+  it and, on a mismatch, refuses the **whole document**: exit 2, nothing
+  written, and a message naming both values. That is deliberate — if the deck
+  moved since the report, every answer in the document is suspect, not just
+  the one that no longer matches.
+- **`deck_key`** / **`ledger`** — the deck's trust identity. Two CLI spellings
+  (`slides_x.de.py` and its `voiceover_x.de.py` companion) are **one** deck
+  with **one** ledger section; the companion form now says so on stderr. Two
+  passes over "different" paths are two passes over the same deck.
+
+A document with no `report_id` is still accepted, with a warning naming the
+field — schema 3 predates it. That grace ends in a future release; emit the
+token now.
 
 **Mechanical actions** (no decision needed — `apply` executes them):
 `propagate_shared_edit`, `copy_new_shared`, `mirror_remove`, `mirror_tags`,
@@ -290,25 +310,33 @@ they do not exist):
 
 ```json
 {
-  "schema": 3, "engine": "v3",
+  "schema": 4, "engine": "v3",
   "dry_run": false,
   "error": null,
   "wrote": true, "written": ["…/slides_x.en.py"],
   "counts": {"applied": 4, "recorded": 2, "deferred": 0, "pending": 1,
-             "rejected": 1, "failed": 0, "skipped": 0},
+             "already_applied": 0, "rejected": 1, "failed": 0, "skipped": 0},
   "items": [
     {"key": "id:intro", "action": "translate_edit",
      "status": "applied", "reason": ""},
     {"key": "id:setup", "action": "verify_cold",
      "status": "rejected", "reason": "…why…"}
   ],
+  "exit_code": 1,
+  "deck_key": "slides_x", "ledger": "…/.clm/sync-ledger.json",
   "ledger_recorded": true,
   "verify_violations": []
 }
 ```
 
 **Always check `counts.rejected` (and each rejected item's `reason`) before
-moving on** — rejections are also echoed to stderr. `pending` = framed items
+moving on** — rejections are also echoed to stderr (in `--json` mode they are
+printed *before* the payload, so a merged stream still ends in valid JSON).
+`already_applied` is **not** a rejection: the member frames nothing now, so
+the state your answer asks for already holds — a sibling pass, an earlier
+apply, or the other CLI spelling of this deck got there first. It does not
+block exit 0. Only a handle naming **no member of this deck** is `rejected`
+as stale. `pending` = framed items
 you did not answer (exit 1, not an error). `deferred` = a record-only row
 whose ledger write was deferred because the member still carries an
 unresolved sibling item — nothing was banked; it re-frames on the next
@@ -486,7 +514,7 @@ sync handoff closes through the ordinary loop.
 
 ## Non-shell agents — the MCP tool
 
-`slides_sync_report` (MCP) returns the same schema-3 pair payload as
+`slides_sync_report` (MCP) returns the same schema-4 pair payload as
 `report --json`, including the `answers` vocabulary per framed item.
 Writing decisions currently requires the CLI `apply --decisions`.
 

--- a/src/clm/mcp/tools.py
+++ b/src/clm/mcp/tools.py
@@ -761,7 +761,7 @@ async def handle_sync_report(file: str, data_dir: Path) -> str:
     """Produce the sync report for a split DE/EN deck pair (v3 engine, #520).
 
     Runs the *same* read verb as ``clm slides sync report --json`` and returns the
-    schema-3 member table: per-member items (mechanical vs framed actions, each
+    schema-4 member table: per-member items (mechanical vs framed actions, each
     framed item carrying its decision-answer vocabulary) diffed against the
     committed per-topic ledger — the only trust store. This is the blessed agent
     contract for non-shell agents (the split-pair analogue of the legacy
@@ -774,7 +774,7 @@ async def handle_sync_report(file: str, data_dir: Path) -> str:
         data_dir: Root data directory (a relative ``file`` resolves against it).
 
     Returns:
-        JSON: the schema-3 pair payload (``de_path`` / ``en_path``, the ``items``
+        JSON: the schema-4 pair payload (``de_path`` / ``en_path``, the ``items``
         rows, and ``is_clean`` / ``needs_model`` / ``needs_agent``), or an
         ``{"error": …}`` object.
     """

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -1669,8 +1669,19 @@ def apply_deck(
     for _, item in ordered:
         if only_members is not None and item.key not in only_members:
             unresolved_items.append(item)  # a skipped pool sibling must not be blessed
+            answered = item.key in decisions
+            if answered:
+                # Claim the handle so the unmatched-decision sweep below does
+                # not then classify it: the answer was neither stale nor
+                # already satisfied — the filter simply did not run it.
+                seen_decisions.add(item.key)
             outcome.results.append(
-                ItemResult(item.key, item.action, "skipped", "excluded by --member")
+                ItemResult(
+                    item.key,
+                    item.action,
+                    "skipped",
+                    "excluded by --member" + (" (its answer was not used)" if answered else ""),
+                )
             )
             continue
         decision = decisions.get(item.key)

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -44,7 +44,7 @@ from pathlib import Path
 
 from attrs import define, evolve, field, frozen
 
-from clm.slides.bilingual_doc import BilingualDeck, Lang, Member, SideCell
+from clm.slides.bilingual_doc import BilingualDeck, Lang, Member, MemberKey, SideCell
 from clm.slides.doc_identity import (
     content_fingerprint,
     iter_with_groups,
@@ -72,6 +72,7 @@ from clm.slides.sync_diff import (
     DeckDiff,
     DiffItem,
 )
+from clm.slides.sync_wire import ACCEPTED_DECISION_SCHEMAS, WIRE_SCHEMA
 from clm.slides.sync_writeback import set_header_tags, swap_lang
 
 __all__ = [
@@ -81,6 +82,7 @@ __all__ = [
     "apply_deck",
     "decision_vocabulary",
     "item_answers",
+    "load_decision_document",
     "parse_decisions",
 ]
 
@@ -223,11 +225,60 @@ def parse_decisions(payload: object) -> tuple[dict[str, Decision], list[str]]:
 
 def load_decisions_text(text: str) -> tuple[dict[str, Decision], list[str]]:
     """:func:`parse_decisions` over raw JSON text."""
+    document, errors = load_decision_document(text)
+    return document.decisions, errors
+
+
+@frozen
+class DecisionDocument:
+    """A parsed decision document: its answers plus its schema-4 envelope.
+
+    ``report_id`` is the freshness token copied out of the report envelope
+    (:func:`clm.slides.doc_report.report_id_for`). ``None`` means a schema-3
+    document that predates the token — accepted for now, warned about by the
+    caller (:mod:`clm.slides.sync_wire`).
+    """
+
+    decisions: dict[str, Decision] = field(factory=dict)
+    report_id: str | None = None
+    schema: int | None = None
+
+
+def load_decision_document(text: str) -> tuple[DecisionDocument, list[str]]:
+    """Decode a decision document's answers *and* its envelope from JSON text.
+
+    The envelope is validated here rather than at the CLI so every consumer
+    (CLI, MCP, a future driver) refuses the same documents: an unknown schema
+    is an error, not a field to ignore — silently accepting a document written
+    for a contract this engine does not implement is how an answer means one
+    thing to its author and another to the executor.
+    """
     try:
         payload = json.loads(text)
     except ValueError as exc:
-        return {}, [f"decision document is not valid JSON: {exc}"]
-    return parse_decisions(payload)
+        return DecisionDocument(), [f"decision document is not valid JSON: {exc}"]
+    decisions, errors = parse_decisions(payload)
+    report_id: str | None = None
+    schema: int | None = None
+    if isinstance(payload, dict):
+        raw_id = payload.get("report_id")
+        if raw_id is not None and not isinstance(raw_id, str):
+            errors.append("'report_id' must be the string from the report envelope")
+        else:
+            report_id = raw_id
+        raw_schema = payload.get("schema")
+        if raw_schema is not None:
+            if not isinstance(raw_schema, int) or isinstance(raw_schema, bool):
+                errors.append("'schema' must be an integer")
+            elif raw_schema not in ACCEPTED_DECISION_SCHEMAS:
+                accepted = ", ".join(str(s) for s in ACCEPTED_DECISION_SCHEMAS)
+                errors.append(
+                    f"decision document announces schema {raw_schema}; this clm "
+                    f"reads {accepted} (see `clm info sync-agents`)"
+                )
+            else:
+                schema = raw_schema
+    return DecisionDocument(decisions=decisions, report_id=report_id, schema=schema), errors
 
 
 def _validate_body(body: str, comment_token: str) -> str | None:
@@ -348,7 +399,14 @@ class ItemResult:
     #:            the member still carries an unresolved sibling item (#615);
     #:            nothing happened — the row re-frames on the next report
     #: pending  — framed item without a decision (untouched residue)
-    #: rejected — a supplied decision failed validation (nothing changed)
+    #: already_applied — the answered member frames nothing now: the effect
+    #:            this decision asks for already holds (a sibling pass, an
+    #:            earlier apply, or the two CLI spellings of one deck). Not a
+    #:            failure — the schema-4 split of the verdict that used to
+    #:            read "rejected — stale handle" while the write had landed
+    #:            (#649)
+    #: rejected — a supplied decision failed validation, or named a member
+    #:            this deck does not have (nothing changed)
     #: failed   — a mechanical row the executor could not resolve safely
     #: skipped  — excluded by the ``--member`` filter
     status: str
@@ -384,11 +442,16 @@ class ApplyOutcome:
 
     @property
     def all_applied(self) -> bool:
-        return self.error is None and all(r.status in ("applied", "recorded") for r in self.results)
+        # ``already_applied`` is a success: the state the decision asks for
+        # holds. Counting it as residue is what made a re-run of a landed
+        # apply exit 1 while reporting nothing left to do (#649).
+        return self.error is None and all(
+            r.status in ("applied", "recorded", "already_applied") for r in self.results
+        )
 
     def to_payload(self) -> dict:
         return {
-            "schema": 3,
+            "schema": WIRE_SCHEMA,
             "engine": "v3",
             "dry_run": self.dry_run,
             "error": self.error,
@@ -401,6 +464,7 @@ class ApplyOutcome:
                     "recorded",
                     "deferred",
                     "pending",
+                    "already_applied",
                     "rejected",
                     "failed",
                     "skipped",
@@ -1533,6 +1597,39 @@ def _execute_mechanical(ex: _Executor, item: DiffItem) -> None:
         raise _ItemError(f"no executor for mechanical action '{action}'")
 
 
+def _unmatched_decision_result(key: str, deck: BilingualDeck) -> ItemResult:
+    """Classify a decision whose key names no item in the current diff.
+
+    Two very different situations wore one verdict before schema 4. If the
+    member *exists* and simply frames nothing, the answer is redundant, not
+    wrong — the effect it asks for already holds, because a sibling pass, an
+    earlier apply, or the other CLI spelling of this same deck already did it.
+    Reporting that as ``rejected`` is what made #649 read as "rejected" while
+    the write had demonstrably landed. Only a key that names no member of this
+    deck at all is a genuine stale handle.
+    """
+    try:
+        member = deck.member_by_key(MemberKey.parse(key))
+    except ValueError:
+        member = None
+    if member is not None:
+        return ItemResult(
+            key,
+            "?",
+            "already_applied",
+            "the member frames nothing in the current report — the state this "
+            "answer asks for already holds (nothing to do)",
+        )
+    return ItemResult(
+        key,
+        "?",
+        "rejected",
+        "no member with this handle in the deck — check the key against "
+        "`report --json`, and note that a companion path and its deck are one "
+        "deck with one ledger section",
+    )
+
+
 def apply_deck(
     bundle: LoadedBundle,
     deck: BilingualDeck,
@@ -1623,11 +1720,7 @@ def apply_deck(
             outcome.results.append(ItemResult(item.key, item.action, status, str(exc)))
     for key in decisions:
         if key not in seen_decisions:
-            outcome.results.append(
-                ItemResult(
-                    key, "?", "rejected", "no such item in the current report (stale handle)"
-                )
-            )
+            outcome.results.append(_unmatched_decision_result(key, deck))
 
     if not landed:
         return outcome

--- a/src/clm/slides/doc_ledger.py
+++ b/src/clm/slides/doc_ledger.py
@@ -36,6 +36,7 @@ runners).
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 from pathlib import Path
@@ -55,6 +56,7 @@ __all__ = [
     "TopicLedger",
     "baseline_from_ledger",
     "deck_key_for",
+    "deck_section_fingerprint",
     "ledger_path_for",
     "load",
     "preserve_unchanged_member",
@@ -149,6 +151,25 @@ def deck_key_for(de_path: Path) -> str:
         if stem.endswith(lang_suffix):
             return stem[: -len(lang_suffix)]
     return stem
+
+
+def deck_section_fingerprint(ledger: TopicLedger, deck_key: str) -> str:
+    """A stable digest of one deck's ledger section — the trust half of the
+    schema-4 ``report_id`` (:mod:`clm.slides.sync_wire`).
+
+    Hashes the section's *canonical* JSON, so it is exactly as sensitive as
+    the committed artifact: any recorded fingerprint, order scope, owner ref
+    or provenance stamp that moved changes the digest, and a re-save that
+    changes no content does not. An absent section (never-recorded deck) is
+    its own value — cold is a state a decision can be written against, and a
+    document answering a cold report must not survive the deck being
+    recorded out from under it.
+    """
+    deck = ledger.decks.get(deck_key)
+    if deck is None:
+        return "cold"
+    payload = json.dumps(_deck_to_json(deck), sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
 
 
 # ---------------------------------------------------------------------------

--- a/src/clm/slides/doc_report.py
+++ b/src/clm/slides/doc_report.py
@@ -12,13 +12,14 @@ from __future__ import annotations
 import hashlib
 
 from clm.slides import doc_apply, doc_ledger
-from clm.slides.doc_lenses import LoadedBundle
+from clm.slides.doc_lenses import LoadedBundle, project
 from clm.slides.sync_diff import DeckDiff, diff_outcome
 
 __all__ = [
     "cold_sweep_hint",
     "diff_bundle",
     "diff_bundle_at_ref",
+    "diff_bundle_with_ledger",
     "item_payloads",
     "pair_payload",
     "report_id_for",
@@ -31,10 +32,21 @@ def diff_bundle(bundle: LoadedBundle) -> DeckDiff:
     A deck with no ledger entry diffs against ``None`` — every member is
     cold (``verify_cold``), never silently trusted (design §5).
     """
+    return diff_bundle_with_ledger(bundle)[0]
+
+
+def diff_bundle_with_ledger(bundle: LoadedBundle) -> tuple[DeckDiff, doc_ledger.TopicLedger]:
+    """:func:`diff_bundle`, handing back the ledger it loaded.
+
+    The report needs the same topic ledger twice — once for the baseline and
+    once for the schema-4 ``report_id`` — and a directory sweep pays that per
+    deck. Threading it through instead of loading it twice is most of the
+    difference between a 37% and an 11% slowdown on a 24-deck module report.
+    """
     ledger = doc_ledger.load(doc_ledger.ledger_path_for(bundle.de_path))
     deck_ledger = ledger.decks.get(doc_ledger.deck_key_for(bundle.de_path))
     base = doc_ledger.baseline_from_ledger(deck_ledger) if deck_ledger is not None else None
-    return diff_outcome(bundle.outcome, base)
+    return diff_outcome(bundle.outcome, base), ledger
 
 
 def diff_bundle_at_ref(bundle: LoadedBundle, ref: str) -> tuple[DeckDiff, list[str]]:
@@ -109,7 +121,7 @@ def cold_sweep_hint(diff: DeckDiff) -> str | None:
     return None
 
 
-def report_id_for(bundle: LoadedBundle) -> str:
+def report_id_for(bundle: LoadedBundle, ledger: doc_ledger.TopicLedger | None = None) -> str:
     """The schema-4 freshness token for one pair (:mod:`clm.slides.sync_wire`).
 
     ``hash(bundle bytes + this deck's ledger section)`` — the two inputs that
@@ -123,25 +135,39 @@ def report_id_for(bundle: LoadedBundle) -> str:
     separated voiceover companion is part of the same member table, and the
     ``voiceover_x`` / ``slides_x`` CLI spellings resolve to one deck, so a
     companion edit must invalidate the deck's report.
+
+    The bundle half comes from the **projection** of the parsed deck, not from
+    re-reading the files. ``project . parse`` is byte-identity by construction
+    (design §4, property-tested), so the value is the same while a sweep pays
+    no second read per file — and, more importantly, report time and apply
+    time run the *same* function, so the two ends cannot disagree even about a
+    byte the lens would normalize. A bundle that refuses to parse has no
+    projection; there the file bytes are hashed directly.
     """
     digest = hashlib.sha256()
-    for path in (
-        bundle.de_path,
-        bundle.en_path,
-        bundle.de_companion_path,
-        bundle.en_companion_path,
+    deck = bundle.outcome.deck
+    for path, lang, part in (
+        (bundle.de_path, "de", "deck"),
+        (bundle.en_path, "en", "deck"),
+        (bundle.de_companion_path, "de", "companion"),
+        (bundle.en_companion_path, "en", "companion"),
     ):
         if path is None:
             digest.update(b"\x00absent\x00")
             continue
         digest.update(path.name.encode("utf-8"))
         digest.update(b"\x00")
-        try:
-            digest.update(path.read_bytes())
-        except OSError:  # pragma: no cover - the bundle was just read
-            digest.update(b"<unreadable>")
+        text = project(deck, lang, part) if deck is not None else None  # type: ignore[arg-type]
+        if text is not None:
+            digest.update(text.encode("utf-8"))
+        else:
+            try:
+                digest.update(path.read_bytes())
+            except OSError:  # pragma: no cover - the bundle was just read
+                digest.update(b"<unreadable>")
         digest.update(b"\x00")
-    ledger = doc_ledger.load(doc_ledger.ledger_path_for(bundle.de_path))
+    if ledger is None:
+        ledger = doc_ledger.load(doc_ledger.ledger_path_for(bundle.de_path))
     digest.update(
         doc_ledger.deck_section_fingerprint(ledger, doc_ledger.deck_key_for(bundle.de_path)).encode(
             "utf-8"
@@ -150,8 +176,15 @@ def report_id_for(bundle: LoadedBundle) -> str:
     return digest.hexdigest()[:16]
 
 
-def pair_payload(bundle: LoadedBundle, diff: DeckDiff) -> dict:
-    """The full schema-4 report payload for one pair."""
+def pair_payload(
+    bundle: LoadedBundle, diff: DeckDiff, *, ledger: doc_ledger.TopicLedger | None = None
+) -> dict:
+    """The full schema-4 report payload for one pair.
+
+    ``ledger`` is the already-loaded topic ledger when the caller has one
+    (:func:`diff_bundle_with_ledger`): the token needs the same section the
+    baseline came from, and re-loading it per deck is pure waste on a sweep.
+    """
     payload = diff.to_payload()
     payload["items"] = item_payloads(diff)
     payload["de_path"] = str(bundle.de_path)
@@ -161,7 +194,7 @@ def pair_payload(bundle: LoadedBundle, diff: DeckDiff) -> dict:
     # #649's second apply found its decisions already satisfied.
     payload["deck_key"] = doc_ledger.deck_key_for(bundle.de_path)
     payload["ledger"] = str(doc_ledger.ledger_path_for(bundle.de_path))
-    payload["report_id"] = report_id_for(bundle)
+    payload["report_id"] = report_id_for(bundle, ledger)
     hint = cold_sweep_hint(diff)
     if hint is not None:
         payload["hint"] = hint

--- a/src/clm/slides/doc_report.py
+++ b/src/clm/slides/doc_report.py
@@ -9,6 +9,8 @@ onto this module). Read-only: nothing here writes a file or the ledger.
 
 from __future__ import annotations
 
+import hashlib
+
 from clm.slides import doc_apply, doc_ledger
 from clm.slides.doc_lenses import LoadedBundle
 from clm.slides.sync_diff import DeckDiff, diff_outcome
@@ -19,6 +21,7 @@ __all__ = [
     "diff_bundle_at_ref",
     "item_payloads",
     "pair_payload",
+    "report_id_for",
 ]
 
 
@@ -106,12 +109,59 @@ def cold_sweep_hint(diff: DeckDiff) -> str | None:
     return None
 
 
+def report_id_for(bundle: LoadedBundle) -> str:
+    """The schema-4 freshness token for one pair (:mod:`clm.slides.sync_wire`).
+
+    ``hash(bundle bytes + this deck's ledger section)`` — the two inputs that
+    together decide every verdict in the report. An agent echoes the value in
+    its decision document and ``apply`` refuses the document when the current
+    value differs, so "the report you answered no longer describes this deck"
+    becomes a first-class, self-explaining refusal instead of a set of
+    handle-by-handle rejections whose writes had already landed (#649, Q2).
+
+    Deliberately covers the *whole* bundle, not just the deck halves: a
+    separated voiceover companion is part of the same member table, and the
+    ``voiceover_x`` / ``slides_x`` CLI spellings resolve to one deck, so a
+    companion edit must invalidate the deck's report.
+    """
+    digest = hashlib.sha256()
+    for path in (
+        bundle.de_path,
+        bundle.en_path,
+        bundle.de_companion_path,
+        bundle.en_companion_path,
+    ):
+        if path is None:
+            digest.update(b"\x00absent\x00")
+            continue
+        digest.update(path.name.encode("utf-8"))
+        digest.update(b"\x00")
+        try:
+            digest.update(path.read_bytes())
+        except OSError:  # pragma: no cover - the bundle was just read
+            digest.update(b"<unreadable>")
+        digest.update(b"\x00")
+    ledger = doc_ledger.load(doc_ledger.ledger_path_for(bundle.de_path))
+    digest.update(
+        doc_ledger.deck_section_fingerprint(ledger, doc_ledger.deck_key_for(bundle.de_path)).encode(
+            "utf-8"
+        )
+    )
+    return digest.hexdigest()[:16]
+
+
 def pair_payload(bundle: LoadedBundle, diff: DeckDiff) -> dict:
-    """The full schema-3 report payload for one pair."""
+    """The full schema-4 report payload for one pair."""
     payload = diff.to_payload()
     payload["items"] = item_payloads(diff)
     payload["de_path"] = str(bundle.de_path)
     payload["en_path"] = str(bundle.en_path)
+    # The deck's trust identity, spelled out: `voiceover_x` and `slides_x` are
+    # two CLI spellings of ONE deck sharing ONE ledger section, which is how
+    # #649's second apply found its decisions already satisfied.
+    payload["deck_key"] = doc_ledger.deck_key_for(bundle.de_path)
+    payload["ledger"] = str(doc_ledger.ledger_path_for(bundle.de_path))
+    payload["report_id"] = report_id_for(bundle)
     hint = cold_sweep_hint(diff)
     if hint is not None:
         payload["hint"] = hint

--- a/src/clm/slides/sync_diff.py
+++ b/src/clm/slides/sync_diff.py
@@ -82,6 +82,7 @@ from clm.slides.doc_identity import (
 from clm.slides.doc_identity import (
     pair_signature as _pair_sig,
 )
+from clm.slides.sync_wire import WIRE_SCHEMA
 
 _SIDES: tuple[Lang, Lang] = ("de", "en")
 
@@ -351,10 +352,10 @@ class DeckDiff:
         )
 
     def to_payload(self) -> dict:
-        """The self-describing JSON envelope (design §12.5, ``schema: 3``)."""
+        """The self-describing JSON envelope (design §12.5, :data:`WIRE_SCHEMA`)."""
         counts = Counter(i.outcome for i in self.items)
         return {
-            "schema": 3,
+            "schema": WIRE_SCHEMA,
             "engine": "v3",
             "is_clean": self.is_clean,
             "needs_model": self.needs_model,

--- a/src/clm/slides/sync_wire.py
+++ b/src/clm/slides/sync_wire.py
@@ -1,0 +1,48 @@
+"""The sync verbs' wire contract version — one number, both directions.
+
+``report``'s envelope and the decision documents ``apply --decisions`` reads
+are **one** contract with **one** version: an agent copies handles (and, since
+schema 4, the freshness token) straight out of a report into its answers, so a
+report envelope and a decision document that disagree about the schema are a
+contradiction in terms. Every payload the sync verbs emit therefore carries
+:data:`WIRE_SCHEMA`, and every document they read is checked against
+:data:`ACCEPTED_DECISION_SCHEMAS`.
+
+Schema 4 (Q2/Q3 of ``docs/claude/sync-v3-adversarial-review.md``) is additive:
+
+* ``report_id`` — a freshness token over the bundle bytes plus this deck's
+  ledger section, echoed back in a decision document so ``apply`` can refuse a
+  document written against a report that no longer describes the deck. Before
+  it existed, "stale handle" named a report that did not exist at apply time
+  and the verdict could contradict the effect (#649).
+* ``already_applied`` — a decision whose effect already holds is no longer
+  reported as ``rejected``.
+* ``deck_key`` / ``ledger`` — the deck's ledger identity, in every payload, so
+  two CLI spellings of one deck are visibly one deck.
+
+Rollout: a decision document with **no** ``report_id`` is accepted with a
+warning naming the field (agents and downstream sweep drivers keep working);
+one whose token does not match is refused wholesale — exit 2, nothing written.
+The maintainer's decision (2026-07-31) is that the token-less form is accepted
+for one release and rejected in the next; that tightening flips
+:data:`REQUIRE_REPORT_ID`.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "ACCEPTED_DECISION_SCHEMAS",
+    "REQUIRE_REPORT_ID",
+    "WIRE_SCHEMA",
+]
+
+#: The version every report / apply / record payload announces.
+WIRE_SCHEMA = 4
+
+#: Decision-document schemas ``apply`` still reads. Schema 3 documents carry no
+#: ``report_id`` and no ``action`` discriminator; they remain valid input for
+#: one release so that a clm upgrade does not break a driver mid-flight.
+ACCEPTED_DECISION_SCHEMAS = (3, 4)
+
+#: Flip to ``True`` in the release that drops schema 3 (see the module doc).
+REQUIRE_REPORT_ID = False

--- a/tests/cli/test_sync_v3_cli.py
+++ b/tests/cli/test_sync_v3_cli.py
@@ -14,6 +14,7 @@ import pytest
 from click.testing import CliRunner
 
 from clm.cli.commands.slides.sync import slides_sync_group
+from clm.slides.sync_wire import WIRE_SCHEMA
 
 
 @pytest.fixture
@@ -50,6 +51,14 @@ def _write_pair(tmp_path: Path) -> tuple[Path, Path]:
     return de, en
 
 
+def _stderr(result) -> str:
+    """The runner's stderr, on Click 8.1 (split streams) and 8.2+ alike."""
+    try:
+        return result.stderr or ""
+    except ValueError:  # streams not separated on this Click
+        return result.output
+
+
 def _json_payload(output: str) -> dict:
     # raw_decode: the runner may append stderr lines (e.g. apply's rejected
     # summary) after the JSON document — parse the object, ignore the rest.
@@ -66,7 +75,7 @@ class TestSyncLoop:
         cold = cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"])
         assert cold.exit_code == 1, cold.output
         payload = _json_payload(cold.output)
-        assert payload["schema"] == 3 and payload["engine"] == "v3"
+        assert payload["schema"] == WIRE_SCHEMA and payload["engine"] == "v3"
         assert payload["is_clean"] is False
         assert payload["needs_agent"] is True
         assert {i["action"] for i in payload["items"]} == {"verify_cold"}
@@ -391,3 +400,175 @@ class TestOrderObservationRender:
         assert result.exit_code == 1
         assert "observation/group_order_divergence" in result.output
         assert "mirror_order" in result.output
+
+
+class TestReportIdentity:
+    """Schema 4's freshness token and deck identity (Q2 / finding C7, #649)."""
+
+    def test_report_payload_carries_the_deck_identity_and_a_token(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        de, _en = _write_pair(tmp_path)
+        payload = _json_payload(
+            cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"]).output
+        )
+        assert payload["deck_key"] == "slides_t"
+        assert payload["ledger"].endswith("sync-ledger.json")
+        assert isinstance(payload["report_id"], str) and payload["report_id"]
+        # M14: the envelope says what the process exited with.
+        assert payload["exit_code"] == 1
+
+    def test_token_tracks_the_bundle_and_the_ledger(self, cli_runner: CliRunner, tmp_path: Path):
+        de, en = _write_pair(tmp_path)
+
+        def token() -> str:
+            out = cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"]).output
+            return _json_payload(out)["report_id"]
+
+        cold = token()
+        assert token() == cold  # stable: same bytes, same ledger
+
+        # `record` changes no file, but it changes the trust half.
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0
+        recorded = token()
+        assert recorded != cold
+
+        # An edit to EITHER half changes the bundle half.
+        en.write_text(en.read_text(encoding="utf-8").replace("EN text", "EN edited"), "utf-8")
+        assert token() != recorded
+
+    def test_stale_token_refuses_the_whole_document_and_writes_nothing(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        de, en = _write_pair(tmp_path)
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0
+        de.write_text(de.read_text(encoding="utf-8").replace("DE Text", "DE neu"), "utf-8")
+        report = _json_payload(
+            cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"]).output
+        )
+        before = en.read_text(encoding="utf-8")
+
+        # The deck moves on after the report was taken (a sibling pass, an
+        # editor save, the companion spelling of the same deck) — #649.
+        de.write_text(de.read_text(encoding="utf-8").replace("DE neu", "DE neuer"), "utf-8")
+
+        result = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--decisions", "-", "--json"],
+            input=json.dumps(
+                {
+                    "schema": WIRE_SCHEMA,
+                    "report_id": report["report_id"],
+                    "decisions": [{"key": "id:s0-m", "body": "# EN new"}],
+                }
+            ),
+        )
+        assert result.exit_code == 2
+        assert en.read_text(encoding="utf-8") == before  # nothing written
+        # The refusal is a JSON envelope, not an empty stdout (M14).
+        payload = _json_payload(result.output)
+        assert payload["exit_code"] == 2 and payload["wrote"] is False
+        assert "report_id" in payload["error"]
+
+    def test_matching_token_applies(self, cli_runner: CliRunner, tmp_path: Path):
+        de, en = _write_pair(tmp_path)
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0
+        de.write_text(de.read_text(encoding="utf-8").replace("DE Text", "DE neu"), "utf-8")
+        report = _json_payload(
+            cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"]).output
+        )
+        result = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--decisions", "-", "--json"],
+            input=json.dumps(
+                {
+                    "schema": WIRE_SCHEMA,
+                    "report_id": report["report_id"],
+                    "decisions": [{"key": "id:s0-m", "body": "# EN new"}],
+                }
+            ),
+        )
+        assert result.exit_code == 0, result.output
+        assert "# EN new" in en.read_text(encoding="utf-8")
+
+    def test_document_without_a_token_is_accepted_with_a_warning(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        # Schema 3 predates the field; drivers emitting those documents keep
+        # working for one release, but they are told what to add.
+        de, en = _write_pair(tmp_path)
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0
+        de.write_text(de.read_text(encoding="utf-8").replace("DE Text", "DE neu"), "utf-8")
+        result = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--decisions", "-", "--json"],
+            input=json.dumps({"decisions": [{"key": "id:s0-m", "body": "# EN new"}]}),
+        )
+        assert result.exit_code == 0, result.output
+        assert "# EN new" in en.read_text(encoding="utf-8")
+        assert "report_id" in _stderr(result)
+
+    def test_unknown_document_schema_is_refused(self, cli_runner: CliRunner, tmp_path: Path):
+        de, _en = _write_pair(tmp_path)
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0
+        result = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--decisions", "-", "--json"],
+            input=json.dumps(
+                {"schema": 99, "decisions": [{"key": "id:s0-m", "choice": "confirm"}]}
+            ),
+        )
+        assert result.exit_code == 2
+        assert "schema 99" in _stderr(result) + result.output
+
+
+class TestAlreadyApplied:
+    """A decision whose effect already holds is not a rejection (#649)."""
+
+    def test_answer_for_an_in_sync_member_is_already_applied_and_exits_zero(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        de, en = _write_pair(tmp_path)
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0
+        de.write_text(de.read_text(encoding="utf-8").replace("DE Text", "DE neu"), "utf-8")
+        decisions = json.dumps({"decisions": [{"key": "id:s0-m", "body": "# EN new"}]})
+
+        first = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--decisions", "-", "--json"],
+            input=decisions,
+        )
+        assert first.exit_code == 0, first.output
+        assert "# EN new" in en.read_text(encoding="utf-8")
+
+        # Re-running the SAME document: the member frames nothing now. The
+        # effect the answer asks for holds, so this is success — not
+        # "rejected, stale handle" while the write had demonstrably landed.
+        second = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--decisions", "-", "--json"],
+            input=decisions,
+        )
+        assert second.exit_code == 0, second.output
+        payload = _json_payload(second.output)
+        assert payload["counts"]["already_applied"] == 1
+        assert payload["counts"]["rejected"] == 0
+        (item,) = [i for i in payload["items"] if i["key"] == "id:s0-m"]
+        assert item["status"] == "already_applied"
+
+    def test_answer_for_an_unknown_member_is_still_rejected(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        de, _en = _write_pair(tmp_path)
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0
+        result = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--decisions", "-", "--json"],
+            input=json.dumps({"decisions": [{"key": "id:no-such-member", "choice": "confirm"}]}),
+        )
+        assert result.exit_code == 1
+        payload = _json_payload(result.output)
+        assert payload["counts"]["rejected"] == 1
+        (item,) = [i for i in payload["items"] if i["key"] == "id:no-such-member"]
+        assert item["status"] == "rejected"
+        assert "no member with this handle" in item["reason"]

--- a/tests/cli/test_sync_v3_cli.py
+++ b/tests/cli/test_sync_v3_cli.py
@@ -556,6 +556,27 @@ class TestAlreadyApplied:
         (item,) = [i for i in payload["items"] if i["key"] == "id:s0-m"]
         assert item["status"] == "already_applied"
 
+    def test_answer_for_a_filtered_out_item_reads_as_skipped_not_applied(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        # A decision for an item `--member` excluded is neither stale nor
+        # satisfied — the filter did not run it. Classifying it as
+        # `already_applied` would claim an effect that did not happen.
+        de, _en = _write_pair(tmp_path)
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0
+        de.write_text(de.read_text(encoding="utf-8").replace("DE Text", "DE neu"), "utf-8")
+        result = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--member", "id:nothing-here", "--decisions", "-", "--json"],
+            input=json.dumps({"decisions": [{"key": "id:s0-m", "body": "# EN new"}]}),
+        )
+        payload = _json_payload(result.output)
+        assert payload["counts"]["already_applied"] == 0
+        assert payload["counts"]["rejected"] == 0
+        (item,) = [i for i in payload["items"] if i["key"] == "id:s0-m"]
+        assert item["status"] == "skipped"
+        assert "answer was not used" in item["reason"]
+
     def test_answer_for_an_unknown_member_is_still_rejected(
         self, cli_runner: CliRunner, tmp_path: Path
     ):

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -25,6 +25,7 @@ from clm.mcp.tools import (
     handle_validate_slides,
     handle_validate_spec,
 )
+from clm.slides.sync_wire import WIRE_SCHEMA
 
 
 @pytest.fixture()
@@ -882,7 +883,7 @@ class TestSyncReport:
         de_path, en_path = self._pair(tmp_path)
         self._record(de_path, en_path)
         data = json.loads(await handle_sync_report(str(de_path), tmp_path))
-        assert data["schema"] == 3
+        assert data["schema"] == WIRE_SCHEMA
         assert data["engine"] == "v3"
         assert data["is_clean"] is True
         assert data["needs_model"] is False
@@ -921,7 +922,7 @@ class TestSyncReport:
         self._pair(tmp_path)
         # The bilingual STEM (no .de/.en tag), passed relative — both halves derive.
         data = json.loads(await handle_sync_report("deck.py", tmp_path))
-        assert data["schema"] == 3 and "is_clean" in data
+        assert data["schema"] == WIRE_SCHEMA and "is_clean" in data
 
     async def test_non_split_file_errors(self, tmp_path):
         lone = tmp_path / "bilingual.py"  # no .de/.en tag, no twin on disk

--- a/tests/slides/test_doc_ledger.py
+++ b/tests/slides/test_doc_ledger.py
@@ -408,3 +408,29 @@ class TestLegacyEnvelopeDropsOnSave:
         again = json.loads(path.read_text(encoding="utf-8"))
         assert set(again.keys()) == {"schema", "decks"}
         assert "slides_x" in again["decks"]
+
+
+class TestDeckSectionFingerprint:
+    """The trust half of the schema-4 ``report_id`` (sync_wire / Q2)."""
+
+    def test_absent_section_is_cold_and_recording_changes_it(self):
+        ledger = doc_ledger.TopicLedger()
+        assert doc_ledger.deck_section_fingerprint(ledger, "slides_x") == "cold"
+        doc_ledger.record_deck_snapshot(ledger, "slides_x", _parse(DE0, EN0), provenance="record")
+        recorded = doc_ledger.deck_section_fingerprint(ledger, "slides_x")
+        assert recorded != "cold"
+        # Stable for the same content, and per-deck.
+        assert doc_ledger.deck_section_fingerprint(ledger, "slides_x") == recorded
+        assert doc_ledger.deck_section_fingerprint(ledger, "slides_other") == "cold"
+
+    def test_a_changed_baseline_changes_the_fingerprint(self):
+        ledger = doc_ledger.TopicLedger()
+        doc_ledger.record_deck_snapshot(ledger, "slides_x", _parse(DE0, EN0), provenance="record")
+        before = doc_ledger.deck_section_fingerprint(ledger, "slides_x")
+        doc_ledger.record_deck_snapshot(
+            ledger,
+            "slides_x",
+            _parse(DE0.replace("# DE Text", "# DE anders"), EN0),
+            provenance="record",
+        )
+        assert doc_ledger.deck_section_fingerprint(ledger, "slides_x") != before

--- a/tests/slides/test_sync_diff.py
+++ b/tests/slides/test_sync_diff.py
@@ -24,6 +24,7 @@ from clm.slides.sync_diff import (
     diff_deck,
     diff_outcome,
 )
+from clm.slides.sync_wire import WIRE_SCHEMA
 
 # ---------------------------------------------------------------------------
 # Builders (the test_doc_lenses.py conventions)
@@ -717,10 +718,12 @@ class TestPreambles:
 
 
 class TestEnvelope:
-    def test_payload_is_schema_3_with_stable_booleans(self):
+    def test_payload_announces_the_wire_schema_with_stable_booleans(self):
         base = _snapshot(DE0, EN0)
         payload = _diff(base, DE0.replace("# DE Text", "# DE v2"), EN0).to_payload()
-        assert payload["schema"] == 3
+        # One version for the report envelope AND the decision documents it is
+        # answered with — they are one contract (clm.slides.sync_wire).
+        assert payload["schema"] == WIRE_SCHEMA
         assert payload["engine"] == "v3"
         assert payload["is_clean"] is False
         assert payload["needs_model"] is True  # translate_edit is model-frameable


### PR DESCRIPTION
First slice of remediation **Phase 2** (the agent contract), unblocked by the maintainer's Q2/Q3 decisions on 2026-07-31. This is the wire core; the rest of Phase 2 follows in separate PRs under the same schema-4 umbrella, all before any release.

## Why

`apply` recomputed the diff and set-checked the answered handles, so *"stale handle"* named a report that **did not exist at apply time**. Combined with the silent companion→deck redirect — `voiceover_x` and `slides_x` are two CLI spellings of **one** deck with **one** ledger section — a second pass found its members already recorded, rejected its decisions as stale, and left the first pass's writes standing. Verdict contradicting effect: that is #649.

## What

**`report_id`** — sha256 over the whole bundle's bytes (companions included: they are part of the same member table) plus this deck's ledger section. Echo it at the top level of a decision document and `apply` refuses the **whole document** on mismatch — exit 2, nothing written. Wholesale is deliberate: if the deck moved since the report, every answer is suspect, not just the one that no longer matches. A document with **no** token is accepted with a warning naming the field (schema 3 predates it); `sync_wire.REQUIRE_REPORT_ID` flips that in the release that drops schema 3, per your Q2 answer.

**`already_applied`** — a decision whose member frames nothing now asks for a state that already holds (a sibling pass, an earlier apply, the other spelling of the deck). No longer `rejected`; no longer blocks exit 0. Only a handle naming no member of the deck is a stale handle.

**Deck identity** — `deck_key` and `ledger` in the report and apply payloads, and the companion redirect now says on stderr which deck it reconciled.

**One wire version** — `clm.slides.sync_wire.WIRE_SCHEMA`. A report envelope and the decision document answering it are one contract; the constant stops the number drifting across five emitters again. `ACCEPTED_DECISION_SCHEMAS = (3, 4)`.

**M14 holes on the paths this touches** — `exit_code` embedded in the report and apply envelopes; a JSON envelope on the decision-refusal path (it used to exit 2 with *empty stdout* while the apply-refusal path emitted one); the rejection block printed to stderr **before** the payload, so a merged stream still ends in valid JSON.

## Tests

New CLI classes `TestReportIdentity` and `TestAlreadyApplied` cover: the token is present and tracks *both* halves of its input (an edit to either deck file, and `record`, which changes no file but changes the trust half); a stale token refuses with exit 2 and **byte-identical files**; a matching token applies; a token-less document still applies but warns; an unknown `schema` is refused. Plus the #649 shape end-to-end — running the same document twice now yields `already_applied` and exit 0 instead of `rejected` after a landed write. Unit tests for `deck_section_fingerprint` (cold / stable / changes with the baseline).

Full fast suite green: **9295 passed, 7 skipped**.

## Migration

Nothing in a repository to convert — decision documents are ephemeral. The producers update: clm itself (here), the MCP tool payload (same helper), `clm info sync-agents` + `commands.md` (here), and any downstream driver, which copies one field out of the report envelope.

Refs #649

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm9cCFzyYG61oQLb7Zmho8