### PR TITLE
fix(tests): pin norecursedirs so tests/build/ is collected again

### DIFF
--- a/changelog.d/776-pytest-collects-tests-build.fixed.md
+++ b/changelog.d/776-pytest-collects-tests-build.fixed.md
@@ -1,0 +1,6 @@
+- **`tests/build/` is collected again.** Pytest's default `norecursedirs`
+  contains `build`, so the `tests/build/` test package (split-source build
+  routing, shared-cell parity messages) was silently never collected by a bare
+  `pytest` — neither the pre-push hook nor any CI job ran it. `pyproject.toml`
+  now pins `norecursedirs` to the pytest default minus `build`; the 14
+  previously-invisible tests pass unchanged. (#776)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -238,6 +238,11 @@ include = [
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 testpaths = ["tests"]
+# Pytest's DEFAULT norecursedirs contains ``build``, which silently shadowed
+# the real test package ``tests/build/`` — nothing in it was ever collected by
+# a bare ``pytest`` (issue #776). This is the default list minus ``build``.
+# If you add a test directory, make sure its name is not on this list.
+norecursedirs = ["*.egg", ".*", "_darcs", "CVS", "dist", "node_modules", "venv", "{arch}"]
 python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]


### PR DESCRIPTION
Closes #776

## What

Pytest's default `norecursedirs` contains `build`, and CLM's `pyproject.toml` never overrode it — so the directory *name* shadowed the real test package `tests/build/`. A bare `pytest` (the pre-push hook and all four CI test jobs) collected **nothing** from it. This pins `norecursedirs` to the pytest default minus `build`, with a comment warning future test-directory naming.

## Findings while fixing

- `pytest --collect-only -q | grep -c tests/build`: **0 before, 14 after**.
- All 14 restored tests **pass unchanged** — no rot accumulated during the invisibility window (the #775 rescope means the `_check_shared_cell_parity` import is intact).
- Swept `tests/` for other names colliding with the default list (`dist`, `node_modules`, `venv`, `CVS`, `_darcs`, `*.egg`, `.*`): **none**.
- Chose the config pin over renaming the directory (`tests/build_pipeline/`) — no path churn, and the comment at the config site documents the trap where it would be re-introduced.

## Checks

- `pytest tests/build/` — 14 passed
- `pytest --collect-only` — tests/build collected (14 items)
- Full fast suite with the new collection — **9418 passed, 7 skipped, 1 xfailed in 69s**
- pre-commit (ruff/mypy) — passed (no Python files changed)

## Adversarial review

Fresh `deep-review` agent, verdict **CLEAN**. It independently confirmed: the pinned list matches the installed pytest 9.0.3 default (and pytest 7/8) minus `build`; the collection delta is exactly the 14 tests (9600 → 9614 collected, deselected unchanged); the tests are hermetic `tmp_path` tests needing no `serial` marker; every CI job and the pre-push hook run bare `pytest` and inherit the fix; `tests/__init__.py` prevents shadowing the PyPA `build` package. Two Minor advisories: the wholesale pin won't inherit future upstream default additions (documented at the config site; `.*` + `testpaths` cover the realistic cases), and one pre-existing restored test partially re-implements the gate it tests — filed as #778 rather than expanding this diff.

## Docs checklist

- `clm info` topics — n/a (no CLI/spec/course-repo behavior change)
- `changelog.d/776-pytest-collects-tests-build.fixed.md` — added
- The trap is documented as a comment at the config site in `pyproject.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh