### PR TITLE
refactor(layering): Phase 8 A2 — move build reporting out of clm.cli

### DIFF
--- a/changelog.d/802-a2-build-reporting-relayer.changed.md
+++ b/changelog.d/802-a2-build-reporting-relayer.changed.md
@@ -1,0 +1,7 @@
+- **Internal re-layering (Phase 8 step A2, refs #802)**: `clm.cli.build_data_classes`
+  and `clm.cli.error_categorizer` moved to `clm.infrastructure.build_data_classes` and
+  `clm.infrastructure.error_categorizer`; `strip_ansi` moved from `clm.cli.text_utils`
+  to `clm.infrastructure.utils.text_utils`. The infrastructure layer no longer imports
+  from the CLI — backends type their reporter against the new structural
+  `BuildReporterProtocol` instead of the CLI's `BuildReporter`. Import paths only; no
+  CLI behavior change.

--- a/src/clm/cli/build_reporter.py
+++ b/src/clm/cli/build_reporter.py
@@ -7,7 +7,8 @@ reporting, error collection, and summary generation during course builds.
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from clm.cli.build_data_classes import (
+from clm.cli.output_formatter import OutputFormatter
+from clm.infrastructure.build_data_classes import (
     BuildError,
     BuildSummary,
     BuildWarning,
@@ -15,7 +16,6 @@ from clm.cli.build_data_classes import (
     OutputConflictInfo,
     ProgressUpdate,
 )
-from clm.cli.output_formatter import OutputFormatter
 
 if TYPE_CHECKING:
     from clm.core.output_write_registry import OutputWriteRegistry

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -17,7 +17,6 @@ import click
 from attrs import evolve
 from rich.console import Console
 
-from clm.cli.build_data_classes import BuildSummary
 from clm.cli.build_reporter import BuildReporter
 
 # Import shared logging setup
@@ -40,6 +39,7 @@ from clm.core.course_spec import (
 )
 from clm.infrastructure.backend import JobsPendingTimeoutError
 from clm.infrastructure.backends.sqlite_backend import SqliteBackend
+from clm.infrastructure.build_data_classes import BuildSummary
 from clm.infrastructure.database.db_operations import DatabaseManager
 from clm.infrastructure.messaging.correlation_ids import all_correlation_ids
 from clm.infrastructure.utils.path_utils import output_path_for
@@ -644,7 +644,7 @@ def report_validation_errors(
     """Report validation errors in the appropriate output format."""
     import json as json_module
 
-    from clm.cli.build_data_classes import BuildError
+    from clm.infrastructure.build_data_classes import BuildError
 
     output_mode = output_mode.lower()
 
@@ -1037,7 +1037,7 @@ def start_managed_workers(lifecycle_manager, worker_config) -> list:
 
 def _report_duplicate_file_warnings(course: Course, build_reporter: BuildReporter) -> None:
     """Check for duplicate output files and report warnings."""
-    from clm.cli.build_data_classes import BuildWarning
+    from clm.infrastructure.build_data_classes import BuildWarning
 
     try:
         duplicates = course.detect_duplicate_output_files()
@@ -1073,7 +1073,7 @@ def _report_image_collisions(course: Course, build_reporter: BuildReporter) -> b
     if course.image_mode == "duplicated":
         return False
 
-    from clm.cli.build_data_classes import BuildError
+    from clm.infrastructure.build_data_classes import BuildError
 
     collisions = course.image_registry.collisions
     if not collisions:
@@ -1107,7 +1107,7 @@ def _report_image_collisions(course: Course, build_reporter: BuildReporter) -> b
 
 def _report_loading_issues(course: Course, build_reporter: BuildReporter) -> None:
     """Report any errors or warnings encountered during course loading."""
-    from clm.cli.build_data_classes import BuildError, BuildWarning
+    from clm.infrastructure.build_data_classes import BuildError, BuildWarning
 
     for error in course.loading_errors:
         category = error.get("category", "loading_error")
@@ -1195,8 +1195,8 @@ def _report_cross_reference_issues(course: Course, build_reporter: BuildReporter
     ``--section`` selection because the resolver is built from the already
     filtered ``course.sections``.
     """
-    from clm.cli.build_data_classes import BuildError, BuildWarning
     from clm.core.cross_references import validate_cross_references
+    from clm.infrastructure.build_data_classes import BuildError, BuildWarning
 
     findings = validate_cross_references(course, fail_on_missing=course.fail_on_missing_xref)
     for finding in findings:
@@ -1688,7 +1688,7 @@ def _record_teardown_orphans(summary: BuildSummary, orphans: list[dict[str, Any]
     ``BuildError`` and the summary is marked timed-out, giving the same
     unconditional non-zero exit a per-stage job timeout gets (issue #617).
     """
-    from clm.cli.build_data_classes import BuildError
+    from clm.infrastructure.build_data_classes import BuildError
 
     for orphan in orphans:
         summary.errors.append(

--- a/src/clm/cli/output_formatter.py
+++ b/src/clm/cli/output_formatter.py
@@ -22,8 +22,9 @@ from rich.progress import (
     TimeRemainingColumn,
 )
 
-from clm.cli.build_data_classes import BuildError, BuildSummary, BuildWarning
-from clm.cli.text_utils import format_error_path, strip_ansi
+from clm.cli.text_utils import format_error_path
+from clm.infrastructure.build_data_classes import BuildError, BuildSummary, BuildWarning
+from clm.infrastructure.utils.text_utils import strip_ansi
 
 
 def _occurrence_note(count: int) -> str:

--- a/src/clm/cli/text_utils.py
+++ b/src/clm/cli/text_utils.py
@@ -1,47 +1,11 @@
-"""Text utilities for CLI output formatting.
+"""Path-formatting utilities for CLI output.
 
-This module provides utilities for cleaning and formatting text output,
-including ANSI escape sequence handling and path formatting.
+ANSI escape handling lives in :mod:`clm.infrastructure.utils.text_utils`
+(it is shared with error categorization, which runs below the CLI).
 """
 
 import os
-import re
 from pathlib import Path
-
-# Regex pattern for ANSI escape sequences
-# Matches: ESC[ followed by any number of parameters and a final letter
-# Also matches ESC followed by other common sequences
-ANSI_ESCAPE_PATTERN = re.compile(
-    r"""
-    \x1b  # ESC character
-    (?:
-        \[  # CSI sequences: ESC[
-        [0-9;]*  # Parameters (numbers and semicolons)
-        [a-zA-Z]  # Final character
-        |
-        \]  # OSC sequences: ESC]
-        [^\x07]*  # Content until BEL
-        \x07  # BEL character
-        |
-        [@-Z\\-_]  # Other escape sequences (ESC followed by single char)
-    )
-    """,
-    re.VERBOSE,
-)
-
-
-def strip_ansi(text: str) -> str:
-    """Remove ANSI escape sequences from text.
-
-    Args:
-        text: Text that may contain ANSI escape codes
-
-    Returns:
-        Text with all ANSI escape sequences removed
-    """
-    if not text:
-        return text
-    return ANSI_ESCAPE_PATTERN.sub("", text)
 
 
 def make_relative_path(file_path: str | Path, base_path: str | Path | None = None) -> str:

--- a/src/clm/core/operations/process_notebook.py
+++ b/src/clm/core/operations/process_notebook.py
@@ -180,7 +180,7 @@ def report_voiceover_merge_issues(
     """
     if build_reporter is None or not unmatched:
         return
-    from clm.cli.build_data_classes import BuildError
+    from clm.infrastructure.build_data_classes import BuildError
 
     for for_slide in unmatched:
         target = "(cell has no for_slide)" if for_slide == "<no for_slide>" else repr(for_slide)

--- a/src/clm/infrastructure/backend.py
+++ b/src/clm/infrastructure/backend.py
@@ -11,7 +11,7 @@ from clm.core.image_registry import ImageRegistry
 from clm.core.output_write_registry import OutputWriteRegistry
 
 if TYPE_CHECKING:
-    from clm.cli.build_data_classes import BuildWarning
+    from clm.infrastructure.build_data_classes import BuildWarning
     from clm.infrastructure.messaging.base_classes import Payload
     from clm.infrastructure.operation import Operation
     from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData
@@ -29,7 +29,7 @@ class JobsPendingTimeoutError(TimeoutError):
     the build orchestration a typed signal that the build did *not*
     complete and must exit non-zero (issue #143, sub-bug A). The pending
     job descriptors are attached so the orchestration can record one
-    infrastructure :class:`~clm.cli.build_data_classes.BuildError` per
+    infrastructure :class:`~clm.infrastructure.build_data_classes.BuildError` per
     stuck job in the build summary.
     """
 

--- a/src/clm/infrastructure/backends/dummy_backend.py
+++ b/src/clm/infrastructure/backends/dummy_backend.py
@@ -4,8 +4,8 @@ from pathlib import Path
 
 from attrs import define
 
-from clm.cli.build_data_classes import BuildWarning
 from clm.infrastructure.backend import Backend
+from clm.infrastructure.build_data_classes import BuildWarning
 from clm.infrastructure.messaging.base_classes import Payload
 from clm.infrastructure.operation import Operation
 from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData

--- a/src/clm/infrastructure/backends/local_ops_backend.py
+++ b/src/clm/infrastructure/backends/local_ops_backend.py
@@ -33,13 +33,13 @@ else:
 
 from attrs import define
 
-from clm.cli.build_data_classes import BuildWarning
 from clm.core.course_file import CourseFile
 from clm.core.output_write_registry import (
     WriteOutcome,
     is_image_path,
 )
 from clm.infrastructure.backend import Backend
+from clm.infrastructure.build_data_classes import BuildWarning
 from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData
 from clm.infrastructure.utils.copy_file_data import CopyFileData
 from clm.infrastructure.utils.file import File

--- a/src/clm/infrastructure/backends/sqlite_backend.py
+++ b/src/clm/infrastructure/backends/sqlite_backend.py
@@ -33,8 +33,7 @@ from clm.infrastructure.utils.path_utils import atomic_write_bytes
 from clm.infrastructure.workers.progress_tracker import ProgressTracker, get_progress_tracker_config
 
 if TYPE_CHECKING:
-    from clm.cli.build_data_classes import BuildWarning
-    from clm.cli.build_reporter import BuildReporter
+    from clm.infrastructure.build_data_classes import BuildReporterProtocol, BuildWarning
     from clm.infrastructure.database.execution_telemetry import ExecutionTelemetryStore
     from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData
     from clm.infrastructure.utils.copy_file_data import CopyFileData
@@ -68,7 +67,9 @@ class SqliteBackend(LocalOpsBackend):
     progress_tracker: ProgressTracker | None = field(init=False, default=None)
     enable_progress_tracking: bool = True
     skip_worker_check: bool = False  # Skip worker availability check (for unit tests only)
-    build_reporter: Optional["BuildReporter"] = None  # Optional build reporter for improved output
+    build_reporter: Optional["BuildReporterProtocol"] = (
+        None  # Reporting surface (CLI's BuildReporter or a test stub)
+    )
     incremental: bool = False  # Incremental mode: skip writing cached results
     # When True (``clm build --explain-rebuilds`` / ``CLM_EXPLAIN_REBUILDS``),
     # a ``processed_files`` cache MISS runs one extra read-only probe to log
@@ -912,7 +913,7 @@ class SqliteBackend(LocalOpsBackend):
                         )
 
                     # Import ErrorCategorizer
-                    from clm.cli.error_categorizer import ErrorCategorizer
+                    from clm.infrastructure.error_categorizer import ErrorCategorizer
 
                     # Categorize the error
                     categorized_error = ErrorCategorizer.categorize_job_error(
@@ -1036,7 +1037,7 @@ class SqliteBackend(LocalOpsBackend):
         if not self.build_reporter:
             return
 
-        from clm.cli.build_data_classes import BuildError
+        from clm.infrastructure.build_data_classes import BuildError
 
         for job_info in self.active_jobs.values():
             input_file = str(job_info.get("input_file", "unknown"))
@@ -1736,7 +1737,7 @@ class SqliteBackend(LocalOpsBackend):
             logger.debug(f"Job {job_id} completed with {len(warnings_data)} warning(s)")
 
             # Import required classes
-            from clm.cli.build_data_classes import BuildWarning
+            from clm.infrastructure.build_data_classes import BuildWarning
 
             # Parse payload for output_metadata
             payload_dict = json.loads(payload_json) if payload_json else {}
@@ -1842,7 +1843,7 @@ class SqliteBackend(LocalOpsBackend):
         Returns:
             List of BuildWarning objects for any issues encountered.
         """
-        from clm.cli.build_data_classes import BuildWarning
+        from clm.infrastructure.build_data_classes import BuildWarning
 
         warnings: list[BuildWarning] = await super().copy_dir_group_to_output(copy_data)
 

--- a/src/clm/infrastructure/build_data_classes.py
+++ b/src/clm/infrastructure/build_data_classes.py
@@ -7,7 +7,7 @@ errors, warnings, and summaries during course builds.
 import json
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any, Literal, Protocol
 
 
 @dataclass
@@ -327,3 +327,43 @@ class ProgressUpdate:
     failed: int
     stage: str | None = None
     cached: int = 0
+
+
+class BuildReporterProtocol(Protocol):
+    """The reporting surface backends call during a build.
+
+    Structural on purpose: the CLI's ``BuildReporter`` satisfies it, and
+    tests drive backends with duck-typed stubs. Infrastructure depends on
+    this protocol, never on the CLI implementation (review finding A2 —
+    the reverse import was the infrastructure→CLI cycle).
+    """
+
+    def on_progress_update(self, update: ProgressUpdate) -> None: ...
+
+    def report_cache_hit(
+        self, file_path: str, job_type: str, detail: str | None = None
+    ) -> None: ...
+
+    def report_rebuild_reason(
+        self, file_path: str, job_type: str, reason: str, reason_code: str
+    ) -> None: ...
+
+    def report_file_started(
+        self, file_path: str, job_type: str, job_id: int | None = None
+    ) -> None: ...
+
+    def report_file_completed(
+        self, file_path: str, job_type: str, job_id: int | None = None, success: bool = True
+    ) -> None: ...
+
+    def report_error(self, error: BuildError) -> None: ...
+
+    def report_warning(self, warning: BuildWarning) -> None: ...
+
+    def report_flaky_file(
+        self,
+        file_path: str,
+        attempts: int,
+        failure_types: list[str] | None = None,
+        language: str = "",
+    ) -> None: ...

--- a/src/clm/infrastructure/database/db_operations.py
+++ b/src/clm/infrastructure/database/db_operations.py
@@ -8,7 +8,7 @@ from clm.infrastructure.database.journal_mode import configure_connection
 from clm.infrastructure.messaging.base_classes import Result
 
 if TYPE_CHECKING:
-    from clm.cli.build_data_classes import BuildError, BuildWarning
+    from clm.infrastructure.build_data_classes import BuildError, BuildWarning
 
 logger = logging.getLogger(__name__)
 
@@ -333,7 +333,7 @@ class DatabaseManager:
         Returns:
             Tuple of (errors list, warnings list)
         """
-        from clm.cli.build_data_classes import BuildError, BuildWarning
+        from clm.infrastructure.build_data_classes import BuildError, BuildWarning
 
         assert self.conn is not None, "Database connection not initialized"
         cursor = self.conn.cursor()

--- a/src/clm/infrastructure/error_categorizer.py
+++ b/src/clm/infrastructure/error_categorizer.py
@@ -9,8 +9,8 @@ import json
 import re
 from typing import Any, Literal, cast
 
-from clm.cli.build_data_classes import BuildError
-from clm.cli.text_utils import strip_ansi
+from clm.infrastructure.build_data_classes import BuildError
+from clm.infrastructure.utils.text_utils import strip_ansi
 
 
 class ErrorCategorizer:

--- a/src/clm/infrastructure/utils/text_utils.py
+++ b/src/clm/infrastructure/utils/text_utils.py
@@ -1,0 +1,43 @@
+"""Text sanitation utilities shared across layers.
+
+ANSI escape handling lives in infrastructure (not the CLI) because worker
+error output is scrubbed before categorization and database storage — the
+CLI's display formatting merely reuses the same scrubber.
+"""
+
+import re
+
+# Regex pattern for ANSI escape sequences
+# Matches: ESC[ followed by any number of parameters and a final letter
+# Also matches ESC followed by other common sequences
+ANSI_ESCAPE_PATTERN = re.compile(
+    r"""
+    \x1b  # ESC character
+    (?:
+        \[  # CSI sequences: ESC[
+        [0-9;]*  # Parameters (numbers and semicolons)
+        [a-zA-Z]  # Final character
+        |
+        \]  # OSC sequences: ESC]
+        [^\x07]*  # Content until BEL
+        \x07  # BEL character
+        |
+        [@-Z\\-_]  # Other escape sequences (ESC followed by single char)
+    )
+    """,
+    re.VERBOSE,
+)
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from text.
+
+    Args:
+        text: Text that may contain ANSI escape codes
+
+    Returns:
+        Text with all ANSI escape sequences removed
+    """
+    if not text:
+        return text
+    return ANSI_ESCAPE_PATTERN.sub("", text)

--- a/src/clm/infrastructure/workers/progress_tracker.py
+++ b/src/clm/infrastructure/workers/progress_tracker.py
@@ -11,6 +11,8 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 
+from clm.infrastructure.build_data_classes import ProgressUpdate
+
 logger = logging.getLogger(__name__)
 
 
@@ -351,21 +353,14 @@ class ProgressTracker:
         """Trigger progress update callback if set."""
         if self.on_progress_update:
             summary = self.get_summary()
-            # Import here to avoid circular dependency
-            try:
-                from clm.cli.build_data_classes import ProgressUpdate
-
-                update = ProgressUpdate(
-                    completed=summary["completed"],
-                    total=summary["total"],
-                    active=summary["active"],
-                    failed=summary["failed"],
-                    stage=self.current_stage,
-                )
-                self.on_progress_update(update)
-            except ImportError:
-                # If build_data_classes is not available, skip callback
-                pass
+            update = ProgressUpdate(
+                completed=summary["completed"],
+                total=summary["total"],
+                active=summary["active"],
+                failed=summary["failed"],
+                stage=self.current_stage,
+            )
+            self.on_progress_update(update)
 
 
 def get_progress_tracker_config() -> dict:

--- a/src/clm/infrastructure/workers/worker_base.py
+++ b/src/clm/infrastructure/workers/worker_base.py
@@ -755,7 +755,7 @@ class Worker(ABC):
 
                     # Add error categorization for better monitoring integration
                     try:
-                        from clm.cli.error_categorizer import ErrorCategorizer
+                        from clm.infrastructure.error_categorizer import ErrorCategorizer
 
                         categorized = ErrorCategorizer.categorize_job_error(
                             job_type=job.job_type,

--- a/tests/cli/test_build_abort_summary.py
+++ b/tests/cli/test_build_abort_summary.py
@@ -13,7 +13,6 @@ import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from clm.cli.build_data_classes import BuildSummary
 from clm.cli.build_reporter import BuildReporter
 from clm.cli.output_formatter import (
     DefaultOutputFormatter,
@@ -21,6 +20,7 @@ from clm.cli.output_formatter import (
     QuietOutputFormatter,
     VerboseOutputFormatter,
 )
+from clm.infrastructure.build_data_classes import BuildSummary
 
 
 def _reporter() -> BuildReporter:

--- a/tests/cli/test_build_command.py
+++ b/tests/cli/test_build_command.py
@@ -20,7 +20,6 @@ import click
 import pytest
 from click.testing import CliRunner
 
-from clm.cli.build_data_classes import BuildError, BuildSummary, BuildWarning
 from clm.cli.commands import build as build_module
 from clm.cli.commands.build import (
     BuildConfig,
@@ -51,6 +50,7 @@ from clm.cli.output_formatter import (
     VerboseOutputFormatter,
 )
 from clm.core.course_spec import CourseSpecError
+from clm.infrastructure.build_data_classes import BuildError, BuildSummary, BuildWarning
 
 # ---------------------------------------------------------------------------
 # Factories

--- a/tests/cli/test_build_flake_list.py
+++ b/tests/cli/test_build_flake_list.py
@@ -3,9 +3,9 @@
 import json
 from unittest.mock import MagicMock
 
-from clm.cli.build_data_classes import BuildSummary, FlakyFileInfo
 from clm.cli.build_reporter import BuildReporter
 from clm.cli.output_formatter import DefaultOutputFormatter, JSONOutputFormatter
+from clm.infrastructure.build_data_classes import BuildSummary, FlakyFileInfo
 
 
 def _reporter() -> BuildReporter:

--- a/tests/cli/test_build_output.py
+++ b/tests/cli/test_build_output.py
@@ -5,15 +5,15 @@ from datetime import datetime
 
 import pytest
 
-from clm.cli.build_data_classes import BuildError, BuildSummary, BuildWarning
 from clm.cli.build_reporter import BuildReporter
-from clm.cli.error_categorizer import ErrorCategorizer
 from clm.cli.output_formatter import (
     DefaultOutputFormatter,
     JSONOutputFormatter,
     QuietOutputFormatter,
     VerboseOutputFormatter,
 )
+from clm.infrastructure.build_data_classes import BuildError, BuildSummary, BuildWarning
+from clm.infrastructure.error_categorizer import ErrorCategorizer
 
 
 class TestBuildDataClasses:
@@ -1280,7 +1280,7 @@ class TestBuildReporterProgressIntegration:
 
     def test_on_progress_update_after_multiple_stages(self):
         """Test on_progress_update callback works across multiple stages."""
-        from clm.cli.build_data_classes import ProgressUpdate
+        from clm.infrastructure.build_data_classes import ProgressUpdate
 
         formatter = DefaultOutputFormatter(show_progress=True, use_color=False)
         reporter = BuildReporter(output_formatter=formatter)

--- a/tests/cli/test_build_rebuild_reasons.py
+++ b/tests/cli/test_build_rebuild_reasons.py
@@ -3,9 +3,9 @@
 import json
 from unittest.mock import MagicMock
 
-from clm.cli.build_data_classes import BuildSummary
 from clm.cli.build_reporter import BuildReporter
 from clm.cli.output_formatter import DefaultOutputFormatter, JSONOutputFormatter
+from clm.infrastructure.build_data_classes import BuildSummary
 
 
 def _reporter() -> BuildReporter:

--- a/tests/cli/test_build_reporter_output_writes.py
+++ b/tests/cli/test_build_reporter_output_writes.py
@@ -12,10 +12,10 @@ the bridge.
 
 from pathlib import Path
 
-from clm.cli.build_data_classes import BuildSummary
 from clm.cli.build_reporter import BuildReporter
 from clm.cli.output_formatter import QuietOutputFormatter
 from clm.core.output_write_registry import OutputWriteRegistry
+from clm.infrastructure.build_data_classes import BuildSummary
 
 
 def _make_reporter() -> BuildReporter:
@@ -189,8 +189,8 @@ class TestJsonFormatterIncludesOutputKeys:
         assert data["output_conflicts"] == []
 
     def test_json_formatter_emits_conflict_records(self, tmp_path, capsys):
-        from clm.cli.build_data_classes import OutputConflictInfo
         from clm.cli.output_formatter import JSONOutputFormatter
+        from clm.infrastructure.build_data_classes import OutputConflictInfo
 
         formatter = JSONOutputFormatter()
         formatter.show_build_start("test", total_files=0, output_dirs=[])

--- a/tests/cli/test_error_categorizer.py
+++ b/tests/cli/test_error_categorizer.py
@@ -6,7 +6,7 @@ properly classified with correct actionable guidance.
 
 import pytest
 
-from clm.cli.error_categorizer import ErrorCategorizer
+from clm.infrastructure.error_categorizer import ErrorCategorizer
 
 
 class TestDrawioErrorCategorization:

--- a/tests/cli/test_error_reporting_integration.py
+++ b/tests/cli/test_error_reporting_integration.py
@@ -15,10 +15,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from clm.cli.build_data_classes import BuildError, BuildWarning
 from clm.cli.build_reporter import BuildReporter
 from clm.cli.output_formatter import QuietOutputFormatter
 from clm.infrastructure.backends.sqlite_backend import SqliteBackend
+from clm.infrastructure.build_data_classes import BuildError, BuildWarning
 from clm.infrastructure.database.db_operations import DatabaseManager
 from clm.infrastructure.database.job_queue import JobQueue
 from clm.infrastructure.messaging.notebook_classes import NotebookPayload
@@ -245,8 +245,8 @@ class TestCachedErrorReportingIntegration:
 
     def test_error_stored_on_job_failure(self, tmp_path):
         """Test that errors are stored in the cache database when jobs fail."""
-        from clm.cli.build_data_classes import BuildError
-        from clm.cli.error_categorizer import ErrorCategorizer
+        from clm.infrastructure.build_data_classes import BuildError
+        from clm.infrastructure.error_categorizer import ErrorCategorizer
 
         db_path = tmp_path / "test_jobs.db"
         cache_db_path = tmp_path / "test_cache.db"

--- a/tests/cli/test_text_utils.py
+++ b/tests/cli/test_text_utils.py
@@ -1,10 +1,12 @@
 """Tests for CLI text utilities.
 
-Tests text manipulation functions including:
-- ANSI escape sequence stripping
+Tests path formatting for CLI output:
 - Path conversion (absolute to relative)
 - Path truncation
 - Error path formatting
+
+ANSI stripping is covered in ``tests/infrastructure/utils/test_text_utils.py``
+(the scrubber moved to infrastructure in #802/A2).
 """
 
 import os
@@ -13,82 +15,10 @@ from pathlib import Path
 import pytest
 
 from clm.cli.text_utils import (
-    ANSI_ESCAPE_PATTERN,
     format_error_path,
     make_relative_path,
-    strip_ansi,
     truncate_path,
 )
-
-
-class TestStripAnsi:
-    """Test ANSI escape sequence removal."""
-
-    def test_strip_ansi_empty_string(self):
-        """Empty string should return empty string."""
-        assert strip_ansi("") == ""
-
-    def test_strip_ansi_none_returns_none(self):
-        """None should return falsy value."""
-        result = strip_ansi(None)
-        assert not result
-
-    def test_strip_ansi_no_codes(self):
-        """Text without ANSI codes should be unchanged."""
-        text = "Hello, World!"
-        assert strip_ansi(text) == "Hello, World!"
-
-    def test_strip_ansi_color_codes(self):
-        """Should strip color codes."""
-        # Red text
-        text = "\033[31mRed text\033[0m"
-        assert strip_ansi(text) == "Red text"
-
-    def test_strip_ansi_bold_codes(self):
-        """Should strip bold codes."""
-        text = "\033[1mBold text\033[0m"
-        assert strip_ansi(text) == "Bold text"
-
-    def test_strip_ansi_multiple_codes(self):
-        """Should strip multiple codes in sequence."""
-        # Bold red with green
-        text = "\033[1m\033[31mBold red\033[0m and \033[32mgreen\033[0m"
-        assert strip_ansi(text) == "Bold red and green"
-
-    def test_strip_ansi_256_color(self):
-        """Should strip 256-color codes."""
-        text = "\033[38;5;208mOrange\033[0m"
-        assert strip_ansi(text) == "Orange"
-
-    def test_strip_ansi_osc_sequences(self):
-        """Should strip OSC sequences (like terminal title)."""
-        text = "\033]0;Window Title\007Normal text"
-        assert strip_ansi(text) == "Normal text"
-
-    def test_strip_ansi_cursor_movement(self):
-        """Should strip cursor movement codes."""
-        # Cursor up, down, forward, back
-        text = "Before\033[2AAfter"  # Move up 2
-        assert strip_ansi(text) == "BeforeAfter"
-
-    def test_strip_ansi_preserves_newlines(self):
-        """Newlines should be preserved."""
-        text = "\033[32mLine 1\033[0m\nLine 2"
-        assert strip_ansi(text) == "Line 1\nLine 2"
-
-
-class TestAnsiEscapePattern:
-    """Test the ANSI escape pattern regex."""
-
-    def test_pattern_matches_csi_sequences(self):
-        """Pattern should match CSI sequences."""
-        assert ANSI_ESCAPE_PATTERN.search("\033[0m")
-        assert ANSI_ESCAPE_PATTERN.search("\033[1;31m")
-        assert ANSI_ESCAPE_PATTERN.search("\033[38;5;208m")
-
-    def test_pattern_matches_osc_sequences(self):
-        """Pattern should match OSC sequences."""
-        assert ANSI_ESCAPE_PATTERN.search("\033]0;Title\007")
 
 
 class TestMakeRelativePath:

--- a/tests/infrastructure/backends/test_sqlite_backend.py
+++ b/tests/infrastructure/backends/test_sqlite_backend.py
@@ -686,7 +686,7 @@ async def test_job_not_found_in_database(temp_db, temp_workspace):
 @pytest.mark.asyncio
 async def test_copy_dir_group_reports_warnings_to_build_reporter(temp_db, temp_workspace):
     """Test that copy_dir_group_to_output reports warnings to build_reporter."""
-    from clm.cli.build_data_classes import BuildWarning
+    from clm.infrastructure.build_data_classes import BuildWarning
     from clm.infrastructure.utils.copy_dir_group_data import CopyDirGroupData
 
     # Create mock build reporter

--- a/tests/infrastructure/backends/test_sqlite_backend_resilience.py
+++ b/tests/infrastructure/backends/test_sqlite_backend_resilience.py
@@ -32,8 +32,8 @@ from unittest.mock import patch
 import pytest
 from attrs import frozen
 
-from clm.cli.build_data_classes import BuildError
 from clm.infrastructure.backends.sqlite_backend import SqliteBackend
+from clm.infrastructure.build_data_classes import BuildError
 from clm.infrastructure.database.db_operations import DatabaseManager
 from clm.infrastructure.database.job_queue import JobQueue
 from clm.infrastructure.database.schema import init_database
@@ -874,7 +874,7 @@ async def test_report_cached_issues_reports_stored_errors_and_warnings(
     backend.db_manager = DatabaseManager(cache_db)
     backend.db_manager.__enter__()
     try:
-        from clm.cli.build_data_classes import BuildWarning
+        from clm.infrastructure.build_data_classes import BuildWarning
 
         backend.db_manager.store_error(
             file_path="f.py",
@@ -983,7 +983,7 @@ async def test_results_cache_hit_replays_stored_issues(temp_db, temp_workspace, 
     hit (e.g. after retention pruned the processed_files entry) returned
     early and the build went silently green.
     """
-    from clm.cli.build_data_classes import BuildWarning
+    from clm.infrastructure.build_data_classes import BuildWarning
 
     cache_db = tmp_path / "cache.db"
     backend = _backend(temp_db, temp_workspace, build_reporter=_StubReporter())

--- a/tests/infrastructure/database/test_cache_path_migration.py
+++ b/tests/infrastructure/database/test_cache_path_migration.py
@@ -15,7 +15,7 @@ import sqlite3
 import pytest
 from nbformat.v4 import new_code_cell, new_markdown_cell, new_notebook
 
-from clm.cli.build_data_classes import BuildError, BuildWarning
+from clm.infrastructure.build_data_classes import BuildError, BuildWarning
 from clm.infrastructure.database.cache_path_migration import (
     PathMapping,
     migrate_cache_paths,

--- a/tests/infrastructure/database/test_processing_issues.py
+++ b/tests/infrastructure/database/test_processing_issues.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from clm.cli.build_data_classes import BuildError, BuildWarning
+from clm.infrastructure.build_data_classes import BuildError, BuildWarning
 from clm.infrastructure.database.db_operations import DatabaseManager
 
 

--- a/tests/infrastructure/utils/test_text_utils.py
+++ b/tests/infrastructure/utils/test_text_utils.py
@@ -1,0 +1,73 @@
+"""Tests for the shared ANSI escape scrubber (moved from clm.cli in #802/A2)."""
+
+from clm.infrastructure.utils.text_utils import ANSI_ESCAPE_PATTERN, strip_ansi
+
+
+class TestStripAnsi:
+    """Test ANSI escape sequence removal."""
+
+    def test_strip_ansi_empty_string(self):
+        """Empty string should return empty string."""
+        assert strip_ansi("") == ""
+
+    def test_strip_ansi_none_returns_none(self):
+        """None should return falsy value."""
+        result = strip_ansi(None)
+        assert not result
+
+    def test_strip_ansi_no_codes(self):
+        """Text without ANSI codes should be unchanged."""
+        text = "Hello, World!"
+        assert strip_ansi(text) == "Hello, World!"
+
+    def test_strip_ansi_color_codes(self):
+        """Should strip color codes."""
+        # Red text
+        text = "\033[31mRed text\033[0m"
+        assert strip_ansi(text) == "Red text"
+
+    def test_strip_ansi_bold_codes(self):
+        """Should strip bold codes."""
+        text = "\033[1mBold text\033[0m"
+        assert strip_ansi(text) == "Bold text"
+
+    def test_strip_ansi_multiple_codes(self):
+        """Should strip multiple codes in sequence."""
+        # Bold red with green
+        text = "\033[1m\033[31mBold red\033[0m and \033[32mgreen\033[0m"
+        assert strip_ansi(text) == "Bold red and green"
+
+    def test_strip_ansi_256_color(self):
+        """Should strip 256-color codes."""
+        text = "\033[38;5;208mOrange\033[0m"
+        assert strip_ansi(text) == "Orange"
+
+    def test_strip_ansi_osc_sequences(self):
+        """Should strip OSC sequences (like terminal title)."""
+        text = "\033]0;Window Title\007Normal text"
+        assert strip_ansi(text) == "Normal text"
+
+    def test_strip_ansi_cursor_movement(self):
+        """Should strip cursor movement codes."""
+        # Cursor up, down, forward, back
+        text = "Before\033[2AAfter"  # Move up 2
+        assert strip_ansi(text) == "BeforeAfter"
+
+    def test_strip_ansi_preserves_newlines(self):
+        """Newlines should be preserved."""
+        text = "\033[32mLine 1\033[0m\nLine 2"
+        assert strip_ansi(text) == "Line 1\nLine 2"
+
+
+class TestAnsiEscapePattern:
+    """Test the ANSI escape pattern regex."""
+
+    def test_pattern_matches_csi_sequences(self):
+        """Pattern should match CSI sequences."""
+        assert ANSI_ESCAPE_PATTERN.search("\033[0m")
+        assert ANSI_ESCAPE_PATTERN.search("\033[1;31m")
+        assert ANSI_ESCAPE_PATTERN.search("\033[38;5;208m")
+
+    def test_pattern_matches_osc_sequences(self):
+        """Pattern should match OSC sequences."""
+        assert ANSI_ESCAPE_PATTERN.search("\033]0;Title\007")

--- a/tests/integration/test_output_dedup_pipeline.py
+++ b/tests/integration/test_output_dedup_pipeline.py
@@ -18,12 +18,12 @@ build-pipeline level:
 import json as _json
 from pathlib import Path
 
-from clm.cli.build_data_classes import BuildSummary
 from clm.cli.build_reporter import BuildReporter
 from clm.cli.output_formatter import JSONOutputFormatter, QuietOutputFormatter
 from clm.core.image_registry import ImageRegistry
 from clm.core.output_write_registry import OutputWriteRegistry
 from clm.infrastructure.backends.local_ops_backend import LocalOpsBackend
+from clm.infrastructure.build_data_classes import BuildSummary
 from clm.infrastructure.messaging.base_classes import Payload
 from clm.infrastructure.operation import Operation
 from clm.infrastructure.utils.copy_file_data import CopyFileData

--- a/tests/test_architecture_contracts.py
+++ b/tests/test_architecture_contracts.py
@@ -90,13 +90,15 @@ def _current_violations() -> set[str]:
 #: (2026-08-06: 50 edges over 40 files — the review's A1/A2/A3 findings plus
 #: the infrastructure→workers and workers→extensions residents its inventory
 #: missed). Phase 8 removes entries as it moves code; nothing may be added.
+#: Ratcheted down so far: A2 (#802) moved build_data_classes +
+#: error_categorizer into infrastructure, clearing every infrastructure→cli
+#: edge and core→cli's only resident → 42 edges over 33 files.
 KNOWN_LAYER_VIOLATIONS = frozenset(
     {
         "infrastructure -> workers: infrastructure/workers/image_identity.py",
         "workers -> slides: workers/notebook/notebook_processor.py",
         "workers -> slides: workers/notebook/output_spec.py",
         "workers -> slides: workers/notebook/utils/jupyter_utils.py",
-        "core -> cli: core/operations/process_notebook.py",
         "core -> infrastructure: core/affected_specs.py",
         "core -> infrastructure: core/cmake_export.py",
         "core -> infrastructure: core/course.py",
@@ -135,13 +137,6 @@ KNOWN_LAYER_VIOLATIONS = frozenset(
         "core -> workers: core/course.py",
         "core -> workers: core/operations/build_jupyterlite_site.py",
         "core -> workers: core/operations/process_notebook.py",
-        "infrastructure -> cli: infrastructure/backend.py",
-        "infrastructure -> cli: infrastructure/backends/dummy_backend.py",
-        "infrastructure -> cli: infrastructure/backends/local_ops_backend.py",
-        "infrastructure -> cli: infrastructure/backends/sqlite_backend.py",
-        "infrastructure -> cli: infrastructure/database/db_operations.py",
-        "infrastructure -> cli: infrastructure/workers/progress_tracker.py",
-        "infrastructure -> cli: infrastructure/workers/worker_base.py",
     }
 )
 
@@ -180,8 +175,10 @@ class TestLayerBoundaryRatchet:
             encoding="utf-8",
         )
         assert "clm.cli.build_data_classes" in _clm_imports(probe)
-        # ...and the live inventory carries a known lazy-import resident.
-        assert "infrastructure -> cli: infrastructure/backends/sqlite_backend.py" in (
+        # ...and the live inventory carries a known lazy-import resident —
+        # an entry that would silently vanish under a module-level-only scan
+        # (image_identity's workers import is function-body only).
+        assert "infrastructure -> workers: infrastructure/workers/image_identity.py" in (
             KNOWN_LAYER_VIOLATIONS
         )
 

--- a/tests/workers/notebook/test_notebook_error_context.py
+++ b/tests/workers/notebook/test_notebook_error_context.py
@@ -24,7 +24,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from nbformat import NotebookNode
 
-from clm.cli.error_categorizer import ErrorCategorizer
+from clm.infrastructure.error_categorizer import ErrorCategorizer
 from clm.infrastructure.messaging.notebook_classes import NotebookPayload
 from clm.workers.notebook.notebook_processor import (
     CellContext,


### PR DESCRIPTION
## Summary

First Phase 8 step (Refs #802 — step A2 of the re-layering plan; the issue stays open for A6–A12).

- `clm.cli.build_data_classes` → `clm.infrastructure.build_data_classes`
- `clm.cli.error_categorizer` → `clm.infrastructure.error_categorizer`
- `strip_ansi` / `ANSI_ESCAPE_PATTERN` → new `clm.infrastructure.utils.text_utils` (error categorization scrubs worker output below the CLI; `clm.cli.text_utils` keeps the path-formatting helpers)
- `SqliteBackend.build_reporter` is now typed against a structural `BuildReporterProtocol` (defined beside the data classes) instead of the CLI's `BuildReporter` — that TYPE_CHECKING import was the last infrastructure→CLI edge, and tests already drive backends with duck-typed stubs
- `progress_tracker`'s `try/except ImportError` around the `ProgressUpdate` import existed only to dodge the cross-layer cycle; it's a plain module-level import now

## Ratchet

`KNOWN_LAYER_VIOLATIONS` shrinks 50 → 42 edges (40 → 33 files): all 7 `infrastructure -> cli` entries and the only `core -> cli` entry are gone. The lazy-import canary in `test_the_scanner_sees_lazy_imports` now pins `image_identity.py`'s lazy-only `infrastructure -> workers` entry (verified lazy-only by AST scan).

No CLI/spec behavior change → no info-topic update needed. Changelog fragment included.

## Testing

- Fast suite: 9518 passed
- Golden characterization suite (`tests/e2e/test_e2e_golden_build.py -m ""`): 2 passed — output trees byte-identical across the move
- mypy: clean (405 files); ruff: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh