### PR TITLE
feat(build): render diagrams into img-generated/, migrate via clm course migrate-generated-images (#664)

### DIFF
--- a/changelog.d/664-img-generated-split.changed.md
+++ b/changelog.d/664-img-generated-split.changed.md
@@ -1,0 +1,13 @@
+- **Generated diagram renders move out of `img/` into `<topic>/img-generated/`
+  (#664).** The topic-level `img/` directory is now exclusively hand-authored —
+  the build never writes into it — while DrawIO/PlantUML renders live in the
+  build-owned `img-generated/` sibling, ending the shared-namespace ambiguity
+  behind the #661 nondeterminism class. Both directories collapse onto the
+  output's `img/`, so slide references (`img/x.png`) never change and a
+  migrated course builds a byte-identical output tree. New command
+  `clm course migrate-generated-images` moves a repo's committed renders
+  (spec-free, idempotent, conflict-safe, `--dry-run`); unmigrated repos keep
+  building exactly as before via a transitional rule (a committed legacy
+  render keeps its location until moved). Inline-image data URLs, the shared
+  and duplicated image modes, the image registry, and the stray-file sweep all
+  understand both layouts.

--- a/changelog.d/664-img-generated-split.changed.md
+++ b/changelog.d/664-img-generated-split.changed.md
@@ -1,13 +1,16 @@
 - **Generated diagram renders move out of `img/` into `<topic>/img-generated/`
-  (#664).** The topic-level `img/` directory is now exclusively hand-authored —
-  the build never writes into it — while DrawIO/PlantUML renders live in the
-  build-owned `img-generated/` sibling, ending the shared-namespace ambiguity
-  behind the #661 nondeterminism class. Both directories collapse onto the
-  output's `img/`, so slide references (`img/x.png`) never change and a
-  migrated course builds a byte-identical output tree. New command
-  `clm course migrate-generated-images` moves a repo's committed renders
-  (spec-free, idempotent, conflict-safe, `--dry-run`); unmigrated repos keep
-  building exactly as before via a transitional rule (a committed legacy
-  render keeps its location until moved). Inline-image data URLs, the shared
-  and duplicated image modes, the image registry, and the stray-file sweep all
-  understand both layouts.
+  (#664).** In a migrated repo the topic-level `img/` directory is exclusively
+  hand-authored — the build never writes into it — while DrawIO/PlantUML
+  renders live in the build-owned `img-generated/` sibling, ending the
+  shared-namespace ambiguity behind the #661 nondeterminism class. Both
+  directories collapse onto the output's `img/`, so slide references
+  (`img/x.png`) never change and a migrated course builds a byte-identical
+  output tree. New command `clm course migrate-generated-images` moves a
+  repo's committed renders (spec-free, idempotent, conflict-safe,
+  `--dry-run`); unmigrated repos keep building exactly as before via a
+  transitional rule (a committed legacy render keeps its location until
+  moved) and get one summary warning per course load naming the diagrams
+  still on the legacy target. Inline-image data URLs, the shared and
+  duplicated image modes, the image registry, the provenance manifest (what
+  the release pipeline copies from), and the stray-file sweep all understand
+  both layouts.

--- a/src/clm/cli/commands/course/__init__.py
+++ b/src/clm/cli/commands/course/__init__.py
@@ -18,6 +18,9 @@ def course_group() -> None:
 
 from clm.cli.commands.course.decks import spec_decks_cmd  # noqa: E402
 from clm.cli.commands.course.gate import course_gate_cmd  # noqa: E402
+from clm.cli.commands.course.migrate_generated_images import (  # noqa: E402
+    migrate_generated_images_cmd,
+)
 from clm.cli.commands.course.orphans import spec_orphans_cmd  # noqa: E402
 from clm.cli.commands.course.renumber import renumber_cmd  # noqa: E402
 from clm.cli.commands.course.resolve_topic import resolve_topic_cmd  # noqa: E402
@@ -28,6 +31,7 @@ course_group.add_command(spec_decks_cmd, name="decks")
 course_group.add_command(spec_orphans_cmd, name="orphans")
 course_group.add_command(list_targets, name="targets")
 course_group.add_command(course_gate_cmd, name="gate")
+course_group.add_command(migrate_generated_images_cmd, name="migrate-generated-images")
 course_group.add_command(renumber_cmd, name="renumber")
 course_group.add_command(resolve_topic_cmd, name="resolve-topic")
 course_group.add_command(sync_includes_cmd, name="sync-includes")

--- a/src/clm/cli/commands/course/migrate_generated_images.py
+++ b/src/clm/cli/commands/course/migrate_generated_images.py
@@ -1,0 +1,113 @@
+"""``clm course migrate-generated-images`` — the #664 layout migration.
+
+Moves committed DrawIO/PlantUML renders from the shared ``<topic>/img/``
+namespace into the build-owned ``<topic>/img-generated/`` sibling, so the
+invariant *"nothing in ``img/`` is ever written by the build; everything in
+``img-generated/`` only ever is"* becomes structural instead of inferred.
+
+Deliberately spec-free: the generated set is derived the same way
+``ImageFile.img_path`` derives it — a diagram source at
+``<topic>/{drawio,pu}/<stem>.<ext>`` renders to ``<topic>/img*/<sanitized
+stem>.{png,svg}`` — so the command covers the whole slides tree, including
+topics no spec currently references. Slide references (``img/x.png``) are
+output-relative and never rewritten; a correct migration produces a
+byte-identical output tree.
+
+Idempotent: an already-migrated render (legacy path gone) is a no-op; a
+duplicate (both locations, identical bytes) drops the legacy copy; diverging
+bytes are a conflict the command reports and refuses to touch — the build has
+been rendering to the legacy location while it existed, so the
+``img-generated/`` copy is the suspect one and a human must look.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from clm.core.utils.text_utils import sanitize_path
+from clm.infrastructure.utils.path_utils import (
+    DIAGRAM_SOURCE_EXTENSIONS,
+    GENERATED_IMG_DIR,
+    is_ignored_dir_for_course,
+)
+
+#: Both formats a repo may have committed over time — a course that switched
+#: ``image_format`` can carry a stale render in the other format beside the
+#: live one, and both are build-owned.
+_RENDER_EXTENSIONS = ("png", "svg")
+
+
+@click.command("migrate-generated-images")
+@click.argument(
+    "root",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=".",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Report what would move without touching any file.",
+)
+def migrate_generated_images_cmd(root: Path, dry_run: bool) -> None:
+    """Move committed diagram renders from img/ into img-generated/ (#664).
+
+    ROOT is a course root, a slides directory, or any subtree of one;
+    every topic below it is migrated. Idempotent — re-running after a
+    partial or completed migration is safe. Exits 1 when a conflict
+    (diverging bytes in both locations) needs a human decision.
+    """
+    moved: list[Path] = []
+    deduped: list[Path] = []
+    conflicts: list[Path] = []
+
+    for source in sorted(root.rglob("*")):
+        if not source.is_file() or source.suffix not in DIAGRAM_SOURCE_EXTENSIONS:
+            continue
+        if is_ignored_dir_for_course(source.parent):
+            continue
+        topic_dir = source.parents[1]
+        for ext in _RENDER_EXTENSIONS:
+            # The exact computation ImageFile.legacy_img_path/generated_img_path
+            # perform, so the moved names match what the build looks for.
+            legacy = sanitize_path((topic_dir / "img" / source.stem).with_suffix(f".{ext}"))
+            target = sanitize_path(
+                (topic_dir / GENERATED_IMG_DIR / source.stem).with_suffix(f".{ext}")
+            )
+            if not legacy.exists():
+                continue
+            if target.exists():
+                if target.read_bytes() == legacy.read_bytes():
+                    deduped.append(legacy)
+                    if not dry_run:
+                        legacy.unlink()
+                else:
+                    conflicts.append(legacy)
+                continue
+            moved.append(legacy)
+            if not dry_run:
+                target.parent.mkdir(parents=True, exist_ok=True)
+                legacy.rename(target)
+
+    prefix = "would move" if dry_run else "moved"
+    for path in moved:
+        click.echo(f"{prefix}: {path} -> {path.parents[1] / GENERATED_IMG_DIR / path.name}")
+    for path in deduped:
+        click.echo(
+            f"{'would drop' if dry_run else 'dropped'} duplicate legacy copy: {path} "
+            f"(byte-identical render already in {GENERATED_IMG_DIR}/)"
+        )
+    for path in conflicts:
+        click.echo(
+            f"CONFLICT: {path} and its {GENERATED_IMG_DIR}/ twin differ — the build "
+            "rendered to the legacy location while it existed, so the "
+            f"{GENERATED_IMG_DIR}/ copy is suspect; resolve by hand and re-run",
+            err=True,
+        )
+    click.echo(
+        f"{len(moved)} {prefix}, {len(deduped)} duplicate(s) dropped, "
+        f"{len(conflicts)} conflict(s)" + (" [dry run]" if dry_run else "")
+    )
+    if conflicts:
+        raise SystemExit(1)

--- a/src/clm/cli/commands/course/migrate_generated_images.py
+++ b/src/clm/cli/commands/course/migrate_generated_images.py
@@ -58,6 +58,11 @@ def migrate_generated_images_cmd(root: Path, dry_run: bool) -> None:
     partial or completed migration is safe. Exits 1 when a conflict
     (diverging bytes in both locations) needs a human decision.
     """
+    # Resolve first: with the default ROOT of ``.`` a shallow relative source
+    # path can have too few parents for the topic-dir derivation (a raw
+    # IndexError, review finding M1), and the containment check below needs
+    # absolute paths on both sides.
+    root = root.resolve()
     moved: list[Path] = []
     deduped: list[Path] = []
     conflicts: list[Path] = []
@@ -68,6 +73,11 @@ def migrate_generated_images_cmd(root: Path, dry_run: bool) -> None:
         if is_ignored_dir_for_course(source.parent):
             continue
         topic_dir = source.parents[1]
+        # A source directly under ROOT derives ROOT's *parent* as its topic
+        # dir; the contract is "every topic below ROOT", so never reach
+        # outside it (review finding M2).
+        if topic_dir != root and root not in topic_dir.parents:
+            continue
         for ext in _RENDER_EXTENSIONS:
             # The exact computation ImageFile.legacy_img_path/generated_img_path
             # perform, so the moved names match what the build looks for.

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1030,6 +1030,33 @@ clm course renumber module_550_ml_azav --spec course-specs/ml.xml
 clm course renumber --spec course-specs/ml.xml --start 10 --step 10 --json
 ```
 
+### `clm course migrate-generated-images`
+
+Move committed DrawIO/PlantUML renders from `<topic>/img/` into the
+build-owned `<topic>/img-generated/` sibling (the #664 layout, CLM {version}).
+
+```
+clm course migrate-generated-images [ROOT] [--dry-run]
+```
+
+`ROOT` is a course root, a slides directory, or any subtree (default: the
+current directory); the command is spec-free and covers every topic below it.
+It derives the generated set exactly the way the build does — a diagram source
+at `<topic>/{drawio,pu}/<stem>` renders to the sanitized
+`<topic>/img/<stem>.{png,svg}` — moves those files, and reports each move.
+Hand-authored files in `img/` are never touched; slide references
+(`img/x.png`) are output-relative and are **not** rewritten (both directories
+collapse to the output's `img/`), so a correct migration produces a
+byte-identical output tree.
+
+Idempotent: re-running is safe. A byte-identical duplicate in both locations
+drops the legacy copy; diverging copies are reported as a **conflict**, left
+untouched, and exit 1 — resolve by hand and re-run. Use `--dry-run` to preview.
+
+After migrating, commit the moves. Unmigrated repos keep building exactly as
+before: a committed legacy render keeps `img/` as its render target until it
+is moved.
+
 ### `clm course gate`
 
 Run the mechanical conversion passes over a course and report **readiness** —

--- a/src/clm/cli/info_topics/commands.md
+++ b/src/clm/cli/info_topics/commands.md
@@ -1051,7 +1051,8 @@ byte-identical output tree.
 
 Idempotent: re-running is safe. A byte-identical duplicate in both locations
 drops the legacy copy; diverging copies are reported as a **conflict**, left
-untouched, and exit 1 — resolve by hand and re-run. Use `--dry-run` to preview.
+untouched, and exit 1 — resolve by hand and re-run. `--dry-run` previews and
+uses the same exit codes (1 = conflicts exist), so it is CI-able.
 
 After migrating, commit the moves. Unmigrated repos keep building exactly as
 before: a committed legacy render keeps `img/` as its render target until it

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -29,7 +29,14 @@ keeps rendering there. To migrate a course repo:
 
 Expect a one-time cache invalidation on the next build (source paths feed the
 cache keys). New diagrams always render to `img-generated/`, so an unmigrated
-repo that adds one becomes mixed — harmless, but migrating once is tidier.
+repo that adds one becomes mixed — functional (both layouts are fully
+understood, including by the provenance manifest the release pipeline copies
+from), and every course load logs one summary warning naming the diagrams
+that still render to the legacy location, so the migration nudge is visible
+until it is done. The same warning is the signal for the reverse accident: a
+legacy render resurrected into a migrated repo (a merge from an old branch)
+silently flips that diagram's render target back until the file is removed
+or re-migrated.
 
 ## German text in a shared code cell now fails `clm validate` ({version})
 

--- a/src/clm/cli/info_topics/migration.md
+++ b/src/clm/cli/info_topics/migration.md
@@ -2,6 +2,35 @@
 
 This guide covers breaking changes across major CLM versions.
 
+## Generated diagram renders move to `<topic>/img-generated/` (#664, {version})
+
+**Breaking only in the source-tree layout; the output tree is byte-identical
+and no slide reference changes.** `<topic>/img/` used to hold both
+hand-authored assets and the DrawIO/PlantUML renders; the build now renders
+into the build-owned sibling `<topic>/img-generated/`, making the split
+structural: nothing in `img/` is ever written by the build, everything in
+`img-generated/` only ever is. Both directories collapse onto the output's
+`img/`, so references like `<img src="img/compiler.svg">` keep working
+unchanged.
+
+**Unmigrated repos keep building exactly as before**: a diagram whose
+committed render still sits at the legacy `<topic>/img/<stem>.<ext>` location
+keeps rendering there. To migrate a course repo:
+
+1. `clm course migrate-generated-images <course-root> --dry-run` — preview.
+2. Run it without `--dry-run`; it moves exactly the generated set (derived
+   from the `drawio/`/`pu/` sources), is idempotent, and exits 1 on a
+   conflict (diverging bytes in both locations — resolve by hand, re-run).
+3. Commit the moves. Keep committing renders — machines without the diagram
+   toolchain need them.
+4. Optional but recommended: verify with the built-in harness — build once
+   before migrating with `--snapshot DIR`, once after with
+   `--verify-against DIR`. A correct migration reports no differences.
+
+Expect a one-time cache invalidation on the next build (source paths feed the
+cache keys). New diagrams always render to `img-generated/`, so an unmigrated
+repo that adds one becomes mixed — harmless, but migrating once is tidier.
+
 ## German text in a shared code cell now fails `clm validate` ({version})
 
 **Breaking only for a repo whose shared (no-`lang`) code cells still carry

--- a/src/clm/cli/info_topics/spec-files.md
+++ b/src/clm/cli/info_topics/spec-files.md
@@ -1116,7 +1116,7 @@ layouts). Within it, CLM distinguishes three kinds of file:
 | Kind | Examples | Copied to output? |
 |---|---|---|
 | **Core source** | `slides_*.<ext>` (incl. split `slides_*.de.<ext>` / `slides_*.en.<ext>`) | processed into notebooks/HTML |
-| **Output companions** | `img/`, `drawio/`, loose data files | **yes**, verbatim |
+| **Output companions** | `img/`, `img-generated/`, `drawio/`, loose data files | **yes**, verbatim (both image dirs land under the output's `img/`) |
 | **Authoring sidecars** | `voiceover_*.<ext>`, `*.http-cassette.yaml` | **no** |
 | **Build-internal tree** | `.clm/` — committed: `cassettes/` (replay input), `sync-ledger.json`; ignored scratch: legacy `voiceover-cache/`, `voiceover-backfill/`, `voiceover-traces/`, `config.toml`. Likewise `.clm-cache/` (the shared LLM + voiceover cache root, usually at the project root) is fully ignored wherever it appears | **no** — `.clm/cassettes/` is a build *input* (read at runtime) but never copied to output; the rest is fully ignored everywhere |
 
@@ -1130,10 +1130,26 @@ tree — `clm slides tidy` migrates a legacy top-level `cassettes/`):
 topic_070_rag_introduction/
 ├── .clm/cassettes/ # *.http-cassette.yaml      (also accepted: legacy top-level cassettes/ , _cassettes/)
 ├── voiceover/      # voiceover_*.<ext>
-├── drawio/  img/   # output companions (unchanged)
+├── drawio/  pu/    # diagram sources
+├── img/            # hand-authored assets — NEVER written by the build (CLM {version}, #664)
+├── img-generated/  # DrawIO/PlantUML renders — ONLY ever written by the build
 ├── slides_010_what_is_rag.de.py
 └── slides_010_what_is_rag.en.py
 ```
+
+**The two image directories (CLM {version}, #664).** `img/` holds hand-authored
+assets (screenshots, photos, hand-drawn SVGs); `img-generated/` holds the
+committed DrawIO/PlantUML renders. The invariant is structural: nothing in
+`img/` is ever written by the build, everything in `img-generated/` only ever
+is. Both collapse onto the **same** output namespace — a render at
+`img-generated/compiler.svg` still lands at `<course>/img/compiler.svg` — so
+slide references keep saying `img/...` and never change. Keep committing the
+renders (a machine without the diagram toolchain needs them). Transitional
+rule for unmigrated repos: a diagram whose committed render still sits at the
+legacy `<topic>/img/<stem>.<ext>` location keeps rendering **there**; run
+`clm course migrate-generated-images` (see `clm info commands`) to move the
+generated set — the migration changes no slide references and produces a
+byte-identical output tree.
 
 Both layouts work everywhere (build, `extract`/`inline`/`sync`, `split`/`unify`,
 `validate`); they are auto-detected by directory presence, so no spec change is

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -1154,7 +1154,10 @@ class Course(NotebookMixin):
             self.dir_groups.append(DirGroup.from_spec(dictionary_spec, self))
 
     def _add_source_output_files(self):
+        from clm.core.course_files.image_file import ImageFile
+
         logger.debug("Adding source output files.")
+        legacy_targets: list[Path] = []
         for topic in self.topics:
             for file in topic.files:
                 for new_file in file.source_outputs:
@@ -1170,6 +1173,30 @@ class Course(NotebookMixin):
                     if mark is not None:
                         mark()
                     logger.debug(f"Added source output file: {new_file}")
+                if isinstance(file, ImageFile) and file.img_path == file.legacy_img_path:
+                    legacy_targets.append(file.path)
+        if legacy_targets:
+            # #664 review finding M3: the transitional rule means a legacy
+            # render resurrected into a MIGRATED repo (a merge from an old
+            # branch, a stray copy) silently flips the render target back —
+            # with the img-generated/ twin now a second, byte-identical writer
+            # that DEDUPs without a signal. One summary line per build is the
+            # signal, and doubles as the migration nudge for unmigrated repos.
+            logger.warning(
+                f"{len(legacy_targets)} diagram(s) still render to the legacy "
+                f"<topic>/img/ location — run `clm course migrate-generated-images` "
+                f"to move them to img-generated/ (#664). First: {legacy_targets[0]}"
+            )
+            self.loading_warnings.append(
+                {
+                    "category": "legacy_img_render_target",
+                    "message": (
+                        f"{len(legacy_targets)} diagram(s) render to the legacy "
+                        "<topic>/img/ location — run `clm course migrate-generated-images`"
+                    ),
+                    "details": {"sources": [str(p) for p in legacy_targets]},
+                }
+            )
 
     def _collect_images(self):
         """Collect all images from course files into the image registry.

--- a/src/clm/core/course_files/duplicated_image_file.py
+++ b/src/clm/core/course_files/duplicated_image_file.py
@@ -114,7 +114,7 @@ class DuplicatedImageFile(CourseFile):
         return Concurrently(
             CopyFileOperation(
                 input_file=self,
-                output_file=self.output_dir(output_dir, lang) / self.relative_path,
+                output_file=self.output_dir(output_dir, lang) / self._output_relative_path,
             )
             for lang, _, _, output_dir in output_specs(
                 self.course,
@@ -124,3 +124,19 @@ class DuplicatedImageFile(CourseFile):
                 target=target,
             )
         )
+
+    @property
+    def _output_relative_path(self) -> Path:
+        """The source-relative path with ``img-generated`` collapsed to ``img``.
+
+        Both image directories share one output namespace (#664): slide
+        references say ``img/...`` and must keep resolving after a source
+        moves to ``img-generated/``, so the output tree only ever contains
+        ``img/``.
+        """
+        from clm.infrastructure.utils.path_utils import GENERATED_IMG_DIR
+
+        rel = self.relative_path
+        if GENERATED_IMG_DIR not in rel.parts:
+            return rel
+        return Path(*("img" if part == GENERATED_IMG_DIR else part for part in rel.parts))

--- a/src/clm/core/course_files/duplicated_image_file.py
+++ b/src/clm/core/course_files/duplicated_image_file.py
@@ -114,7 +114,7 @@ class DuplicatedImageFile(CourseFile):
         return Concurrently(
             CopyFileOperation(
                 input_file=self,
-                output_file=self.output_dir(output_dir, lang) / self._output_relative_path,
+                output_file=self.output_dir(output_dir, lang) / self.output_relative_path,
             )
             for lang, _, _, output_dir in output_specs(
                 self.course,
@@ -126,17 +126,25 @@ class DuplicatedImageFile(CourseFile):
         )
 
     @property
-    def _output_relative_path(self) -> Path:
-        """The source-relative path with ``img-generated`` collapsed to ``img``.
+    def output_relative_path(self) -> Path:
+        """The source-relative path with a leading ``img-generated`` collapsed to ``img``.
 
         Both image directories share one output namespace (#664): slide
         references say ``img/...`` and must keep resolving after a source
         moves to ``img-generated/``, so the output tree only ever contains
-        ``img/``.
+        ``img/``. Public because the provenance manifest must enumerate the
+        SAME path the copy writes — using the raw ``relative_path`` there
+        silently dropped every migrated render from the manifest, and the
+        release pipeline copies by manifest (review finding H1).
+
+        Only the FIRST component collapses: the render target is always
+        topic-level, and a hand-authored file that happens to live under a
+        deeper directory named ``img-generated`` keeps its pre-#664 verbatim
+        copy (review finding L1).
         """
         from clm.infrastructure.utils.path_utils import GENERATED_IMG_DIR
 
         rel = self.relative_path
-        if GENERATED_IMG_DIR not in rel.parts:
-            return rel
-        return Path(*("img" if part == GENERATED_IMG_DIR else part for part in rel.parts))
+        if rel.parts and rel.parts[0] == GENERATED_IMG_DIR:
+            return Path("img", *rel.parts[1:])
+        return rel

--- a/src/clm/core/course_files/image_file.py
+++ b/src/clm/core/course_files/image_file.py
@@ -17,17 +17,56 @@ class ImageFile(CourseFile):
     """
 
     @property
-    def img_path(self) -> Path:
-        """Path to the generated image.
+    def generated_img_path(self) -> Path:
+        """The #664 render target: ``<topic>/img-generated/<stem>.<ext>``.
 
-        Images are generated in an 'img' subdirectory relative to the
-        file's parent directory, with the same stem but format-appropriate extension.
+        The build-owned sibling of the hand-authored ``img/`` — nothing in
+        ``img/`` is ever written by the build, everything here only ever is.
+        """
+        from clm.core.utils.text_utils import sanitize_path
+        from clm.infrastructure.utils.path_utils import GENERATED_IMG_DIR
+
+        ext = f".{self.course.image_format}"
+        unsanitized = (self.path.parents[1] / GENERATED_IMG_DIR / self.path.stem).with_suffix(ext)
+        return sanitize_path(unsanitized)
+
+    @property
+    def legacy_img_path(self) -> Path:
+        """The pre-#664 render target: ``<topic>/img/<stem>.<ext>``.
+
+        Only still rendered to when a committed legacy render sits there
+        (see :attr:`img_path`); ``clm course migrate-generated-images``
+        moves such files to :attr:`generated_img_path`.
         """
         from clm.core.utils.text_utils import sanitize_path
 
         ext = f".{self.course.image_format}"
         unsanitized = (self.path.parents[1] / "img" / self.path.stem).with_suffix(ext)
         return sanitize_path(unsanitized)
+
+    @property
+    def img_path(self) -> Path:
+        """Path to the generated image.
+
+        Since #664 images render into the build-owned ``img-generated/``
+        sibling of ``img/`` — with one transitional exception: a repo that
+        still keeps a *committed* render at the legacy ``<topic>/img/``
+        location keeps rendering there, so an unmigrated checkout builds
+        exactly as before (rendering to the new directory while the stale
+        legacy copy still ships as a hand-authored-looking image would have
+        both copied to the same output path, resurrecting the #661 conflict
+        class). ``clm course migrate-generated-images`` moves the files;
+        after that — and for any freshly added diagram — the new directory
+        is the only target.
+
+        Disk-dependent, deliberately: the choice is stable within a build
+        (the legacy file either exists at course load or it does not), and
+        the first render into ``img-generated/`` makes it permanent.
+        """
+        legacy = self.legacy_img_path
+        if legacy.exists():
+            return legacy
+        return self.generated_img_path
 
     @property
     def source_outputs(self) -> frozenset[Path]:

--- a/src/clm/core/image_registry.py
+++ b/src/clm/core/image_registry.py
@@ -18,28 +18,33 @@ logger = logging.getLogger(__name__)
 
 
 def get_relative_img_path(source_path: Path) -> str:
-    """Get the relative path from the img/ folder for an image file.
+    """Get the relative path from the image folder for an image file.
 
     For a path like /course/slides/module/topic/img/foo/bar.png, this returns
     "foo/bar.png". For a path like /course/slides/module/topic/img/bar.png,
-    this returns "bar.png".
+    this returns "bar.png". The build-owned ``img-generated/`` sibling (#664)
+    is recognized the same way, so both directories collapse onto one
+    namespace — which is what puts a migrated render at the *same* output
+    location (``<course>/img/...``) as before the migration.
 
-    If no "img" folder is found in the path, returns just the filename.
+    If neither folder is found in the path, returns just the filename.
 
     Args:
         source_path: Full path to the image file
 
     Returns:
-        The relative path from the img/ folder, using forward slashes
+        The relative path from the image folder, using forward slashes
     """
+    from clm.infrastructure.utils.path_utils import IMG_DIRS
+
     parts = source_path.parts
-    # Find the img folder in the path (searching from the end)
+    # Find the image folder in the path (searching from the end)
     for i in range(len(parts) - 1, -1, -1):
-        if parts[i] == "img":
-            # Return all parts after "img" joined with /
+        if parts[i] in IMG_DIRS:
+            # Return all parts after the folder joined with /
             rel_parts = parts[i + 1 :]
             return "/".join(rel_parts)
-    # Fallback to just the filename if no img folder found
+    # Fallback to just the filename if no image folder found
     return source_path.name
 
 

--- a/src/clm/core/output_write_registry.py
+++ b/src/clm/core/output_write_registry.py
@@ -94,9 +94,14 @@ def is_image_path(source_path: Path) -> bool:
     This one selects the sources that additionally need an
     ``ImageRegistry.record_output_write`` call. Mirrors
     :func:`clm.core.image_registry.get_relative_img_path`'s detection rule
-    (presence of an ``img`` segment in the path).
+    (presence of an ``img`` or ``img-generated`` segment in the path, #664 —
+    without the latter, a migrated render's output copies would be absent
+    from the image registry's tracked set and the stray-file sweep would
+    delete them).
     """
-    return "img" in source_path.parts
+    from clm.infrastructure.utils.path_utils import IMG_DIRS
+
+    return bool(IMG_DIRS.intersection(source_path.parts))
 
 
 class WriteOutcome(Enum):

--- a/src/clm/core/provenance_manifest.py
+++ b/src/clm/core/provenance_manifest.py
@@ -150,11 +150,21 @@ def enumerate_expected_outputs(
             if isinstance(file, DataFile) and is_ignored_file_for_output(file.path):
                 continue
             asset_format = "image" if isinstance(file, DuplicatedImageFile) else "data"
+            # A duplicated image copies to its COLLAPSED path (#664:
+            # ``img-generated/`` lands under the output's ``img/``). The
+            # manifest must enumerate what the copy writes, or every migrated
+            # render is silently dropped from ``.clm-manifest.json`` — and the
+            # release pipeline copies by manifest (review finding H1).
+            rel_path = (
+                file.output_relative_path
+                if isinstance(file, DuplicatedImageFile)
+                else file.relative_path
+            )
             for lang, _fmt, _kind, output_dir in output_specs(
                 course, target.output_root, target=target
             ):
                 try:
-                    out_path = file.output_dir(output_dir, lang) / file.relative_path
+                    out_path = file.output_dir(output_dir, lang) / rel_path
                 except (KeyError, ValueError) as e:
                     logger.debug("provenance: skip asset %s (%s): %s", file.path, lang, e)
                     continue

--- a/src/clm/infrastructure/utils/path_utils.py
+++ b/src/clm/infrastructure/utils/path_utils.py
@@ -166,6 +166,16 @@ IMG_FILE_EXTENSIONS = frozenset({".png", ".jpg", ".jpeg", ".gif", ".svg"})
 
 IMG_DATA_FOLDERS = frozenset({"imgdata"})
 
+# The two topic-level image directories (#664). ``img/`` is hand-authored and
+# never written by the build; ``img-generated/`` holds the DrawIO/PlantUML
+# renders and is only ever written by the build. Both collapse to ``img/`` in
+# every output tree, so slide references (``<img src="img/x.png">``) never
+# change. ``img/`` remains a *legal* render target only for unmigrated repos
+# (a committed legacy render keeps its location until
+# ``clm course migrate-generated-images`` moves it).
+GENERATED_IMG_DIR = "img-generated"
+IMG_DIRS = frozenset({"img", GENERATED_IMG_DIR})
+
 IMG_SOURCE_FILE_EXTENSIONS = frozenset({".pu", ".drawio", ".psd", ".xfc"})
 
 SUPPORTED_PROG_LANG_EXTENSIONS = frozenset(

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -9,7 +9,7 @@ from base64 import b64decode
 from collections.abc import Iterable
 from dataclasses import dataclass
 from hashlib import sha3_224
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, cast
 
@@ -1546,15 +1546,24 @@ class NotebookProcessor:
             if image_url.startswith(("data:", "http:", "https:")):
                 return match_tag
 
-            # Try reading from filesystem first
+            # Try reading from filesystem first. References always say
+            # ``img/...``, but since #664 a generated render lives in the
+            # build-owned ``img-generated/`` sibling — same output location,
+            # different source location — so a miss under ``img/`` retries
+            # there before giving up on the filesystem.
             image_data: bytes | None = None
             if source_dir:
-                image_path = source_dir / image_url
-                if image_path.is_file():
-                    try:
-                        image_data = image_path.read_bytes()
-                    except OSError:
-                        pass
+                candidates = [source_dir / image_url]
+                url_path = PurePosixPath(image_url)
+                if url_path.parts and url_path.parts[0] == "img":
+                    candidates.append(source_dir / "img-generated" / Path(*url_path.parts[1:]))
+                for image_path in candidates:
+                    if image_path.is_file():
+                        try:
+                            image_data = image_path.read_bytes()
+                            break
+                        except OSError:
+                            pass
 
             # Fall back to other_files payload
             if image_data is None and image_url in payload.other_files:

--- a/tests/cli/test_migrate_generated_images.py
+++ b/tests/cli/test_migrate_generated_images.py
@@ -126,19 +126,31 @@ class TestMigration:
 
     def test_running_from_inside_a_topic_works_with_the_default_root(self, runner, tmp_path):
         """Review M1: with ROOT defaulting to ``.``, shallow relative source
-        paths used to crash on ``parents[1]``. Resolving ROOT makes running
-        from inside a topic directory both safe and useful."""
+        paths used to crash on ``parents[1]``. The crash shape is a ONE-part
+        relative source — cwd directly containing the ``.pu`` (running from
+        inside ``<topic>/pu/``), where an unresolved ``parents[1]`` does not
+        exist (review R2-1: chdir'ing into the topic yields two-part paths,
+        which never crashed). Resolving ROOT makes both shapes safe."""
         topic = _topic(tmp_path)
         (topic / "img" / "diag.png").write_bytes(b"render")
 
         cwd = Path.cwd()
-        os.chdir(topic)
+        os.chdir(topic / "pu")
         try:
-            result = runner.invoke(migrate_generated_images_cmd, [])
+            inside_pu = runner.invoke(migrate_generated_images_cmd, [])
         finally:
             os.chdir(cwd)
+        # From inside pu/ the derived topic dir is cwd's PARENT — outside the
+        # resolved root, so the M2 guard skips it rather than crashing.
+        assert inside_pu.exit_code == 0, inside_pu.output
+        assert (topic / "img" / "diag.png").exists()
 
-        assert result.exit_code == 0, result.output
+        os.chdir(topic)
+        try:
+            inside_topic = runner.invoke(migrate_generated_images_cmd, [])
+        finally:
+            os.chdir(cwd)
+        assert inside_topic.exit_code == 0, inside_topic.output
         assert (topic / "img-generated" / "diag.png").exists()
 
     def test_never_reaches_outside_the_given_root(self, runner, tmp_path):

--- a/tests/cli/test_migrate_generated_images.py
+++ b/tests/cli/test_migrate_generated_images.py
@@ -1,0 +1,140 @@
+"""``clm course migrate-generated-images`` — the #664 migration command.
+
+Moves committed DrawIO/PlantUML renders from ``<topic>/img/`` into the
+build-owned ``<topic>/img-generated/``. Pinned here: it moves exactly the
+generated set (hand-authored files stay), matches ``ImageFile``'s sanitized
+naming, is idempotent, drops byte-identical duplicates, refuses diverging
+conflicts with exit 1, honors ``--dry-run``, and skips ignored trees.
+"""
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from clm.cli.commands.course.migrate_generated_images import migrate_generated_images_cmd
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _topic(root: Path, name: str = "topic_100_t") -> Path:
+    topic = root / "slides" / "module_100_m" / name
+    (topic / "pu").mkdir(parents=True)
+    (topic / "drawio").mkdir()
+    (topic / "img").mkdir()
+    (topic / "pu" / "diag.pu").write_text("@startuml\n@enduml\n", encoding="utf-8")
+    (topic / "drawio" / "drawing.drawio").write_text("<mxfile/>", encoding="utf-8")
+    return topic
+
+
+class TestMigration:
+    def test_moves_generated_renders_and_leaves_hand_authored_files(self, runner, tmp_path):
+        topic = _topic(tmp_path)
+        (topic / "img" / "diag.png").write_bytes(b"pu render")
+        (topic / "img" / "drawing.png").write_bytes(b"drawio render")
+        (topic / "img" / "photo.png").write_bytes(b"hand-authored")
+
+        result = runner.invoke(migrate_generated_images_cmd, [str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert (topic / "img-generated" / "diag.png").read_bytes() == b"pu render"
+        assert (topic / "img-generated" / "drawing.png").read_bytes() == b"drawio render"
+        assert (topic / "img" / "photo.png").exists(), "hand-authored files must stay"
+        assert not (topic / "img" / "diag.png").exists()
+        assert "2 moved" in result.output
+
+    def test_both_render_formats_move(self, runner, tmp_path):
+        """A repo that switched image_format carries stale renders in the
+        other format — both are build-owned."""
+        topic = _topic(tmp_path)
+        (topic / "img" / "diag.png").write_bytes(b"png render")
+        (topic / "img" / "diag.svg").write_bytes(b"svg render")
+
+        result = runner.invoke(migrate_generated_images_cmd, [str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert (topic / "img-generated" / "diag.png").exists()
+        assert (topic / "img-generated" / "diag.svg").exists()
+
+    def test_idempotent_second_run_is_a_no_op(self, runner, tmp_path):
+        topic = _topic(tmp_path)
+        (topic / "img" / "diag.png").write_bytes(b"render")
+        assert runner.invoke(migrate_generated_images_cmd, [str(tmp_path)]).exit_code == 0
+
+        second = runner.invoke(migrate_generated_images_cmd, [str(tmp_path)])
+
+        assert second.exit_code == 0
+        assert "0 moved, 0 duplicate(s) dropped, 0 conflict(s)" in second.output
+        assert (topic / "img-generated" / "diag.png").read_bytes() == b"render"
+
+    def test_a_byte_identical_duplicate_is_dropped(self, runner, tmp_path):
+        topic = _topic(tmp_path)
+        (topic / "img" / "diag.png").write_bytes(b"render")
+        (topic / "img-generated").mkdir()
+        (topic / "img-generated" / "diag.png").write_bytes(b"render")
+
+        result = runner.invoke(migrate_generated_images_cmd, [str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert not (topic / "img" / "diag.png").exists()
+        assert "1 duplicate(s) dropped" in result.output
+
+    def test_diverging_copies_are_a_conflict_and_exit_1(self, runner, tmp_path):
+        topic = _topic(tmp_path)
+        (topic / "img" / "diag.png").write_bytes(b"the build rendered this")
+        (topic / "img-generated").mkdir()
+        (topic / "img-generated" / "diag.png").write_bytes(b"something else entirely")
+
+        result = runner.invoke(migrate_generated_images_cmd, [str(tmp_path)])
+
+        assert result.exit_code == 1
+        assert (topic / "img" / "diag.png").exists(), "a conflict must not be touched"
+        assert (topic / "img-generated" / "diag.png").read_bytes() == b"something else entirely"
+        assert "CONFLICT" in result.output
+
+    def test_dry_run_reports_but_moves_nothing(self, runner, tmp_path):
+        topic = _topic(tmp_path)
+        (topic / "img" / "diag.png").write_bytes(b"render")
+
+        result = runner.invoke(migrate_generated_images_cmd, [str(tmp_path), "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "would move" in result.output
+        assert (topic / "img" / "diag.png").exists()
+        assert not (topic / "img-generated").exists()
+
+    def test_sanitized_render_names_are_matched(self, runner, tmp_path):
+        """The command must find exactly the name the build writes —
+        ``ImageFile.img_path`` sanitizes the stem, so the lookup must too."""
+        from clm.core.utils.text_utils import sanitize_path
+
+        topic = _topic(tmp_path)
+        source = topic / "pu" / "Über Diagramm.pu"
+        source.write_text("@startuml\n@enduml\n", encoding="utf-8")
+        legacy = sanitize_path((topic / "img" / source.stem).with_suffix(".png"))
+        legacy.write_bytes(b"render")
+
+        result = runner.invoke(migrate_generated_images_cmd, [str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        expected = sanitize_path((topic / "img-generated" / source.stem).with_suffix(".png"))
+        assert expected.exists()
+
+    def test_ignored_trees_are_skipped(self, runner, tmp_path):
+        """A diagram source inside e.g. ``__pycache__``/``.venv`` must not
+        drive a move (mirrors the course scan's ignore rules): a vendored
+        package can ship ``.pu`` files, and its neighbors are not ours."""
+        ghost_topic = tmp_path / "slides" / "__pycache__" / "topic_999_ghost"
+        (ghost_topic / "pu").mkdir(parents=True)
+        (ghost_topic / "img").mkdir()
+        (ghost_topic / "pu" / "ghost.pu").write_text("@startuml\n@enduml\n", encoding="utf-8")
+        (ghost_topic / "img" / "ghost.png").write_bytes(b"not ours to move")
+
+        result = runner.invoke(migrate_generated_images_cmd, [str(tmp_path)])
+
+        assert result.exit_code == 0
+        assert (ghost_topic / "img" / "ghost.png").exists()
+        assert not (ghost_topic / "img-generated").exists()

--- a/tests/cli/test_migrate_generated_images.py
+++ b/tests/cli/test_migrate_generated_images.py
@@ -7,6 +7,7 @@ naming, is idempotent, drops byte-identical duplicates, refuses diverging
 conflicts with exit 1, honors ``--dry-run``, and skips ignored trees.
 """
 
+import os
 from pathlib import Path
 
 import pytest
@@ -122,6 +123,40 @@ class TestMigration:
         assert result.exit_code == 0, result.output
         expected = sanitize_path((topic / "img-generated" / source.stem).with_suffix(".png"))
         assert expected.exists()
+
+    def test_running_from_inside_a_topic_works_with_the_default_root(self, runner, tmp_path):
+        """Review M1: with ROOT defaulting to ``.``, shallow relative source
+        paths used to crash on ``parents[1]``. Resolving ROOT makes running
+        from inside a topic directory both safe and useful."""
+        topic = _topic(tmp_path)
+        (topic / "img" / "diag.png").write_bytes(b"render")
+
+        cwd = Path.cwd()
+        os.chdir(topic)
+        try:
+            result = runner.invoke(migrate_generated_images_cmd, [])
+        finally:
+            os.chdir(cwd)
+
+        assert result.exit_code == 0, result.output
+        assert (topic / "img-generated" / "diag.png").exists()
+
+    def test_never_reaches_outside_the_given_root(self, runner, tmp_path):
+        """Review M2: a diagram source directly under ROOT derives ROOT's
+        parent as its topic dir — the contract is "every topic below ROOT",
+        so nothing outside ROOT may move."""
+        outside_img = tmp_path / "img"
+        outside_img.mkdir()
+        (outside_img / "loose.png").write_bytes(b"outside the root")
+        inner = tmp_path / "inner"
+        inner.mkdir()
+        (inner / "loose.drawio").write_text("<mxfile/>", encoding="utf-8")
+
+        result = runner.invoke(migrate_generated_images_cmd, [str(inner)])
+
+        assert result.exit_code == 0, result.output
+        assert (outside_img / "loose.png").exists()
+        assert not (tmp_path / "img-generated").exists()
 
     def test_ignored_trees_are_skipped(self, runner, tmp_path):
         """A diagram source inside e.g. ``__pycache__``/``.venv`` must not

--- a/tests/core/test_img_generated_layout.py
+++ b/tests/core/test_img_generated_layout.py
@@ -13,11 +13,14 @@ migration is byte-identical in the output tree), sweep/registry recognition,
 and the data-URL inliner's source-tree fallback.
 """
 
+import os
 from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+
+DATA_DIR = Path(__file__).parent.parent / "test-data"
 
 from clm.core.course_files.duplicated_image_file import DuplicatedImageFile
 from clm.core.course_files.image_file import ImageFile
@@ -100,7 +103,7 @@ class TestOneOutputNamespace:
         image = DuplicatedImageFile(
             course=MagicMock(), path=tmp_path / "img-generated" / "diagram.png", topic=topic
         )
-        assert image._output_relative_path == Path("img") / "diagram.png"
+        assert image.output_relative_path == Path("img") / "diagram.png"
 
     def test_duplicated_mode_output_keeps_plain_img_unchanged(self, tmp_path):
         topic = MagicMock()
@@ -110,7 +113,79 @@ class TestOneOutputNamespace:
         image = DuplicatedImageFile(
             course=MagicMock(), path=tmp_path / "img" / "photo.png", topic=topic
         )
-        assert image._output_relative_path == Path("img") / "photo.png"
+        assert image.output_relative_path == Path("img") / "photo.png"
+
+    def test_only_the_leading_component_collapses(self, tmp_path):
+        """Review L1: the render target is always topic-level. A hand-authored
+        file under a DEEPER directory that happens to be named img-generated
+        keeps its pre-#664 verbatim copy — collapsing it would silently move
+        the output and break references to it."""
+        topic = MagicMock()
+        topic.path = tmp_path
+        nested = tmp_path / "data" / "img-generated"
+        nested.mkdir(parents=True)
+        (nested / "x.png").write_bytes(b"x")
+        image = DuplicatedImageFile(course=MagicMock(), path=nested / "x.png", topic=topic)
+        assert image.output_relative_path == Path("data") / "img-generated" / "x.png"
+
+
+class TestProvenanceManifest:
+    """Review H1: the manifest must enumerate what the copy WRITES. Using the
+    raw relative path silently dropped every migrated render from
+    ``.clm-manifest.json`` — and the release pipeline copies by manifest, so
+    frozen cohorts would have shipped without a single generated diagram."""
+
+    @pytest.fixture
+    def migrated_course(self, course_1_spec, tmp_path):
+        import shutil
+
+        from clm.cli.commands.course.migrate_generated_images import (
+            migrate_generated_images_cmd,
+        )
+        from clm.core.course import Course
+
+        data_dir = tmp_path / "test-data"
+        shutil.copytree(DATA_DIR, data_dir)
+        from click.testing import CliRunner
+
+        result = CliRunner().invoke(migrate_generated_images_cmd, [str(data_dir)])
+        assert result.exit_code == 0, result.output
+        assert "2 moved" in result.output
+        return Course.from_spec(course_1_spec, data_dir, tmp_path / "output")
+
+    def test_migrated_renders_stay_in_the_manifest(self, migrated_course):
+        from clm.core.provenance_manifest import enumerate_expected_outputs
+
+        target = migrated_course.output_targets[0]
+        expected_paths = [str(p) for p, _r in enumerate_expected_outputs(migrated_course, target)]
+        assert not any("img-generated" in p for p in expected_paths), (
+            "the manifest must enumerate the COLLAPSED output paths — "
+            "the build never writes an img-generated/ directory to output"
+        )
+        diag_paths = [p for p in expected_paths if p.endswith("my_diag.png")]
+        assert diag_paths, "the migrated render must still be enumerated"
+        assert all(f"img{os.sep}my_diag.png" in p for p in diag_paths)
+
+    def test_a_migrated_course_loads_without_the_legacy_warning(self, migrated_course):
+        assert not [
+            w
+            for w in migrated_course.loading_warnings
+            if w["category"] == "legacy_img_render_target"
+        ]
+
+    def test_an_unmigrated_course_warns_once_per_load(self, course_1_spec, tmp_path):
+        """Review M3: the transitional rule needs a signal — a resurrected
+        legacy render silently flips the target back, and unmigrated repos
+        should be nudged toward the migration."""
+        from clm.core.course import Course
+
+        course = Course.from_spec(course_1_spec, DATA_DIR, tmp_path / "out")
+        warnings = [
+            w for w in course.loading_warnings if w["category"] == "legacy_img_render_target"
+        ]
+        assert len(warnings) == 1
+        assert "migrate-generated-images" in warnings[0]["message"]
+        assert len(warnings[0]["details"]["sources"]) >= 2  # my_diag.pu + my_drawing.drawio
 
 
 class TestRegistryRecognition:

--- a/tests/core/test_img_generated_layout.py
+++ b/tests/core/test_img_generated_layout.py
@@ -1,0 +1,171 @@
+"""The #664 namespace split: ``img/`` is human-owned, ``img-generated/`` build-owned.
+
+``<topic>/img/`` used to hold both hand-authored assets and the DrawIO/PlantUML
+renders, distinguishable only through the course model — the ambiguity behind
+the #661 nondeterminism class. Diagrams now render into the build-owned
+``img-generated/`` sibling, with one transitional exception: a committed legacy
+render keeps its location until ``clm course migrate-generated-images`` moves
+it, so unmigrated repos build exactly as before.
+
+Pinned here: the render-target choice, that both directories collapse onto the
+SAME output namespace (slide references ``img/...`` never change, so a correct
+migration is byte-identical in the output tree), sweep/registry recognition,
+and the data-URL inliner's source-tree fallback.
+"""
+
+from pathlib import Path, PurePosixPath
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from clm.core.course_files.duplicated_image_file import DuplicatedImageFile
+from clm.core.course_files.image_file import ImageFile
+from clm.core.image_registry import get_relative_img_path
+from clm.core.output_write_registry import is_image_path
+
+
+@pytest.fixture
+def mock_course():
+    course = MagicMock()
+    course.image_format = "png"
+    return course
+
+
+def _diagram_file(course, tmp_path: Path) -> ImageFile:
+    source = tmp_path / "topic" / "pu" / "diagram.pu"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("@startuml\n@enduml\n", encoding="utf-8")
+    return ImageFile(course=course, path=source, topic=MagicMock())
+
+
+class TestRenderTarget:
+    def test_a_fresh_diagram_renders_into_img_generated(self, mock_course, tmp_path):
+        image = _diagram_file(mock_course, tmp_path)
+        assert image.img_path == tmp_path / "topic" / "img-generated" / "diagram.png"
+        assert image.source_outputs == frozenset({image.img_path})
+
+    def test_a_committed_legacy_render_keeps_its_location(self, mock_course, tmp_path):
+        """The transitional rule: an unmigrated repo builds exactly as before.
+
+        Rendering to the new directory while the stale legacy copy still
+        shipped as a hand-authored-looking image would put two writers on one
+        output path — the #661 conflict class this issue exists to end.
+        """
+        image = _diagram_file(mock_course, tmp_path)
+        legacy = tmp_path / "topic" / "img" / "diagram.png"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_bytes(b"committed render")
+        assert image.img_path == legacy
+
+    def test_migrating_the_file_flips_the_target(self, mock_course, tmp_path):
+        image = _diagram_file(mock_course, tmp_path)
+        legacy = tmp_path / "topic" / "img" / "diagram.png"
+        legacy.parent.mkdir(parents=True)
+        legacy.write_bytes(b"committed render")
+        target = tmp_path / "topic" / "img-generated" / "diagram.png"
+        target.parent.mkdir(parents=True)
+        legacy.rename(target)
+        assert image.img_path == target
+
+    def test_image_format_is_respected(self, mock_course, tmp_path):
+        mock_course.image_format = "svg"
+        image = _diagram_file(mock_course, tmp_path)
+        assert image.img_path.name == "diagram.svg"
+
+
+class TestOneOutputNamespace:
+    """Both directories collapse to ``img/`` in the output — the property that
+    makes the migration byte-identical and keeps every slide reference valid."""
+
+    def test_shared_mode_relative_path_is_identical_for_both_layouts(self, tmp_path):
+        legacy = tmp_path / "topic" / "img" / "diagram.png"
+        migrated = tmp_path / "topic" / "img-generated" / "diagram.png"
+        assert get_relative_img_path(legacy) == get_relative_img_path(migrated) == "diagram.png"
+
+    def test_subfolders_are_preserved_from_either_root(self, tmp_path):
+        assert get_relative_img_path(tmp_path / "img" / "foo" / "bar.png") == "foo/bar.png"
+        assert (
+            get_relative_img_path(tmp_path / "img-generated" / "foo" / "bar.png") == "foo/bar.png"
+        )
+
+    def test_no_image_folder_still_falls_back_to_the_filename(self, tmp_path):
+        assert get_relative_img_path(tmp_path / "elsewhere" / "pic.png") == "pic.png"
+
+    def test_duplicated_mode_output_collapses_img_generated(self, tmp_path):
+        topic = MagicMock()
+        topic.path = tmp_path
+        (tmp_path / "img-generated").mkdir()
+        (tmp_path / "img-generated" / "diagram.png").write_bytes(b"x")
+        image = DuplicatedImageFile(
+            course=MagicMock(), path=tmp_path / "img-generated" / "diagram.png", topic=topic
+        )
+        assert image._output_relative_path == Path("img") / "diagram.png"
+
+    def test_duplicated_mode_output_keeps_plain_img_unchanged(self, tmp_path):
+        topic = MagicMock()
+        topic.path = tmp_path
+        (tmp_path / "img").mkdir()
+        (tmp_path / "img" / "photo.png").write_bytes(b"x")
+        image = DuplicatedImageFile(
+            course=MagicMock(), path=tmp_path / "img" / "photo.png", topic=topic
+        )
+        assert image._output_relative_path == Path("img") / "photo.png"
+
+
+class TestRegistryRecognition:
+    def test_is_image_path_accepts_both_directories(self):
+        assert is_image_path(Path("slides/module/topic/img/x.png"))
+        assert is_image_path(Path("slides/module/topic/img-generated/x.png"))
+
+    def test_is_image_path_still_rejects_unrelated_paths(self):
+        assert not is_image_path(Path("slides/module/topic/data/x.png"))
+
+
+class TestInlineImageFallback:
+    """``_inject_data_urls`` resolves references against the SOURCE tree, so a
+    reference saying ``img/x.png`` must find a migrated render in
+    ``img-generated/`` — silently keeping the tag would un-inline every
+    generated diagram after migration."""
+
+    def _inject(self, source_dir: Path, content: str) -> str:
+        from clm.workers.notebook.notebook_processor import NotebookProcessor
+
+        payload = SimpleNamespace(source_topic_dir=str(source_dir), other_files={})
+        return NotebookProcessor._inject_data_urls(NotebookProcessor, content, payload)
+
+    def test_a_migrated_render_still_inlines(self, tmp_path):
+        (tmp_path / "img-generated").mkdir()
+        (tmp_path / "img-generated" / "diagram.png").write_bytes(b"\x89PNG fake")
+        result = self._inject(tmp_path, '<img src="img/diagram.png">')
+        assert result.startswith('<img src="data:image/png;base64,')
+
+    def test_a_hand_authored_image_inlines_from_img(self, tmp_path):
+        (tmp_path / "img").mkdir()
+        (tmp_path / "img" / "photo.png").write_bytes(b"\x89PNG fake")
+        result = self._inject(tmp_path, '<img src="img/photo.png">')
+        assert result.startswith('<img src="data:image/png;base64,')
+
+    def test_img_takes_precedence_over_img_generated(self, tmp_path):
+        """The reference names ``img/``; if a file genuinely sits there it wins
+        (the transitional legacy layout, where the render target IS img/)."""
+        import base64
+
+        (tmp_path / "img").mkdir()
+        (tmp_path / "img-generated").mkdir()
+        (tmp_path / "img" / "diagram.png").write_bytes(b"legacy")
+        (tmp_path / "img-generated" / "diagram.png").write_bytes(b"migrated")
+        result = self._inject(tmp_path, '<img src="img/diagram.png">')
+        assert base64.b64encode(b"legacy").decode() in result
+
+    def test_a_missing_image_keeps_the_original_tag(self, tmp_path):
+        content = '<img src="img/absent.png">'
+        assert self._inject(tmp_path, content) == content
+
+    def test_the_fallback_only_rewrites_the_img_root(self, tmp_path):
+        """A reference outside ``img/`` must not be probed under img-generated."""
+        (tmp_path / "img-generated").mkdir()
+        (tmp_path / "img-generated" / "x.png").write_bytes(b"render")
+        content = '<img src="data/x.png">'
+        assert self._inject(tmp_path, content) == content
+        assert PurePosixPath("data/x.png").parts[0] != "img"  # the guard the test rides on


### PR DESCRIPTION
## Root cause

`<topic>/img/` held two kinds of thing under one namespace — hand-authored assets and DrawIO/PlantUML renders — distinguishable only through the course model. That ambiguity is the *class* behind the #661 run-to-run nondeterminism: the build writes into a directory humans also curate, and every consumer re-derives which files are machine-owned.

## Change

Diagrams now render into the build-owned `<topic>/img-generated/` sibling. The invariant is structural: **nothing in `img/` is ever written by the build; everything in `img-generated/` only ever is.** Both directories collapse onto the output's `img/` (shared mode via `get_relative_img_path`, duplicated mode via an explicit leading-component collapse), so the ~920 slide references (`img/x.png`) across the course repos never change.

- **Transitional rule**: a committed legacy render keeps `img/` as its render target until moved — unmigrated repos build exactly as before, with one summary warning per course load naming the diagrams still on the legacy target (also the only signal when a legacy render is resurrected into a migrated repo).
- **New command** `clm course migrate-generated-images [ROOT] [--dry-run]`: spec-free, idempotent, drops byte-identical duplicates, refuses diverging conflicts with exit 1, never reaches outside ROOT.
- Understood everywhere the old layout was: image registry, `is_image_path`/stray-file sweep, **provenance manifest** (what the release pipeline copies from), inline-image data-URL resolution, both image modes.

## Verification

- **Byte-identical output**: `clm build --snapshot` on an unmigrated copy of the bundled test course, then `--verify-against` from a migrated copy — passed (108/108 images, all notebooks/code/data identical).
- **Two adversarial review rounds** (deep-review agent). Round 1 found 1 High: the provenance manifest still enumerated raw relative paths, silently dropping every migrated render from `.clm-manifest.json` — the release pipeline copies by manifest, so frozen cohorts would have shipped without diagrams (invisible to the snapshot verification, which suppresses the manifest by design). Plus two confirmed CLI defects (IndexError on shallow relative roots; moves outside ROOT), a silent-regression gap (no signal when a resurrected legacy file flips the render target back), and an over-broad collapse. All fixed and pinned; round 2 re-verified every fix, ran 13 mutations (12 killed, the one survivor was a misaimed test, re-aimed and verified killing its mutant), verdict **ship**.
- 39 new tests; full fast suite green (9507), e2e conversion suite green (234), ruff + mypy clean.

Docs: `clm info spec-files` (topic layout + the two-directory invariant), `clm info commands` (new command), `clm info migration` (step-by-step repo migration incl. the snapshot/verify-against recipe), changelog fragment.

Downstream: PythonCourses/CppCourses/CSharpCourses migrations follow after the next release (an old clm against a migrated repo would re-render into `img/`, so the repos upgrade clm first, then migrate).

Fixes #664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh
