### PR TITLE
docs(ci): Docker Integration Tests is a required check since #679

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,17 +275,17 @@ jobs:
   docker-test:
     name: Docker Integration Tests
     needs: changes
-    # Not a required status check, so it is safe to skip the whole job for
-    # docs-only changes.
+    # A REQUIRED status check since 2026-08-04 (#679): the image builds reach
+    # four external hosts and used to flake ~12% of runs, but the BuildKit
+    # layer cache + the retry loops in docker/notebook/Dockerfile (#678) held
+    # 25/25 consecutive green runs on master, so the job joined the
+    # `Require CI green` ruleset.
     #
-    # It is not required because its image builds reach four external hosts
-    # (Docker Hub, dot.net, astral.sh, the pinned GitHub release assets) and
-    # flaked ~12% of recent runs on registry timeouts and partial transfers —
-    # failures unrelated to the change under test. The layer cache below plus
-    # the retry loops in docker/notebook/Dockerfile exist to drive that toward
-    # zero, so this job can eventually join the ruleset. Until it does,
-    # remember: a green PR proves nothing about this job, and
-    # ``report-master-failure`` is what surfaces a breakage that slips through.
+    # The job-level skip below is safe for a required check: a job skipped by
+    # its `if:` reports conclusion `skipped`, which SATISFIES a required
+    # status check (only a check that never reports — workflow-level path
+    # filtering — would block the PR). Docs-only changes therefore still
+    # merge without paying the ~15-minute image builds.
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -388,17 +388,16 @@ jobs:
   # ------------------------------------------------------------------
   # A red master must be impossible to miss.
   #
-  # "Docker Integration Tests" is deliberately NOT a required status check
-  # (its image builds fetch from four external hosts and flake ~12% of the
-  # time on registry timeouts and partial transfers). That is a reasonable
-  # trade, but it has a sharp edge: a PR can be green and still break master,
-  # which is exactly what happened when PR #667 un-skipped a module containing
-  # docker-marked tests. Nothing surfaced it until someone happened to look.
-  #
-  # This job closes that gap for EVERY job in the workflow, not just docker:
-  # any failure on a push to the default branch files (or comments on) an
-  # issue within minutes. It never runs for pull requests — a red PR is
-  # already visible to the person who opened it.
+  # Historically "Docker Integration Tests" was not a required status check
+  # (external-host flakes), so a green PR could still break master — which
+  # happened when PR #667 un-skipped a module containing docker-marked tests
+  # and nothing surfaced it until someone happened to look. The job became
+  # required on 2026-08-04 (#679), closing that particular gap, but this
+  # reporter stays: it covers EVERY job in the workflow, including future
+  # non-required ones and the required-check bypass cases (a direct push, a
+  # ruleset bypass). Any failure on a push to the default branch files (or
+  # comments on) an issue within minutes. It never runs for pull requests —
+  # a red PR is already visible to the person who opened it.
   # ------------------------------------------------------------------
   report-master-failure:
     name: Report master failure
@@ -419,7 +418,7 @@ jobs:
           title: CI is failing on master
           label-description: A post-merge CI run on master failed
           context: >-
-            At least one job failed on `master` after a merge. Note that the
-            **Docker Integration Tests** job is not a required status check, so
-            a failure there can reach `master` through a fully green PR — check
-            it explicitly before assuming the required suites are at fault.
+            At least one job failed on `master` after a merge. All CI jobs,
+            including **Docker Integration Tests** (required since #679), gate
+            PR merges — so a failure here usually means a direct push, a
+            required-check bypass, or a flake that only reproduces on master.

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -439,8 +439,10 @@ in one job, and the Docker tier (images built from scratch) in another.
 That is the one thing PR CI structurally cannot do. A PR run tells you "this
 change is fine"; thirty runs of identical code tell you "this test is 3% flaky",
 which is how a contention regression like issue #163 surfaces before it wastes
-someone's afternoon. It also means a red Docker tier — not a required check —
-surfaces within a day even if nobody inspects the merge commit's CI.
+someone's afternoon. It also re-runs the Docker tier (a required PR check since
+#679, but skipped for docs-only changes) against unchanged master, so an
+environment-induced Docker breakage surfaces within a day even when no code PR
+happens to trigger it.
 
 (Dependency drift, the other usual nightly justification, barely applies here:
 CI installs from `uv.lock` with `UV_EXCLUDE_NEWER` pinned, so nothing moves


### PR DESCRIPTION
The maintainer approved promoting `Docker Integration Tests` to the `Require CI green` ruleset (#679's criterion was met: 25/25 consecutive non-skipped green runs on master since #678's BuildKit layer cache + installer retries). The ruleset now carries 10 contexts — the promotion itself is a repo-settings change, already applied and verified.

This PR updates the three places that documented the old trade-off:

- the `docker-test` job comment — now records the promotion and explains why the job-level `if:` skip is safe under a required check (a job skipped by its conditional reports conclusion `skipped`, which satisfies the ruleset; docs-only PRs still merge without paying the image builds);
- the `report-master-failure` rationale — the reporter stays despite the gate closing, because it covers direct pushes, ruleset bypasses, and master-only flakes for every job;
- `testing.md`'s nightly section — the nightly's Docker tier is now mainly an environment-rot detector, not the sole gate.

Refs #679.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh
