### PR TITLE
fix(sync): stop the contract docs claiming things the engine does not do (#656)

### DIFF
--- a/changelog.d/656-contract-doc-drift.fixed.md
+++ b/changelog.d/656-contract-doc-drift.fixed.md
@@ -1,0 +1,11 @@
+- `clm info sync-agents` no longer states two things the engine does not do:
+  `--dry-run` was described as validating "everything", but it stops before the
+  write and therefore never runs the structural verify gate — a clean dry run
+  is not a promise that the pass will record; and `pos: → id:` was called the
+  only key migration, which stopped being true when `clm slides rename-id`
+  gained `id: → id:` (including the cascade of a renamed group anchor into its
+  members' positional keys and order scopes).
+- The refusal for an unanswerable item no longer says "has no decision
+  vocabulary in Phase 3" — internal jargon with no remedy in it. It now names
+  the state (`resolution: manual`) and the way out: read the item's detail,
+  repair the files, re-report.

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -354,8 +354,11 @@ clm slides sync apply DECK --decisions decisions.json --json
 clm slides sync apply DECK --decisions - --json < decisions.json
 ```
 
-`--member KEY` restricts a pass to named handles; `--dry-run` validates
-everything and writes nothing. Landed items are recorded into the ledger
+`--member KEY` restricts a pass to named handles; `--dry-run` validates every
+answer and writes nothing. Note what it does **not** cover: a dry run stops
+before the write, so it never runs the structural verify gate that a real pass
+runs afterwards — a document that dry-runs clean can still end in
+`verify_violations` (writes landed, nothing recorded). Landed items are recorded into the ledger
 **on fully resolved members only**, and the recording is **gated on the
 structural verify** — file writes from a pass that ends structurally corrupt
 stay on disk for review, but nothing is recorded as trusted. A landed row on
@@ -479,8 +482,11 @@ case where cold items sit next to real work.
 automatically, so a normal authoring flow starts warm.
 
 **Renaming a `slide_id` is a common way to fall cold — do not do it by hand.**
-The ledger keys trust by `id:<slide_id>`, and the only key migration the engine
-recovers is `pos: → id:` (an id-less cell gaining an id). A hand `id: → id:`
+The ledger keys trust by `id:<slide_id>`. The engine performs exactly two key
+migrations, and neither is ever *inferred*: `pos: → id:` (an id-less cell
+gaining an id, at record time) and `id: → id:` (only through
+`clm slides rename-id`, which also cascades a renamed group anchor into its
+members' `pos:` keys and order scopes). A hand `id: → id:`
 rename therefore reads as a cold add on the new id (and a `record_remove` on the
 old one), so a cell you *renamed and edited* in one go reports `verify_cold` —
 whose `confirm` would bank the existing, now-stale twin. Use
@@ -610,7 +616,9 @@ rejected decisions; the sessions that improvised did not):
   `body`/`keep_twin` — a `confirm` on it is rejected. Branch on each item's
   `answers` list.
 - **Always `--dry-run` first** on a nontrivial decision document; it
-  validates every answer without writing.
+  validates every answer without writing. It does not run the structural
+  verify gate (that happens after the write), so a clean dry run is not a
+  promise that the pass will record.
 - **Many `translate_new` bodies at once** (e.g. a whole deck authored in one
   language): answering each in JSON works but is heavy. The sanctioned bulk
   alternative is `clm slides translate DECK.en.py` to bootstrap the missing

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -1323,8 +1323,9 @@ def _execute_decision(
     allowed = decision_vocabulary(item.action)
     if not allowed:
         raise _ItemError(
-            f"'{item.action}' has no decision vocabulary in Phase 3 — edit the files, "
-            f"re-run report, then record"
+            f"'{item.action}' takes no answer (resolution: manual) — read the "
+            f"item's detail, repair the files yourself, then re-run report; "
+            f"`sync record` banks the result once the pair is in sync"
         )
     if decision.body is not None:
         if "body" not in allowed:


### PR DESCRIPTION
Findings **M7** and **M16** — the residue of remediation Phase 2, after #754/#755/#756/#757 landed the schema-4 fields.

Three statements that were wrong in the place agents actually read:

- **`--dry-run` "validates everything".** It stops before the write, so it never runs the structural verify gate that a real pass runs *afterwards*. A document that dry-runs clean can still end in `verify_violations` — writes landed, nothing recorded. Both places that recommend the flag now say what it does not cover.
- **"the only key migration is `pos: → id:`".** That stopped being true when `clm slides rename-id` gained `id: → id:`, including the cascade of a renamed group anchor into its members' positional keys and order scopes (#718). Both sanctioned migrations are now named, along with the standing rule that neither is ever *inferred*.
- **"has no decision vocabulary in Phase 3"** — the refusal an agent hits on an unanswerable item leaked an internal phase number and contained no remedy. It now names the state (`resolution: manual`, from #755) and the way out: read the item's detail, repair the files, re-report.

Docs and one message; no behavior change. Full fast suite green (9304 passed).

Refs #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm9cCFzyYG61oQLb7Zmho8