### PR TITLE
fix(cli): migrate-generated-images never enters .claude/; dry-run counts shared stems once

### DIFF
--- a/changelog.d/664-migrate-claude-dir.fixed.md
+++ b/changelog.d/664-migrate-claude-dir.fixed.md
@@ -1,0 +1,7 @@
+- **`clm course migrate-generated-images` no longer enters `.claude/`.** The
+  agent-state directory can hold linked git worktrees whose `slides/` copies
+  belong to other sessions' checkouts; the root-scanning migration walked into
+  them and moved their files (found on repos carrying `.claude/worktrees/`).
+  Also fixed: `--dry-run` counted a render once per diagram *source*, so a
+  `.pu`/`.drawio` pair sharing one stem over-reported the move count relative
+  to the real run.

--- a/src/clm/cli/commands/course/migrate_generated_images.py
+++ b/src/clm/cli/commands/course/migrate_generated_images.py
@@ -66,11 +66,20 @@ def migrate_generated_images_cmd(root: Path, dry_run: bool) -> None:
     moved: list[Path] = []
     deduped: list[Path] = []
     conflicts: list[Path] = []
+    seen_legacy: set[Path] = set()
 
     for source in sorted(root.rglob("*")):
         if not source.is_file() or source.suffix not in DIAGRAM_SOURCE_EXTENSIONS:
             continue
         if is_ignored_dir_for_course(source.parent):
+            continue
+        # ``.claude/`` holds agent state, including LINKED GIT WORKTREES whose
+        # ``slides/`` copies belong to other sessions' checkouts — moving
+        # files inside them corrupts those checkouts (found the hard way on a
+        # course repo carrying ``.claude/worktrees/``). ``is_ignored_dir_for_
+        # course`` does not know the directory because the course scan starts
+        # below it; this command scans the repo ROOT, so it must.
+        if ".claude" in source.parts:
             continue
         topic_dir = source.parents[1]
         # A source directly under ROOT derives ROOT's *parent* as its topic
@@ -82,6 +91,13 @@ def migrate_generated_images_cmd(root: Path, dry_run: bool) -> None:
             # The exact computation ImageFile.legacy_img_path/generated_img_path
             # perform, so the moved names match what the build looks for.
             legacy = sanitize_path((topic_dir / "img" / source.stem).with_suffix(f".{ext}"))
+            # Two sources can share one stem (a ``.pu`` and a ``.drawio``
+            # sibling): the render is one file, and counting it once per
+            # source made ``--dry-run`` over-report what the real run
+            # (whose first move empties the path) would do.
+            if legacy in seen_legacy:
+                continue
+            seen_legacy.add(legacy)
             target = sanitize_path(
                 (topic_dir / GENERATED_IMG_DIR / source.stem).with_suffix(f".{ext}")
             )

--- a/tests/cli/test_migrate_generated_images.py
+++ b/tests/cli/test_migrate_generated_images.py
@@ -170,6 +170,41 @@ class TestMigration:
         assert (outside_img / "loose.png").exists()
         assert not (tmp_path / "img-generated").exists()
 
+    def test_claude_agent_dirs_are_never_entered(self, runner, tmp_path):
+        """Field regression (CppCourses/PythonCourses): ``.claude/`` holds
+        linked git worktrees whose slides copies belong to OTHER sessions'
+        checkouts — moving files inside them corrupts those checkouts. The
+        course scan never sees ``.claude`` (it starts below it), so the
+        root-scanning migrate command must exclude it itself."""
+        wt_topic = tmp_path / ".claude" / "worktrees" / "some-session" / "slides" / "m" / "t"
+        (wt_topic / "pu").mkdir(parents=True)
+        (wt_topic / "img").mkdir()
+        (wt_topic / "pu" / "diag.pu").write_text("@startuml\n@enduml\n", encoding="utf-8")
+        (wt_topic / "img" / "diag.png").write_bytes(b"another session's checkout")
+
+        result = runner.invoke(migrate_generated_images_cmd, [str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert (wt_topic / "img" / "diag.png").exists()
+        assert not (wt_topic / "img-generated").exists()
+
+    def test_dry_run_counts_a_shared_stem_once(self, runner, tmp_path):
+        """Field regression: a ``.pu`` and a ``.drawio`` sharing one stem
+        render to ONE file; the dry run counted it per source, over-reporting
+        against the real run (692 vs 688 on PythonCourses)."""
+        topic = _topic(tmp_path)
+        (topic / "pu" / "same.pu").write_text("@startuml\n@enduml\n", encoding="utf-8")
+        (topic / "drawio" / "same.drawio").write_text("<mxfile/>", encoding="utf-8")
+        (topic / "img" / "same.png").write_bytes(b"one render")
+
+        dry = runner.invoke(migrate_generated_images_cmd, [str(tmp_path), "--dry-run"])
+        assert dry.exit_code == 0
+        assert "1 would move" in dry.output
+
+        real = runner.invoke(migrate_generated_images_cmd, [str(tmp_path)])
+        assert real.exit_code == 0
+        assert "1 moved" in real.output
+
     def test_ignored_trees_are_skipped(self, runner, tmp_path):
         """A diagram source inside e.g. ``__pycache__``/``.venv`` must not
         drive a move (mirrors the course scan's ignore rules): a vendored


### PR DESCRIPTION
Two field regressions found while running the #664 migrations across the three course repos:

1. **`.claude/` walk-descent**: the directory can hold linked git worktrees whose `slides/` copies belong to other sessions' checkouts; the root-scanning walk entered them and moved their files (caught on CppCourses' dry-run count of 3598 vs 361 real; PythonCourses' `.claude/worktrees/sk-build-venv-note` was physically hit — restored exactly, verified clean, and the merged migration commit contains zero worktree paths). The course scan never sees `.claude` because it starts below it; the root-scanning command now excludes it itself.
2. **Dry-run over-count**: a `.pu`/`.drawio` pair sharing one stem renders to one file, but the dry run counted it per source (692 vs 688 on PythonCourses). Legacy paths are now visited once, so dry-run and real-run reports agree.

Both pinned by tests; full fast suite green (9510).

Refs #664 (the migrations themselves are complete: PythonCourses#358, CppCourses#107, CSharpCourses#5 — all merged, 0 conflicts, idempotent re-runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh