### PR TITLE
feat(sync): sanction the two hand-edit flows — verify_translation body, mark_twin (#656)

### DIFF
--- a/changelog.d/656-sanctioned-flows.added.md
+++ b/changelog.d/656-sanctioned-flows.added.md
@@ -1,0 +1,14 @@
+- `verify_translation` now accepts a **`body` + `side`** answer, not only
+  `confirm`. Both sides moved off base; when your review finds one of them
+  wrong you can replace it in the same pass instead of hand-editing the file
+  and re-reporting. (`side` is required here — both sides moved, so the engine
+  cannot infer which one you corrected.) `clm info sync-agents` documented this
+  answer before the engine accepted it; that contradiction is gone.
+- `fork_pending_twin` gains the **`mark_twin`** answer. Turning a shared cell
+  into a localized pair left the twin's `lang=` attribute to a hand edit —
+  which is precisely the operation the doctrine forbids ("never hand-edit the
+  other language"), so the flow's only route was the one it prohibits. The
+  engine now writes the attribute; the body adaptation stays yours, framed as
+  `translate_edit` on the next pass. The two-pass fork recipe is documented in
+  `clm info sync-agents` for the first time, including why doing both steps in
+  one edit drops the member's ledger history.

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -115,7 +115,10 @@ fork/unify/id-stamp transitions. Trust them; review with `git diff`.
 **Framed actions** (answer them): `translate_edit` / `translate_new` (produce
 the target-language body — or answer `translate_edit` with `keep_twin` when
 your edit did not change what the twin should say), `verify_translation` (both
-sides moved — confirm or supply a body), `conflict_shared` / `remove_vs_edit`
+sides moved off base — `confirm` banks them as they are, or supply a `body`
+plus the `side` it replaces when your review found one of them wrong; the
+side is required here because *both* moved, so the engine cannot infer which
+one you corrected), `conflict_shared` / `remove_vs_edit`
 / `unify_choose_body` / `order_decision` / `conflict_preamble` (choose a side),
 `conflict_tags` (the twins' tag sets diverged with no attributable direction —
 answer `de` or `en`; mirrors **only the chosen side's tag set** onto the twin,
@@ -148,8 +151,10 @@ follow the rename — narration is never a removal decision when its slide
 still exists, #650), `ambiguous_alignment` (genuinely ambiguous residue
 — rival id stamps, both sides adding different content into one pool;
 carries **no** answers: reconcile by editing, minting ids, then re-report),
-and the normalize-refusal deck item (run `clm slides normalize`, then
-re-report).
+`fork_pending_twin` (a shared cell is becoming a localized pair: one side
+carries a `lang=` attribute and its twin does not — answer `mark_twin` and the
+engine writes the twin's attribute; see "Forking a shared cell" below), and
+the normalize-refusal deck item (run `clm slides normalize`, then re-report).
 
 ### Parse refusals: read the code, not the header
 
@@ -170,6 +175,24 @@ only when at least one such reason is present. The others carry their own
 one-sided-retag shape of #653; until the engine frames it as a mechanical tag
 row, mirroring the tag by hand is the sanctioned repair — the refusal tells
 you which side carries it.
+
+### Forking a shared cell (two passes, both in-engine)
+
+A shared cell becomes a localized pair in **two** steps, and doing both in one
+edit silently drops the member's ledger history (the fork identity-carry needs
+one side still at its recorded baseline):
+
+1. Add `lang="<your side>"` to the cell on the half you are editing. Report
+   frames `fork_pending_twin`; answer **`mark_twin`**. The engine writes the
+   twin's `lang=` attribute — that attribute only. (Marking the twin by hand is
+   what "never hand-edit the other language" forbids, and it used to be the
+   only route.)
+2. Re-report. The pair is now localized and its bodies are identical, so the
+   member frames `translate_edit`; answer it with the adapted body.
+
+Do **not** stamp the id, add `lang=`, and rewrite the body in one pass: the
+differ can no longer prove the two cells are the same member, and the fork
+records as a fresh pair.
 
 ## Tag parity (tags are language-independent)
 

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -122,7 +122,11 @@ class Decision:
 _DECISION_VOCABULARY: dict[str, tuple[str, ...]] = {
     "translate_edit": ("body", "keep_twin"),
     "translate_new": ("body",),
-    "verify_translation": ("confirm",),
+    #: ``body`` is symmetric with ``verify_cold``'s #572 recovery: both
+    #: sides moved, the agent read them, and one is wrong — name it with
+    #: ``side`` and supply the correction instead of hand-editing the file
+    #: and then confirming (findings M7 / Q6a; the info topic promised it).
+    "verify_translation": ("confirm", "body"),
     "verify_cold": ("confirm", "body"),
     "conflict_shared": ("de", "en", "body"),
     "pending_divergence": ("de", "en"),
@@ -140,6 +144,12 @@ _DECISION_VOCABULARY: dict[str, tuple[str, ...]] = {
     #: silently. The non-remove remedies (retarget for_slide, restore the
     #: slide) stay hand-edits: they need a target no answer shape carries.
     "broken_owner": ("remove",),
+    #: The fork transition's only route used to be the hand edit the doctrine
+    #: forbids: the detail said "mark the twin", the vocabulary was empty, and
+    #: `sync-agents` says never to hand-edit the other language (M11 / F1).
+    #: `mark_twin` writes the twin's `lang=` attribute — nothing else; the
+    #: body adaptation stays the agent's, framed as translate_edit next pass.
+    "fork_pending_twin": ("mark_twin",),
 }
 
 
@@ -1278,10 +1288,11 @@ def _execute_decision(
             raise _ItemError(
                 f"'{item.action}' does not accept a body answer (allowed: {', '.join(allowed)})"
             )
-        if decision.side is not None and item.action != "verify_cold":
+        if decision.side is not None and item.action not in _SIDE_BODY_ACTIONS:
             raise _ItemError(
-                f"'side' is only meaningful on a two-sided verify_cold body answer, "
-                f"not on '{item.action}' (which derives its target side itself)"
+                f"'side' is only meaningful on a two-sided "
+                f"{' / '.join(sorted(_SIDE_BODY_ACTIONS))} body answer, not on "
+                f"'{item.action}' (which derives its target side itself)"
             )
         # A j2-kind member may be a single-line macro cell whose only valid
         # replacement text IS a boundary line — its validation is
@@ -1300,10 +1311,40 @@ def _execute_decision(
     _apply_choice_decision(ex, item, choice)
 
 
+#: Framed actions whose ``body`` answer targets a *named* side. Both are
+#: two-sided review states — the agent read both halves and judged one of them
+#: wrong — so neither can derive its target from the item.
+_SIDE_BODY_ACTIONS = frozenset({"verify_cold", "verify_translation"})
+
+
 def _apply_body_decision(
     ex: _Executor, item: DiffItem, body: str, *, side: str | None = None
 ) -> None:
     member = item.member
+    if item.action == "verify_translation":
+        # Both sides moved off base. `confirm` banks them as-is; a body says
+        # "the named side is the wrong one" and replaces it in the same pass —
+        # the review-after-translate case that otherwise costs an out-of-band
+        # edit plus a second report (M7 / Q6a).
+        if member is None or member.is_one_sided:
+            raise _ItemError("a verify_translation body answer needs a two-sided member")
+        if side is None:
+            raise _ItemError(
+                "a verify_translation body answer must name the 'side' to "
+                "overwrite ('de' or 'en') — both sides moved, so the engine "
+                "cannot tell which one you corrected"
+            )
+        target_side: Lang = side  # type: ignore[assignment]
+        holder = ex._holder(item, target_side)
+        cell = holder.side(target_side) if holder is not None else None
+        if holder is None or cell is None:
+            raise _ItemError(f"the {target_side} side of {item.key} is missing")
+        ex.set_side(
+            holder,
+            target_side,
+            evolve(cell, lines=_replacement_lines(cell, body, ex.comment_token)),
+        )
+        return
     if item.action == "verify_cold":
         # Cold recovery (issue #572): the agent read both bodies, judged the
         # named twin stale, and supplies the corrected text — a one-pass fix
@@ -1431,6 +1472,29 @@ def _reject_divergent_tags(de_cell: SideCell, en_cell: SideCell) -> None:
 
 def _apply_choice_decision(ex: _Executor, item: DiffItem, choice: str) -> None:
     action = item.action
+    if choice == "mark_twin":
+        # The fork's structural half, executed instead of hand-edited: give the
+        # unmarked twin its own `lang=` attribute. The BODY adaptation is not
+        # done here — the two cells still say the same thing, so the next
+        # report frames the localized pair's translate_edit and the agent
+        # answers that with the adapted text. Two passes, both in-engine
+        # (the fork two-pass recipe, previously documented nowhere).
+        marked = item.side
+        if marked is None:
+            raise _ItemError("item names no marked side")
+        target: Lang = _other(marked)
+        holder = ex._holder(item, target)
+        cell = holder.side(target) if holder is not None else None
+        if holder is None or cell is None:
+            raise _ItemError(
+                f"the {target} side of {item.key} is missing — a fork marks an "
+                "EXISTING twin; supply the twin first"
+            )
+        if cell.lang_attr is not None:  # pragma: no cover - differ frames only unmarked twins
+            raise _ItemError(f"the {target} side already carries a lang attribute")
+        header = swap_lang(cell.lines[0], target)
+        ex.set_side(holder, target, evolve(cell, lines=(header, *cell.lines[1:])))
+        return
     if choice == "confirm":
         de_holder = ex._holder(item, "de")
         en_holder = ex._holder(item, "en")

--- a/tests/cli/test_sync_v3_cli.py
+++ b/tests/cli/test_sync_v3_cli.py
@@ -522,6 +522,119 @@ class TestReportIdentity:
         assert "schema 99" in _stderr(result) + result.output
 
 
+class TestSanctionedFlows:
+    """Q6a: the two flows the doctrine forbade doing by hand, in-engine."""
+
+    def test_verify_translation_takes_a_body_for_the_named_side(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        # Both sides moved off base. `confirm` banks them as they are; a body
+        # says "the named side is the wrong one" and fixes it in the same pass
+        # instead of an out-of-band edit plus a second report (M7). The info
+        # topic promised this answer; the engine used to reject it.
+        de, en = _write_pair(tmp_path)
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0
+        de.write_text(de.read_text(encoding="utf-8").replace("DE Text", "DE neu"), "utf-8")
+        en.write_text(en.read_text(encoding="utf-8").replace("EN text", "EN wrong"), "utf-8")
+
+        report = _json_payload(
+            cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"]).output
+        )
+        item = next(i for i in report["items"] if i["key"] == "id:s0-m")
+        assert item["action"] == "verify_translation"
+        assert item["answers"] == ["confirm", "body"]
+
+        applied = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--decisions", "-", "--json"],
+            input=json.dumps(
+                {
+                    "schema": WIRE_SCHEMA,
+                    "report_id": report["report_id"],
+                    "decisions": [{"key": "id:s0-m", "body": "# EN right", "side": "en"}],
+                }
+            ),
+        )
+        assert applied.exit_code == 0, applied.output
+        assert "# EN right" in en.read_text(encoding="utf-8")
+        assert "DE neu" in de.read_text(encoding="utf-8")  # the reviewed side stands
+
+    def test_verify_translation_body_needs_a_side(self, cli_runner: CliRunner, tmp_path: Path):
+        de, en = _write_pair(tmp_path)
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0
+        de.write_text(de.read_text(encoding="utf-8").replace("DE Text", "DE neu"), "utf-8")
+        en.write_text(en.read_text(encoding="utf-8").replace("EN text", "EN wrong"), "utf-8")
+        result = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--decisions", "-", "--json"],
+            input=json.dumps({"decisions": [{"key": "id:s0-m", "body": "# ambiguous"}]}),
+        )
+        payload = _json_payload(result.output)
+        (row,) = [i for i in payload["items"] if i["key"] == "id:s0-m"]
+        assert row["status"] == "rejected"
+        assert "must name the 'side'" in row["reason"]
+
+    def _fork_pair(self, tmp_path: Path) -> tuple[Path, Path]:
+        # A SHARED id'd cell — an id-less fork refuses the whole deck (M5).
+        shared = '# %% [markdown] tags=["keep"] slide_id="shared-note"\n#\n# Shared note\n'
+        de = tmp_path / "slides_f.de.py"
+        en = tmp_path / "slides_f.en.py"
+        de.write_text(
+            HEADER_DE
+            + '# %% [markdown] lang="de" tags=["slide"] slide_id="s0"\n#\n# # Titel\n\n'
+            + shared,
+            encoding="utf-8",
+        )
+        en.write_text(
+            HEADER_EN
+            + '# %% [markdown] lang="en" tags=["slide"] slide_id="s0"\n#\n# # Title\n\n'
+            + shared,
+            encoding="utf-8",
+        )
+        return de, en
+
+    def test_mark_twin_completes_a_fork_without_a_hand_edit(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ):
+        # A fork in progress: the DE side gained a lang attribute, the twin has
+        # none. The detail said "mark the twin" while the vocabulary was empty
+        # and the doctrine forbids hand-editing the other language (M11 / F1).
+        de, en = self._fork_pair(tmp_path)
+        assert cli_runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0
+        de.write_text(
+            de.read_text(encoding="utf-8").replace(
+                '# %% [markdown] tags=["keep"]', '# %% [markdown] lang="de" tags=["keep"]'
+            ),
+            encoding="utf-8",
+        )
+
+        report = _json_payload(
+            cli_runner.invoke(slides_sync_group, ["report", str(de), "--json"]).output
+        )
+        item = next(i for i in report["items"] if i["key"] == "id:shared-note")
+        assert item["action"] == "fork_pending_twin"
+        assert item["answers"] == ["mark_twin"]
+        assert item["resolution"] == "decision"  # no longer a dead end
+
+        applied = cli_runner.invoke(
+            slides_sync_group,
+            ["apply", str(de), "--decisions", "-", "--json"],
+            input=json.dumps(
+                {
+                    "schema": WIRE_SCHEMA,
+                    "report_id": report["report_id"],
+                    "decisions": [{"key": "id:shared-note", "choice": "mark_twin"}],
+                }
+            ),
+        )
+        assert applied.exit_code == 0, applied.output
+        en_text = en.read_text(encoding="utf-8")
+        assert 'lang="en"' in en_text
+        # ONLY the attribute — the body adaptation is the next pass's
+        # translate_edit, not something mark_twin guesses.
+        assert "Shared note" in en_text
+
+
 class TestItemShape:
     """Schema 4's `resolution` discriminator and body-only excerpts (Q3)."""
 


### PR DESCRIPTION
Third slice of remediation **Phase 2**, implementing review question **Q6a**: the doctrine says *"never hand-edit the other language"*, and two flows required exactly that.

## `verify_translation` accepts `body` + `side`

Both sides moved off base. `confirm` banks them as they are, but when your review finds one of them wrong, the correction had to be an out-of-band file edit followed by a second report. The info topic **already documented** this answer — the engine rejecting it was the #1 field-reported contradiction (finding M7).

`side` is required here, unlike `translate_edit`: both sides moved, so nothing in the item can infer which one you corrected. A body without a side is rejected with that reason.

## `fork_pending_twin` gains `mark_twin`

Turning a shared cell into a localized pair left the twin's `lang=` attribute to a hand edit — the one operation the doctrine forbids. So the flow's only route was the route it prohibits, and the item's own detail (*"mark the twin"*) pointed straight at it while its answer vocabulary was empty (findings M11 / F1).

The engine now writes the attribute — **and nothing else**. The body adaptation is the next pass's `translate_edit`. That split is deliberate: a one-pass stamp + `lang=` + rewrite defeats the fork identity-carry, so the fork records as a fresh pair and silently drops the member's ledger history (field report F3).

## The fork recipe is documented for the first time

`clm info sync-agents` gains a "Forking a shared cell (two passes, both in-engine)" section — the sequencing existed nowhere, which is how F3 happened.

## Tests

`TestSanctionedFlows`: the `verify_translation` body applied to the named side (with the reviewed side left standing); a body without a side rejected with an actionable reason; and the full fork — `fork_pending_twin` advertising `mark_twin` and resolving as `decision` rather than a dead end, the twin's attribute written, and the body deliberately *not* touched.

Full fast suite green: **9301 passed, 7 skipped**.

Refs #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm9cCFzyYG61oQLb7Zmho8