### PR TITLE
feat(tests): CI-runnable pinned public-corpus gates (#682)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,15 @@ jobs:
       run: |
         uv run --no-sync pytest -v -m "not slow and not integration and not e2e and not docker" --timeout=120 --cov=src/clm --cov-report=xml --cov-report=term
 
+    # The pinned public corpus (#682): tests/slides/test_public_corpus.py
+    # skips cleanly when the checkout is absent, so only the integration
+    # suite pays the (shallow, pinned) fetch. Best-effort on purpose — a
+    # GitHub hiccup fetching the corpus must not fail the whole suite; the
+    # gates simply skip and the pin keeps every successful run comparable.
+    - name: Fetch the pinned public test corpus
+      if: needs.changes.outputs.code == 'true' && matrix.suite == 'integration'
+      run: python scripts/fetch_test_corpus.py || echo "corpus fetch failed - gates will skip"
+
     - name: Run integration tests
       if: needs.changes.outputs.code == 'true' && matrix.suite == 'integration'
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -292,3 +292,4 @@ tests/test-data/_volatile_specs/
 .clm-cache/
 clm-http-replay-traces*/
 clm_telemetry.db
+.clm-test-corpus/

--- a/changelog.d/682-public-corpus-gates.added.md
+++ b/changelog.d/682-public-corpus-gates.added.md
@@ -1,0 +1,10 @@
+- **CI-runnable pinned public corpus gates (#682).** The new
+  [ClmTestCourse](https://github.com/hoelzl/ClmTestCourse) repo (curated and
+  sanitized from the course repos, CC BY-NC-SA 4.0) is fetched at a pinned
+  commit by `scripts/fetch_test_corpus.py` and asserted on by
+  `tests/slides/test_public_corpus.py` — exact numbers, not ceilings: pair
+  population, the full refusal-code set, parse observations, `project ∘
+  parse` byte-identity, and the self-diff noise floor. CI runs it in the
+  integration suite; the private full-corpus run stays available locally via
+  `CLM_SYNC_CORPUS_DIR`. Course specs in the corpus make every spec-driven
+  surface exercisable against it.

--- a/docs/developer-guide/testing.md
+++ b/docs/developer-guide/testing.md
@@ -430,6 +430,28 @@ Marker choice, restated: `integration` keeps a test off the per-commit gate but
 on every PR. `slow` now also runs on every PR, so the two differ only in which
 job they land in — pick by what the test *is*, not by where you want it to run.
 
+### The corpus gates: bundled, pinned-public, and private
+
+Three tiers exercise the sync/lens engines against real deck corpora:
+
+1. **Bundled fixtures** (`tests/data/doc_corpus/`) — five pairs, fast suite,
+   always present.
+2. **Pinned public corpus** (`tests/slides/test_public_corpus.py`,
+   `integration`) — the [ClmTestCourse](https://github.com/hoelzl/ClmTestCourse)
+   repo at the commit pinned in `tests/slides/public_corpus_pin.py`, fetched
+   by `python scripts/fetch_test_corpus.py` into the gitignored
+   `.clm-test-corpus/` (CI does this for the integration suite). Because the
+   corpus is pinned, the gates assert **exact** numbers, not ceilings — any
+   drift is a CLM behavior change. Bump the pin and the expected numbers
+   together, deliberately; regenerate the corpus itself with
+   `scripts/curate_test_course.py` (#682).
+3. **Private full corpus** (`TestRealCorpus*` in `test_doc_lens_corpus.py` /
+   `test_sync_diff_corpus.py`, `integration + slow`) — the maintainer's live
+   PythonCourses checkout via `CLM_SYNC_CORPUS_DIR`; local/release-time only.
+   Its ceilings carry a corpus-revision context line
+   (`tests/slides/corpus_revision.py`) so a breach says whether CLM or the
+   corpus moved.
+
 ### The nightly full-suite run
 
 `.github/workflows/nightly.yml` is a **flake and rot detector**, not a coverage

--- a/scripts/curate_test_course.py
+++ b/scripts/curate_test_course.py
@@ -274,12 +274,15 @@ _SYNTHETIC_DECKS: dict[str, dict[str, str]] = {
         + '# %% [markdown] lang="en" tags=["slide"]\n#\n# # No identifier\n',
     },
     "idless_narrative": {
+        # The canonical blank `#` lead keeps validate quiet here — this deck
+        # exists for exactly ONE finding class (the id-less narrative), and a
+        # cosmetic co-finding would blur what a gate failure on it means.
         "slides_idless_narrative.de.py": _HDR_DE
         + _slide("de", "s0", "Titel")
-        + '# %% [markdown] lang="de" tags=["notes"]\n# Notiz ohne Bezeichner.\n',
+        + '# %% [markdown] lang="de" tags=["notes"]\n#\n# Notiz ohne Bezeichner.\n',
         "slides_idless_narrative.en.py": _HDR_EN
         + _slide("en", "s0", "Title")
-        + '# %% [markdown] lang="en" tags=["notes"]\n# Note without identifier.\n',
+        + '# %% [markdown] lang="en" tags=["notes"]\n#\n# Note without identifier.\n',
     },
     "legacy_title_companion": {
         "slides_legacy_title.de.py": _HDR_DE + _slide("de", "s0", "Titel"),

--- a/scripts/fetch_test_corpus.py
+++ b/scripts/fetch_test_corpus.py
@@ -1,0 +1,77 @@
+"""Fetch the pinned public test corpus (#682) into ``.clm-test-corpus/``.
+
+The corpus gates in ``tests/slides/test_public_corpus.py`` run against the
+`ClmTestCourse <https://github.com/hoelzl/ClmTestCourse>`_ checkout this
+script produces — always at the pin recorded in
+``tests/slides/public_corpus_pin.py``, so the gates measure a fixed corpus
+and a failure is attributable to CLM. Idempotent: an up-to-date checkout is
+left alone; a stale one is fetched forward and hard-reset to the pin (the
+directory is disposable — it is gitignored and never hand-edited).
+
+Usage::
+
+    python scripts/fetch_test_corpus.py          # into <repo>/.clm-test-corpus
+    python scripts/fetch_test_corpus.py DIR      # elsewhere (CI caches, etc.)
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_DIR = REPO_ROOT / ".clm-test-corpus"
+
+# Read (not import) the pin module: one source of truth, no sys.path games.
+_PIN_FILE = REPO_ROOT / "tests" / "slides" / "public_corpus_pin.py"
+_pin_text = _PIN_FILE.read_text(encoding="utf-8")
+
+
+def _pinned(name: str) -> str:
+    match = re.search(rf'^{name} = "([^"]+)"', _pin_text, re.MULTILINE)
+    assert match is not None, f"{name} not found in {_PIN_FILE}"
+    return match.group(1)
+
+
+PUBLIC_CORPUS_REPO = _pinned("PUBLIC_CORPUS_REPO")
+PUBLIC_CORPUS_PIN = _pinned("PUBLIC_CORPUS_PIN")
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, encoding="utf-8", check=False
+    )
+
+
+def main() -> int:
+    target = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_DIR
+    if not (target / ".git").exists():
+        target.mkdir(parents=True, exist_ok=True)
+        for step in (
+            ("init", "-q"),
+            ("remote", "add", "origin", PUBLIC_CORPUS_REPO),
+        ):
+            result = _git(target, *step)
+            if result.returncode != 0:
+                print(result.stderr.strip(), file=sys.stderr)
+                return 1
+    head = _git(target, "rev-parse", "HEAD")
+    if head.returncode == 0 and head.stdout.strip() == PUBLIC_CORPUS_PIN:
+        print(f"corpus already at pin {PUBLIC_CORPUS_PIN[:12]} -> {target}")
+        return 0
+    fetch = _git(target, "fetch", "--depth", "1", "origin", PUBLIC_CORPUS_PIN)
+    if fetch.returncode != 0:
+        print(fetch.stderr.strip(), file=sys.stderr)
+        return 1
+    reset = _git(target, "reset", "--hard", PUBLIC_CORPUS_PIN)
+    if reset.returncode != 0:
+        print(reset.stderr.strip(), file=sys.stderr)
+        return 1
+    print(f"corpus fetched at pin {PUBLIC_CORPUS_PIN[:12]} -> {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/slides/public_corpus_pin.py
+++ b/tests/slides/public_corpus_pin.py
@@ -1,0 +1,11 @@
+"""The public-corpus pin (#682): which ClmTestCourse commit the gates assert on.
+
+One constant, imported by the gate module and read by
+``scripts/fetch_test_corpus.py``, so the fetch and the assertion can never
+disagree. Bump it DELIBERATELY, together with the expected numbers in
+``test_public_corpus.py`` — the whole point of the pin is that a gate failure
+means *CLM changed*, never "the corpus moved underneath us".
+"""
+
+PUBLIC_CORPUS_REPO = "https://github.com/hoelzl/ClmTestCourse.git"
+PUBLIC_CORPUS_PIN = "c536d5bb5ded8cb60a49180cbb64fa9f8e03e17b"  # 2026-08-05

--- a/tests/slides/test_public_corpus.py
+++ b/tests/slides/test_public_corpus.py
@@ -1,0 +1,144 @@
+"""The pinned public-corpus gates (#682) — CI-runnable, exact, attributable.
+
+The private-corpus modules (``test_doc_lens_corpus`` / ``test_sync_diff_corpus``
+``TestRealCorpus*``) measure ceilings against a moving checkout and can only
+run on the maintainer's machine. These gates run against the **pinned**
+`ClmTestCourse <https://github.com/hoelzl/ClmTestCourse>`_ checkout
+(``python scripts/fetch_test_corpus.py``), so they run anywhere — including
+CI — and assert **exact** numbers, not ceilings: the corpus cannot move, so
+any drift is a CLM behavior change. Bump the pin and these numbers together,
+deliberately (see ``public_corpus_pin.py``).
+
+The corpus was curated to preserve, deck for deck, the structural properties
+the private originals measured (16/16 parity-clean at curation; see
+``scripts/curate_test_course.py``): the refusal-code population, the parse
+observations, byte-identity of ``project ∘ parse``, and the honest self-diff
+noise floor of the observation-carrying decks.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+from clm.slides.doc_identity import baseline_from_deck
+from clm.slides.doc_lenses import load_bundle, project
+from clm.slides.pairing import find_split_slide_files_recursive, iter_split_pairs
+from clm.slides.sync_diff import FRAMED_ACTIONS, MECHANICAL_ACTIONS, diff_deck
+
+from .public_corpus_pin import PUBLIC_CORPUS_PIN
+
+# The pinned corpus, measured 2026-08-05 at c536d5bb. Exact, not ceilings.
+_EXPECTED_PAIRS = 16
+_EXPECTED_PARSED = 11
+_EXPECTED_REFUSED = 5
+_EXPECTED_REFUSAL_CODES = {
+    "duplicate_id",
+    "idless_anchor",
+    "idless_localized",
+    "idless_narrative",
+    "legacy_title_companion",
+}
+_EXPECTED_OBSERVATIONS = {
+    "slides_functions_very_short.de.py": ["one_sided_member", "shared_divergence"],
+    "slides_signatures.de.py": ["shared_divergence"],
+}
+#: Self-diffing a parsed deck against its own complete snapshot is 0 items for
+#: every clean deck; the two observation carriers contribute an honest noise
+#: floor (one-sided members frame adds, diverged shared cells frame
+#: pending_divergence) that the bundled fixtures are too small to show.
+_EXPECTED_SELF_DIFF_ITEMS = {
+    "slides_functions_very_short.de.py": 11,
+    "slides_signatures.de.py": 1,
+}
+
+
+def _corpus_dir() -> Path | None:
+    env = os.environ.get("CLM_PUBLIC_CORPUS_DIR")
+    if env:
+        path = Path(env)
+        return path if path.is_dir() else None
+    default = Path(__file__).parent.parent.parent / ".clm-test-corpus"
+    return default if (default / "slides").is_dir() else None
+
+
+_corpus = _corpus_dir()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    _corpus is None,
+    reason="public corpus not fetched — run `python scripts/fetch_test_corpus.py`",
+)
+class TestPublicCorpus:
+    def test_checkout_is_at_the_pin(self):
+        """A checkout at the wrong revision must FAIL, not measure — the pin
+        is what makes a gate failure attributable to CLM."""
+        assert _corpus is not None
+        completed = subprocess.run(
+            ["git", "-C", str(_corpus), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+        if completed.returncode != 0:
+            pytest.skip("corpus dir is not a git checkout (env-provided) — pin not checkable")
+        assert completed.stdout.strip() == PUBLIC_CORPUS_PIN, (
+            "corpus checkout is not at the pin — re-run `python scripts/fetch_test_corpus.py`"
+        )
+
+    def test_population_refusals_and_byte_identity(self):
+        assert _corpus is not None
+        pairs, solos = iter_split_pairs(find_split_slide_files_recursive(_corpus / "slides"))
+        assert not solos
+        assert len(pairs) == _EXPECTED_PAIRS
+        parsed = 0
+        codes: set[str] = set()
+        observations: dict[str, list[str]] = {}
+        for de_path, _en_path in pairs:
+            bundle = load_bundle(de_path)
+            if bundle.outcome.refusal is not None:
+                codes |= {r.code for r in bundle.outcome.refusal.reasons}
+                continue
+            parsed += 1
+            deck = bundle.outcome.deck
+            assert deck is not None
+            for lang, part, path in (
+                ("de", "deck", bundle.de_path),
+                ("en", "deck", bundle.en_path),
+                ("de", "companion", bundle.de_companion_path),
+                ("en", "companion", bundle.en_companion_path),
+            ):
+                want = path.read_text(encoding="utf-8") if path else None
+                got = project(deck, lang, part)  # type: ignore[arg-type]
+                assert got == want, f"projection diverges: {de_path.name} {lang}/{part}"
+            kinds = sorted({o.kind for o in deck.observations})
+            if kinds:
+                observations[de_path.name] = kinds
+        assert parsed == _EXPECTED_PARSED
+        assert len(pairs) - parsed == _EXPECTED_REFUSED
+        assert codes == _EXPECTED_REFUSAL_CODES
+        assert observations == _EXPECTED_OBSERVATIONS
+
+    def test_self_diff_noise_floor_is_exact(self):
+        assert _corpus is not None
+        pairs, _solos = iter_split_pairs(find_split_slide_files_recursive(_corpus / "slides"))
+        noise: Counter = Counter()
+        unregistered: set[str] = set()
+        for de_path, _en_path in pairs:
+            bundle = load_bundle(de_path)
+            if bundle.outcome.deck is None:
+                continue
+            diff = diff_deck(bundle.outcome.deck, baseline_from_deck(bundle.outcome.deck))
+            if diff.items:
+                noise[de_path.name] = len(diff.items)
+            for item in diff.items:
+                if item.action not in MECHANICAL_ACTIONS | FRAMED_ACTIONS:
+                    unregistered.add(item.action)
+        assert not unregistered, f"actions outside the closed registry: {unregistered}"
+        assert dict(noise) == _EXPECTED_SELF_DIFF_ITEMS


### PR DESCRIPTION
The corpus is published — **https://github.com/hoelzl/ClmTestCourse** (CC BY-NC-SA 4.0, maintainer-reviewed content decisions recorded in its `REVIEW.md`, course specs included, LF-pinned). This PR wires CLM's gates to it:

- `tests/slides/public_corpus_pin.py` — the single pin (repo + commit `c536d5bb`). Bump it deliberately, together with the expected numbers.
- `scripts/fetch_test_corpus.py` — idempotent shallow fetch at the pin into the gitignored `.clm-test-corpus/`; reads (not imports) the pin module so the fetch and the assertion cannot disagree.
- `tests/slides/test_public_corpus.py` (`integration`) — **exact** assertions, not ceilings, because the corpus cannot move: 16 pairs, 11 parsed / 5 refused, the full refusal-code population, both observation carriers, `project ∘ parse` byte-identity, the measured self-diff noise floor (12 items concentrated in the observation decks), and that the checkout is at the pin (wrong revision fails; env-provided plain dirs skip the pin check but still face the exact numbers).
- CI: the integration suite fetches the corpus best-effort (a GitHub hiccup skips the gates rather than failing the run; the pin keeps every successful run comparable).
- `testing.md` documents the three corpus tiers (bundled / pinned-public / private); the `idless_narrative` synthetic template gains its canonical blank lead so each refusal deck carries exactly one finding class.

Verified locally: fresh fetch → 3/3 gates green; second fetch short-circuits at the pin; full fast suite green (9510).

Refs #682 — remaining on the issue: the PythonCourses-side hygiene gate (pinned clm, pre-push + CI backstop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh
