### PR TITLE
feat(tests): Phase 7 re-layering prerequisites — the D11 gate (#801)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,12 @@ jobs:
       run: |
         uv run --no-sync pytest -v -m "not slow and not integration and not e2e and not docker" --timeout=120 --cov=src/clm --cov-report=xml --cov-report=term
 
+    # Phase 7 item 4 (#801): the modules the #802 re-layering will move may
+    # not lose test coverage on the way — floors measured on this suite.
+    - name: Coverage floors on the re-layering modules
+      if: needs.changes.outputs.code == 'true' && matrix.suite == 'unit'
+      run: python scripts/check_coverage_floor.py coverage.xml
+
     # The pinned public corpus (#682): tests/slides/test_public_corpus.py
     # skips cleanly when the checkout is absent, so only the integration
     # suite pays the (shallow, pinned) fetch. Best-effort on purpose — a

--- a/changelog.d/801-phase7-relayering-prerequisites.added.md
+++ b/changelog.d/801-phase7-relayering-prerequisites.added.md
@@ -1,0 +1,15 @@
+- **Re-layering prerequisites (#801, remediation Phase 7 / D11) — the gate on
+  the #802 re-layering is in place.** Four pieces: a golden double-build
+  characterization suite (`tests/e2e/test_e2e_golden_build.py` — the rich and
+  the minimal reference courses each built twice from scratch and byte-compared
+  via `--snapshot`/`--verify-against`; acceptance met with two consecutive
+  green runs on unchanged code); executable layer-boundary contracts
+  (`tests/test_architecture_contracts.py` — the complete 46-file inventory of
+  today's layering violations as a shrink-only ratchet, plus pins on the
+  `Backend` surface and the worker payload schemas); real unmocked
+  build-pipeline tests in the fast suite
+  (`tests/build/test_pipeline_unmocked.py` — a data-only course through the
+  real stages and a PlantUML job round-tripping a real queue on a temp DB);
+  and per-module coverage floors on everything Phase 8 moves
+  (`scripts/check_coverage_floor.py`, checked in CI's unit job). Remediation
+  Phases 4–8 now have tracking issues (#798–#802).

--- a/changelog.d/801-phase7-relayering-prerequisites.added.md
+++ b/changelog.d/801-phase7-relayering-prerequisites.added.md
@@ -4,8 +4,9 @@
   the minimal reference courses each built twice from scratch and byte-compared
   via `--snapshot`/`--verify-against`; acceptance met with two consecutive
   green runs on unchanged code); executable layer-boundary contracts
-  (`tests/test_architecture_contracts.py` — the complete 46-file inventory of
-  today's layering violations as a shrink-only ratchet, plus pins on the
+  (`tests/test_architecture_contracts.py` — the complete 50-edge inventory (40 files)
+  of today's layering violations over the documented layer stack as a
+  shrink-only ratchet, plus pins on the
   `Backend` surface and the worker payload schemas); real unmocked
   build-pipeline tests in the fast suite
   (`tests/build/test_pipeline_unmocked.py` — a data-only course through the

--- a/docs/claude/handovers/adversarial-review-remediation-handover.md
+++ b/docs/claude/handovers/adversarial-review-remediation-handover.md
@@ -1095,16 +1095,18 @@ which is another reason Phase 1 precedes everything.
 
 ---
 
-### Phase 7 — Re-layering prerequisites (D11)  ▸ STATUS: DONE 2026-08-06 ▸ TRACKED: #801
+### Phase 7 — Re-layering prerequisites (D11)  ▸ STATUS: DONE 2026-08-06 (wiring proof = the delivering PR's own CI run) ▸ TRACKED: #801
 
 **Landed as** (all four items; acceptance met — the golden suite passed
 twice in a row on unchanged code): (1) `tests/e2e/test_e2e_golden_build.py`
 — double-build byte-identity over test-spec-1 (rich) and test-spec-3
 (minimal), on the `--snapshot`/`--verify-against` harness; the #681 replay
 round trip covers the http-replay course. (2)
-`tests/test_architecture_contracts.py` — the 46-entry layer-violation
-RATCHET (file-level, both-direction, lazy-import-aware; Phase 8's
-shrinking checklist), the Backend-surface pin (incl. the honest A11
+`tests/test_architecture_contracts.py` — the 50-edge layer-violation
+RATCHET over the FULL documented stack (file-level, both-direction,
+lazy-import-aware, string-import-guarded; the round-2 review added the
+infrastructure→workers and workers→extensions edges its round-1 inventory
+missed; Phase 8's shrinking checklist), the Backend-surface pin (incl. the honest A11
 ladder shape: LocalOpsBackend is itself partially abstract), and the
 worker payload schema pins. (3) `tests/build/test_pipeline_unmocked.py`
 — T3: real Course + real SqliteBackend + temp DB, data-only stage flow

--- a/docs/claude/handovers/adversarial-review-remediation-handover.md
+++ b/docs/claude/handovers/adversarial-review-remediation-handover.md
@@ -950,7 +950,7 @@ keep the security change reviewable in one sitting, and neither is blocked.
 
 ---
 
-### Phase 4 — Filesystem containment & secrets  ▸ STATUS: not started (S5 pulled forward to Phase 3a)
+### Phase 4 — Filesystem containment & secrets  ▸ STATUS: not started (S5 pulled forward to Phase 3a) ▸ TRACKED: #798
 
 **Goal**: content and config from a course repo cannot reach outside the paths
 CLM owns, and secrets stay out of logs and commits.
@@ -1020,7 +1020,7 @@ recorded cassette contains no Azure/Gemini key and no `Set-Cookie`;
 
 ---
 
-### Phase 5 — Job-queue correctness  ▸ STATUS: not started
+### Phase 5 — Job-queue correctness  ▸ STATUS: not started ▸ TRACKED: #799
 **Depends on**: Phase 1 (T1's resurrected tests cover exactly this code).
 
 **Goal**: no job runs twice, no build interferes with another, no corrupted
@@ -1072,7 +1072,7 @@ deliberately torn output file is rejected rather than cached.
 
 ---
 
-### Phase 6 — Cross-machine coordination via the worker API (D5)  ▸ STATUS: not started
+### Phase 6 — Cross-machine coordination via the worker API (D5)  ▸ STATUS: not started ▸ TRACKED: #800
 **Depends on**: Phase 2 (auth + coordinator-mode binding) and Phase 5 (the queue
 semantics being replicated must be correct first).
 
@@ -1095,7 +1095,23 @@ which is another reason Phase 1 precedes everything.
 
 ---
 
-### Phase 7 — Re-layering prerequisites (D11)  ▸ STATUS: not started
+### Phase 7 — Re-layering prerequisites (D11)  ▸ STATUS: DONE 2026-08-06 ▸ TRACKED: #801
+
+**Landed as** (all four items; acceptance met — the golden suite passed
+twice in a row on unchanged code): (1) `tests/e2e/test_e2e_golden_build.py`
+— double-build byte-identity over test-spec-1 (rich) and test-spec-3
+(minimal), on the `--snapshot`/`--verify-against` harness; the #681 replay
+round trip covers the http-replay course. (2)
+`tests/test_architecture_contracts.py` — the 46-entry layer-violation
+RATCHET (file-level, both-direction, lazy-import-aware; Phase 8's
+shrinking checklist), the Backend-surface pin (incl. the honest A11
+ladder shape: LocalOpsBackend is itself partially abstract), and the
+worker payload schema pins. (3) `tests/build/test_pipeline_unmocked.py`
+— T3: real Course + real SqliteBackend + temp DB, data-only stage flow
+and a real PlantUML worker round-tripping a job through the queue, in
+the fast suite (~15 s). (4) `scripts/check_coverage_floor.py` + a CI
+unit-job step flooring `build.py`, `course.py`, `path_utils.py`, the
+backends.
 
 **Hard gate**: no Phase 8 commit lands until all four items below are complete
 and green. This is the maintainer's explicit condition on D10.
@@ -1167,7 +1183,7 @@ unchanged code (proving determinism) before it is trusted as a refactor gate.
 
 ---
 
-### Phase 8 — Full re-layering (D10)  ▸ STATUS: blocked on Phase 7
+### Phase 8 — Full re-layering (D10)  ▸ STATUS: blocked on Phase 7 ▸ TRACKED: #802
 
 **Goal**: the architecture the docs describe. Work strictly in dependency order,
 one PR per step, golden suite green after each.

--- a/scripts/check_coverage_floor.py
+++ b/scripts/check_coverage_floor.py
@@ -1,0 +1,76 @@
+"""Phase 7 item 4 (#801): per-module coverage floors on what Phase 8 moves.
+
+The re-layering (#802) relocates ``build.py``, ``course.py``, ``path_utils.py``
+and the backends. A refactor of those modules with sinking test coverage is
+exactly how a "mechanical move" quietly sheds behavior, so their line coverage
+is floored here and checked in CI's unit job. Floors are set a few points
+below the measured baseline (so ordinary churn does not flake the gate) and
+should be RAISED as coverage genuinely improves — never lowered to make a
+red gate green without a maintainer decision.
+
+The handover's landmine applies: a coverage number can be met by tautological
+tests. The floor is the cheap tripwire; the Phase-7 review round and the
+golden suite are what make the number mean something.
+
+Usage::
+
+    python scripts/check_coverage_floor.py coverage.xml
+"""
+
+from __future__ import annotations
+
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+#: filename suffix (as it appears in coverage.xml) -> minimum line-rate %.
+#: Baselines measured 2026-08-06 on the unit suite (`-m "not slow and not
+#: integration and not e2e and not docker" --cov=src/clm`); floors sit ~5
+#: points below the measurement.
+FLOORS: dict[str, float] = {
+    "cli/commands/build.py": 75.0,  # measured 2026-08-06: 80.9
+    "core/course.py": 84.0,  # measured 2026-08-06: 89.5
+    "infrastructure/utils/path_utils.py": 91.0,  # measured 2026-08-06: 96.5
+    "infrastructure/backend.py": 95.0,  # measured 2026-08-06: 100.0
+    "infrastructure/backends/local_ops_backend.py": 83.0,  # measured 2026-08-06: 88.6
+    "infrastructure/backends/sqlite_backend.py": 79.0,  # measured 2026-08-06: 84.2
+}
+
+
+def module_line_rates(coverage_xml: Path) -> dict[str, float]:
+    """``suffix -> line-rate %`` for every floored module found in the report."""
+    tree = ET.parse(coverage_xml)
+    rates: dict[str, float] = {}
+    for cls in tree.iter("class"):
+        filename = (cls.get("filename") or "").replace("\\", "/")
+        for suffix in FLOORS:
+            if filename.endswith(suffix):
+                rates[suffix] = float(cls.get("line-rate") or 0.0) * 100.0
+    return rates
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(__doc__)
+        return 2
+    report = Path(sys.argv[1])
+    if not report.is_file():
+        print(f"ERROR: {report} not found", file=sys.stderr)
+        return 2
+    rates = module_line_rates(report)
+    failures = 0
+    for suffix, floor in sorted(FLOORS.items()):
+        rate = rates.get(suffix)
+        if rate is None:
+            failures += 1
+            print(f"FLOOR MISS  {suffix}: not present in the coverage report")
+            continue
+        verdict = "ok" if rate >= floor else "BELOW FLOOR"
+        if rate < floor:
+            failures += 1
+        print(f"{verdict:>12}  {suffix}: {rate:.1f}% (floor {floor:.1f}%)")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/build/test_pipeline_unmocked.py
+++ b/tests/build/test_pipeline_unmocked.py
@@ -1,0 +1,142 @@
+"""Phase 7 item 3 (#801, T3): real, unmocked build-pipeline tests, fast suite.
+
+The review's T3: the only fast-suite coverage of the build pipeline stubbed
+``Course``, both backends, the reporter, and made ``execution_stages()``
+return ``[]`` — so "the pipeline works" was asserted by tests that never ran
+any of it. These tests run the REAL pipeline end to end with **zero mocks**:
+a real parsed :class:`Course`, the real ``SqliteBackend`` against a temp DB,
+real stage sequencing via ``Course.process_all``, and — in the worker test —
+real job submission, claiming and completion through the queue by a real
+direct-mode PlantUML worker process.
+
+Deliberately kernel-free (no notebook execution) so the fast suite stays
+fast; the notebook path's unmocked coverage is the e2e tier (the golden
+double-build suite and the #681 replay gates). Worker startup and the JVM
+render cost ~8s, isolated to one test and serialized in the ``subproc``
+resource class.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from clm.core.course import Course
+from clm.core.course_spec import CourseSpec
+
+_TEST_DATA = Path(__file__).resolve().parent.parent / "test-data"
+
+_DATA_ONLY_SPEC = """<course>
+    <name><de>Datenkurs</de><en>Data Course</en></name>
+    <prog-lang>python</prog-lang>
+    <description><de>Nur Daten.</de><en>Data only.</en></description>
+    <certificate><de>Kein.</de><en>None.</en></certificate>
+    <project-slug>data-only</project-slug>
+    <sections>
+        <section>
+            <name><de>Daten</de><en>Data</en></name>
+            <topics><topic>just_data</topic></topics>
+        </section>
+    </sections>
+</course>
+"""
+
+
+@pytest.mark.asyncio
+async def test_data_only_course_flows_through_the_real_stages(tmp_path: Path) -> None:
+    """Real Course, real SqliteBackend, real stage sequencing, real file I/O —
+    no queue jobs needed (copies execute host-side), no mocks anywhere."""
+    from clm.infrastructure.backends.sqlite_backend import SqliteBackend
+
+    course_root = tmp_path / "course"
+    topic = course_root / "slides" / "module_100_data" / "topic_100_just_data"
+    topic.mkdir(parents=True)
+    (topic / "payload.data").write_text("bytes that must arrive verbatim\n", encoding="utf-8")
+    spec_path = course_root / "course-specs" / "spec.xml"
+    spec_path.parent.mkdir(parents=True)
+    spec_path.write_text(_DATA_ONLY_SPEC, encoding="utf-8")
+
+    output_root = tmp_path / "out"
+    spec = CourseSpec.from_file(spec_path)
+    course = Course.from_spec(spec, course_root, output_root)
+
+    backend = SqliteBackend(
+        db_path=tmp_path / "jobs.db",
+        workspace_path=tmp_path / "workspace",
+        ignore_db=True,
+        max_wait_for_completion_duration=60,
+    )
+    async with backend:
+        await course.process_all(backend)
+
+    copies = list(output_root.rglob("payload.data"))
+    assert copies, "the data file must reach the output tree"
+    for copy in copies:
+        assert copy.read_text(encoding="utf-8") == "bytes that must arrive verbatim\n"
+    # The temp DB is real and was really opened — the point of T3 is that
+    # nothing on this path is a stub.
+    assert (tmp_path / "jobs.db").is_file()
+
+
+@pytest.mark.asyncio
+@pytest.mark.serial("subproc")
+async def test_plantuml_job_round_trips_through_the_real_queue(tmp_path: Path) -> None:
+    """Real job submission against a temp DB, claimed and completed by a real
+    direct-mode PlantUML worker process, output rendered — the exact seam the
+    mocked tests never exercised (T3)."""
+    from clm.infrastructure.backends.sqlite_backend import SqliteBackend
+    from clm.infrastructure.workers.pool_manager import WorkerConfig, WorkerPoolManager
+
+    course_root = tmp_path / "course"
+    shutil.copytree(_TEST_DATA, course_root)
+    output_root = tmp_path / "out"
+    spec = CourseSpec.from_file(course_root / "course-specs" / "test-spec-4.xml")
+    course = Course.from_spec(spec, course_root, output_root)
+
+    db_path = tmp_path / "jobs.db"
+    workspace = tmp_path / "workspace"
+    backend = SqliteBackend(
+        db_path=db_path,
+        workspace_path=workspace,
+        ignore_db=True,
+        max_wait_for_completion_duration=120,
+    )
+    manager = WorkerPoolManager(
+        db_path=db_path,
+        workspace_path=workspace,
+        worker_configs=[WorkerConfig(worker_type="plantuml", count=1, execution_mode="direct")],
+    )
+    manager.start_pools()
+    try:
+        deadline = time.monotonic() + 30
+        while True:
+            conn = manager.job_queue._get_conn()
+            active = conn.execute(
+                "SELECT COUNT(*) FROM workers WHERE status IN ('idle', 'busy')"
+            ).fetchone()[0]
+            if active >= 1:
+                break
+            assert time.monotonic() < deadline, "plantuml worker never became active"
+            time.sleep(0.1)
+
+        async with backend:
+            await course.process_all(backend)
+    finally:
+        manager.stop_pools()
+        manager.close()
+
+    rendered = list(output_root.rglob("simple_diagram.png"))
+    assert rendered, "the PlantUML render must reach the output tree"
+    assert rendered[0].stat().st_size > 0
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute("SELECT status, COUNT(*) FROM jobs GROUP BY status").fetchall()
+    by_status = dict(rows)
+    assert by_status.get("completed", 0) >= 1, (
+        f"at least one job must round-trip the real queue; saw {by_status}"
+    )
+    assert not (set(by_status) - {"completed"}), f"non-terminal/failed jobs: {by_status}"

--- a/tests/e2e/test_e2e_golden_build.py
+++ b/tests/e2e/test_e2e_golden_build.py
@@ -53,6 +53,15 @@ def _build(course: Path, spec_name: str, *args: str) -> subprocess.CompletedProc
             sys.executable,
             "-m",
             "clm",
+            # Round-2 review finding: without these, the CWD-anchored defaults
+            # put BOTH builds' cache/jobs DBs at the repo root — shared state
+            # whose harmlessness rested entirely on --ignore-cache staying
+            # total. Per-course DBs make the isolation structural (and stop
+            # golden runs from growing a cache DB at every dev's repo root).
+            "--cache-db-path",
+            str(course / "golden-cache.db"),
+            "--jobs-db-path",
+            str(course / "golden-jobs.db"),
             "build",
             str(course / "course-specs" / spec_name),
             "-d",
@@ -69,7 +78,7 @@ def _build(course: Path, spec_name: str, *args: str) -> subprocess.CompletedProc
     )
 
 
-def _double_build_is_byte_identical(tmp_path: Path, spec_name: str) -> None:
+def _double_build_is_byte_identical(tmp_path: Path, spec_name: str, min_files: int) -> None:
     snapshot = tmp_path / "snapshot"
 
     course_a = tmp_path / "a"
@@ -77,7 +86,16 @@ def _double_build_is_byte_identical(tmp_path: Path, spec_name: str) -> None:
     first = _build(course_a, spec_name, "--snapshot", str(snapshot))
     assert first.returncode == 0, first.stdout + first.stderr
 
-    # A completely fresh copy: cold job/cache DBs, untouched source tree —
+    # Round-2 review finding: the verifier reports has_diffs=False over an
+    # empty or all-missing tree, so without a floor a build that produced
+    # NOTHING would still "verify". The comparison must be about something.
+    compared = [p for p in snapshot.rglob("*") if p.is_file() and p.suffix != ".html"]
+    assert len(compared) >= min_files, (
+        f"snapshot holds only {len(compared)} non-html files (< {min_files}) — "
+        "the golden comparison would be vacuous"
+    )
+
+    # A completely fresh copy with its own cold DBs and untouched source tree —
     # nothing from build A can leak into build B except through the outputs
     # being genuinely deterministic.
     course_b = tmp_path / "b"
@@ -87,13 +105,17 @@ def _double_build_is_byte_identical(tmp_path: Path, spec_name: str) -> None:
     assert "Verification passed" in second.stdout
 
 
+# Explicit per-test budgets: CI runs e2e with a 600 s default that would cap
+# BOTH builds of one test (round-2 finding); these markers take precedence.
+@pytest.mark.timeout(1900)
 def test_rich_course_double_build_is_byte_identical(tmp_path: Path) -> None:
     """test-spec-1: notebooks, both diagram converters, images, data,
     dir-groups — the golden gate over the paths Phase 8 will move."""
-    _double_build_is_byte_identical(tmp_path, "test-spec-1.xml")
+    _double_build_is_byte_identical(tmp_path, "test-spec-1.xml", min_files=50)
 
 
+@pytest.mark.timeout(1900)
 def test_minimal_notebook_course_double_build_is_byte_identical(tmp_path: Path) -> None:
     """test-spec-3: the single-notebook course — a determinism break in the
     core notebook path fails here without the full course's noise."""
-    _double_build_is_byte_identical(tmp_path, "test-spec-3.xml")
+    _double_build_is_byte_identical(tmp_path, "test-spec-3.xml", min_files=20)

--- a/tests/e2e/test_e2e_golden_build.py
+++ b/tests/e2e/test_e2e_golden_build.py
@@ -1,0 +1,99 @@
+"""Phase 7 item 1 (#801): the golden end-to-end build characterization suite.
+
+The D11 hard gate on the Phase 8 re-layering (#802): reference courses built
+end-to-end, full output trees snapshotted, and asserted **byte-identical** —
+so a refactor that changes any output byte fails before it merges. Each test
+here builds the same course twice from scratch (fresh source copies, cold
+caches, ``--ignore-cache``) and verifies build B against build A's snapshot:
+green means the pipeline is deterministic on unchanged code, which is the
+handover's acceptance criterion and what makes the suite trustworthy as a
+refactor gate. During Phase 8 the workflow is the same mechanism across the
+refactor boundary: snapshot before, verify after.
+
+Two reference courses:
+
+* ``test-spec-1`` — the rich course: notebooks (bilingual + split routing),
+  PlantUML + DrawIO conversions, static and generated images, data files,
+  dir-groups. This is the tree most of the A-findings' code paths feed.
+* ``test-spec-3`` — the minimal single-notebook course, so a determinism
+  break in the core notebook path is attributable without the noise of the
+  full course.
+
+The HTTP-replay course has its own golden-style round trip in
+``test_e2e_http_replay.py``.
+
+``--verify-against`` skips ``.html`` by default (live-kernel output is
+inherently nondeterministic — object reprs, ASLR); everything else, including
+executed ``.ipynb``, images and copied data, is byte-compared. Builds run as
+CLI subprocesses with a scrubbed environment (no inherited ``CLM_*``), the
+standing hermeticity landmine.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.e2e, pytest.mark.serial("subproc")]
+
+_TEST_DATA = Path(__file__).resolve().parent.parent / "test-data"
+_BUILD_TIMEOUT = 900
+
+
+def _build(course: Path, spec_name: str, *args: str) -> subprocess.CompletedProcess:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("CLM_")}
+    env.pop("CI", None)
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "clm",
+            "build",
+            str(course / "course-specs" / spec_name),
+            "-d",
+            str(course),
+            "--ignore-cache",
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=_BUILD_TIMEOUT,
+        env=env,
+    )
+
+
+def _double_build_is_byte_identical(tmp_path: Path, spec_name: str) -> None:
+    snapshot = tmp_path / "snapshot"
+
+    course_a = tmp_path / "a"
+    shutil.copytree(_TEST_DATA, course_a)
+    first = _build(course_a, spec_name, "--snapshot", str(snapshot))
+    assert first.returncode == 0, first.stdout + first.stderr
+
+    # A completely fresh copy: cold job/cache DBs, untouched source tree —
+    # nothing from build A can leak into build B except through the outputs
+    # being genuinely deterministic.
+    course_b = tmp_path / "b"
+    shutil.copytree(_TEST_DATA, course_b)
+    second = _build(course_b, spec_name, "--verify-against", str(snapshot))
+    assert second.returncode == 0, second.stdout + second.stderr
+    assert "Verification passed" in second.stdout
+
+
+def test_rich_course_double_build_is_byte_identical(tmp_path: Path) -> None:
+    """test-spec-1: notebooks, both diagram converters, images, data,
+    dir-groups — the golden gate over the paths Phase 8 will move."""
+    _double_build_is_byte_identical(tmp_path, "test-spec-1.xml")
+
+
+def test_minimal_notebook_course_double_build_is_byte_identical(tmp_path: Path) -> None:
+    """test-spec-3: the single-notebook course — a determinism break in the
+    core notebook path fails here without the full course's noise."""
+    _double_build_is_byte_identical(tmp_path, "test-spec-3.xml")

--- a/tests/test_architecture_contracts.py
+++ b/tests/test_architecture_contracts.py
@@ -37,20 +37,24 @@ def _extension_packages() -> frozenset[str]:
 
 
 def _forbidden_targets() -> dict[str, frozenset[str]]:
-    """The documented layering, as forbidden import edges (review §4).
+    """The documented layering, as forbidden import edges.
 
-    ``core`` may depend on nothing above it — not infrastructure (A1), not
-    the CLI (A2's mirror), not workers or extension packages (A3).
-    ``infrastructure`` and ``workers`` may not reach into the CLI (A2).
-    Extension packages are derived, not hardcoded, so a new top-level
-    package is automatically protected from ``core`` without editing this
-    test.
+    ``architecture.md`` stacks core → infrastructure → workers → extensions
+    → cli: each layer may depend only on the layers *below* it. So ``core``
+    depends on nothing (A1/A2/A3), ``infrastructure`` may not reach up into
+    workers, extensions or the CLI (A2), and ``workers`` may not reach into
+    extensions or the CLI. Extension packages and the CLI are unconstrained
+    (they sit at the top). The extension set is derived, not hardcoded, so a
+    new top-level package is automatically protected without editing this
+    test. (The review's own inventory covered only the A1/A2/A3 edges; the
+    round-2 review of this gate found live violations on the two missing
+    edge classes, now part of the ratchet.)
     """
     extensions = _extension_packages()
     return {
         "core": frozenset({"infrastructure", "cli", "workers"} | extensions),
-        "infrastructure": frozenset({"cli"}),
-        "workers": frozenset({"cli"}),
+        "infrastructure": frozenset({"cli", "workers"} | extensions),
+        "workers": frozenset({"cli"} | extensions),
     }
 
 
@@ -83,10 +87,15 @@ def _current_violations() -> set[str]:
 
 
 #: The complete violation inventory at the time the ratchet was pinned
-#: (2026-08-06, 46 files — matching the review's A1/A2/A3 findings). Phase 8
-#: removes entries as it moves code; nothing may be added.
+#: (2026-08-06: 50 edges over 40 files — the review's A1/A2/A3 findings plus
+#: the infrastructure→workers and workers→extensions residents its inventory
+#: missed). Phase 8 removes entries as it moves code; nothing may be added.
 KNOWN_LAYER_VIOLATIONS = frozenset(
     {
+        "infrastructure -> workers: infrastructure/workers/image_identity.py",
+        "workers -> slides: workers/notebook/notebook_processor.py",
+        "workers -> slides: workers/notebook/output_spec.py",
+        "workers -> slides: workers/notebook/utils/jupyter_utils.py",
         "core -> cli: core/operations/process_notebook.py",
         "core -> infrastructure: core/affected_specs.py",
         "core -> infrastructure: core/cmake_export.py",
@@ -152,31 +161,49 @@ class TestLayerBoundaryRatchet:
             "KNOWN_LAYER_VIOLATIONS (the list only shrinks):\n  " + "\n  ".join(sorted(fixed))
         )
 
-    def test_the_scanner_sees_lazy_imports(self):
+    def test_the_scanner_sees_lazy_imports(self, tmp_path):
         """The ratchet is only as good as the scanner: A2's inventory hid in
-        function bodies, so a module-level-only scan would ratchet a fiction."""
+        function bodies, so a module-level-only scan would ratchet a fiction.
+        Exercises the REAL ``_clm_imports`` (review round 2: an inline
+        reimplementation would pass while the scanner itself regressed)."""
         import textwrap
 
-        tree_file = _SRC / "infrastructure" / "backends" / "sqlite_backend.py"
+        probe = tmp_path / "probe.py"
+        probe.write_text(
+            textwrap.dedent(
+                """
+                def lazy():
+                    from clm.cli.build_data_classes import BuildWarning
+                    return BuildWarning
+                """
+            ),
+            encoding="utf-8",
+        )
+        assert "clm.cli.build_data_classes" in _clm_imports(probe)
+        # ...and the live inventory carries a known lazy-import resident.
         assert "infrastructure -> cli: infrastructure/backends/sqlite_backend.py" in (
             KNOWN_LAYER_VIOLATIONS
         )
-        # And on a synthetic module, straight from source text:
-        snippet = textwrap.dedent(
-            """
-            def lazy():
-                from clm.cli.build_data_classes import BuildWarning
-                return BuildWarning
-            """
+
+    def test_no_string_based_imports_dodge_the_ratchet(self):
+        """The scanner is AST-based, so ``importlib.import_module("clm...")``
+        or ``__import__("clm...")`` would slip past it (round-2 finding M4).
+        There are none in the constrained layers today, and this guard keeps
+        it that way — a Phase 8 mover must not "fix" a ratchet entry by
+        stringifying the import."""
+        offenders: list[str] = []
+        for file in sorted(_SRC.rglob("*.py")):
+            rel = file.relative_to(_SRC).as_posix()
+            if rel.split("/", 1)[0] not in _forbidden_targets():
+                continue
+            text = file.read_text(encoding="utf-8")
+            for needle in ('import_module("clm.', "import_module('clm.", '__import__("clm.'):
+                if needle in text:
+                    offenders.append(f"{rel}: {needle}")
+        assert not offenders, (
+            "string-based clm imports in constrained layers dodge the AST "
+            "ratchet — use a real import statement:\n  " + "\n  ".join(offenders)
         )
-        tree = ast.parse(snippet)
-        found = {
-            node.module
-            for node in ast.walk(tree)
-            if isinstance(node, ast.ImportFrom) and node.module
-        }
-        assert "clm.cli.build_data_classes" in found
-        assert tree_file.is_file()
 
 
 class TestBackendContract:
@@ -255,10 +282,38 @@ class TestWorkerPayloadContract:
         "worker_image_identity",
     }
 
+    #: PlantUML/DrawIO extend the image payload with the output file NAME —
+    #: renaming it strands lagging Docker workers, the exact scenario this
+    #: class exists to make deliberate (round-2 finding: it was unpinned).
+    DIAGRAM_FIELDS = IMAGE_FIELDS | {"output_file_name"}
+    JUPYTERLITE_FIELDS = BASE_FIELDS | {
+        "app_archive",
+        "branding_logo",
+        "branding_site_name",
+        "branding_theme",
+        "course_root",
+        "environment_yml",
+        "jupyterlite_core_version",
+        "kernel",
+        "kinds",
+        "language",
+        "launcher",
+        "notebook_trees",
+        "output_dir",
+        "target_name",
+        "wheels",
+    }
+
     def test_payload_schemas_are_pinned(self):
         from clm.infrastructure.messaging.base_classes import ImagePayload, Payload
+        from clm.infrastructure.messaging.drawio_classes import DrawioPayload
+        from clm.infrastructure.messaging.jupyterlite_classes import JupyterLitePayload
         from clm.infrastructure.messaging.notebook_classes import NotebookPayload
+        from clm.infrastructure.messaging.plantuml_classes import PlantUmlPayload
 
         assert frozenset(Payload.model_fields) == self.BASE_FIELDS
         assert frozenset(ImagePayload.model_fields) == self.IMAGE_FIELDS
         assert frozenset(NotebookPayload.model_fields) == self.NOTEBOOK_FIELDS
+        assert frozenset(PlantUmlPayload.model_fields) == self.DIAGRAM_FIELDS
+        assert frozenset(DrawioPayload.model_fields) == self.DIAGRAM_FIELDS
+        assert frozenset(JupyterLitePayload.model_fields) == self.JUPYTERLITE_FIELDS

--- a/tests/test_architecture_contracts.py
+++ b/tests/test_architecture_contracts.py
@@ -1,0 +1,264 @@
+"""Phase 7 item 2 (#801): layer-boundary contracts, as executable ratchets.
+
+The 2026-07-24 adversarial review's §4 verdict: *"The documented four-layer
+architecture does not exist in the code… the boundaries are fiction"* (A1–A6).
+Since every documented boundary is currently violated, the Phase-7 form of a
+"contract" is a **ratchet**: the complete, file-level inventory of today's
+violations is pinned below, and the test fails in BOTH directions — a new
+forbidden import fails immediately, and a fixed file must be removed from the
+inventory, so the list only shrinks. Phase 8 (#802) works this list down to
+empty, at which point the ratchet collapses into the real contract
+(import-linter in CI, per Phase 8 item 4).
+
+Also pinned, as the boundaries Phase 8 must not silently change while moving
+code beneath them: the abstract :class:`Backend` surface and the worker-side
+Pydantic payload schemas (the process boundary every worker deserializes).
+
+The scanner is deliberately total: it sees module-level AND lazy (function-
+body) imports, because the review's A2 inventory showed the cycle hiding in
+both.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src" / "clm"
+_LAYERS = {"core", "infrastructure", "cli", "workers"}
+
+
+def _extension_packages() -> frozenset[str]:
+    return frozenset(
+        p.name
+        for p in _SRC.iterdir()
+        if p.is_dir() and p.name not in _LAYERS and not p.name.startswith("_")
+    )
+
+
+def _forbidden_targets() -> dict[str, frozenset[str]]:
+    """The documented layering, as forbidden import edges (review §4).
+
+    ``core`` may depend on nothing above it — not infrastructure (A1), not
+    the CLI (A2's mirror), not workers or extension packages (A3).
+    ``infrastructure`` and ``workers`` may not reach into the CLI (A2).
+    Extension packages are derived, not hardcoded, so a new top-level
+    package is automatically protected from ``core`` without editing this
+    test.
+    """
+    extensions = _extension_packages()
+    return {
+        "core": frozenset({"infrastructure", "cli", "workers"} | extensions),
+        "infrastructure": frozenset({"cli"}),
+        "workers": frozenset({"cli"}),
+    }
+
+
+def _clm_imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            found |= {alias.name for alias in node.names if alias.name.startswith("clm.")}
+        elif isinstance(node, ast.ImportFrom) and node.module and node.module.startswith("clm."):
+            found.add(node.module)
+    return found
+
+
+def _current_violations() -> set[str]:
+    """Every ``"<edge>: <file>"`` where a layer imports a forbidden target."""
+    forbidden = _forbidden_targets()
+    violations: set[str] = set()
+    for file in sorted(_SRC.rglob("*.py")):
+        rel = file.relative_to(_SRC).as_posix()
+        source_pkg = rel.split("/", 1)[0] if "/" in rel else None
+        if source_pkg not in forbidden:
+            continue
+        for target in _clm_imports(file):
+            parts = target.split(".")
+            target_pkg = parts[1] if len(parts) > 1 else ""
+            if target_pkg in forbidden[source_pkg]:
+                violations.add(f"{source_pkg} -> {target_pkg}: {rel}")
+    return violations
+
+
+#: The complete violation inventory at the time the ratchet was pinned
+#: (2026-08-06, 46 files — matching the review's A1/A2/A3 findings). Phase 8
+#: removes entries as it moves code; nothing may be added.
+KNOWN_LAYER_VIOLATIONS = frozenset(
+    {
+        "core -> cli: core/operations/process_notebook.py",
+        "core -> infrastructure: core/affected_specs.py",
+        "core -> infrastructure: core/cmake_export.py",
+        "core -> infrastructure: core/course.py",
+        "core -> infrastructure: core/course_file.py",
+        "core -> infrastructure: core/course_files/data_file.py",
+        "core -> infrastructure: core/course_files/drawio_file.py",
+        "core -> infrastructure: core/course_files/duplicated_image_file.py",
+        "core -> infrastructure: core/course_files/image_file.py",
+        "core -> infrastructure: core/course_files/notebook_file.py",
+        "core -> infrastructure: core/course_files/plantuml_file.py",
+        "core -> infrastructure: core/course_files/shared_image_file.py",
+        "core -> infrastructure: core/cross_references.py",
+        "core -> infrastructure: core/dir_group.py",
+        "core -> infrastructure: core/image_registry.py",
+        "core -> infrastructure: core/operations/build_jupyterlite_site.py",
+        "core -> infrastructure: core/operations/convert_drawio_file.py",
+        "core -> infrastructure: core/operations/convert_plantuml_file.py",
+        "core -> infrastructure: core/operations/convert_source_output_file.py",
+        "core -> infrastructure: core/operations/copy_dir_group.py",
+        "core -> infrastructure: core/operations/copy_file.py",
+        "core -> infrastructure: core/operations/delete_file.py",
+        "core -> infrastructure: core/operations/process_notebook.py",
+        "core -> infrastructure: core/output_write_registry.py",
+        "core -> infrastructure: core/provenance_manifest.py",
+        "core -> infrastructure: core/section.py",
+        "core -> infrastructure: core/spec_orphans.py",
+        "core -> infrastructure: core/topic.py",
+        "core -> infrastructure: core/topic_resolver.py",
+        "core -> notebooks: core/cmake_export.py",
+        "core -> notebooks: core/operations/process_notebook.py",
+        "core -> slides: core/cmake_export.py",
+        "core -> slides: core/course.py",
+        "core -> slides: core/course_files/notebook_file.py",
+        "core -> slides: core/course_spec.py",
+        "core -> slides: core/operations/process_notebook.py",
+        "core -> workers: core/course.py",
+        "core -> workers: core/operations/build_jupyterlite_site.py",
+        "core -> workers: core/operations/process_notebook.py",
+        "infrastructure -> cli: infrastructure/backend.py",
+        "infrastructure -> cli: infrastructure/backends/dummy_backend.py",
+        "infrastructure -> cli: infrastructure/backends/local_ops_backend.py",
+        "infrastructure -> cli: infrastructure/backends/sqlite_backend.py",
+        "infrastructure -> cli: infrastructure/database/db_operations.py",
+        "infrastructure -> cli: infrastructure/workers/progress_tracker.py",
+        "infrastructure -> cli: infrastructure/workers/worker_base.py",
+    }
+)
+
+
+class TestLayerBoundaryRatchet:
+    def test_no_new_violations_and_no_stale_entries(self):
+        current = _current_violations()
+        new = current - KNOWN_LAYER_VIOLATIONS
+        fixed = KNOWN_LAYER_VIOLATIONS - current
+        assert not new, (
+            "NEW layer-boundary violation(s) — the documented architecture "
+            "forbids these imports (review §4 / #801); import the other "
+            "direction or move the code:\n  " + "\n  ".join(sorted(new))
+        )
+        assert not fixed, (
+            "layer violation(s) fixed — ratchet down by removing them from "
+            "KNOWN_LAYER_VIOLATIONS (the list only shrinks):\n  " + "\n  ".join(sorted(fixed))
+        )
+
+    def test_the_scanner_sees_lazy_imports(self):
+        """The ratchet is only as good as the scanner: A2's inventory hid in
+        function bodies, so a module-level-only scan would ratchet a fiction."""
+        import textwrap
+
+        tree_file = _SRC / "infrastructure" / "backends" / "sqlite_backend.py"
+        assert "infrastructure -> cli: infrastructure/backends/sqlite_backend.py" in (
+            KNOWN_LAYER_VIOLATIONS
+        )
+        # And on a synthetic module, straight from source text:
+        snippet = textwrap.dedent(
+            """
+            def lazy():
+                from clm.cli.build_data_classes import BuildWarning
+                return BuildWarning
+            """
+        )
+        tree = ast.parse(snippet)
+        found = {
+            node.module
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom) and node.module
+        }
+        assert "clm.cli.build_data_classes" in found
+        assert tree_file.is_file()
+
+
+class TestBackendContract:
+    """What a backend must implement — pinned before Phase 8 moves anything
+    beneath the interface."""
+
+    EXPECTED_ABSTRACT = frozenset(
+        {
+            "copy_dir_group_to_output",
+            "copy_file_to_output",
+            "delete_dependencies",
+            "delete_file",
+            "execute_operation",
+            "wait_for_completion",
+        }
+    )
+
+    def test_abstract_surface_is_exactly_the_contract(self):
+        from clm.infrastructure.backend import Backend
+
+        assert frozenset(Backend.__abstractmethods__) == self.EXPECTED_ABSTRACT, (
+            "the Backend contract changed — update every implementation AND "
+            "this pin in the same commit, deliberately"
+        )
+
+    def test_the_backend_ladder_shape_is_pinned(self):
+        """The review's A11 ladder, pinned as it IS: ``SqliteBackend`` is the
+        one concrete production backend; ``LocalOpsBackend`` is a *partial*
+        base that leaves exactly the dispatch pair abstract (the e2e tests
+        subclass it to fill them in). Phase 8's A11 step flattens this —
+        which will fail this pin, deliberately."""
+        from clm.infrastructure.backend import Backend
+        from clm.infrastructure.backends.local_ops_backend import LocalOpsBackend
+        from clm.infrastructure.backends.sqlite_backend import SqliteBackend
+
+        assert issubclass(SqliteBackend, Backend)
+        assert not SqliteBackend.__abstractmethods__, "the production backend must be concrete"
+        assert issubclass(LocalOpsBackend, Backend)
+        assert frozenset(LocalOpsBackend.__abstractmethods__) == frozenset(
+            {"execute_operation", "wait_for_completion"}
+        )
+
+
+class TestWorkerPayloadContract:
+    """The worker process boundary: every field a worker deserializes.
+
+    A renamed or removed field here silently breaks workers built against
+    the old schema (Docker images lag the host), so the schema changes only
+    deliberately — update the pin in the same commit as the model.
+    """
+
+    BASE_FIELDS = frozenset(
+        {"correlation_id", "data", "input_file", "input_file_name", "output_file"}
+    )
+    IMAGE_FIELDS = BASE_FIELDS | {"output_format", "worker_image_identity"}
+    NOTEBOOK_FIELDS = BASE_FIELDS | {
+        "author",
+        "cross_references",
+        "fallback_execute",
+        "format",
+        "http_replay_cassette_name",
+        "http_replay_mode",
+        "http_replay_trace_dir",
+        "img_path_prefix",
+        "inline_images",
+        "kind",
+        "language",
+        "organization",
+        "other_files",
+        "prog_lang",
+        "skip_errors",
+        "skip_evaluation",
+        "source_topic_dir",
+        "svg_available_stems",
+        "template_fingerprint",
+        "worker_image_identity",
+    }
+
+    def test_payload_schemas_are_pinned(self):
+        from clm.infrastructure.messaging.base_classes import ImagePayload, Payload
+        from clm.infrastructure.messaging.notebook_classes import NotebookPayload
+
+        assert frozenset(Payload.model_fields) == self.BASE_FIELDS
+        assert frozenset(ImagePayload.model_fields) == self.IMAGE_FIELDS
+        assert frozenset(NotebookPayload.model_fields) == self.NOTEBOOK_FIELDS


### PR DESCRIPTION
Implements **remediation Phase 7** — the maintainer's hard gate (D11) that must be green before any Phase 8 re-layering commit (#802) touches the code whose review verdict was *"the documented four-layer architecture does not exist in the code"* (A1–A6). Also files the missing tracking issues for remediation Phases 4–8 (#798–#802), which previously lived only in the handover.

**The four gate pieces:**

1. **Golden double-build characterization suite** (`tests/e2e/test_e2e_golden_build.py`): test-spec-1 (rich: notebooks, both diagram converters, images, data, dir-groups) and test-spec-3 (minimal) each built twice from scratch — fresh copies, per-course cache/jobs DBs, `--ignore-cache` — and byte-compared via `--snapshot`/`--verify-against`, with a snapshot non-triviality floor so an empty comparison can never "pass". **D11 acceptance met**: two consecutive green runs on unchanged code, plus a third under the final invocation.
2. **Layer-boundary contracts as ratchets** (`tests/test_architecture_contracts.py`): the complete **50-edge / 40-file inventory** of today's violations over the full documented stack (core → infrastructure → workers → extensions → cli), file-level, both-direction (a new violation fails; a fixed file must leave the list), lazy-import-aware, with a guard against string-based import dodges. Plus pins on the `Backend` abstract surface — including the honest A11 ladder shape (only `SqliteBackend` is concrete) — and **all five** worker payload schemas.
3. **T3 — real unmocked pipeline tests in the fast suite** (`tests/build/test_pipeline_unmocked.py`): a data-only course through the real stages (real `Course`, real `SqliteBackend`, temp DB, zero mocks) and a PlantUML job **round-tripping the real queue** via a real direct-mode worker (~15 s, `serial("subproc")`).
4. **Coverage floors** on everything Phase 8 moves (`scripts/check_coverage_floor.py` + a CI unit-job step): build.py 75, course.py 84, path_utils 91, backend 95, local_ops 83, sqlite_backend 79 — ~5 points under measured baselines; both verdict directions verified.

**Two adversarial review rounds on the gate itself** (brief: the tautology hunt — this codebase has shipped tautological tests before). Round 1: 9 mutations run, every core mechanism killed (including a live corrupted-snapshot double build with exact file attribution); verdict fix-first on six overclaims — the ratchet was missing two documented edges *with live residents*, golden builds shared repo-root DBs, the empty-comparison hole, three unpinned payload surfaces, a timeout mis-budget, and DONE-before-CI. All six fixed in the second commit; this PR's own CI run is the wiring proof the handover now names.

Full fast suite 9518 green; golden suite 3 consecutive green runs total.

Fixes #801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh
