### PR TITLE
docs(sync): close Q6b as measured out; add the ceremony measurement

### DIFF
--- a/docs/claude/handovers/sync-v3-q-register-handover.md
+++ b/docs/claude/handovers/sync-v3-q-register-handover.md
@@ -1,6 +1,7 @@
 # Sync v3 Q-Register — Handover
 
-**Created**: 2026-08-02 | **Status**: Q1–Q5, Q6a, Q7 closed; three items remain
+**Created**: 2026-08-02 | **Updated**: 2026-08-03 | **Status**: Q1–Q7 all closed;
+**one build item remains** (Q4's delegation half)
 | **Source review**: `docs/claude/sync-v3-adversarial-review.md` (2026-07-29)
 
 The seven maintainer questions in **§7** of the sync-v3 adversarial review are
@@ -39,136 +40,64 @@ against any slides root. Use them.
 
 ---
 
-## 1. `record_neutral` — issue #764 *(do this first)*
+## 1. `record_neutral` (#764) — **DONE** (PR #771)
 
-**Why first.** The design is complete and merged (note §6.2.1, PR #765); the
-issue carries a scope checklist; the measurement is committed and re-runnable;
-nothing else depends on it and it depends on nothing. It is also the largest
-single payoff in the register: **45.4% of the 28,791 cold-start verification
-questions** on the PythonCourses corpus are this class.
+Shipped 2026-08-03. 45.4% of cold-start items (13,059 of 28,791) now resolve
+mechanically. Landmines for anyone touching it:
 
-**What it is.** A cold member is framed as a question only when the relationship
-between its halves is genuinely unknown. A new **mechanical** row,
-`record_neutral`, resolves it instead — writing **no file bytes, only the ledger
-entry**, like the existing `record_order` / `record_owner` rows — when all five
-clauses of §6.2.1 hold: no ledger entry; two-sided; langness `shared`; kind
-`code` or `j2`; and every per-side field the differ compares is equal across the
-halves.
+- **A `pos:` record must re-record its whole pool.** Ordinals renumber together,
+  so patching one slot never converges. The first draft did that.
+- **Therefore the `structural` stamp is applied ONCE, after the whole landing
+  loop.** Per-item stamping was clobbered by the next sibling's `rerecord_pool`
+  — measured at 65% of positional neutral members. Every test fixture used a
+  single-member pool, so it shipped green through one review round.
+- **The entry's owner is dropped when the anchor is still cold**, or #718's
+  dangling-reference detector fires on every cold apply and stops meaning
+  anything.
+- **Clause 4's premise is false and was shipped knowingly.** "Code carries no
+  natural language" is wrong for ~0.9% of shared code cells (120 cells, 43
+  decks) that carry German in comments or string literals. The maintainer
+  shipped on the base rate (vs ~100% for markdown); the docs now say "compared,
+  not read" rather than claiming a guarantee. The detector that would make the
+  boundary categorical is **#772**.
 
-**Clause 5 is defined over the generic record-diff (§6.3), not a hand-written
-field list.** That is deliberate (P6): a field added to the comparison later
-tightens the predicate automatically. Do not re-enumerate the fields.
+## 2. Q6b mechanical sweeps — **CLOSED, measured out** (2026-08-03)
 
-**Clause 4 is load-bearing and was the maintainer's explicit decision.** For
-`markdown`, `shared` + byte-identical has two readings the engine cannot
-distinguish — a genuinely neutral cell (fenced code, a shell snippet, an
-`<img>`), or German prose duplicated onto the EN side and mis-declared shared.
-Auto-blessing the second banks an untranslated cell as in-sync. `wrong_language_cell`
-cannot catch it either: a shared cell carries no `lang=` to contradict. The
-price is 282 corpus members that stay real questions. **Do not widen clause 4
-to `markdown` without a new maintainer decision.**
+Do not build this. `scripts/measure_sync_ceremony.py` replays real commits and
+classifies every changed cell by the row it frames. Over 200 commits of the
+reference course repo:
 
-### The one thing that changed under it since the design landed
+| | rows | share of framed |
+|---|---:|---:|
+| `verify_translation` (both halves moved) | **1053** | **68.4%** |
+| `translate_edit` (one half moved) | 487 | 31.6% |
+| shared member moved — *already mechanical* | 346 | — |
 
-The design says trust banked this way carries provenance `structural`. PR #768
-(Q7) **removed the string-enumeration approach to provenance entirely** — there
-is no `_AUTOMATIC_PROVENANCE` set any more. `preserve_unchanged_member` now
-takes `deliberate_provenance`, defaulting to `False`, and intent is threaded
-from the caller.
+**The normalizer-equivalence row — Q6b's whole remaining substance after design
+§6.2.1 rejected the auto-answer sweep — would remove 1 of 487 rows (0.2%).** The
+mechanism is real (v3 fingerprints are raw bytes, so unlike v1/v2 a soft re-wrap
+does read as drift, #429) but the population is not.
 
-That is *good news* for this item: writing `provenance="structural"` needs no
-registration anywhere. It will be treated as automatic by default, which is
-correct — a structural observation must not overwrite a human's `agent` or
-`semantic:<model>` attestation on a member whose content is unchanged. **Do not
-add `structural` to any list.** If you find yourself wanting to, re-read
-`preserve_unchanged_member`'s docstring; that mistake is recorded there.
+Two things worth carrying forward:
 
-### Where the code goes
+- **Beware the naive count.** A first pass said 5.1%. It counted all changed
+  cells; cosmetic edits land overwhelmingly on *shared* cells
+  (`propagate_shared_edit`) or identically on both halves
+  (`record_symmetric_edit`), neither of which is ceremony. Filtering to the only
+  shape a normalizer row could help collapses it 25x.
+- **`uniform_drift_side` (#767) already covers the shape.** Of the 57
+  (commit, deck) pairs framing ≥3 one-sided edits, **55 have every edit on one
+  side**. Median one-sided edits per deck is 1.
 
-`_diff_unmatched_current` in `src/clm/slides/sync_diff.py` is the branch being
-replaced — it currently gates the cold decision on *sidedness*, never on
-*langness*:
+**What the measurement surfaced instead**: `verify_translation` is 68% of framed
+rows, up to 32 in one deck — and it fires exactly when both halves moved apart,
+the one shape where the engine has *observed* a divergence it cannot resolve.
+Q6b proposed auto-`confirm`ing it; that would bank 1053 unread divergences. The
+volume is real ceremony and needs a different answer. Tracked as **#773**.
 
-```python
-if not self.base.complete and not member.is_one_sided:
-    self.emit(handle, "unverified", "verify_cold", "none", ...)
-```
+## 3. Q4 delegation half — validate as an adapter — **THE ONLY BUILD ITEM LEFT**
 
-The executor side needs a ledger-only write; `record_order` / `record_owner` are
-the shape to copy in `doc_apply.py`.
-
-### Acceptance
-
-- `python scripts/measure_positional_composition.py <slides-root>` section 3
-  should show the decidable class resolving, and the residual cold count
-  dropping by ~45%.
-- The suppression doctrine must be untouched: a member carrying any framed row
-  is not a candidate, because clause 5 cannot hold. Pin that.
-- Info topics: `sync-agents.md` (the agent sees a new mechanical action) and
-  `commands.md`. Per the CLAUDE.md rule these are version-accurate and
-  downstream course-repo agents read them.
-- §13 amendments row.
-
----
-
-## 2. Q6b — mechanical sweeps *(second; the principle is shared with #1)*
-
-**Why second.** The design note's §6.2.1 already contains the answer, and it is
-freshest immediately after building #764. **Q6b as the review states it was
-superseded by that design** — read §6.2.1's "Why this is not the auto-confirm
-mistake" before you read the review's Q6b, or you will build the rejected thing.
-
-### What the review proposed, and why it is wrong
-
-> `apply --mechanical` (auto-answer exactly `translate_edit→keep_twin`,
-> `verify_translation→confirm`, hard-fail on anything else, never default-on)
-
-Auto-answering `translate_edit → keep_twin` banks the claim *"my edit did not
-change what the twin should say"* — a **semantic** claim about two *different*
-texts that the tool cannot verify. Banking it unverified is exactly the
-silent-divergence class the programme exists to remove.
-
-This is not theoretical. PR #767 established (and `clm info sync-agents` now
-documents) that **`keep_twin` banks the pair**: the member reports in sync from
-then on, so an unfaithful twin waved through is never raised again. A sweep that
-applies it across a deck permanently blesses every twin it touches.
-
-### What to build instead
-
-The governing principle from §6.2.1: **auto-resolve only what the engine can
-observe, never what it must assume.**
-
-Applied to a *cold* member that yields `record_neutral` (item 1). Applied to an
-*edited* member it yields a different but equally observable test: **the
-source-side change is normalizer-equivalent, so the twin is provably
-unaffected**. A whitespace-only or normalizer-canonical edit to one half cannot
-change what the other half should say — and that is checkable, not assumable.
-
-Both are **mechanical rows under §6.2**. So `apply --mechanical` becomes *a
-caller of existing mechanical rows*, not a new contract with its own auto-answer
-policy. That is the whole difference: no new trust semantics, no new vocabulary,
-nothing to get wrong at the contract layer.
-
-### Sequencing note
-
-`uniform_drift_side` (PR #767) is the report-level signal that tells an agent
-when a bulk `keep_twin` is *appropriate* — it fires when every `translate_edit`
-drifted on one side, the review-after-translate shape. That is the honest
-version of the ceremony fix: **surface the pattern, let the human who knows
-which half they reviewed decide**. Check whether that already removes enough
-ceremony before building an auto-answer at all. If it does, Q6b may reduce to
-the normalizer-equivalence row and no flag.
-
-**Q6a is DONE** — all four hand-edit flows have in-engine answers now: fork
-twin-marking (`mark_twin`, #656), order repair (first-class order items, #654),
-anchor-shape framing (#653), and `verify_translation` with a stale twin
-(`body`+`side`, #656). No issue exists for Q6b; open one.
-
----
-
-## 3. Q4 delegation half — validate as an adapter *(third; largest blast radius)*
-
-**Why last.** It is the biggest refactor of the three, and it touches
+**Why it was scheduled last.** It is the biggest refactor of the three, and it touches
 `clm validate`, which runs on the **pre-commit gate in course repositories**. A
 regression here blocks every commit in every downstream repo, not just CLM's.
 Do it when the two cheaper items are behind you.

--- a/docs/claude/sync-v3-adversarial-review.md
+++ b/docs/claude/sync-v3-adversarial-review.md
@@ -518,8 +518,8 @@ distinct cheap `confirm_twin` framing. The information is already computed.
 
 **Q6 — Sanction the two flows the doctrine pretends don't exist.**
 
-> ◐ **(a) DONE. (b) SUPERSEDED — do not implement the auto-answer sweep
-> described below.**
+> ✅ **(a) DONE. (b) CLOSED — superseded by design §6.2.1, then measured out.
+> Do not implement the auto-answer sweep described below.**
 >
 > **(a)** All four hand-edit flows have in-engine answers now: fork
 > twin-marking (`mark_twin`, #656), order repair (first-class order items,
@@ -537,11 +537,40 @@ distinct cheap `confirm_twin` framing. The information is already computed.
 >
 > The governing rule is §6.2.1's: **auto-resolve only what the engine can
 > observe, never what it must assume.** On a cold member that yields
-> `record_neutral` (#764); on an *edited* member it yields a different
-> observable test — the source-side change is normalizer-equivalent, so the
-> twin is provably unaffected. Both are ordinary mechanical rows, so any
-> `--mechanical` flag is a *caller of existing rows*, never a new auto-answer
-> policy. Build notes in the handover.
+> `record_neutral` (#764). On an *edited* member it would yield a
+> normalizer-equivalence test — the source-side change is cosmetic, so the twin
+> is provably unaffected.
+>
+> **(b) is now CLOSED — measured out (2026-08-03).** `scripts/measure_sync_ceremony.py`
+> replays real commits and classifies every changed cell by the row it frames.
+> Over 200 commits of the reference course repo:
+>
+> | | rows | share of framed |
+> |---|---:|---:|
+> | `verify_translation` (both halves moved) | **1053** | **68.4%** |
+> | `translate_edit` (one half moved) | 487 | 31.6% |
+> | shared member moved — *already mechanical* | 346 | — |
+>
+> **The normalizer-equivalence row would remove 1 of 487 rows — 0.2%.** The
+> mechanism is real (v3 fingerprints are raw bytes, so unlike v1/v2 a re-wrap
+> does read as drift, #429) but the population is not: authors do not re-wrap
+> one half without touching content. A first count said 5.1%; it was wrong,
+> because cosmetic edits land overwhelmingly on *shared* cells
+> (`propagate_shared_edit`) or identically on both halves
+> (`record_symmetric_edit`) — neither is ceremony.
+>
+> **`uniform_drift_side` (#767) already covers the shape (b) was aimed at.** Of
+> the 57 (commit, deck) pairs framing ≥3 one-sided edits — the "N rows, one
+> decision" ceremony — **55 have every edit on one side**, exactly what that
+> observation fires on. Median one-sided edits per deck is **1**.
+>
+> **And the class (b) would have swept hardest is the one that most needs a
+> human.** `verify_translation` is 68% of framed rows, up to 32 in a single
+> deck, and fires precisely when *both halves moved apart* — the one shape where
+> the engine has positively observed a divergence it cannot resolve.
+> Auto-`confirm`ing it banks 1053 unread divergences. That volume is the real
+> open ceremony question and needs a different answer (better framing or
+> batching, not auto-answering); it is tracked separately.
 
 *Original recommendation (2026-07-29), for the record:* (a)
 Hand-edits: four flows *require* them today (fork twin-marking, order
@@ -701,12 +730,13 @@ open UX question, fine to defer behind everything above; corpus-gate split
 per #682 with the Phase-0 probe fixtures folded into the bundled corpus
 (D7).
 
-> **Read §7 Q5 and Q6 before starting either of the first two items.** Q5
-> shipped as a `uniform_drift_side` observation and the `drift:` field named
-> here was rejected; the `apply --mechanical` policy named here was superseded
-> by design note §6.2.1. Building either as written would undo a decision. P6,
-> P5 and D7 stand as written. Build order:
-> `docs/claude/handovers/sync-v3-q-register-handover.md`.
+> **Both of the first two items are CLOSED (2026-08-03); do not build them.**
+> Q5 shipped as a `uniform_drift_side` observation — the `drift:` field named
+> here was rejected. `apply --mechanical` (Q6b) was superseded by design
+> §6.2.1 and then **measured out**: the remaining normalizer-equivalence row
+> would remove 0.2% of `translate_edit` rows
+> (`scripts/measure_sync_ceremony.py`). P6, P5 and D7 stand as written. Build
+> order: `docs/claude/handovers/sync-v3-q-register-handover.md`.
 
 ---
 

--- a/scripts/measure_sync_ceremony.py
+++ b/scripts/measure_sync_ceremony.py
@@ -1,0 +1,187 @@
+"""Where does sync ceremony actually live? Measured from a course repo's history.
+
+Companion to ``measure_positional_composition.py`` (which asks what a *cold*
+deck costs). This one asks what *ongoing authoring* costs: it replays real
+commits and classifies every changed cell by the row it would frame.
+
+The distinction that matters, and that a naive count gets wrong: a cosmetic edit
+to a **shared** cell already resolves mechanically (``propagate_shared_edit``),
+and an identical edit to both halves is ``record_symmetric_edit``. Neither is
+ceremony. Only a **localized** member changed on **exactly one** half frames
+``translate_edit`` — a question. Counting all changed cells overstates the
+addressable population by ~25x (5.1% vs 0.2% on the reference repo).
+
+Three questions it answers:
+
+1. **Ceremony profile** — how the framed rows split between ``translate_edit``
+   (one half moved) and ``verify_translation`` (both moved apart).
+2. **The normalizer-equivalence candidate** (review Q6b) — of the real
+   ``translate_edit`` rows, how many are *cosmetic*: the source-side change is
+   normalizer-equivalent, so the twin is provably unaffected and the row could
+   resolve mechanically. v3 fingerprints are raw bytes, so unlike v1/v2 (which
+   hashed through ``normalize_for_hash``, #429) a pure re-wrap does read as
+   drift — the mechanism is real; this measures whether the population is.
+3. **Batching pressure** — how often one deck frames several one-sided edits at
+   once, and how often those all sit on the same side (what the
+   ``uniform_drift_side`` observation fires on).
+
+Usage::
+
+    python scripts/measure_sync_ceremony.py <course-repo> [commit-limit] [--since DATE]
+"""
+
+from __future__ import annotations
+
+import statistics
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+from clm.notebooks.slide_parser import comment_token_for_path
+from clm.slides.raw_cells import split_cells
+from clm.slides.sync_writeback import normalize_for_hash
+
+#: A deck frames this many one-sided edits before answering them row-by-row is
+#: worth calling ceremony. Matches ``_UNIFORM_DRIFT_MIN`` in ``sync_diff``.
+BATCH_THRESHOLD = 3
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    ).stdout
+
+
+def _cells(text: str, token: str) -> dict[str, tuple[str, bool]]:
+    """``key -> (raw cell text, is_localized)``; id'd cells key by id, else by ordinal."""
+    try:
+        _preamble, cells = split_cells(text, token)
+    except Exception:  # noqa: BLE001 - a mid-history parse failure just skips the file
+        return {}
+    out: dict[str, tuple[str, bool]] = {}
+    for index, cell in enumerate(cells):
+        sid = cell.metadata.slide_id
+        key = f"id:{sid}" if sid else f"pos:{index}"
+        out[key] = ("\n".join(cell.lines), 'lang="' in cell.lines[0])
+    return out
+
+
+def _body(cell_text: str) -> str:
+    return "\n".join(cell_text.split("\n")[1:])
+
+
+def main(repo: Path, limit: int, since: str) -> int:
+    commits = _git(
+        repo,
+        "log",
+        f"--since={since}",
+        "--format=%H",
+        "--",
+        "slides/**/*.de.py",
+        "slides/**/*.en.py",
+    ).split()[:limit]
+
+    stats: Counter = Counter()
+    per_deck: list[tuple[int, bool]] = []
+    cosmetic_samples: list[tuple[str, str]] = []
+
+    for sha in commits:
+        touched = [
+            f
+            for f in _git(
+                repo, "diff-tree", "--no-commit-id", "--name-only", "-r", sha
+            ).splitlines()
+            if f.startswith("slides/") and f.endswith((".de.py", ".en.py"))
+        ]
+        for stem in sorted({f.rsplit(".", 2)[0] for f in touched}):
+            de_path, en_path = f"{stem}.de.py", f"{stem}.en.py"
+            token = comment_token_for_path(Path(de_path))
+            before_de = _git(repo, "show", f"{sha}~1:{de_path}")
+            after_de = _git(repo, "show", f"{sha}:{de_path}")
+            before_en = _git(repo, "show", f"{sha}~1:{en_path}")
+            after_en = _git(repo, "show", f"{sha}:{en_path}")
+            if not all((before_de, after_de, before_en, after_en)):
+                continue  # deck created or deleted in this commit
+
+            a_de, b_de = _cells(before_de, token), _cells(after_de, token)
+            a_en, b_en = _cells(before_en, token), _cells(after_en, token)
+            edits = 0
+            sides: set[str] = set()
+
+            for key in set(a_de) & set(b_de) & set(a_en) & set(b_en):
+                de_moved = a_de[key][0] != b_de[key][0]
+                en_moved = a_en[key][0] != b_en[key][0]
+                if not (de_moved or en_moved):
+                    continue
+                if not (b_de[key][1] and b_en[key][1]):
+                    stats["shared member moved -> already mechanical"] += 1
+                    continue
+                if de_moved and en_moved:
+                    stats["localized, BOTH halves moved -> verify_translation"] += 1
+                    continue
+                stats["localized, ONE half moved -> translate_edit"] += 1
+                edits += 1
+                sides.add("de" if de_moved else "en")
+                old, new = (a_de, b_de) if de_moved else (a_en, b_en)
+                if normalize_for_hash(_body(old[key][0]), token) == normalize_for_hash(
+                    _body(new[key][0]), token
+                ):
+                    stats["  ...COSMETIC (normalizer-equivalent)"] += 1
+                    if len(cosmetic_samples) < 5:
+                        cosmetic_samples.append((Path(stem).name, key))
+            if edits:
+                per_deck.append((edits, len(sides) == 1))
+
+    framed = (
+        stats["localized, ONE half moved -> translate_edit"]
+        + stats["localized, BOTH halves moved -> verify_translation"]
+    )
+    print(f"commits replayed : {len(commits)}  (since {since})")
+    print(f"framed rows      : {framed}\n")
+    for key, n in stats.most_common():
+        share = f"{100 * n / max(framed, 1):5.1f}%" if not key.startswith(" ") else ""
+        print(f"  {key:<50} {n:>6} {share}")
+
+    edits = stats["localized, ONE half moved -> translate_edit"]
+    cosmetic = stats["  ...COSMETIC (normalizer-equivalent)"]
+    if edits:
+        print(
+            f"\nnormalizer-equivalence candidate: {cosmetic}/{edits} "
+            f"= {100 * cosmetic / edits:.1f}% of translate_edit rows"
+        )
+    if per_deck:
+        counts = [n for n, _ in per_deck]
+        batched = [(n, uniform) for n, uniform in per_deck if n >= BATCH_THRESHOLD]
+        print(
+            f"\nbatching: median {statistics.median(counts):.0f} translate_edit rows per "
+            f"(commit, deck), max {max(counts)}"
+        )
+        print(
+            f"  pairs framing >= {BATCH_THRESHOLD}: {len(batched)} of {len(per_deck)}; "
+            f"of those, {sum(u for _n, u in batched)} have every edit on ONE side "
+            f"(what `uniform_drift_side` fires on)"
+        )
+    if cosmetic_samples:
+        print("\ncosmetic samples:")
+        for name, key in cosmetic_samples:
+            print(f"  {name} {key}")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(__doc__)
+        raise SystemExit(2)
+    argv = sys.argv[1:]
+    since = "2025-08-01"
+    if "--since" in argv:
+        i = argv.index("--since")
+        since = argv[i + 1]
+        argv = argv[:i] + argv[i + 2 :]
+    raise SystemExit(main(Path(argv[0]), int(argv[1]) if len(argv) > 1 else 200, since))


### PR DESCRIPTION
Closes the second of the three remaining Q-register items — **by measuring it, not building it**. Refs #653, #773.

## What Q6b had left

Design §6.2.1 already rejected the review's `apply --mechanical` auto-answer sweep. What remained was a **normalizer-equivalence row**: resolve a `translate_edit` mechanically when the source-side change is cosmetic, so the twin is provably unaffected.

## Measured: 1 of 487 rows — 0.2%

`scripts/measure_sync_ceremony.py` replays real commits and classifies every changed cell by the row it frames. Over 200 commits of the reference course repo:

| framed row | count | share |
|---|---:|---:|
| **`verify_translation`** (both halves moved) | **1053** | **68.4%** |
| `translate_edit` (one half moved) | 487 | 31.6% |
| shared member moved — *already mechanical* | 346 | — |

**The mechanism is real; the population is not.** v3 fingerprints are raw bytes, so unlike v1/v2 — which hashed through `normalize_for_hash` precisely because a soft re-wrap otherwise reads as drift (#429) — a cosmetic edit *does* register in v3. Authors here just don't re-wrap one half without touching content.

**A first count said 5.1% and was wrong**, which is the main reason this ships as a script rather than a number in a doc. It counted every changed cell; cosmetic edits land overwhelmingly on *shared* cells (already `propagate_shared_edit`) or identically on both halves (already `record_symmetric_edit`) — neither is ceremony. Filtering to the only shape a normalizer row could help collapses it **25×**.

**`uniform_drift_side` (#767) already covers the shape Q6b targeted.** Of the 57 (commit, deck) pairs framing ≥3 one-sided edits — the "N rows, one decision" ceremony — **55 have every edit on one side**, exactly what that observation fires on. Median one-sided edits per deck is **1**.

## What the measurement surfaced instead

`verify_translation` is **68% of framed rows**, twice `translate_edit`, up to **32 in a single deck** — and it fires precisely when *both halves moved apart*, the one shape where the engine has positively **observed** a divergence it cannot resolve.

Q6b proposed auto-`confirm`ing it. That would bank **1053 unread divergences** — the silent-divergence class this whole programme exists to remove. So the largest ceremony class has no answer, and the obvious answer is the dangerous one.

Filed as **#773** with framing directions that don't involve auto-answering (show the per-side diff rather than two full cells; group by cause; separate structurally-parallel edits; batch the *writing* without batching the *reading*).

## Changes

- `scripts/measure_sync_ceremony.py` — new, companion to `measure_positional_composition.py` (that one measures **cold-start** cost; this one measures **ongoing authoring** cost). Re-runnable against any course repo.
- Review §7 Q6 banner: (b) marked **CLOSED, measured out**, with the table and the reasoning.
- Review §8 Phase 5: both of its first two items are now closed; the pointer says so.
- Handover: items 1 and 2 recorded as done/closed with their landmines; **Q4's delegation half is now the only build item left**.

## Verification

The committed script reproduces the numbers in the docs exactly. Full fast suite: **9403 passed**, 7 skipped, 1 xfailed. ruff clean. No source changes — docs and one script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qm9cCFzyYG61oQLb7Zmho8