### PR TITLE
docs(sync): withdraw the id-delimited scope mechanism on measurement (#653)

### DIFF
--- a/docs/claude/design/sync-slide-hood-is-presentation.md
+++ b/docs/claude/design/sync-slide-hood-is-presentation.md
@@ -1,6 +1,7 @@
 # Slide-hood is presentation, not identity
 
-**Status**: design addendum, awaiting adversarial pass | **Created**: 2026-07-31
+**Status**: thesis SHIPPED (#761); the §3 scope mechanism **withdrawn** on
+measurement — see §13 | **Created**: 2026-07-31 | **Amended**: 2026-07-31
 **Parent**: `docs/claude/design/sync-total-identity-document-model.md` (§3.3, §3.4, §7.4)
 **Supersedes**: Phase 3 of `docs/claude/sync-v3-adversarial-review.md` §8
 **Issues**: #653 (the refusal), #652/#738 (order), #650 (owner rows), #656 (ceremony)
@@ -67,6 +68,12 @@ non-anchor half of the axis is broken, which is exactly the half authors flip
 for layout reasons.
 
 ## 3. The rule: scopes are delimited by id-bearing cells
+
+> **Withdrawn — see §13.** Implementing this rule and measuring it against the
+> corpus showed it makes positional keys *more* fragile overall, not less. The
+> thesis (§1) and the dissolution it implies (§4.1 items 1–3) shipped in #761
+> and stand; what follows in this section is kept as the record of a design
+> that measurement rejected.
 
 **Scope owner.** A deck cell carrying a bare `slide_id`, whether or not it is a
 slide start. Plus the existing synthetic owners: `HEADER_GROUP` (cells before
@@ -359,3 +366,56 @@ apart would mean two migrations.
 Add to the parent design note: a §13 row when the engine change lands, an entry
 in the satellite-doc index pointing here (review finding D2), the §7.4 property
 4 text (§6 above), and the L6 residue in §9.
+
+---
+
+## 13. Amendment (2026-07-31): the scope mechanism is withdrawn
+
+**What shipped.** §1's thesis and §4.1's dissolution: slide-hood is a property
+of the *pair*, a boundary only one half draws opens no group on either side,
+and the state frames a mechanical `mirror_tags` row instead of refusing the
+deck (#761, closing #653). That part is settled and correct — it removes the
+tag from the *identity-regime* decision, which was the P2 violation.
+
+**What is withdrawn.** §3's "positional keys scope to the nearest id-bearing
+cell", and with it §8's schema 2→3 ledger migration.
+
+**Why — the measurement.** A positional key re-keys when a *change point*
+above it inside its slide is added, removed or renamed. The two rules differ
+only in what counts as a change point:
+
+| Rule | Change points | Count (PythonCourses, 730 decks) |
+|---|---|---|
+| anchor-scoped (today) | slide anchors | 9,950 |
+| id-scoped (§3) | anchors **+ every id'd cell** | 13,217 — **1.3× more** |
+
+The corpus has 3,267 id'd non-anchor cells (overwhelmingly localized markdown
+cells, which must carry ids by §3.4). Under §3 each of them becomes a scope
+owner, so *inserting, deleting or renaming any of them* re-keys the un-id'd
+cells below it within its slide — an edit at least as routine as toggling a
+slide tag, and one the current rule handles for free.
+
+So the rule does not remove churn; it **relocates** it, from one frequent
+trigger to a more numerous class of triggers — and charges a 1,792-entry
+ledger migration plus a schema bump for the move. Implementation confirmed the
+shape of it before the numbers did: the change broke 18 tests, and the
+representative one is exactly the trap — a shared code cell under a localized
+note re-keyed `pos:intro/code/0` → `pos:intro-note/code/0`, becoming hostage
+to a cell that has nothing to do with it.
+
+§9.1 already flagged the stamp cascade as "the one place this makes things
+worse". The measurement shows that was the general case, not a corner: every
+id'd cell is a stamp that already happened.
+
+**What this leaves.** After #761 a boundary move still re-keys the un-id'd
+cells in the affected span, so they report `verify_cold` once and re-bank with
+`record`. That is bounded, visible, and loses nothing — noise, not damage.
+
+**The real escalation path is Q1, not this.** Positional keys are fragile
+because they are positional; scoping them differently only chooses which
+neighbours they are hostage to. The way to make them stable is to stop having
+them: a per-deck opt-in "fully id'd" mode (stamp on first sync touch), which
+the review's Q1 already names as the escalation to take *after* measuring what
+the Phase-0 guards left behind. That measurement now exists — this is a data
+point for Q1, and the id-delimited-scope idea should not be re-proposed
+without addressing the change-point count above.

--- a/scripts/measure_sync_change_points.py
+++ b/scripts/measure_sync_change_points.py
@@ -1,0 +1,72 @@
+"""How many structural change points does each keying rule expose?
+
+A positional key re-keys when a "change point" above it inside its slide is
+added, removed or renamed.
+
+  anchor-scoped (today) : change points = slide anchors
+  id-scoped (proposed)  : change points = slide anchors + every id'd cell
+
+Counts both, so the trade can be argued from numbers instead of intuition.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from clm.notebooks.slide_parser import comment_token_for_path
+from clm.slides.doc_lenses import _bare, load_bundle
+from clm.slides.raw_cells import split_cells
+
+
+def counts(raw_cells: list) -> tuple[int, int, int]:
+    """(anchors, id'd non-anchors, id-less cells) in one deck half."""
+    anchors = idd_non_anchor = idless = 0
+    for cell in raw_cells:
+        meta = cell.metadata
+        bare = _bare(meta.slide_id)
+        if meta.is_slide_start:
+            anchors += 1
+        elif bare is not None:
+            idd_non_anchor += 1
+        else:
+            idless += 1
+    return anchors, idd_non_anchor, idless
+
+
+def main(root: Path) -> int:
+    skip = {"_archive", "voiceover", "notes"}
+    decks = sorted(
+        p
+        for p in root.rglob("*.de.py")
+        if not (skip & set(p.parts)) and not p.name.startswith(("voiceover_", "notes_"))
+    )
+    anchors = idd = idless = 0
+    for de_path in decks:
+        try:
+            bundle = load_bundle(de_path)
+        except Exception:  # noqa: BLE001
+            continue
+        if bundle.outcome.deck is None:
+            continue
+        token = comment_token_for_path(bundle.de_path)
+        _, raw = split_cells(bundle.de_path.read_text(encoding="utf-8"), token)
+        a, i, n = counts(raw)
+        anchors += a
+        idd += i
+        idless += n
+    print(f"decks                     : {len(decks)}")
+    print(f"slide anchors             : {anchors}")
+    print(f"id'd NON-anchor cells     : {idd}")
+    print(f"id-less (positional) cells: {idless}")
+    print()
+    print(f"change points, anchor-scoped : {anchors}")
+    print(
+        f"change points, id-scoped     : {anchors + idd}"
+        f"  ({(anchors + idd) / max(anchors, 1):.1f}x more)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(Path(sys.argv[1])))


### PR DESCRIPTION
The adversarial pass the addendum asked for, done from the inside — by implementing the mechanism and measuring it.

**The thesis stands and has shipped** (#761): slide-hood is a property of the pair, a boundary only one half draws opens no group, and #653's refusal is gone. That is what removed the tag from the *identity-regime* decision, which was the actual P2 violation.

**Its §3 mechanism does not survive the corpus.** A positional key re-keys when a *change point* above it inside its slide is added, removed or renamed. The two rules differ only in what counts as one:

| Rule | Change points | PythonCourses (730 decks) |
|---|---|---|
| anchor-scoped (today) | slide anchors | 9,950 |
| id-scoped (§3) | anchors **+ every id'd cell** | 13,217 — **1.3× more** |

The corpus carries **3,267 id'd non-anchor cells** — overwhelmingly localized markdown, which *must* carry ids under §3.4. Under the proposed rule each becomes a scope owner, so inserting, deleting or renaming any of them re-keys the un-id'd cells below it within its slide. That is an edit at least as routine as toggling a slide tag — and one the current rule handles for free.

So the rule does not remove churn. It **relocates** it onto a larger class of triggers, and charges a 1,792-entry ledger migration plus a schema bump for the move.

Implementation showed the shape before the numbers did: the change broke 18 tests, and the representative failure is the trap itself — a shared code cell under a localized note re-keying `pos:intro/code/0` → `pos:intro-note/code/0`, hostage to a cell that has nothing to do with it. §9.1 had already flagged the stamp cascade as "the one place this makes things worse"; the measurement shows that was the general case, not a corner. Every id'd cell is a stamp that already happened.

## What this leaves

After #761 a boundary move still re-keys the span once: those members report `verify_cold` and `record` re-banks them. Bounded, visible, loses nothing — noise, not damage.

The escalation path for positional fragility is **Q1** (a per-deck opt-in "fully id'd" mode), not a different scoping rule — scoping only chooses which neighbours a key is hostage to. This measurement becomes a data point for that decision, and `scripts/measure_sync_change_points.py` re-runs it on any corpus.

Docs plus one measurement script; no behavior change.

Refs #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm9cCFzyYG61oQLb7Zmho8