### PR TITLE
feat(sync): schema 4 — resolution discriminator and body-only excerpts (#656)

### DIFF
--- a/changelog.d/656-resolution-and-body-excerpts.added.md
+++ b/changelog.d/656-resolution-and-body-excerpts.added.md
@@ -1,0 +1,16 @@
+- Sync report items carry **`resolution`** (`mechanical` / `decision` /
+  `manual`). An empty `answers` list meant two opposite things — "nothing to
+  answer, `apply` executes it" on a mechanical row and "blocked, repair the
+  files yourself" on a framed one — and `clm info sync-agents` documented only
+  the first, so its own example filter script misclassified every blocked item.
+  Branch on `resolution`.
+- Report items also carry **`de_body`/`en_body`**: the same cell bytes as
+  `de`/`en` but without the `# %%` delimiter line, which is exactly what a
+  `body` answer must contain. Report output is now valid decision input; agents
+  no longer have to rediscover "strip line 1".
+- A cold member present on **one half only** no longer advertises `confirm`.
+  The executor always refused it (confirm asserts that both halves agree), and
+  for a positional member the rejection then blocked its whole `(group, kind)`
+  pool with no visible cause. The item now comes back with no answers,
+  `resolution: manual`, and a `detail` naming the repair — give the cell a
+  `slide_id` so its twin can be framed, or delete it.

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -61,11 +61,25 @@ Each item row carries `key` (the member handle), `outcome`, `action`,
 current cell bytes for both sides under **`de` and `en`** (those exact key
 names — so you never re-read files to act), and an **`answers` list naming
 exactly the decision shapes `apply --decisions` accepts** for that item.
-`answers` is present on every item; `[]` means mechanical (nothing to
-answer — `apply` executes it). Note the `de`/`en` excerpts **include** the
-`# %%` header line; a `body` answer must **not** (see below). A report whose
-items are *all* `verify_cold` also carries a top-level `hint` — that is the
-seeding case; use `record`, not a confirm-all document (see "Cold members").
+`answers` is present on every item. Branch on **`resolution`**, not on the
+emptiness of that list:
+
+| `resolution` | meaning | what you do |
+|---|---|---|
+| `mechanical` | `apply` executes it; `answers` is `[]` | nothing — review with `git diff` |
+| `decision` | answerable; `answers` names the shapes | put one in the decision document |
+| `manual` | framed but **unanswerable**; `answers` is `[]` | read `detail`, repair the files, re-report |
+
+An empty `answers` used to mean both the first and the third case, and this
+topic documented only the first — its own example filter script therefore
+misclassified every blocked item. `resolution` is the schema-4 discriminator.
+
+The `de`/`en` excerpts are the full cell bytes **including** the `# %%` header
+line; **`de_body`/`en_body`** are the same cells without it — which is exactly
+what a `body` answer must contain, so you can feed an excerpt straight back
+(trailing blank lines are ignored at the write boundary). A report whose items
+are *all* `verify_cold` also carries a top-level `hint` — that is the seeding
+case; use `record`, not a confirm-all document (see "Cold members").
 
 ### The freshness token (`report_id`) — copy it into your answers
 
@@ -107,7 +121,10 @@ sides moved — confirm or supply a body), `conflict_shared` / `remove_vs_edit`
 answer `de` or `en`; mirrors **only the chosen side's tag set** onto the twin,
 bodies untouched — see "Tag parity" below),
 `verify_cold` (confirm the member is in sync — or, on an **id-keyed** member,
-supply a `body` + `side` to overwrite a stale twin in the same pass),
+supply a `body` + `side` to overwrite a stale twin in the same pass; a cold
+member present on **one half only** carries no answers at all — `confirm`
+asserts both halves agree — so it comes back `resolution: manual` with the
+repair in its `detail`),
 `stamp_vs_new` (a new id'd cell appeared while a positional cell of the same
 pool vanished on that side — answer `treat_as_new` when the id'd cell really
 is new; see "Replacing a positional cell" below), `remove_vs_split` (a

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -151,17 +151,45 @@ def decision_vocabulary(action: str) -> tuple[str, ...]:
 def item_answers(item: DiffItem) -> tuple[str, ...]:
     """The key-aware answer vocabulary the report advertises for one item.
 
-    Identical to :func:`decision_vocabulary` except for ``verify_cold``: a
-    ``body`` recovery targets a named ``side`` and can only be placed on an
-    **id-keyed** two-sided member. A *positional* cold member has no stable
-    id to address and its ordinal aliases a neighboring slot, so it accepts
-    only ``confirm`` (or: mint a ``slide_id`` and re-report). Advertising
-    ``body`` there would be a lie the executor then rejects.
+    Identical to :func:`decision_vocabulary` except for ``verify_cold``, where
+    two narrowings keep the advertisement honest — the design's standing rule
+    is that advertising an answer the executor then rejects is a defect:
+
+    * A ``body`` recovery targets a named ``side`` and can only be placed on
+      an **id-keyed** two-sided member. A *positional* cold member has no
+      stable id to address and its ordinal aliases a neighboring slot, so it
+      drops ``body`` (mint a ``slide_id`` and re-report instead).
+    * A **one-sided** cold member accepts *nothing*: `confirm` asserts the two
+      halves agree, and the executor unconditionally refuses to confirm a
+      member with only one side. Advertising it sent agents into a rejection
+      that then blocked the whole positional pool (finding M6). The item stays
+      framed, with ``resolution: manual`` and a detail naming the repair.
     """
     answers = decision_vocabulary(item.action)
-    if item.action == "verify_cold" and not item.key.startswith("id:"):
+    if item.action != "verify_cold":
+        return answers
+    if item.member is not None and item.member.is_one_sided:
+        return ()
+    if not item.key.startswith("id:"):
         return tuple(a for a in answers if a != "body")
     return answers
+
+
+def item_resolution(item: DiffItem) -> str:
+    """How this item gets resolved: ``mechanical`` / ``decision`` / ``manual``.
+
+    Schema 4's discriminator for the ``answers: []`` ambiguity (finding M6):
+    the empty list meant "mechanical — apply executes it" on 21 actions and
+    "blocked — go edit the files" on the framed ones, the info topic
+    documented only the first meaning as universal, and its own example
+    filter script misclassified every instance of the second.
+
+    Derived from the sets ``apply_deck`` itself branches on, so the report
+    cannot drift from the executor.
+    """
+    if item.action in _RECORD_ONLY or item.action in MECHANICAL_ACTIONS:
+        return "mechanical"
+    return "decision" if item_answers(item) else "manual"
 
 
 def parse_decisions(payload: object) -> tuple[dict[str, Decision], list[str]]:

--- a/src/clm/slides/doc_report.py
+++ b/src/clm/slides/doc_report.py
@@ -82,17 +82,22 @@ def diff_bundle_at_ref(bundle: LoadedBundle, ref: str) -> tuple[DeckDiff, list[s
 
 
 def item_payloads(diff: DeckDiff) -> list[dict]:
-    """The §6.4 item rows, each item carrying its answer vocabulary.
+    """The §6.4 item rows, each carrying its vocabulary and how it resolves.
 
-    ``answers`` is present on **every** item — ``[]`` on mechanical rows
-    (nothing to answer; ``apply`` executes them) — so consumers can filter
-    with ``item["answers"]`` without guarding a missing key. Agent drivers
-    provably crashed on the key's absence before this was guaranteed.
+    ``answers`` is present on **every** item so consumers can filter with
+    ``item["answers"]`` without guarding a missing key — agent drivers
+    provably crashed on the key's absence before this was guaranteed. But an
+    empty list alone is ambiguous, and that ambiguity is finding M6: on a
+    mechanical row it means "nothing to answer, apply executes it", on a
+    framed row it means "blocked — repair the files yourself". Schema 4 adds
+    ``resolution`` (``mechanical`` / ``decision`` / ``manual``) so the two
+    cases are distinguishable without a hardcoded action list.
     """
     items = []
     for item in diff.items:
         payload = item.payload()
         payload["answers"] = list(doc_apply.item_answers(item))
+        payload["resolution"] = doc_apply.item_resolution(item)
         items.append(payload)
     return items
 

--- a/src/clm/slides/sync_diff.py
+++ b/src/clm/slides/sync_diff.py
@@ -86,6 +86,38 @@ from clm.slides.sync_wire import WIRE_SCHEMA
 
 _SIDES: tuple[Lang, Lang] = ("de", "en")
 
+
+def _cold_detail(member: Member, base_text: str) -> str:
+    """The ``verify_cold`` detail, spelling out the one unanswerable shape.
+
+    A cold member present on ONE half only carries no answer at all (finding
+    M6): ``confirm`` asserts that the two halves agree and the executor
+    unconditionally refuses a one-sided member. The report advertised
+    ``confirm`` here anyway, and for a positional member the rejection then
+    blocked its whole pool with no visible cause. The advertisement is now
+    empty (:func:`clm.slides.doc_apply.item_answers`), so the detail has to
+    carry the repair.
+    """
+    if not member.is_one_sided:
+        return base_text
+    side = "de" if member.de is not None else "en"
+    if member.key.scheme == "pos":
+        return (
+            f"{base_text}, and this positional cell exists on the {side} half "
+            "ONLY — it cannot be confirmed (confirm asserts both halves agree) "
+            "and cannot be mirrored mechanically (its ordinal aliases a "
+            "different twin slot). Give it a slide_id so the twin can be "
+            "framed, or delete it, then re-report. The other cold members of "
+            "its (group, kind) pool cannot be confirmed until then — "
+            "positional members record per pool"
+        )
+    return (
+        f"{base_text}, and this member exists on the {side} half ONLY — a "
+        "one-sided member cannot be confirmed (confirm asserts both halves "
+        "agree). Supply the twin (or delete this cell) and re-report"
+    )
+
+
 __all__ = [
     "COSMETIC_SIDECELL_FIELDS",
     "COMPARED_MEMBER_FIELDS",
@@ -311,6 +343,11 @@ class DiffItem:
             cell = holder.side(lang) if holder is not None else None
             if cell is not None:
                 entry[lang] = "\n".join(cell.lines)
+                # …and the same cell WITHOUT its `# %%` delimiter line, which
+                # is exactly what a `body` answer must contain (finding M10:
+                # report output was not valid decision input, so every agent
+                # independently rediscovered "strip line 1").
+                entry[f"{lang}_body"] = cell.body
         return entry
 
 
@@ -492,7 +529,7 @@ class _Differ:
                     "unverified",
                     "verify_cold",
                     "none",
-                    "no baseline entry — cold member, needs verification",
+                    _cold_detail(member, "no baseline entry — cold member, needs verification"),
                     group=group,
                     member=member,
                 )
@@ -2819,7 +2856,7 @@ class _Differ:
                     "unverified",
                     "verify_cold",
                     "none",
-                    "no ledger entry — cold member, needs verification",
+                    _cold_detail(member, "no ledger entry — cold member, needs verification"),
                     group=group,
                     member=member,
                 )

--- a/tests/cli/test_sync_v3_cli.py
+++ b/tests/cli/test_sync_v3_cli.py
@@ -522,6 +522,79 @@ class TestReportIdentity:
         assert "schema 99" in _stderr(result) + result.output
 
 
+class TestItemShape:
+    """Schema 4's `resolution` discriminator and body-only excerpts (Q3)."""
+
+    # A DE-only un-id'd code cell: a POSITIONAL one-sided cold member, the one
+    # shape that carries no answer at all (finding M6).
+    DE_EXTRA = DE + '\n# %% tags=["keep"]\ny = 2\n'
+
+    def test_resolution_distinguishes_mechanical_decision_and_manual(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        de, en = _write_pair(tmp_path)
+        de.write_text(self.DE_EXTRA, encoding="utf-8")
+        payload = _json_payload(
+            cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"]).output
+        )
+        by_key = {i["key"]: i for i in payload["items"]}
+
+        # An id-keyed cold member is answerable.
+        assert by_key["id:s0"]["resolution"] == "decision"
+        assert by_key["id:s0"]["answers"] == ["confirm", "body"]
+
+        # The DE-only positional cell can be neither confirmed (confirm
+        # asserts both halves agree) nor mirrored (its ordinal aliases a
+        # different twin slot). It used to advertise `confirm` anyway, and the
+        # rejection then blocked its whole pool with no visible cause.
+        one_sided = by_key["pos:s0/code/1"]
+        assert one_sided["answers"] == []
+        assert one_sided["resolution"] == "manual"
+        assert "half ONLY" in one_sided["detail"]
+        assert "slide_id" in one_sided["detail"]  # names the repair
+
+        # `answers: []` on a MECHANICAL row means the opposite — apply runs it.
+        # (Restore the symmetric pair first: `record` refuses a structurally
+        # divergent one, which is the gate doing its job.)
+        de.write_text(DE, encoding="utf-8")
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0
+        de.write_text(DE.replace("x = 1", "x = 42"), encoding="utf-8")
+        mech = _json_payload(
+            cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"]).output
+        )
+        (row,) = [i for i in mech["items"] if i["action"] == "propagate_shared_edit"]
+        assert row["answers"] == [] and row["resolution"] == "mechanical"
+
+    def test_body_excerpts_are_valid_decision_input(self, cli_runner: CliRunner, tmp_path: Path):
+        # M10: the `de`/`en` excerpts include the `# %%` delimiter that a body
+        # answer must NOT contain, so report output was not decision input.
+        de, en = _write_pair(tmp_path)
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0
+        de.write_text(de.read_text(encoding="utf-8").replace("DE Text", "DE neu"), "utf-8")
+        report = _json_payload(
+            cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"]).output
+        )
+        item = next(i for i in report["items"] if i["key"] == "id:s0-m")
+        assert item["de"].startswith("# %%")
+        assert "# %%" not in item["de_body"]
+        assert item["de_body"].strip() == "# DE neu"
+
+        # Feed the excerpt straight back as an answer — no stripping needed.
+        applied = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--decisions", "-", "--json"],
+            input=json.dumps(
+                {
+                    "schema": WIRE_SCHEMA,
+                    "report_id": report["report_id"],
+                    "decisions": [{"key": "id:s0-m", "body": item["de_body"]}],
+                }
+            ),
+        )
+        assert applied.exit_code == 0, applied.output
+        assert "# DE neu" in en.read_text(encoding="utf-8")
+
+
 class TestAlreadyApplied:
     """A decision whose effect already holds is not a rejection (#649)."""
 


### PR DESCRIPTION
Second slice of remediation **Phase 2**, covering Q3's decision-document warts. Follows #754 (report_id / already_applied), same schema-4 umbrella, all landing before any release.

## `resolution` — the `answers: []` ambiguity (finding M6)

An empty `answers` list carried two **opposite** meanings:

- on 21 mechanical actions: *nothing to answer, `apply` executes it*;
- on the framed-but-blocked ones: *stop, repair the files yourself*.

`clm info sync-agents` documented only the first as universal, and its own recommended filter script therefore misclassified every blocked item. Every report item now carries `resolution: mechanical | decision | manual`, derived from the very sets `apply_deck` branches on — so the report cannot drift from the executor.

## `de_body` / `en_body` — report output is now decision input (finding M10)

The `de`/`en` excerpts include the `# %%` delimiter that a `body` answer must **not** contain, so every agent independently rediscovered "strip line 1". Items now also carry the same cells without the delimiter. The write boundary already strips trailing blanks, so an excerpt can be fed straight back — pinned by a test that does exactly that.

## The one-sided cold member (M6's other half)

A cold member present on **one half only** advertised `confirm`, which the executor has always refused — `confirm` asserts that both halves agree. For a *positional* member the rejection then blocked its whole `(group, kind)` pool, because positional members record per pool, and nothing said why.

It now comes back **answerless**, `resolution: manual`, with the repair in its `detail`: give the cell a `slide_id` so its twin can be framed, or delete it. The pool staying unconfirmable is correct and fail-safe — a confirm there would bank an asymmetric pair; what was missing was any statement of the cause. Reproduced first with a probe, then pinned as a test.

## Tests

New `TestItemShape`: all three `resolution` values on one deck (including a mechanical row, to prove `answers: []` still means the opposite there); the one-sided positional cold member's empty vocabulary, `manual` resolution and repair detail; and the `de_body` round-trip through `apply`.

Full fast suite green: **9298 passed, 7 skipped**.

Refs #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm9cCFzyYG61oQLb7Zmho8