### PR TITLE
test(sync): name the corpus revision in every real-corpus gate verdict (#682 step 1)

### DIFF
--- a/tests/slides/corpus_revision.py
+++ b/tests/slides/corpus_revision.py
@@ -1,0 +1,68 @@
+"""#682 half 1, the cheap pin: make a real-corpus gate failure interpretable.
+
+The two real-corpus modules (``test_doc_lens_corpus`` / ``test_sync_diff_corpus``)
+measure their ceilings against the maintainer's private, continuously edited
+PythonCourses checkout. A bare ceiling breach is therefore uninterpretable —
+did CLM regress, or did a deck change? Recording the revision the ceilings
+were last measured against, and reporting the revision the failing run
+actually used, answers that at zero infrastructure cost. The real fix — a
+derived, CI-runnable corpus with a curated public test-course repo — is
+tracked on #682; until it lands, every real-corpus assertion message carries
+:func:`revision_context`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+#: The corpus revision the current ceilings/floors/refusal-code sets were last
+#: measured against (PythonCourses). Update DELIBERATELY whenever a ceiling is
+#: re-measured — this constant is what turns "the number moved" into "the
+#: number moved relative to a named corpus state".
+CEILINGS_MEASURED_AT = "36f66ba970313635d592926b2f658a8a073466cd"  # 2026-08-04
+
+
+def corpus_revision(corpus_dir: Path) -> str:
+    """The corpus checkout's revision: ``<sha>`` (+ ``-dirty``), or ``unknown``.
+
+    Best-effort by design — a corpus that is not a git checkout (a plain
+    directory passed via ``CLM_SYNC_CORPUS_DIR``) reports ``unknown`` rather
+    than failing the very assertion message that is trying to explain a
+    failure.
+    """
+
+    def _git(*args: str) -> str | None:
+        try:
+            completed = subprocess.run(
+                ["git", "-C", str(corpus_dir), *args],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                check=False,
+            )
+        except (FileNotFoundError, OSError):
+            return None
+        return completed.stdout.strip() if completed.returncode == 0 else None
+
+    sha = _git("rev-parse", "HEAD")
+    if not sha:
+        return "unknown (not a git checkout)"
+    dirty = _git("status", "--porcelain", "--untracked-files=no")
+    return f"{sha}-dirty" if dirty else sha
+
+
+def revision_context(corpus_dir: Path) -> str:
+    """The one line every real-corpus assertion message carries (#682)."""
+    current = corpus_revision(corpus_dir)
+    hint = (
+        "the corpus moved since the ceilings were measured — decide whether "
+        "the corpus or CLM changed before touching any ceiling"
+        if current.split("-")[0] != CEILINGS_MEASURED_AT
+        else "the corpus is at the measured revision — this is a CLM change"
+    )
+    return (
+        f"\n[corpus revision: running against {current}; ceilings measured at "
+        f"{CEILINGS_MEASURED_AT} — {hint}]"
+    )

--- a/tests/slides/test_doc_lens_corpus.py
+++ b/tests/slides/test_doc_lens_corpus.py
@@ -34,6 +34,8 @@ import pytest
 from clm.slides.doc_lenses import LoadedBundle, load_bundle, project
 from clm.slides.pairing import find_split_slide_files_recursive, iter_split_pairs
 
+from .corpus_revision import revision_context
+
 _BUNDLED_CORPUS = Path(__file__).parent.parent / "data" / "doc_corpus"
 
 # The known v3-precondition failures on the real corpus, measured 2026-07-02
@@ -153,8 +155,12 @@ class TestRealCorpus:
                 continue
             parsed += 1
             _assert_byte_identity(bundle)
-        assert parsed >= _REAL_PARSED_FLOOR, f"only {parsed} pairs parsed"
+        # #682: every scale-dependent verdict names the corpus revision it ran
+        # against, so a breach is interpretable (CLM regression vs corpus drift).
+        context = revision_context(_real)
+        assert parsed >= _REAL_PARSED_FLOOR, f"only {parsed} pairs parsed{context}"
         assert len(refused) <= _REAL_REFUSAL_CEILING, (
-            f"{len(refused)} refusals exceed the ceiling {_REAL_REFUSAL_CEILING}: {refused[:10]}…"
+            f"{len(refused)} refusals exceed the ceiling {_REAL_REFUSAL_CEILING}: "
+            f"{refused[:10]}…{context}"
         )
-        assert not unexpected_codes, f"refusals with unexpected codes: {unexpected_codes}"
+        assert not unexpected_codes, f"refusals with unexpected codes: {unexpected_codes}{context}"

--- a/tests/slides/test_sync_diff_corpus.py
+++ b/tests/slides/test_sync_diff_corpus.py
@@ -30,6 +30,8 @@ from clm.slides.sync_diff import (
     diff_deck,
 )
 
+from .corpus_revision import revision_context
+
 _BUNDLED_CORPUS = Path(__file__).parent.parent / "data" / "doc_corpus"
 
 # Phase 1 measured 33 parse observations over 644 parsed pairs; carried
@@ -120,9 +122,12 @@ class TestRealCorpusSelfDiff:
             for item in diff.items:
                 if item.action not in MECHANICAL_ACTIONS | FRAMED_ACTIONS:
                     unregistered.add(item.action)
-        assert parsed >= _REAL_PARSED_FLOOR
-        assert not unregistered, f"actions outside the closed registry: {unregistered}"
+        # #682: every scale-dependent verdict names the corpus revision it ran
+        # against, so a breach is interpretable (CLM regression vs corpus drift).
+        context = revision_context(_real)
+        assert parsed >= _REAL_PARSED_FLOOR, f"only {parsed} pairs parsed{context}"
+        assert not unregistered, f"actions outside the closed registry: {unregistered}{context}"
         assert total_items <= _REAL_SELF_DIFF_ITEM_CEILING, (
             f"{total_items} self-diff items exceed the noise ceiling "
-            f"{_REAL_SELF_DIFF_ITEM_CEILING}: {noisy[:10]}…"
+            f"{_REAL_SELF_DIFF_ITEM_CEILING}: {noisy[:10]}…{context}"
         )


### PR DESCRIPTION
The issue's own sequencing, step 1 — the cheap pin. The real-corpus gates in `test_doc_lens_corpus.py` / `test_sync_diff_corpus.py` measure ceilings against a private, continuously edited checkout, so a bare breach was uninterpretable: CLM regression or corpus drift?

Every scale-dependent assertion now appends `revision_context()` from the new `tests/slides/corpus_revision.py`: the revision the run actually used (`<sha>`, `-dirty` when modified, `unknown` for a non-git `CLM_SYNC_CORPUS_DIR`) against `CEILINGS_MEASURED_AT` (pinned to PythonCourses `36f66ba9`, 2026-08-04), plus which conclusion the comparison supports ("corpus moved — decide which side changed before touching a ceiling" vs "corpus at the measured revision — this is a CLM change").

Verified against the live corpus: both modules pass with the wiring in place (7 tests, `-m ""`).

Refs #682 — steps 2 (course-side gate with a pinned clm) and the maintainer-approved curated public test-course repo (the CI-runnable corpus, shared with #681) remain on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh
