### PR TITLE
feat(sync): record_neutral — do not ask what the engine can observe

### DIFF
--- a/changelog.d/764-record-neutral.changed.md
+++ b/changelog.d/764-record-neutral.changed.md
@@ -16,6 +16,13 @@
   English side look the same to the tool, and auto-blessing the second would bank
   an untranslated cell as in-sync. Those stay `verify_cold` for a human to judge.
 
+  That boundary is a **base-rate trade, not a guarantee**: about 0.6% of the
+  members this now records (83 of 13,049 on the reference corpus, across 41 of
+  730 decks) carry German inside a comment or string literal, so they are
+  untranslated cells in the English deck too. Code cells are auto-recorded
+  because prose is *rare* there, not because it is impossible — the tool
+  compares the two halves, it does not read them.
+
   Nothing that was previously mechanical becomes a question, and nothing that
   required judgement is now decided for you — a member failing any part of the
   test keeps exactly its old framing.

--- a/changelog.d/764-record-neutral.changed.md
+++ b/changelog.d/764-record-neutral.changed.md
@@ -1,0 +1,21 @@
+- **`clm slides sync`** no longer asks you to verify what it can see for itself.
+  A member with no ledger entry used to be framed as a question purely because
+  both halves were present — including cells the two halves share *byte for
+  byte*, where there is no translation divergence to verify and the question has
+  one possible answer. Such members now resolve as a new mechanical
+  `record_neutral` row that writes **no file bytes**, only the ledger entry
+  (provenance `structural`). On the reference corpus this removes **13,059 of a
+  cold start's 28,791 items — 45.4%**.
+
+  It fires only when the engine can check the claim rather than trust it: no
+  ledger entry, both halves present, declared language-neutral (no `lang=`), of
+  kind `code` or `j2`, and agreeing on every field the differ compares.
+
+  **Prose is deliberately excluded**, even when the halves are byte-identical: a
+  genuinely language-neutral `markdown` cell and German prose duplicated onto the
+  English side look the same to the tool, and auto-blessing the second would bank
+  an untranslated cell as in-sync. Those stay `verify_cold` for a human to judge.
+
+  Nothing that was previously mechanical becomes a question, and nothing that
+  required judgement is now decided for you — a member failing any part of the
+  test keeps exactly its old framing.

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1981,6 +1981,17 @@ and carries the stable booleans:
 - `needs_agent` — judgment beyond translation is required (a conflict, a cold
   member, a normalize refusal).
 
+**A never-recorded deck no longer asks about everything (CLM {version}).**
+Members the engine can settle by direct comparison — no ledger entry, both
+halves present, declared language-neutral, of kind `code` or `j2`, and agreeing
+on every field the differ compares — resolve as the mechanical `record_neutral`
+row instead of a `verify_cold` question. It writes **no file bytes**, only the
+ledger entry, stamped with provenance `structural`. On the reference corpus that
+is ~45% of a cold deck's items. Prose (`markdown`) is excluded even when the two
+halves are byte-identical, because a genuinely neutral cell and German prose
+copied onto the EN side are indistinguishable to the tool; those stay questions.
+The all-cold seeding hint still applies to what remains.
+
 Two `observations` kinds are also printed in the text report:
 `group_order_divergence` (the one that suppresses `is_clean`) and
 `uniform_drift_side` — emitted when three or more `translate_edit` rows exist

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1935,12 +1935,14 @@ trust store: no watermark cache, no git-HEAD baseline. Each member is keyed by
 a stable handle (`id:<slide-id>` for id'd cells, `pos:<group>/<kind>/<n>` for
 id-less shared cells), invariant under the class transitions
 (neutral↔localized, id-less→id'd, inline↔companion) — those are diff rows, not
-identity changes. A member with **no ledger entry is cold** (`verify_cold`) —
-framed for confirmation, never silently trusted. Ledger files are committed
-with the course content; merge conflicts in them are true positives.
+identity changes. A member with **no ledger entry is cold** — framed
+`verify_cold` for confirmation, never silently trusted. The one exception is
+the member whose halves the engine can compare *directly* (`record_neutral`,
+below): there the relationship is observed, not assumed. Ledger files are
+committed with the course content; merge conflicts in them are true positives.
 
-**Seeding.** A fresh checkout or a never-recorded deck reports everything
-cold. Seed trust once from a verified state: `clm slides sync record DIR`
+**Seeding.** A fresh checkout or a never-recorded deck reports every member it
+cannot settle by direct comparison as cold. Seed trust once from a verified state: `clm slides sync record DIR`
 (gated per pair on the structural verify). `clm slides split` and
 `clm slides translate` record freshly-created pairs automatically.
 
@@ -2039,8 +2041,10 @@ which re-frame on the next report once the tags are reconciled),
 `answers` list — the decision shapes `apply --decisions` accepts for it, `[]`
 on mechanical items (nothing to answer) — plus the full current cell bytes
 (`de` / `en`) so an agent can answer without re-reading files. A report whose
-items are all `verify_cold` (a never-recorded deck) carries a top-level
-`hint` pointing at `sync record`, the wholesale seeding verb.
+**questions** are all `verify_cold` (a never-recorded deck) carries a
+top-level `hint` pointing at `sync record`, the wholesale seeding verb. The
+mechanical `record_neutral` rows beside them do not suppress it — branch on
+`resolution`, not on every item being `verify_cold`.
 
 `--since DATE|REF` — the **forensic view**: diff against the bundle at a git
 ref instead of the ledger ("what changed in this window?"). A ref is used

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -235,8 +235,10 @@ ignored.
 
 **One-time seeding.** The committed per-topic ledger
 (`<topic>/.clm/sync-ledger.json`) is the only trust store: a deck with no
-ledger entries reports every member **cold** (framed `verify_cold`, exit 1)
-instead of silently trusting a git baseline. Seed each course repo once from
+ledger entries reports every member it cannot settle by direct comparison as
+**cold** (framed `verify_cold`, exit 1) instead of silently trusting a git
+baseline. Members that are language-neutral `code`/`j2` with byte-identical
+halves are recorded mechanically instead of asked about (`record_neutral`). Seed each course repo once from
 a verified state:
 
 ```bash

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -103,9 +103,11 @@ misclassified every blocked item. `resolution` is the schema-4 discriminator.
 The `de`/`en` excerpts are the full cell bytes **including** the `# %%` header
 line; **`de_body`/`en_body`** are the same cells without it — which is exactly
 what a `body` answer must contain, so you can feed an excerpt straight back
-(trailing blank lines are ignored at the write boundary). A report whose items
-are *all* `verify_cold` also carries a top-level `hint` — that is the seeding
-case; use `record`, not a confirm-all document (see "Cold members").
+(trailing blank lines are ignored at the write boundary). A report whose
+**questions** are all `verify_cold` also carries a top-level `hint` — that is
+the seeding case; use `record`, not a confirm-all document (see "Cold
+members"). Mechanical `record_neutral` rows sit beside them and do not suppress
+it, so test the items that have `answers`, not every item.
 
 ### Naming the row you are answering (`action`)
 
@@ -465,7 +467,14 @@ whole-pass abort: all other items still land. The remedy is the same as for
 A brand-new checkout, a never-synced deck, or a deck whose ledger entries
 predate a fingerprint-function bump reports **two-sided** members (both halves
 present) as `verify_cold` — the engine will not silently trust a pair it has
-never recorded. Two ways to converge:
+never recorded.
+
+The exception is the member it does not have to trust: two-sided, declared
+language-neutral, of kind `code` or `j2`, and the same bytes on both halves.
+That is `record_neutral` — mechanical, answerless, and roughly **45% of a cold
+deck**. It writes no file bytes, only the ledger entry. Prose stays a question
+even when byte-identical, because a neutral cell and untranslated German look
+the same to the tool. Two ways to converge on what remains:
 
 - **Per item**: answer `{"key": …, "choice": "confirm"}` in a decision
   document after you have checked the pair is genuinely in sync. `confirm`
@@ -509,8 +518,10 @@ harvest write lands narration on one language side, and recording that one-sided
 member is what frames the twin as `translate_new` — see `clm info
 harvest-agents`.)
 
-**Rule of thumb: when a report is *all* `verify_cold` (the report says so in
-a `hint`), use `record`, not a confirm-all decision document.** They assert
+**Rule of thumb: when every question in a report is `verify_cold` (the report
+says so in a `hint`), use `record`, not a confirm-all decision document.**
+Mechanical rows alongside them do not change that — `apply` executes those and
+`record` supersedes them. They assert
 the same trust; `record` is one command instead of a scripted
 report→build-JSON→apply pipeline. Reserve per-item `confirm` for the mixed
 case where cold items sit next to real work.

--- a/src/clm/cli/info_topics/sync-agents.md
+++ b/src/clm/cli/info_topics/sync-agents.md
@@ -154,6 +154,16 @@ pass is answering a deck that has already moved.
 `mirror_order`, `mirror_layout`, the `record_*` acknowledgements, and the
 fork/unify/id-stamp transitions. Trust them; review with `git diff`.
 
+`record_neutral` is the one you will see most on a **never-recorded deck**, and
+it writes no file bytes at all — only the ledger entry. It fires for a member
+with no ledger entry whose two halves the engine can compare *directly*: both
+sides present, declared language-neutral (no `lang=`), of kind `code` or `j2`,
+and agreeing on every field the differ compares. There is no translation
+divergence to verify there, so it is recorded instead of asked about — roughly
+**45% of a cold deck's items**. Prose (`markdown`) is deliberately excluded even
+when byte-identical: the engine cannot tell a genuinely neutral cell from German
+prose duplicated onto the EN side, so those stay `verify_cold` for you to judge.
+
 **Framed actions** (answer them): `translate_edit` / `translate_new` (produce
 the target-language body — or answer `translate_edit` with `keep_twin` when
 your edit did not change what the twin should say), `verify_translation` (both

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -1159,31 +1159,6 @@ def _record_item(
         # co-emission rule suppressed — those never reach unresolved_items,
         # so the unresolved-key guard in apply_deck cannot see them.
         return set()
-    if action == "record_neutral":
-        # §6.2.1 (#764). The pass provenance says who ran the verb; this row was
-        # not established by them — the engine observed that the two halves are
-        # the same bytes. Stamping the pass provenance would let a later
-        # "distrust everything from <source>" sweep discard, or keep, this trust
-        # on the strength of an attribution nobody made. `structural` is that
-        # attribution, and it is written directly rather than being registered
-        # anywhere: `preserve_unchanged_member` decides overwriting from the
-        # caller's declared intent, and an undeclared stamp is automatic, which
-        # is exactly right — a structural observation must never overwrite a
-        # human's `agent` / `semantic:<model>` attestation on unchanged content.
-        pool = _pool_scope(item)
-        if pool is not None:
-            # A `pos:` record must re-record its WHOLE pool, never a single
-            # entry: positional ordinals renumber together, so patching one slot
-            # leaves its siblings' ordinals aliasing different cells and the
-            # member re-frames forever. Same rule the other record rows follow.
-            if pool in frozen_pools:
-                return set()
-            rerecord_pool(target, fresh, *pool)
-            _stamp_structural(target, key)
-            return {pool}
-        _upsert(target, fresh, key, "structural")
-        _stamp_structural(target, key)
-        return set()
     if action in ("record_key_migration",):
         if item.base is not None:
             target.members.pop(item.base.key, None)
@@ -1253,31 +1228,45 @@ def _record_item(
     return set()
 
 
-def _stamp_structural(target: DeckLedger, key: str) -> None:
-    """Mark one landed entry as engine-observed, and drop what it cannot back.
+def _stamp_structural(target: DeckLedger, keys: set[str]) -> None:
+    """Mark the engine-observed entries, and drop ownership they cannot back.
 
-    Two corrections to whatever the surrounding record path wrote (#764):
+    Two corrections to whatever the record paths wrote for a ``record_neutral``
+    row (#764), applied **once, after every landed item has been recorded**.
 
-    **Provenance.** A pool re-record stamps every slot with the *pass*
-    provenance — who ran the verb. This row was not established by them; the
-    engine observed that the two halves are the same bytes. Leaving the pass
-    provenance would let a later "distrust everything from <source>" sweep keep
-    or discard this trust on an attribution nobody made.
+    Doing it per item was wrong and measurably so: a ``pos:`` record re-records
+    its whole pool, so in a pool holding N neutral members each item's
+    ``rerecord_pool`` reset the stamp the previous one had just written — 65% of
+    positional neutral members ended up carrying the pass provenance and a
+    re-created dangling owner. A landing ``record_order`` on the same pool did
+    the same. Stamping after the loop is immune to both, because nothing
+    re-records afterwards.
 
-    **Ownership.** The row fires on a cold deck, where the member's anchor is
+    **Provenance.** The pass provenance says who ran the verb. This row was not
+    established by them; the engine observed that the two halves are the same
+    bytes. Leaving the pass provenance would let a later "distrust everything
+    from <source>" sweep keep or discard this trust on an attribution nobody
+    made.
+
+    **Ownership.** The row fires on cold decks, where the member's anchor is
     normally still cold, so the entry would name an owner the store has no entry
     for. :func:`~clm.slides.doc_ledger.save` prunes exactly that and warns that
     nothing should create it (#718) — creating it on every cold apply would turn
     a corruption detector into noise. The ownership claim is not what this row
     observed anyway, so drop it and let ownership record when the anchor lands.
+
+    A key absent from ``target`` is skipped: the pool it belonged to may have
+    been frozen (#600/#630), dropped as unresolved, or renumbered by a landed
+    removal in the same pass.
     """
-    landed = target.members.get(key)
-    if landed is None:
-        return
-    entry = landed.entry
-    if entry.owner is not None and entry.owner not in target.members:
-        entry = evolve(entry, owner=None)
-    target.members[key] = evolve(landed, entry=entry, provenance="structural")
+    for key in keys:
+        landed = target.members.get(key)
+        if landed is None:
+            continue
+        entry = landed.entry
+        if entry.owner is not None and entry.owner not in target.members:
+            entry = evolve(entry, owner=None)
+        target.members[key] = evolve(landed, entry=entry, provenance="structural")
 
 
 def _upsert(target: DeckLedger, fresh: DeckLedger, key: str, provenance: str) -> None:
@@ -2017,6 +2006,8 @@ def apply_deck(
     priority = {"record_group_rename": 0, "record_key_migration": 1}
     frozen_pools = _frozen_pools(unresolved_items)
     rerecorded_pools: set[tuple[str, str]] = set()
+    #: `record_neutral` keys to re-stamp once every record has landed (#764).
+    structural_keys: set[str] = set()
     # Never bless a member with unresolved rows (#615 F2, fixes S3): a
     # landed row on a member whose framed sibling row is still pending /
     # rejected / failed must not record the member's fresh snapshot — that
@@ -2067,6 +2058,10 @@ def apply_deck(
         rerecorded_pools |= _record_item(
             target, fresh, item, provenance=provenance, frozen_pools=frozen_pools
         )
+        if item.action == "record_neutral":
+            structural_keys.add(item.key)
+    # After every record, so no later pool re-record can reset these (#764).
+    _stamp_structural(target, structural_keys)
     # Never bless the unresolved: a wholesale pool re-record must not trust
     # siblings whose framed items were left pending/rejected/failed — nor
     # the slot of an answered conflict_tags (which re-frames next pass).

--- a/src/clm/slides/doc_apply.py
+++ b/src/clm/slides/doc_apply.py
@@ -688,6 +688,7 @@ _RECORD_ONLY = frozenset(
         "record_order",
         "record_group_rename",
         "record_preamble",
+        "record_neutral",
     }
 )
 
@@ -1158,6 +1159,31 @@ def _record_item(
         # co-emission rule suppressed — those never reach unresolved_items,
         # so the unresolved-key guard in apply_deck cannot see them.
         return set()
+    if action == "record_neutral":
+        # §6.2.1 (#764). The pass provenance says who ran the verb; this row was
+        # not established by them — the engine observed that the two halves are
+        # the same bytes. Stamping the pass provenance would let a later
+        # "distrust everything from <source>" sweep discard, or keep, this trust
+        # on the strength of an attribution nobody made. `structural` is that
+        # attribution, and it is written directly rather than being registered
+        # anywhere: `preserve_unchanged_member` decides overwriting from the
+        # caller's declared intent, and an undeclared stamp is automatic, which
+        # is exactly right — a structural observation must never overwrite a
+        # human's `agent` / `semantic:<model>` attestation on unchanged content.
+        pool = _pool_scope(item)
+        if pool is not None:
+            # A `pos:` record must re-record its WHOLE pool, never a single
+            # entry: positional ordinals renumber together, so patching one slot
+            # leaves its siblings' ordinals aliasing different cells and the
+            # member re-frames forever. Same rule the other record rows follow.
+            if pool in frozen_pools:
+                return set()
+            rerecord_pool(target, fresh, *pool)
+            _stamp_structural(target, key)
+            return {pool}
+        _upsert(target, fresh, key, "structural")
+        _stamp_structural(target, key)
+        return set()
     if action in ("record_key_migration",):
         if item.base is not None:
             target.members.pop(item.base.key, None)
@@ -1225,6 +1251,33 @@ def _record_item(
         return {pool}
     _upsert(target, fresh, key, provenance)
     return set()
+
+
+def _stamp_structural(target: DeckLedger, key: str) -> None:
+    """Mark one landed entry as engine-observed, and drop what it cannot back.
+
+    Two corrections to whatever the surrounding record path wrote (#764):
+
+    **Provenance.** A pool re-record stamps every slot with the *pass*
+    provenance — who ran the verb. This row was not established by them; the
+    engine observed that the two halves are the same bytes. Leaving the pass
+    provenance would let a later "distrust everything from <source>" sweep keep
+    or discard this trust on an attribution nobody made.
+
+    **Ownership.** The row fires on a cold deck, where the member's anchor is
+    normally still cold, so the entry would name an owner the store has no entry
+    for. :func:`~clm.slides.doc_ledger.save` prunes exactly that and warns that
+    nothing should create it (#718) — creating it on every cold apply would turn
+    a corruption detector into noise. The ownership claim is not what this row
+    observed anyway, so drop it and let ownership record when the anchor lands.
+    """
+    landed = target.members.get(key)
+    if landed is None:
+        return
+    entry = landed.entry
+    if entry.owner is not None and entry.owner not in target.members:
+        entry = evolve(entry, owner=None)
+    target.members[key] = evolve(landed, entry=entry, provenance="structural")
 
 
 def _upsert(target: DeckLedger, fresh: DeckLedger, key: str, provenance: str) -> None:

--- a/src/clm/slides/doc_report.py
+++ b/src/clm/slides/doc_report.py
@@ -114,8 +114,16 @@ def cold_sweep_hint(diff: DeckDiff) -> str | None:
     companions too, so a divergence hidden in the narration refuses the
     record rather than being swept up by it — but the gate is structural, and
     only the reader can judge whether the two halves *say the same thing*.
+
+    "Whole report" means every **question**. Since #764 a cold deck also emits
+    mechanical ``record_neutral`` rows for the members the engine could settle
+    by observation, and those change nothing about the advice — the remaining
+    items are still an all-cold seeding case, and ``record`` is still the
+    efficient answer. Keying the test on *all* items would have silently
+    withdrawn the hint from exactly the freshly-authored decks it exists for.
     """
-    if diff.items and all(item.action == "verify_cold" for item in diff.items):
+    questions = [item for item in diff.items if item.action != "record_neutral"]
+    if questions and all(item.action == "verify_cold" for item in questions):
         return (
             "every member is cold (no ledger entry) — for a freshly authored or "
             "never-recorded deck, review both halves (`record` asserts they are in "

--- a/src/clm/slides/sync_diff.py
+++ b/src/clm/slides/sync_diff.py
@@ -90,9 +90,15 @@ _SIDES: tuple[Lang, Lang] = ("de", "en")
 #: The ``record_neutral`` detail. Says what was *observed*, not what is assumed:
 #: an agent reading a ledger diff has to be able to tell this row apart from a
 #: confirmation somebody actually made.
+#:
+#: It deliberately does **not** claim "no translation divergence is possible".
+#: That is false for a measurable minority: 0.6% of the corpus's neutral members
+#: carry German in a comment or a string literal (``# Das ist ein Kommentar.``),
+#: sitting untranslated in the English deck. The engine compared the halves; it
+#: did not read them.
 _NEUTRAL_DETAIL = (
-    "language-neutral and byte-identical on both halves — recorded without "
-    "asking (no translation divergence is possible)"
+    "declared language-neutral and byte-identical on both halves — recorded "
+    "without asking (the halves were compared, not read)"
 )
 
 
@@ -453,13 +459,25 @@ COMPARED_SIDECELL_FIELDS = frozenset(
 )
 COSMETIC_SIDECELL_FIELDS = frozenset({"index", "line_number"})
 
-#: Kinds carrying no natural-language content, so a ``shared`` declaration on
-#: them is verifiable by inspection rather than trusted (§6.2.1 clause 4).
+#: Kinds whose ``shared`` declaration is *usually* checkable rather than trusted
+#: (§6.2.1 clause 4).
+#:
 #: **Do not add ``markdown``**: there, ``shared`` + byte-identical cannot be
 #: told apart from German prose duplicated onto the EN side and mis-declared
 #: neutral, and auto-blessing that banks an untranslated cell as in-sync. The
 #: exclusion is the maintainer's explicit decision and costs 282 corpus
 #: members that stay real questions.
+#:
+#: **This is a base-rate trade, not a categorical guarantee.** §6.2.1 justified
+#: the boundary as "code and j2 carry no natural language". Measured, that is
+#: false for **~0.6% of neutral members** — 83 of 13,049, across 41 of 730 decks
+#: — which carry German in comments or string literals (``# Das ist ein
+#: Kommentar.``) and are therefore untranslated cells sitting in the English
+#: deck. The kind does not change what the engine can *see*; it only changes how
+#: often prose turns up. What makes this boundary defensible is the base rate
+#: (0.6% vs an assumed ~100% for markdown), not the categorical claim. A
+#: ``validate`` rule for natural-language content in a ``shared`` cell is the
+#: detector it would need to be categorical.
 NEUTRAL_KINDS = frozenset({"code", "j2"})
 
 

--- a/src/clm/slides/sync_diff.py
+++ b/src/clm/slides/sync_diff.py
@@ -87,6 +87,15 @@ from clm.slides.sync_wire import WIRE_SCHEMA
 _SIDES: tuple[Lang, Lang] = ("de", "en")
 
 
+#: The ``record_neutral`` detail. Says what was *observed*, not what is assumed:
+#: an agent reading a ledger diff has to be able to tell this row apart from a
+#: confirmation somebody actually made.
+_NEUTRAL_DETAIL = (
+    "language-neutral and byte-identical on both halves — recorded without "
+    "asking (no translation divergence is possible)"
+)
+
+
 def _cold_detail(member: Member, base_text: str) -> str:
     """The ``verify_cold`` detail, spelling out the one unanswerable shape.
 
@@ -177,6 +186,7 @@ MECHANICAL_ACTIONS = frozenset(
         "record_group_rename",  # anchor id renamed, anchor content matched
         "propagate_preamble",  # file preamble moved on one side
         "record_preamble",  # file preambles moved identically
+        "record_neutral",  # §6.2.1 cold + observably language-neutral (#764)
     }
 )
 
@@ -443,6 +453,47 @@ COMPARED_SIDECELL_FIELDS = frozenset(
 )
 COSMETIC_SIDECELL_FIELDS = frozenset({"index", "line_number"})
 
+#: Kinds carrying no natural-language content, so a ``shared`` declaration on
+#: them is verifiable by inspection rather than trusted (§6.2.1 clause 4).
+#: **Do not add ``markdown``**: there, ``shared`` + byte-identical cannot be
+#: told apart from German prose duplicated onto the EN side and mis-declared
+#: neutral, and auto-blessing that banks an untranslated cell as in-sync. The
+#: exclusion is the maintainer's explicit decision and costs 282 corpus
+#: members that stay real questions.
+NEUTRAL_KINDS = frozenset({"code", "j2"})
+
+
+def _halves_observably_identical(member: Member) -> bool:
+    """Do the two halves agree on **every per-side field the differ compares**?
+
+    §6.2.1 clause 5, and deliberately generic: it walks
+    :data:`COMPARED_SIDECELL_FIELDS` rather than naming fields, so a field
+    added to the comparison later tightens this predicate automatically (P6)
+    instead of silently widening what gets auto-recorded. The member-level
+    fields (``layout``, ``owner``, ``langness``, ``kind``, ``role``) are single
+    values shared by both halves, so they cannot disagree across sides — they
+    are covered by the clauses around this one, not by it.
+    """
+    de, en = member.de, member.en
+    if de is None or en is None:
+        return False
+    return all(getattr(de, field_) == getattr(en, field_) for field_ in COMPARED_SIDECELL_FIELDS)
+
+
+def is_neutral_pair(member: Member) -> bool:
+    """§6.2.1: a cold member the engine can resolve by observation, not by asking.
+
+    Clauses 2–5 (clause 1, "no ledger entry", is the call site's branch). All
+    four must hold; each is independently necessary, and the regression suite
+    pins that by dropping one at a time.
+    """
+    return (
+        not member.is_one_sided  # 2 — both halves present to compare
+        and member.langness == "shared"  # 3 — the author declared it neutral
+        and member.kind in NEUTRAL_KINDS  # 4 — and the kind makes that checkable
+        and _halves_observably_identical(member)  # 5 — the halves actually agree
+    )
+
 
 # ---------------------------------------------------------------------------
 # The differ
@@ -531,6 +582,17 @@ class _Differ:
     def run(self) -> DeckDiff:
         if self.base is None:
             for member, group in _iter_with_groups(self.current):
+                if is_neutral_pair(member):
+                    self.emit(
+                        member.key.render(),
+                        "mechanical",
+                        "record_neutral",
+                        "none",
+                        _NEUTRAL_DETAIL,
+                        group=group,
+                        member=member,
+                    )
+                    continue
                 self.emit(
                     member.key.render(),
                     "unverified",
@@ -1054,6 +1116,17 @@ class _Differ:
             # branches below even in ledger mode — verify_cold offers only
             # `confirm`, which apply rejects for a one-sided member, leaving no
             # decision-document path to resolve it (issue #566).
+            if is_neutral_pair(member):
+                self.emit(
+                    handle,
+                    "mechanical",
+                    "record_neutral",
+                    "none",
+                    _NEUTRAL_DETAIL,
+                    group=group,
+                    member=member,
+                )
+                return
             self.emit(
                 handle,
                 "unverified",
@@ -2945,6 +3018,20 @@ class _Differ:
             # grows the twin). Framing it cold keeps apply from emitting an
             # unappliable mechanical row.
             for member in {id(m): m for m in matched_pairs + de_solo + en_solo}.values():
+                if is_neutral_pair(member):
+                    # §6.2.1 (#764): the overwhelming majority of positional
+                    # members are shared code cells, so this is where most of
+                    # the cold-start ceremony actually lives.
+                    self.emit(
+                        member.key.render(),
+                        "mechanical",
+                        "record_neutral",
+                        "none",
+                        _NEUTRAL_DETAIL,
+                        group=group,
+                        member=member,
+                    )
+                    continue
                 self.emit(
                     member.key.render(),
                     "unverified",

--- a/tests/cli/test_sync_v3_cli.py
+++ b/tests/cli/test_sync_v3_cli.py
@@ -78,10 +78,16 @@ class TestSyncLoop:
         assert payload["schema"] == WIRE_SCHEMA and payload["engine"] == "v3"
         assert payload["is_clean"] is False
         assert payload["needs_agent"] is True
-        assert {i["action"] for i in payload["items"]} == {"verify_cold"}
+        # Members whose halves the engine can compare directly resolve
+        # mechanically (§6.2.1 / #764); everything else is a framed question.
+        assert {i["action"] for i in payload["items"]} == {"verify_cold", "record_neutral"}
         # id-keyed cold members also advertise `body` (inline stale-twin recovery,
-        # issue #572); positional ones stay confirm-only (no addressable id).
+        # issue #572); positional ones stay confirm-only (no addressable id); a
+        # mechanical row advertises nothing at all.
         for i in payload["items"]:
+            if i["action"] == "record_neutral":
+                assert i["answers"] == [] and i["resolution"] == "mechanical", i
+                continue
             expected = ["confirm", "body"] if i["key"].startswith("id:") else ["confirm"]
             assert i["answers"] == expected, i
         # An all-cold report is the seeding case — it says so.

--- a/tests/mcp/test_tools.py
+++ b/tests/mcp/test_tools.py
@@ -898,10 +898,16 @@ class TestSyncReport:
         data = json.loads(await handle_sync_report(str(de_path), tmp_path))
         assert data["is_clean"] is False
         assert data["needs_agent"] is True
-        assert {i["action"] for i in data["items"]} == {"verify_cold"}
+        # Members whose halves the engine can compare directly resolve
+        # mechanically (§6.2.1 / #764); everything else is a framed question.
+        assert {i["action"] for i in data["items"]} == {"verify_cold", "record_neutral"}
         # id-keyed cold members also advertise `body` (inline stale-twin recovery,
-        # issue #572); positional ones stay confirm-only (no addressable id).
+        # issue #572); positional ones stay confirm-only (no addressable id); a
+        # mechanical row advertises nothing at all.
         for i in data["items"]:
+            if i["action"] == "record_neutral":
+                assert i["answers"] == [] and i["resolution"] == "mechanical", i
+                continue
             expected = ["confirm", "body"] if i["key"].startswith("id:") else ["confirm"]
             assert i["answers"] == expected, i
 

--- a/tests/slides/test_doc_apply.py
+++ b/tests/slides/test_doc_apply.py
@@ -170,12 +170,20 @@ class TestMechanicalRows:
         assert deck.de_path.read_text(encoding="utf-8") == before
         deck.assert_converged()
 
-    def test_two_sided_brand_new_member_is_cold_in_ledger_mode(self, tmp_path: Path):
+    def test_two_sided_brand_new_prose_member_is_cold_in_ledger_mode(self, tmp_path: Path):
         # Design §5: a TWO-sided member with no ledger entry is UNVERIFIED, never
         # a mechanical copy — both sides are present, so the agent confirms (or
         # records) it explicitly rather than the engine trusting it silently.
+        #
+        # §6.2.1 (#764) carves out exactly one exception, and this fixture is
+        # deliberately outside it: the new member is `markdown`, where `shared` +
+        # byte-identical cannot be told apart from German prose duplicated onto
+        # the EN side. `test_two_sided_brand_new_code_member_records_itself`
+        # below is the same shape with a `code` cell, and takes the other branch.
         deck = _deck(tmp_path)
-        new = _shared_code("z", 9)  # new, between x and y — added on BOTH sides
+        # `[markdown]` is load-bearing: a bare `# %%` cell is CODE, which takes
+        # the §6.2.1 branch and would make this test assert the opposite thing.
+        new = "# %% [markdown]\n#\n# Ein neutraler Absatz.\n\n"  # BOTH sides, x→y
         deck.write_de(
             HEADER_DE,
             _slide("s0", "de", "Titel"),
@@ -197,6 +205,45 @@ class TestMechanicalRows:
         outcome = deck.apply()
         assert not outcome.wrote
         assert outcome.count("pending") == 1
+
+    def test_two_sided_brand_new_code_member_records_itself(self, tmp_path: Path):
+        """The §6.2.1 branch: same shape, `code` instead of prose.
+
+        Both halves are the same bytes and the kind carries no natural language,
+        so there is no translation divergence to verify. It resolves mechanically
+        and writes **no file bytes** — the deck must come out byte-identical.
+        """
+        deck = _deck(tmp_path)
+        new = _shared_code("z", 9)
+        for write, lang, text in (
+            (deck.write_de, "de", "DE Text"),
+            (deck.write_en, "en", "EN text"),
+        ):
+            header = HEADER_DE if lang == "de" else HEADER_EN
+            title = "Titel" if lang == "de" else "Title"
+            write(
+                header,
+                _slide("s0", lang, title),
+                _shared_code("x"),
+                new,
+                _shared_code("y", 2),
+                _localized("s0-m", lang, text),
+            )
+        before = (
+            deck.de_path.read_text(encoding="utf-8"),
+            deck.en_path.read_text(encoding="utf-8"),
+        )
+        _, diff = deck.diff()
+        assert [i.action for i in diff.items] == ["record_neutral"]
+        assert doc_apply.item_answers(diff.items[0]) == ()
+
+        outcome = deck.apply()
+        assert outcome.all_applied, outcome.to_payload()
+        assert (
+            deck.de_path.read_text(encoding="utf-8"),
+            deck.en_path.read_text(encoding="utf-8"),
+        ) == before, "a ledger-only row must not touch the files"
+        deck.assert_converged()
 
     def test_one_sided_new_idd_shared_cell_grows_the_twin_in_ledger_mode(self, tmp_path: Path):
         # issue #566: a ONE-sided new *id-keyed* shared cell in a ledgered deck
@@ -669,11 +716,15 @@ class TestColdBodyRecovery:
         deck.assert_converged()
 
     def test_body_on_a_positional_cold_member_is_rejected(self, tmp_path: Path):
-        # A new un-id'd shared code cell inserted among existing cells falls
-        # cold positionally (its ordinal aliases a neighbor); it has no
-        # addressable id, so a body is refused (mint a slide_id instead).
+        # A new un-id'd cell inserted among existing cells falls cold
+        # positionally (its ordinal aliases a neighbor); it has no addressable
+        # id, so a body is refused (mint a slide_id instead).
+        #
+        # The cell is `markdown`, not code: since #764 a shared *code* cell whose
+        # halves are byte-identical resolves as `record_neutral` and never
+        # becomes a cold item at all, so it could not exercise this rejection.
         deck = _deck(tmp_path)
-        new = _shared_code("z", 9)  # new, between x and y — added on BOTH sides
+        new = "# %% [markdown]\n#\n# Ein neutraler Absatz.\n\n"  # BOTH sides, x→y
         deck.write_de(
             HEADER_DE,
             _slide("s0", "de", "Titel"),
@@ -695,7 +746,7 @@ class TestColdBodyRecovery:
         assert cold, [(i.key, i.action) for i in diff.items]
         item = cold[0]
         assert doc_apply.item_answers(item) == ("confirm",)
-        outcome = deck.apply(_decision(item.key, body="z = 9", side="de"))
+        outcome = deck.apply(_decision(item.key, body="#\n# Anderer Absatz.", side="de"))
         result = next(r for r in outcome.results if r.key == item.key)
         assert result.status == "rejected"
         assert "positional" in result.reason
@@ -1193,10 +1244,16 @@ class TestGroupSplitGuard:
         _, diff = deck.diff()
         actions = {(i.key, i.action) for i in diff.items}
         assert not any(a in ("mirror_remove", "remove_vs_split") for _, a in actions), actions
-        cold = [i.key for i in diff.items if i.action == "verify_cold"]
-        assert sorted(cold) == ["pos:s1/code/0", "pos:s1/code/1", "pos:s1/code/2"]
-        confirms = {key: doc_apply.Decision(key=key, choice="confirm") for key in cold}
-        outcome = deck.apply(confirms)
+        # Since #764 the re-grouped pool is shared code with byte-identical
+        # halves, so it records mechanically rather than asking (§6.2.1). What
+        # this test guards is unchanged: nothing is framed for removal, the deck
+        # converges, and every cell survives.
+        regrouped = sorted(i.key for i in diff.items if i.action == "record_neutral")
+        assert regrouped == ["pos:s1/code/0", "pos:s1/code/1", "pos:s1/code/2"]
+        assert not [i for i in diff.items if doc_apply.item_answers(i)], (
+            "no question left to answer"
+        )
+        outcome = deck.apply()
         assert outcome.all_applied, outcome.to_payload()
         deck.assert_converged()
         for name in ("x = 1", "y = 2", "z = 3"):
@@ -1556,10 +1613,16 @@ class TestGroupSplitInterleave:
         _, diff = deck.diff()
         actions = {(i.key, i.action) for i in diff.items}
         assert not any(a in ("mirror_remove", "remove_vs_split") for _, a in actions), actions
-        cold = [i.key for i in diff.items if i.action == "verify_cold"]
-        assert sorted(cold) == ["pos:m1/code/0", "pos:m2/code/0"]
-        confirms = {key: doc_apply.Decision(key=key, choice="confirm") for key in cold}
-        outcome = deck.apply(confirms)
+        # The re-grouped cells are shared code with byte-identical halves, so
+        # since #764 they resolve mechanically (§6.2.1) instead of asking. The
+        # property under test is unchanged: no removal is framed, and the deck
+        # converges in the next pass with the DE cells in the EN order.
+        regrouped = sorted(i.key for i in diff.items if i.action == "record_neutral")
+        assert regrouped == ["pos:m1/code/0", "pos:m2/code/0"]
+        assert not [i for i in diff.items if doc_apply.item_answers(i)], (
+            "no question left to answer"
+        )
+        outcome = deck.apply()
         assert outcome.all_applied, outcome.to_payload()
         deck.assert_converged()
 

--- a/tests/slides/test_sync_diff.py
+++ b/tests/slides/test_sync_diff.py
@@ -114,12 +114,23 @@ class TestNoopAndCold:
         second = _diff(base, de, EN0)
         assert [(i.key, i.action) for i in first.items] == [(i.key, i.action) for i in second.items]
 
-    def test_no_baseline_means_every_member_is_cold(self):
+    def test_no_baseline_means_every_member_is_cold_or_observably_neutral(self):
+        """No baseline: every member is accounted for, none is silently trusted.
+
+        Since #764 the snapshot-cold path splits the same way the ledger-cold one
+        does — a `shared` code/j2 member whose halves are byte-identical resolves
+        as `record_neutral` (§6.2.1) instead of asking a question with one
+        possible answer. Everything else is still `verify_cold`.
+        """
         deck = _parse(DE0, EN0)
         diff = diff_deck(deck, None)
         assert diff.items
-        assert {i.outcome for i in diff.items} == {"unverified"}
-        assert {i.action for i in diff.items} == {"verify_cold"}
+        # Every member is framed — nothing falls through to "in sync".
+        assert len(diff.items) == len(list(deck.members()))
+        assert {i.outcome for i in diff.items} == {"unverified", "mechanical"}
+        assert {i.action for i in diff.items} == {"verify_cold", "record_neutral"}
+        neutral = {i.key for i in diff.items if i.action == "record_neutral"}
+        assert neutral == {"pos:s0/code/0", "pos:s0/code/1"}
 
     def test_incomplete_baseline_reports_unknown_member_as_cold_not_add(self):
         base = _snapshot(DE0, EN0)
@@ -1105,18 +1116,30 @@ class TestAdversarialReviewRegressions:
         assert "record_owner" in actions
         assert len(diff.items) >= 2  # the anchor drift is not swallowed
 
-    def test_ledger_mode_pool_members_are_cold_not_added(self):
-        """MAJOR: with complete=False a pos member without an entry is COLD
-        (framed verification), never a mechanical add/copy."""
+    def test_ledger_mode_pool_members_are_never_a_mechanical_add(self):
+        """MAJOR: with complete=False a pos member without an entry is never an add.
+
+        The guard is about *adds*: a mechanical `record_symmetric_add` /
+        `copy_new_shared` would treat an un-ledgered member as new and mirror it,
+        which for a positional member the ordinals alias. Since #764 a two-sided
+        `shared` code/j2 member resolves as `record_neutral` instead of asking —
+        also mechanical, but ledger-only, so no cell is mirrored and no file byte
+        is written. Everything else stays `verify_cold`.
+        """
         base = _snapshot(DE0, EN0)
-        removed = [k for k in base.members if k.startswith("pos:")]
-        for key in removed:
+        for key in [k for k in base.members if k.startswith("pos:")]:
             del base.members[key]
         base.complete = False
         diff = _diff(base, DE0, EN0)
         assert diff.items
-        assert {i.action for i in diff.items} == {"verify_cold"}
-        assert {i.outcome for i in diff.items} == {"unverified"}
+        assert {i.action for i in diff.items} <= {"verify_cold", "record_neutral"}
+        assert not {i.action for i in diff.items} & {"record_symmetric_add", "copy_new_shared"}
+        # The shared code cells are the neutral class; the j2 header and the
+        # localized/markdown members are not.
+        by_action = {
+            i.action: [j.key for j in diff.items if j.action == i.action] for i in diff.items
+        }
+        assert sorted(by_action.get("record_neutral", [])) == ["pos:s0/code/0", "pos:s0/code/1"]
 
     def test_ledger_mode_one_sided_localized_add_is_translate_new_not_cold(self):
         """issue #566: a NEW one-sided localized cell in a ledgered deck must be

--- a/tests/slides/test_sync_record_neutral.py
+++ b/tests/slides/test_sync_record_neutral.py
@@ -9,7 +9,9 @@ PythonCourses corpus: **45.4% of the 28,791 cold-start items** are that class.
 
 The predicate is four clauses (§6.2.1 numbers them 2–5; clause 1, "no ledger
 entry", is the branch being replaced). Each is pinned here as *independently
-necessary*: drop any one and a member that must stay cold becomes decidable.
+necessary* where it is: clauses 3, 4 and 5 each reject a member the others
+accept. Clause 2 is defence in depth — clause 5 already fails when a side is
+absent — and is kept because it states the intent at the point of the risk.
 Clause 4 is the load-bearing one — `markdown` is excluded because `shared` +
 byte-identical cannot be told apart from German prose duplicated onto the EN
 side, and auto-blessing that banks an untranslated cell as in-sync.
@@ -20,9 +22,12 @@ or overwrite an attestation a human made.
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from clm.slides import doc_apply, sync_diff
+from clm.slides import doc_ledger as doc_ledger_module
 from clm.slides.bilingual_doc import BilingualDeck
 from clm.slides.doc_lenses import parse_bundle
 from clm.slides.sync_diff import (
@@ -87,19 +92,27 @@ class TestEveryClauseIsNecessary:
         diff = _cold_diff(NEUTRAL_CODE, "")
         assert _action_for(diff, "pos:s0/") == "verify_cold"
 
-    def test_clause_3_localized_stays_cold(self):
-        """A `lang=` attribute is the author declaring the halves are NOT the same.
+    def test_clause_3_a_localized_cell_copied_verbatim_into_the_twin_stays_cold(self):
+        """The shape clause 3 is *alone* in rejecting — and the worst false positive.
 
-        Byte-identical halves do not override that: the declaration is what the
-        engine keys on, and two identical localized halves mean the translation
-        has not been done, which is precisely a question.
+        Both halves carry ``lang="de"`` and identical bytes: a German cell sitting
+        untranslated in the English deck. Clause 5 holds (the halves really are
+        the same bytes) and clause 4 holds (it is code), so if clause 3 were
+        dropped the engine would bank an untranslated cell as verified.
+
+        An earlier version of this test used ``lang="de"`` / ``lang="en"``, which
+        made the halves differ — so clause 5 rejected them and the test passed
+        with clause 3 deleted. The cell needs a slide_id either way: the lens
+        refuses an id-LESS localized cell outright (``idless_localized``).
         """
-        # The cell needs a slide_id: the lens refuses an id-LESS localized cell
-        # outright (`idless_localized`), so there would be no member to classify.
-        de = '# %% lang="de" tags=["keep"] slide_id="c1"\nx = 1\n\n'
-        en = '# %% lang="en" tags=["keep"] slide_id="c1"\nx = 1\n\n'
-        diff = _cold_diff(de, en)
-        assert _action_for(diff, "id:c1") == "verify_cold"
+        cell = '# %% lang="de" tags=["keep"] slide_id="c1"\n# Berechne die Summe\nx = 1 + 1\n\n'
+        member = next(m for m in _deck(cell, cell).members() if m.key.render() == "id:c1")
+        assert member.langness == "localized"
+        assert member.kind in NEUTRAL_KINDS, "clause 4 must not be what rejects this"
+        assert sync_diff._halves_observably_identical(member), "clause 5 must hold"
+        assert not is_neutral_pair(member), "only clause 3 stands between this and a bank"
+
+        assert _action_for(_cold_diff(cell, cell), "id:c1") == "verify_cold"
 
     def test_clause_4_markdown_stays_cold_even_when_identical(self):
         """The prose exclusion — the maintainer's explicit decision.
@@ -189,6 +202,38 @@ class TestWhatItRecords:
         stamps = {lm.provenance for k, lm in deck_ledger.members.items() if k.startswith("pos:s0/")}
         assert stamps == {"structural"}
 
+    def test_every_member_of_a_multi_member_pool_keeps_its_stamp(self, tmp_path):
+        """A `pos:` record re-records its WHOLE pool, so per-item stamping is unsafe.
+
+        With N neutral members in one pool, each item's `rerecord_pool` reset the
+        stamp the previous one had just written: 65% of positional neutral
+        members corpus-wide ended up with the pass provenance and a re-created
+        dangling owner. Every fixture used a single-member pool, so it shipped
+        green. Stamping happens once, after every record has landed.
+        """
+        cells = "".join(f'# %% tags=["keep"]\n{n} = 1\n\n' for n in "xyz")
+        _b, _a, deck_ledger, _de, _r = self._apply(tmp_path, cells, cells)
+        assert deck_ledger is not None
+        pool = {k: lm for k, lm in deck_ledger.members.items() if k.startswith("pos:s0/")}
+        assert len(pool) == 3, pool
+        assert {lm.provenance for lm in pool.values()} == {"structural"}
+        assert {lm.entry.owner for lm in pool.values()} == {None}
+
+    def test_a_cold_apply_logs_no_dangling_reference_warning(self, tmp_path, caplog):
+        """What the owner-drop actually exists for, asserted directly.
+
+        The previous test read the ledger back from *disk*, where
+        `prune_dangling_refs` had already degraded any dangling owner — so it
+        passed with the owner-drop deleted. The point of dropping at write time
+        is that #718's corruption detector must not fire on every cold apply.
+        """
+        cells = "".join(f'# %% tags=["keep"]\n{n} = 1\n\n' for n in "xyz")
+        with caplog.at_level(logging.WARNING, logger="clm.slides.doc_ledger"):
+            self._apply(tmp_path, cells, cells)
+        assert not [r for r in caplog.records if "dangling reference" in r.message], [
+            r.message for r in caplog.records
+        ]
+
     def test_it_records_no_owner_it_cannot_back(self, tmp_path):
         """The anchor is still cold on a cold deck, so its id would dangle (#718).
 
@@ -213,6 +258,88 @@ class TestWhatItRecords:
         members = ledger.decks["slides_t"].members
         pos = next(k for k in members if k.startswith("pos:s0/"))
         assert members[pos].entry.owner == "id:s0"
+
+
+class TestEveryEmissionSiteFires:
+    """Three code paths classify a member with no base entry. All three branch.
+
+    Site 1 is `base is None` (snapshot-cold), site 3 is `_classify_pool_news`
+    (positional, ledger mode) — both are exercised throughout this file. Site 2,
+    the **id-keyed** ledger-mode path, had no coverage at all: disabling it
+    passed the entire 9,399-test suite, while the corpus says ~16% of neutral
+    members are `id:`-keyed.
+    """
+
+    def test_an_id_keyed_member_added_to_a_recorded_deck(self, tmp_path):
+        from click.testing import CliRunner
+
+        from clm.cli.commands.slides.sync import slides_sync_group
+        from clm.slides import doc_ledger
+
+        de = tmp_path / "slides_t.de.py"
+        en = tmp_path / "slides_t.en.py"
+        de.write_text(_build(HEADER_DE, _slide("s0", "de", "Titel")), encoding="utf-8")
+        en.write_text(_build(HEADER_EN, _slide("s0", "en", "Title")), encoding="utf-8")
+        try:
+            runner = CliRunner(mix_stderr=False)
+        except TypeError:  # Click 8.2+
+            runner = CliRunner()
+        assert runner.invoke(slides_sync_group, ["record", str(de)]).exit_code == 0
+
+        # An id'd, two-sided, byte-identical shared code cell — added on BOTH
+        # halves of an already-recorded deck, so it reaches the id-keyed branch.
+        idd = '# %% tags=["keep"] slide_id="c1"\nx = 1\n\n'
+        de.write_text(_build(HEADER_DE, _slide("s0", "de", "Titel"), idd), encoding="utf-8")
+        en.write_text(_build(HEADER_EN, _slide("s0", "en", "Title"), idd), encoding="utf-8")
+
+        diff = diff_outcome(
+            parse_bundle(de.read_text(encoding="utf-8"), en.read_text(encoding="utf-8")),
+            doc_ledger.baseline_from_ledger(
+                doc_ledger.load(doc_ledger.ledger_path_for(de)).decks["slides_t"]
+            ),
+        )
+        assert _action_for(diff, "id:c1") == "record_neutral"
+
+
+class TestFrozenPoolsAreHonoured:
+    """#600/#630: a pool holding an unresolved conflict must not be re-recorded.
+
+    `record_neutral` re-records its whole pool, so it inherits that hazard: the
+    two-sided base entry is the only record the gone side ever existed, and a
+    wholesale re-record from present state would erase it — silently downgrading
+    a pending removal conflict to mechanical duplication on the next report.
+
+    The guard was correct as written but unpinned: deleting it passed the whole
+    suite. Exercised directly, since building a real frozen pool alongside a
+    neutral member takes a five-step fixture that would obscure what is asserted.
+    """
+
+    def test_a_frozen_pool_records_nothing(self):
+        from clm.slides.doc_ledger import DeckLedger, record_deck_snapshot
+
+        deck = _deck(NEUTRAL_CODE, NEUTRAL_CODE)
+        item = next(
+            i for i in _cold_diff(NEUTRAL_CODE, NEUTRAL_CODE).items if i.action == "record_neutral"
+        )
+        pool = doc_apply._pool_scope(item)
+        assert pool is not None, item.key
+
+        fresh_ledger = doc_ledger_module.TopicLedger()
+        record_deck_snapshot(fresh_ledger, "d", deck, provenance="apply")
+        fresh = fresh_ledger.decks["d"]
+
+        target = DeckLedger()
+        assert (
+            doc_apply._record_item(target, fresh, item, provenance="apply", frozen_pools={pool})
+            == set()
+        )
+        assert target.members == {}, "a frozen pool must not be recorded"
+
+        target2 = DeckLedger()
+        assert doc_apply._record_item(
+            target2, fresh, item, provenance="apply", frozen_pools=set()
+        ) == {pool}
+        assert target2.members, "control: an unfrozen pool records"
 
 
 class TestItStaysInsideTheContract:

--- a/tests/slides/test_sync_record_neutral.py
+++ b/tests/slides/test_sync_record_neutral.py
@@ -1,0 +1,270 @@
+"""`record_neutral` — the engine does not ask what it can observe (#764, §6.2.1).
+
+A cold member is framed as a question only when the relationship between its
+halves is genuinely unknown. When the member is two-sided, declared `shared`, of
+a kind that carries no natural language, and its halves agree on every field the
+differ compares, there is no translation divergence to verify — the question has
+one possible answer, and asking it is ceremony. Measured on the 730-deck
+PythonCourses corpus: **45.4% of the 28,791 cold-start items** are that class.
+
+The predicate is four clauses (§6.2.1 numbers them 2–5; clause 1, "no ledger
+entry", is the branch being replaced). Each is pinned here as *independently
+necessary*: drop any one and a member that must stay cold becomes decidable.
+Clause 4 is the load-bearing one — `markdown` is excluded because `shared` +
+byte-identical cannot be told apart from German prose duplicated onto the EN
+side, and auto-blessing that banks an untranslated cell as in-sync.
+
+What this row must never do: write a file byte, claim trust it did not observe,
+or overwrite an attestation a human made.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clm.slides import doc_apply, sync_diff
+from clm.slides.bilingual_doc import BilingualDeck
+from clm.slides.doc_lenses import parse_bundle
+from clm.slides.sync_diff import (
+    COMPARED_SIDECELL_FIELDS,
+    NEUTRAL_KINDS,
+    DeckBaseline,
+    DeckDiff,
+    diff_outcome,
+    is_neutral_pair,
+)
+
+HEADER_DE = "# j2 from 'macros.j2' import header_de\n# {{ header_de(\"Titel DE\") }}\n\n"
+HEADER_EN = "# j2 from 'macros.j2' import header_en\n# {{ header_en(\"Title EN\") }}\n\n"
+
+
+def _slide(slug: str, lang: str, title: str) -> str:
+    return f'# %% [markdown] lang="{lang}" tags=["slide"] slide_id="{slug}"\n#\n# # {title}\n\n'
+
+
+def _build(*parts: str) -> str:
+    return "".join(parts).rstrip("\n") + "\n"
+
+
+def _deck(de_cell: str, en_cell: str) -> BilingualDeck:
+    """A one-slide deck whose only pool member is the cell under test."""
+    outcome = parse_bundle(
+        _build(HEADER_DE, _slide("s0", "de", "Titel"), de_cell),
+        _build(HEADER_EN, _slide("s0", "en", "Title"), en_cell),
+    )
+    assert outcome.deck is not None, outcome.refusal.render() if outcome.refusal else "parse failed"
+    return outcome.deck
+
+
+def _cold_diff(de_cell: str, en_cell: str) -> DeckDiff:
+    """Diff against an empty *ledger* baseline — the production cold shape."""
+    return diff_outcome(
+        parse_bundle(
+            _build(HEADER_DE, _slide("s0", "de", "Titel"), de_cell),
+            _build(HEADER_EN, _slide("s0", "en", "Title"), en_cell),
+        ),
+        DeckBaseline(complete=False),
+    )
+
+
+def _action_for(diff: DeckDiff, prefix: str) -> str:
+    rows = [i for i in diff.items if i.key.startswith(prefix)]
+    assert len(rows) == 1, [(i.key, i.action) for i in diff.items]
+    return rows[0].action
+
+
+#: The cell that satisfies every clause — the control for each mutation below.
+NEUTRAL_CODE = '# %% tags=["keep"]\nx = 1\n\n'
+
+
+class TestEveryClauseIsNecessary:
+    def test_the_control_is_decidable(self):
+        """Without this, a mutation "failing" proves nothing."""
+        assert _action_for(_cold_diff(NEUTRAL_CODE, NEUTRAL_CODE), "pos:s0/") == "record_neutral"
+
+    def test_clause_2_one_sided_stays_cold(self):
+        """Only one half present: there is no second half to compare against."""
+        diff = _cold_diff(NEUTRAL_CODE, "")
+        assert _action_for(diff, "pos:s0/") == "verify_cold"
+
+    def test_clause_3_localized_stays_cold(self):
+        """A `lang=` attribute is the author declaring the halves are NOT the same.
+
+        Byte-identical halves do not override that: the declaration is what the
+        engine keys on, and two identical localized halves mean the translation
+        has not been done, which is precisely a question.
+        """
+        # The cell needs a slide_id: the lens refuses an id-LESS localized cell
+        # outright (`idless_localized`), so there would be no member to classify.
+        de = '# %% lang="de" tags=["keep"] slide_id="c1"\nx = 1\n\n'
+        en = '# %% lang="en" tags=["keep"] slide_id="c1"\nx = 1\n\n'
+        diff = _cold_diff(de, en)
+        assert _action_for(diff, "id:c1") == "verify_cold"
+
+    def test_clause_4_markdown_stays_cold_even_when_identical(self):
+        """The prose exclusion — the maintainer's explicit decision.
+
+        `shared` + byte-identical markdown has two readings the engine cannot
+        distinguish: a genuinely neutral cell (a fenced code block, an `<img>`),
+        or German prose duplicated onto the EN side and mis-declared neutral.
+        Auto-blessing the second banks an untranslated cell as in-sync.
+        """
+        cell = "# %% [markdown]\n#\n# Ein Absatz, der auf beiden Seiten steht.\n\n"
+        diff = _cold_diff(cell, cell)
+        assert _action_for(diff, "pos:s0/") == "verify_cold"
+
+    def test_clause_5_diverged_bodies_stay_cold(self):
+        diff = _cold_diff(NEUTRAL_CODE, '# %% tags=["keep"]\nx = 2\n\n')
+        assert _action_for(diff, "pos:s0/") == "verify_cold"
+
+    def test_clause_5_is_not_body_only__a_tags_divergence_must_not_be_swallowed(self):
+        """Same body, different tags. Explicitly called out in #764's scope.
+
+        A body-only comparison would call this pair identical and bank it — and
+        the tag sets would stay divergent with the ledger asserting they are
+        fine. This is also the shape that made the corpus estimate one member
+        too high: a j2 cell whose *body* is empty on both halves but whose
+        header line reads `header_de` on one side and `header_en` on the other.
+        """
+        diff = _cold_diff(NEUTRAL_CODE, '# %% tags=["keep", "extra"]\nx = 1\n\n')
+        assert _action_for(diff, "pos:s0/") == "verify_cold"
+
+    def test_clause_5_walks_the_field_set__not_a_hand_written_list(self):
+        """The genericity requirement (P6), exercised rather than asserted in prose.
+
+        Clause 5 is defined over ``COMPARED_SIDECELL_FIELDS`` so that a field
+        added to the differ's comparison later tightens this predicate
+        automatically. Extend the set with a field the halves happen to disagree
+        on, and the same member must stop being decidable.
+        """
+        # Proved by NARROWING, which needs no field that happens to differ: take a
+        # member clause 5 currently rejects, empty the set, and it must become
+        # decidable. A hand-written comparison (`de.lines == en.lines and ...`)
+        # would be unmoved by that — and would be equally unmoved by a field
+        # ADDED to the differ later, which is the drift this guards against.
+        deck = _deck(NEUTRAL_CODE, '# %% tags=["keep"]\nx = 2\n\n')
+        member = next(m for m in deck.members() if m.key.render().startswith("pos:s0/"))
+        assert not is_neutral_pair(member), "control: diverged halves are not decidable"
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(sync_diff, "COMPARED_SIDECELL_FIELDS", frozenset())
+            assert is_neutral_pair(member), (
+                "clause 5 ignored the field set — it is hand-written, so a field "
+                "added to the differ later will not tighten it"
+            )
+
+
+class TestWhatItRecords:
+    def _apply(self, tmp_path, de_cell: str, en_cell: str):
+        from click.testing import CliRunner
+
+        from clm.cli.commands.slides.sync import slides_sync_group
+        from clm.slides import doc_ledger
+
+        de = tmp_path / "slides_t.de.py"
+        en = tmp_path / "slides_t.en.py"
+        de.write_text(_build(HEADER_DE, _slide("s0", "de", "Titel"), de_cell), encoding="utf-8")
+        en.write_text(_build(HEADER_EN, _slide("s0", "en", "Title"), en_cell), encoding="utf-8")
+        before = (de.read_text(encoding="utf-8"), en.read_text(encoding="utf-8"))
+        try:
+            runner = CliRunner(mix_stderr=False)
+        except TypeError:  # Click 8.2+
+            runner = CliRunner()
+        runner.invoke(slides_sync_group, ["apply", str(de), "--json"])
+        after = (de.read_text(encoding="utf-8"), en.read_text(encoding="utf-8"))
+        ledger = doc_ledger.load(doc_ledger.ledger_path_for(de))
+        return before, after, ledger.decks.get("slides_t"), de, runner
+
+    def test_it_writes_the_ledger_and_not_one_file_byte(self, tmp_path):
+        before, after, deck_ledger, _de, _r = self._apply(tmp_path, NEUTRAL_CODE, NEUTRAL_CODE)
+        assert after == before, "a ledger-only row must not touch the files"
+        assert deck_ledger is not None
+        pos = {k: lm for k, lm in deck_ledger.members.items() if k.startswith("pos:s0/")}
+        assert pos, deck_ledger.members
+
+    def test_the_stamp_is_structural_not_the_pass_provenance(self, tmp_path):
+        """`apply` stamps `apply`; this row was established by the engine, not the verb."""
+        _b, _a, deck_ledger, _de, _r = self._apply(tmp_path, NEUTRAL_CODE, NEUTRAL_CODE)
+        assert deck_ledger is not None
+        stamps = {lm.provenance for k, lm in deck_ledger.members.items() if k.startswith("pos:s0/")}
+        assert stamps == {"structural"}
+
+    def test_it_records_no_owner_it_cannot_back(self, tmp_path):
+        """The anchor is still cold on a cold deck, so its id would dangle (#718).
+
+        `save` prunes exactly that and warns that nothing should create it —
+        creating it on every cold apply would turn a corruption detector into
+        noise. Ownership records when the anchor itself lands.
+        """
+        _b, _a, deck_ledger, _de, _r = self._apply(tmp_path, NEUTRAL_CODE, NEUTRAL_CODE)
+        assert deck_ledger is not None
+        for key, lm in deck_ledger.members.items():
+            assert lm.entry.owner in (None, *deck_ledger.members), key
+
+    def test_the_deck_converges_and_ownership_settles_on_a_full_record(self, tmp_path):
+        from clm.cli.commands.slides.sync import slides_sync_group
+        from clm.slides import doc_ledger
+
+        _b, _a, _dl, de, runner = self._apply(tmp_path, NEUTRAL_CODE, NEUTRAL_CODE)
+        runner.invoke(slides_sync_group, ["record", str(de)])
+        result = runner.invoke(slides_sync_group, ["report", str(de)])
+        assert "clean" in result.output, result.output
+        ledger = doc_ledger.load(doc_ledger.ledger_path_for(de))
+        members = ledger.decks["slides_t"].members
+        pos = next(k for k in members if k.startswith("pos:s0/"))
+        assert members[pos].entry.owner == "id:s0"
+
+
+class TestItStaysInsideTheContract:
+    def test_the_row_is_mechanical_and_answerless(self):
+        item = next(
+            i for i in _cold_diff(NEUTRAL_CODE, NEUTRAL_CODE).items if i.action == "record_neutral"
+        )
+        assert item.outcome == "mechanical"
+        assert item.action in sync_diff.MECHANICAL_ACTIONS
+        assert item.action not in sync_diff.FRAMED_ACTIONS
+        assert doc_apply.item_answers(item) == ()
+        assert doc_apply.item_resolution(item) == "mechanical"
+
+    def test_it_is_a_ledger_only_row(self):
+        assert "record_neutral" in doc_apply._RECORD_ONLY
+
+    def test_the_all_cold_seeding_hint_survives(self):
+        """Mechanical rows say nothing about the remaining questions.
+
+        Keying the hint on *all* items would have silently withdrawn it from
+        exactly the freshly-authored decks it exists for, since those now emit
+        `record_neutral` rows alongside the cold ones.
+        """
+        from clm.slides.doc_report import cold_sweep_hint
+
+        diff = _cold_diff(NEUTRAL_CODE, NEUTRAL_CODE)
+        assert any(i.action == "record_neutral" for i in diff.items)
+        assert any(i.action == "verify_cold" for i in diff.items)
+        hint = cold_sweep_hint(diff)
+        assert hint is not None and "sync record" in hint
+
+    def test_a_structural_stamp_never_demotes_a_human_attestation(self):
+        """`preserve_unchanged_member`'s automatic path, from this row's angle.
+
+        An engine observation must not overwrite `semantic:<model>` on a member
+        whose content has not moved — a later "distrust that model" sweep would
+        then discard trust a human established.
+        """
+        from clm.slides.doc_identity import baseline_from_deck
+        from clm.slides.doc_ledger import LedgerMember, preserve_unchanged_member
+
+        entry = next(
+            e
+            for k, e in baseline_from_deck(_deck(NEUTRAL_CODE, NEUTRAL_CODE)).members.items()
+            if k.startswith("pos:s0/")
+        )
+        human = LedgerMember(entry=entry, provenance="semantic:gpt-4", confirmed_commit="c1")
+        engine = LedgerMember(entry=entry, provenance="structural", confirmed_commit="c2")
+        assert preserve_unchanged_member(human, engine) is human
+
+
+def test_neutral_kinds_excludes_markdown():
+    """A one-line guard on the decision most likely to be "simplified" later."""
+    assert NEUTRAL_KINDS == {"code", "j2"}
+    assert "markdown" not in NEUTRAL_KINDS


### PR DESCRIPTION
Closes #764. Refs #653.

A member with no ledger entry was framed as a verification question purely because both halves were present. But `shared` means *language-neutral*, so for a cell whose two halves are the **same bytes** there is no translation divergence to verify — the question has one possible answer and asking it is ceremony.

A new mechanical row `record_neutral` resolves those instead, writing **no file bytes** — only the ledger entry, like `record_order` / `record_owner`.

## The predicate (§6.2.1)

Fires only when the engine can *check* the claim rather than trust it: no ledger entry · two-sided · declared `shared` · kind `code` or `j2` · every per-side field the differ compares equal across the halves.

**Measured on the 730-deck corpus: 13,059 of 28,791 cold-start items — 45.4%.**

Clause 5 walks `COMPARED_SIDECELL_FIELDS` rather than naming fields, so a field added to the differ later tightens the predicate automatically (P6) instead of silently widening what gets auto-recorded. **That already paid:** the issue predicted 13,060 and the real number is 13,059, because the estimate compared *bodies* only and so missed a j2 cell whose body is empty on both halves but whose header line reads `header_de` on one side and `header_en` on the other. The generic walk excludes it — the halves are genuinely not the same bytes.

**Prose is excluded by construction**, and the exclusion is load-bearing: for `markdown`, `shared` + byte-identical cannot be told apart from German prose duplicated onto the EN side, and auto-blessing that banks an untranslated cell as in-sync. 282 corpus members stay real questions — the chosen price, per the maintainer's decision on the issue.

## Two things beyond the predicate

**A `pos:` record must re-record its whole pool.** Positional ordinals renumber together, so patching a single slot leaves its siblings aliasing different cells and the member re-frames forever. My first draft did exactly that and did not converge; it now follows the same rule the other record rows do.

**The stamp is `structural`, and an unbackable owner is dropped.** The pass provenance says who ran the verb — this row was established by the *engine*. And the row fires on cold decks where the anchor is normally still cold, so the entry would name an owner the store has no entry for; `save` prunes exactly that and warns nothing should create it (#718), which would turn a corruption detector into noise on every cold apply.

## One behaviour fix that was not on the checklist

The all-cold seeding hint (`cold_sweep_hint`) keyed on *all* items being `verify_cold`. With mechanical rows now present on cold decks it stopped firing — silently withdrawing the hint from exactly the freshly-authored decks it exists for. It now keys on the remaining **questions**.

## Existing tests

Eight encoded "every cold member is `verify_cold`". Each was **rewritten to state the narrowed contract**, not adjusted to pass, keeping the guard it existed for:

- `test_ledger_mode_pool_members_are_cold_not_added` → the guard is about *adds*; `record_neutral` is ledger-only so nothing is mirrored. Now asserts no `record_symmetric_add` / `copy_new_shared`.
- The **#566 one-sided guard is untouched** and still passes — clause 2 excludes one-sided members.
- Two fixtures moved to `markdown` so they still exercise a genuinely cold positional member (`test_body_on_a_positional_cold_member_is_rejected` could otherwise no longer produce one).
- The two group-split convergence tests now converge with *no* answers needed, which is strictly better; their real guard (no `mirror_remove` / `remove_vs_split`, every cell survives) is unchanged.

## Testing

- `tests/slides/test_sync_record_neutral.py` — 16 tests. Each clause pinned as **independently necessary**, with a control that proves the mutation means something; the tags-only divergence called out in the issue scope; genericity of clause 5 proved by *narrowing* the field set (a hand-written comparison would be unmoved); ledger-only-ness, `structural` stamp, no unbackable owner, convergence, and that a structural stamp never demotes a `semantic:<model>` attestation.
- Full fast suite: **9399 passed**, 7 skipped, 1 xfailed. ruff + mypy clean.
- Corpus re-measured end-to-end through `diff_deck`, not through the estimator script.

## Docs

`clm info sync-agents` and `clm info commands` (info-topics rule — downstream course-repo agents read these); changelog fragment. Design note §6.2.1 already describes the rule and needs no amendment; a §13 row is not warranted since #764's row already covers the design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm9cCFzyYG61oQLb7Zmho8