### PR TITLE
refactor(layering): Phase 8 S3 — cassette staging leaves Course

### DIFF
--- a/changelog.d/802-s3-cassette-staging-relocation.changed.md
+++ b/changelog.d/802-s3-cassette-staging-relocation.changed.md
@@ -1,0 +1,9 @@
+- **Internal re-layering (Phase 8 step S3 of the A1/A3 plan, refs #802)**: the
+  HTTP-replay cassette staging maintenance left `Course` — the pre-build orphan
+  sweep and post-build mitmproxy merge are now functions in
+  `clm.infrastructure.http_replay_mitm.cassette_staging`, fed by the new public
+  `Course.http_replay_canonical_paths()`; the `http_replay_cassette` module
+  moved from `clm.workers.notebook` to `clm.infrastructure.http_replay_mitm`.
+  Sweeping is now the entry points' job (`clm build`'s pre-stage hook, watch
+  mode's `FileEventHandler`) instead of a `Course.process_*` side effect. No
+  CLI behavior change.

--- a/docs/claude/handovers/adversarial-review-remediation-handover.md
+++ b/docs/claude/handovers/adversarial-review-remediation-handover.md
@@ -1225,7 +1225,13 @@ one PR per step, golden suite green after each.
    build_profiling) descended into core; ratchet 19 → 5 edges over 4 files
    (exactly the S3/S4/S5 residue). `clm.infrastructure`'s lazy
    Backend/Operation exports stay as a compatibility surface, now pointing
-   at core.
+   at core. **S3 DONE 2026-08-06** — cassette staging maintenance moved off
+   `Course` into `infrastructure.http_replay_mitm.cassette_staging`
+   (functions take `Course.http_replay_canonical_paths()`; sweeping is the
+   entry points' job — build pre-stage hook + watch-mode FileEventHandler);
+   `http_replay_cassette` moved workers → infrastructure. Ratchet 5 → 4
+   edges over 3 files. Remaining: S4 (identity inversion), S5 (slide-text
+   cone), S6 (import-linter).
 4. **A11 — import-linter contract in CI.** Add it as soon as the first contract
    is true, not at the end — each subsequent step then cannot regress.
 5. **A4 — extract build orchestration** from `cli/commands/build.py` (2694 lines;

--- a/src/clm/cli/commands/build.py
+++ b/src/clm/cli/commands/build.py
@@ -1421,7 +1421,11 @@ async def process_course_with_backend(
         # the per-stage build path used by ``clm build`` previously did
         # not, leaving the sweep unreachable in normal use.
         try:
-            swept = course._sweep_orphan_cassette_staging_files()
+            from clm.infrastructure.http_replay_mitm.cassette_staging import (
+                sweep_orphan_cassette_staging_files,
+            )
+
+            swept = sweep_orphan_cassette_staging_files(course.http_replay_canonical_paths())
         except Exception as exc:  # noqa: BLE001 — defensive: sweep failure must not block build
             logger.warning(
                 f"Pre-build orphan cassette sweep raised "
@@ -2082,8 +2086,14 @@ async def main_build(
             # never reaches this point) stay markerless and are discarded by the
             # next build's pre-build sweep.
             try:
-                course.merge_mitmproxy_cassette_staging(
-                    mitm_manager.build_id, mode=config.http_replay_mode
+                from clm.infrastructure.http_replay_mitm.cassette_staging import (
+                    merge_mitmproxy_cassette_staging,
+                )
+
+                merge_mitmproxy_cassette_staging(
+                    course.http_replay_canonical_paths(),
+                    mitm_manager.build_id,
+                    mode=config.http_replay_mode,
                 )
             except Exception as e:
                 logger.error(f"Failed to merge mitmproxy cassettes: {e}", exc_info=True)

--- a/src/clm/cli/file_event_handler.py
+++ b/src/clm/cli/file_event_handler.py
@@ -125,10 +125,32 @@ class FileEventHandler(PatternMatchingEventHandler):
         await backend.delete_dependencies(file)
 
     @staticmethod
+    def _sweep_orphan_cassettes(course: Course) -> None:
+        """Sweep orphan staging cassettes before a watch-mode rebuild.
+
+        ``Course.process_file`` no longer sweeps for itself (Phase 8 S3) —
+        the sweep belongs to the entry points, exactly as ``clm build``
+        sweeps before its stage loop. Defensive: a sweep failure must not
+        block the rebuild.
+        """
+        try:
+            from clm.infrastructure.http_replay_mitm.cassette_staging import (
+                sweep_orphan_cassette_staging_files,
+            )
+
+            sweep_orphan_cassette_staging_files(course.http_replay_canonical_paths())
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.warning(
+                f"Orphan cassette sweep raised {type(exc).__name__}: {exc}; "
+                f"continuing without sweep."
+            )
+
+    @staticmethod
     async def on_file_created(course: Course, backend: Backend, path: Path):
         logger.debug(f"On file created: {path}")
         topic = course.add_file(path, warn_if_no_topic=False)
         if topic is not None:
+            FileEventHandler._sweep_orphan_cassettes(course)
             await course.process_file(backend, path)
         else:
             logger.debug(f"File not in course: {path}")
@@ -140,6 +162,7 @@ class FileEventHandler(PatternMatchingEventHandler):
             # Cancel any pending jobs for this file before reprocessing
             # This prevents stale jobs from running with outdated content
             await backend.cancel_jobs_for_file(path)
+            FileEventHandler._sweep_orphan_cassettes(course)
             await course.process_file(backend, path)
 
     def _schedule_debounced_task(self, method, event_name: str, *args):

--- a/src/clm/core/course.py
+++ b/src/clm/core/course.py
@@ -440,8 +440,10 @@ class Course(NotebookMixin):
             logger.warning(f"Cannot process file: not in course: {path}")
             return
 
-        # Sweep orphan staging cassettes (see ``process_all``).
-        self._sweep_orphan_cassette_staging_files()
+        # Orphan-staging-cassette sweeping is the CALLER's job (Phase 8 S3):
+        # watch mode sweeps in ``FileEventHandler`` before invoking this, and
+        # ``clm build`` sweeps before its stage loop — core no longer reaches
+        # into the cassette machinery.
 
         # Process file for each output target
         for target in self.output_targets:
@@ -454,16 +456,13 @@ class Course(NotebookMixin):
         logger.info(f"Processing all files for {self.course_root}")
         logger.debug(f"Output targets: {[t.name for t in self.output_targets]}")
 
-        # Sweep orphan HTTP-replay staging files into their canonical
-        # cassettes *before* any payload is constructed. Otherwise a
-        # ``*.http-cassette.yaml.staging-*`` file left behind by a
-        # previously-killed worker can race with concurrent worker B's
-        # merge-and-delete pass, causing worker A's payload builder to
-        # crash with ``FileNotFoundError`` when it tries to b64-encode
-        # the file. The sweep folds the orphan's recorded interactions
-        # into the canonical cassette via the existing dedup helper, so
-        # no recordings are lost.
-        self._sweep_orphan_cassette_staging_files()
+        # NOTE (Phase 8 S3): callers that may encounter orphan HTTP-replay
+        # staging files must sweep them BEFORE invoking this (see
+        # ``infrastructure.http_replay_mitm.cassette_staging``) — otherwise a
+        # ``*.staging-*`` file left by a previously-killed worker can race a
+        # concurrent worker's merge-and-delete pass and crash payload
+        # construction with ``FileNotFoundError``. ``clm build`` sweeps in its
+        # pre-stage hook; watch mode sweeps in ``FileEventHandler``.
 
         for stage in execution_stages():
             logger.debug(f"Processing stage {stage}")
@@ -485,7 +484,7 @@ class Course(NotebookMixin):
         await self.process_dir_group_for_targets(backend)
         await self.process_jupyterlite_for_targets(backend)
 
-    def _collect_http_replay_canonical_paths(self) -> set[Path]:
+    def http_replay_canonical_paths(self) -> set[Path]:
         """Unique canonical cassette paths for every http-replay notebook.
 
         A topic may contain several notebooks but only one canonical
@@ -493,8 +492,9 @@ class Course(NotebookMixin):
         canonical (preferring the nested ``_cassettes/`` layout);
         ``expected_cassette_path`` always yields a path even when no
         cassette has been recorded yet, and its parent dir is the right
-        glob target for staging files on a first run. Shared by the
-        pre-build orphan sweep and the post-build mitmproxy merge.
+        glob target for staging files on a first run. Consumed by the
+        pre-build orphan sweep and the post-build mitmproxy merge in
+        ``infrastructure.http_replay_mitm.cassette_staging`` (Phase 8 S3).
         """
         from clm.core.course_files.notebook_file import NotebookFile
 
@@ -507,175 +507,6 @@ class Course(NotebookMixin):
             canonical = file.cassette_path or file.expected_cassette_path
             canonical_paths.add(canonical)
         return canonical_paths
-
-    def merge_mitmproxy_cassette_staging(
-        self, build_id: str | None = None, *, mode: str | None = None
-    ) -> int:
-        """Fold per-target staging files written by the mitmproxy transport.
-
-        The replay proxy (issue #165) records into per-(topic,
-        language,kind) ``<cassette>.staging-mitm-<build_id>`` files beside
-        each canonical cassette. This runs **after** the proxy stops (from
-        the build's ``finally``) to fold them into their canonicals via the
-        shared dedup/merge path.
-
-        Reaching this method *is* the build-completion signal (the build's
-        ``finally`` ran), so for each canonical we write the ``.completed``
-        marker for **this build's** staging file (``build_id``) — the marker
-        is what tells the merge a staging file holds a complete recording
-        session. mitmproxy's ``done`` hook is unreliable on a Windows
-        ``CTRL_BREAK`` shutdown, so the host owns this signal. A force-killed
-        build never reaches here, so its staging stays markerless and is
-        discarded by the next build's pre-build sweep (issue #115).
-
-        ``sweep_orphans=False``: markerless staging (older builds, or a
-        concurrent build still recording) is left untouched. A no-op for
-        builds that did not use the transport.
-
-        ``mode`` is the CLM http-replay mode; ``refresh`` folds with
-        ``overwrite_existing=True`` so a re-recorded interaction supersedes the
-        stale canonical entry (issue #165 P3), matching vcrpy ``all`` semantics.
-
-        Returns the number of staging files folded into canonical.
-        """
-        canonical_paths = self._collect_http_replay_canonical_paths()
-        if not canonical_paths:
-            return 0
-
-        from clm.workers.notebook.http_replay_cassette import (
-            CassettePaths,
-            merge_staging_into_canonical,
-            write_completion_marker,
-        )
-
-        overwrite_existing = mode == "refresh"
-        folded = 0
-        for canonical in sorted(canonical_paths):
-            if not canonical.parent.is_dir():
-                continue
-            # Mark this build's staging file complete so the merge folds it.
-            if build_id:
-                staging = canonical.parent / f"{canonical.name}.staging-mitm-{build_id}"
-                if staging.is_file():
-                    write_completion_marker(CassettePaths(canonical=canonical, staging=staging))
-            if not any(canonical.parent.glob(f"{canonical.name}.staging-*")):
-                continue
-            synthetic = canonical.parent / f"{canonical.name}.staging-mitm-merge"
-            try:
-                merged = merge_staging_into_canonical(
-                    CassettePaths(canonical=canonical, staging=synthetic),
-                    sweep_orphans=False,
-                    overwrite_existing=overwrite_existing,
-                    # The replay proxy records a per-request response
-                    # *sequence* (a non-deterministic endpoint answers an
-                    # identical request differently on successive calls); fold it
-                    # order-preserving so a downstream request that embedded the
-                    # later response still replay-matches. Only the pre-build
-                    # orphan sweep keeps the deduped fold (preserve_sequence
-                    # defaults to False there).
-                    preserve_sequence=True,
-                )
-            except Exception as exc:  # noqa: BLE001 — never mask the build result
-                logger.warning(
-                    f"Post-build mitmproxy cassette merge failed for "
-                    f"'{canonical}' ({type(exc).__name__}: {exc})."
-                )
-                continue
-            if merged:
-                logger.info(f"Merged {merged} mitmproxy staging cassette(s) into '{canonical}'.")
-                folded += merged
-        return folded
-
-    def _sweep_orphan_cassette_staging_files(self) -> int:
-        """Merge any orphan HTTP-replay staging cassettes into canonical.
-
-        Walks every notebook file whose topic opted into ``http_replay``
-        and, for each *unique* canonical cassette location with at least
-        one ``*.http-cassette.yaml.staging-*`` sibling, invokes
-        :func:`merge_staging_into_canonical` with ``sweep_orphans=True``.
-        That helper takes the cross-process file lock, folds completed
-        sibling stagings (those with a ``.completed`` marker) into
-        canonical and **discards** markerless stagings — partial chains
-        from previously-aborted recording sessions whose chain-closing
-        request never landed on disk (issue #115). Without the discard,
-        a markerless chain-opener with a body that depends on the
-        chain-closer's stored response would poison the canonical
-        cassette permanently (dedup is first-seen-wins).
-
-        Running this *before* payload construction prevents a stale
-        staging file from being enumerated by
-        :meth:`ProcessNotebookOperation.compute_other_files` and then
-        deleted by a concurrent worker's post-execution merge, which
-        used to surface as a ``FileNotFoundError`` during base64
-        encoding. Defense-in-depth: ``compute_other_files`` also filters
-        ``*.staging-*`` via ``is_ignored_file_for_output`` so a *new*
-        orphan appearing mid-build can't sneak into the payload either.
-
-        The discriminator between "decisive discard" here and
-        "conservative leave-alone" in the post-execution worker sweep
-        is the ``sweep_orphans`` flag: by contract this method runs
-        single-threaded before any worker starts, so every staging file
-        present must be from a previous build — no concurrency, no risk
-        of clobbering a still-recording worker.
-
-        Returns:
-            Number of canonical cassettes for which a merge ran (i.e.,
-            had at least one staging file present). Zero when nothing
-            needed sweeping or when ``http-replay`` is not used.
-        """
-        canonical_paths = self._collect_http_replay_canonical_paths()
-        if not canonical_paths:
-            return 0
-
-        # Import here so the dependency on vcrpy / filelock (the
-        # ``[replay]`` extra) only kicks in for courses that actually use
-        # http-replay. Otherwise the module-level import would force the
-        # extra on every install.
-        from clm.core.http_replay_trace import get_writer
-        from clm.workers.notebook.http_replay_cassette import (
-            CassettePaths,
-            merge_staging_into_canonical,
-        )
-
-        _host_writer = get_writer("host")
-        _host_writer.emit(
-            "cassette.sweep.start",
-            {"n_canonical_paths": len(canonical_paths)},
-        )
-
-        swept = 0
-        for canonical in sorted(canonical_paths):
-            staging_glob = f"{canonical.name}.staging-*"
-            if not canonical.parent.is_dir():
-                continue
-            if not any(canonical.parent.glob(staging_glob)):
-                continue
-            # The ``staging`` field is irrelevant for the sweep call —
-            # ``merge_staging_into_canonical`` globs for every staging
-            # file in the canonical's parent dir, including orphans this
-            # worker did not produce. Pass a synthetic name to satisfy
-            # the dataclass.
-            synthetic = canonical.parent / f"{canonical.name}.staging-sweep"
-            try:
-                merged = merge_staging_into_canonical(
-                    CassettePaths(canonical=canonical, staging=synthetic),
-                    sweep_orphans=True,
-                )
-            except Exception as exc:  # noqa: BLE001 — defensive
-                logger.warning(
-                    f"Pre-build orphan staging sweep failed for "
-                    f"'{canonical}' ({type(exc).__name__}: {exc}); "
-                    f"continuing — the worker-side sweep will retry."
-                )
-                continue
-            if merged:
-                logger.info(f"Merged {merged} orphan staging cassette(s) into '{canonical}'.")
-                swept += 1
-        _host_writer.emit(
-            "cassette.sweep.end",
-            {"n_canonical_paths": len(canonical_paths), "swept": swept},
-        )
-        return swept
 
     async def process_stage_for_target(
         self,

--- a/src/clm/infrastructure/http_replay_mitm/addon.py
+++ b/src/clm/infrastructure/http_replay_mitm/addon.py
@@ -231,7 +231,7 @@ class ClmReplayAddon:
 
     The ``.completed`` markers that tell the host merge a staging file is
     safe to fold are written by the **host** in the build's ``finally``
-    (see ``Course.merge_mitmproxy_cassette_staging``) — that is the
+    (see ``cassette_staging.merge_mitmproxy_cassette_staging``) — that is the
     reliable build-completion signal, and mitmproxy's ``done`` hook does
     not fire on a Windows ``CTRL_BREAK`` shutdown. A force-killed build
     never reaches the host marker step, so its staging stays markerless

--- a/src/clm/infrastructure/http_replay_mitm/cassette_format.py
+++ b/src/clm/infrastructure/http_replay_mitm/cassette_format.py
@@ -4,7 +4,7 @@ The mitmproxy addon records and replays at the network layer, but the
 *on-disk* format must stay byte-compatible with the vcrpy v1 YAML
 cassette schema so that committed course cassettes, ``clm cassette
 doctor``, ``strip_cassette_hosts.py`` and
-:func:`clm.workers.notebook.http_replay_cassette.merge_staging_into_canonical`
+:func:`clm.infrastructure.http_replay_mitm.http_replay_cassette.merge_staging_into_canonical`
 keep working unchanged.
 
 The format itself (Request model, YAML (de)serialization, secret filters,
@@ -185,7 +185,7 @@ def vcr_response_dict_from_parts(
 def fingerprint(request: Request) -> tuple[str, str, bytes]:
     """Dedup/replay fingerprint: ``(method, uri, body-bytes)``.
 
-    Matches :func:`clm.workers.notebook.http_replay_cassette._dedup_key`
+    Matches :func:`clm.infrastructure.http_replay_mitm.http_replay_cassette._dedup_key`
     so the addon's in-build dedup and the host-side merge agree on what
     counts as "the same request". (JSON-semantic body matching is P3.)
     """
@@ -412,7 +412,7 @@ def write_cassette(path: Path, interactions: Iterable[Interaction]) -> None:
     """Serialize and atomically write a cassette with LF line endings.
 
     LF-only writes are required (see
-    :func:`clm.workers.notebook.http_replay_cassette._atomic_write_text`):
+    :func:`clm.infrastructure.http_replay_mitm.http_replay_cassette._atomic_write_text`):
     the repo's ``eol=lf`` gitattributes would otherwise flap the cassette
     CRLF↔LF between builds and checkouts and perturb its bytes.
     """

--- a/src/clm/infrastructure/http_replay_mitm/cassette_staging.py
+++ b/src/clm/infrastructure/http_replay_mitm/cassette_staging.py
@@ -1,0 +1,179 @@
+"""Host-side cassette staging maintenance (Phase 8 S3, #802).
+
+The pre-build orphan sweep and the post-build mitmproxy merge, relocated
+from ``Course`` — every live entry point was already CLI-layer (the build's
+pre-stage/finally hooks and watch mode), and the machinery they drive lives
+in this package. Both functions take the canonical cassette paths directly
+(``Course.http_replay_canonical_paths()``), so they carry no course
+dependency.
+"""
+
+import logging
+from collections.abc import Iterable
+from pathlib import Path
+
+from clm.core.http_replay_trace import get_writer
+from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
+    CassettePaths,
+    merge_staging_into_canonical,
+    write_completion_marker,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def merge_mitmproxy_cassette_staging(
+    canonical_paths: Iterable[Path],
+    build_id: str | None = None,
+    *,
+    mode: str | None = None,
+) -> int:
+    """Fold per-target staging files written by the mitmproxy transport.
+
+    The replay proxy (issue #165) records into per-(topic,
+    language,kind) ``<cassette>.staging-mitm-<build_id>`` files beside
+    each canonical cassette. This runs **after** the proxy stops (from
+    the build's ``finally``) to fold them into their canonicals via the
+    shared dedup/merge path.
+
+    Reaching this function *is* the build-completion signal (the build's
+    ``finally`` ran), so for each canonical we write the ``.completed``
+    marker for **this build's** staging file (``build_id``) — the marker
+    is what tells the merge a staging file holds a complete recording
+    session. mitmproxy's ``done`` hook is unreliable on a Windows
+    ``CTRL_BREAK`` shutdown, so the host owns this signal. A force-killed
+    build never reaches here, so its staging stays markerless and is
+    discarded by the next build's pre-build sweep (issue #115).
+
+    ``sweep_orphans=False``: markerless staging (older builds, or a
+    concurrent build still recording) is left untouched. A no-op for
+    builds that did not use the transport.
+
+    ``mode`` is the CLM http-replay mode; ``refresh`` folds with
+    ``overwrite_existing=True`` so a re-recorded interaction supersedes the
+    stale canonical entry (issue #165 P3), matching vcrpy ``all`` semantics.
+
+    Returns the number of staging files folded into canonical.
+    """
+    canonical_set = set(canonical_paths)
+    if not canonical_set:
+        return 0
+
+    overwrite_existing = mode == "refresh"
+    folded = 0
+    for canonical in sorted(canonical_set):
+        if not canonical.parent.is_dir():
+            continue
+        # Mark this build's staging file complete so the merge folds it.
+        if build_id:
+            staging = canonical.parent / f"{canonical.name}.staging-mitm-{build_id}"
+            if staging.is_file():
+                write_completion_marker(CassettePaths(canonical=canonical, staging=staging))
+        if not any(canonical.parent.glob(f"{canonical.name}.staging-*")):
+            continue
+        synthetic = canonical.parent / f"{canonical.name}.staging-mitm-merge"
+        try:
+            merged = merge_staging_into_canonical(
+                CassettePaths(canonical=canonical, staging=synthetic),
+                sweep_orphans=False,
+                overwrite_existing=overwrite_existing,
+                # The replay proxy records a per-request response
+                # *sequence* (a non-deterministic endpoint answers an
+                # identical request differently on successive calls); fold it
+                # order-preserving so a downstream request that embedded the
+                # later response still replay-matches. Only the pre-build
+                # orphan sweep keeps the deduped fold (preserve_sequence
+                # defaults to False there).
+                preserve_sequence=True,
+            )
+        except Exception as exc:  # noqa: BLE001 — never mask the build result
+            logger.warning(
+                f"Post-build mitmproxy cassette merge failed for "
+                f"'{canonical}' ({type(exc).__name__}: {exc})."
+            )
+            continue
+        if merged:
+            logger.info(f"Merged {merged} mitmproxy staging cassette(s) into '{canonical}'.")
+            folded += merged
+    return folded
+
+
+def sweep_orphan_cassette_staging_files(canonical_paths: Iterable[Path]) -> int:
+    """Merge any orphan HTTP-replay staging cassettes into canonical.
+
+    For each *unique* canonical cassette location with at least one
+    ``*.http-cassette.yaml.staging-*`` sibling, invokes
+    :func:`merge_staging_into_canonical` with ``sweep_orphans=True``.
+    That helper takes the cross-process file lock, folds completed
+    sibling stagings (those with a ``.completed`` marker) into
+    canonical and **discards** markerless stagings — partial chains
+    from previously-aborted recording sessions whose chain-closing
+    request never landed on disk (issue #115). Without the discard,
+    a markerless chain-opener with a body that depends on the
+    chain-closer's stored response would poison the canonical
+    cassette permanently (dedup is first-seen-wins).
+
+    Running this *before* payload construction prevents a stale
+    staging file from being enumerated by
+    ``ProcessNotebookOperation.compute_other_files`` and then
+    deleted by a concurrent worker's post-execution merge, which
+    used to surface as a ``FileNotFoundError`` during base64
+    encoding. Defense-in-depth: ``compute_other_files`` also filters
+    ``*.staging-*`` via ``is_ignored_file_for_output`` so a *new*
+    orphan appearing mid-build can't sneak into the payload either.
+
+    The discriminator between "decisive discard" here and
+    "conservative leave-alone" in the post-execution worker sweep
+    is the ``sweep_orphans`` flag: by contract this function runs
+    single-threaded before any worker starts, so every staging file
+    present must be from a previous build — no concurrency, no risk
+    of clobbering a still-recording worker.
+
+    Returns:
+        Number of canonical cassettes for which a merge ran (i.e.,
+        had at least one staging file present). Zero when nothing
+        needed sweeping or when ``http-replay`` is not used.
+    """
+    canonical_set = set(canonical_paths)
+    if not canonical_set:
+        return 0
+
+    _host_writer = get_writer("host")
+    _host_writer.emit(
+        "cassette.sweep.start",
+        {"n_canonical_paths": len(canonical_set)},
+    )
+
+    swept = 0
+    for canonical in sorted(canonical_set):
+        staging_glob = f"{canonical.name}.staging-*"
+        if not canonical.parent.is_dir():
+            continue
+        if not any(canonical.parent.glob(staging_glob)):
+            continue
+        # The ``staging`` field is irrelevant for the sweep call —
+        # ``merge_staging_into_canonical`` globs for every staging
+        # file in the canonical's parent dir, including orphans this
+        # worker did not produce. Pass a synthetic name to satisfy
+        # the dataclass.
+        synthetic = canonical.parent / f"{canonical.name}.staging-sweep"
+        try:
+            merged = merge_staging_into_canonical(
+                CassettePaths(canonical=canonical, staging=synthetic),
+                sweep_orphans=True,
+            )
+        except Exception as exc:  # noqa: BLE001 — defensive
+            logger.warning(
+                f"Pre-build orphan staging sweep failed for "
+                f"'{canonical}' ({type(exc).__name__}: {exc}); "
+                f"continuing — the worker-side sweep will retry."
+            )
+            continue
+        if merged:
+            logger.info(f"Merged {merged} orphan staging cassette(s) into '{canonical}'.")
+            swept += 1
+    _host_writer.emit(
+        "cassette.sweep.end",
+        {"n_canonical_paths": len(canonical_set), "swept": swept},
+    )
+    return swept

--- a/src/clm/infrastructure/http_replay_mitm/http_replay_cassette.py
+++ b/src/clm/infrastructure/http_replay_mitm/http_replay_cassette.py
@@ -13,7 +13,7 @@ addon). This module owns the host-side logic that
 4. manages the per-staging ``.completed`` markers that distinguish a
    finished recording session from a partial chain (issue #115).
 
-The merge runs after the proxy stops (``Course.merge_mitmproxy_cassette_staging``,
+The merge runs after the proxy stops (``cassette_staging.merge_mitmproxy_cassette_staging``,
 called from the build's ``finally``), so it executes even when the build
 raised — the addon's eager per-response writes mean recordings are already
 on disk by the time a failure propagates.
@@ -108,11 +108,11 @@ def merge_staging_into_canonical(
             field is only relevant for naming; the merge globs every
             ``*.staging-*`` sibling of the canonical regardless.
         sweep_orphans: When ``True`` (pre-build invocation from
-            :meth:`clm.core.course.Course._sweep_orphan_cassette_staging_files`),
+            :func:`clm.infrastructure.http_replay_mitm.cassette_staging.sweep_orphan_cassette_staging_files`),
             markerless staging files are treated as confirmed orphans from
             aborted previous builds: their entries are discarded and the
             staging files are deleted. When ``False`` (default — the
-            post-build host merge, ``Course.merge_mitmproxy_cassette_staging``),
+            post-build host merge, ``cassette_staging.merge_mitmproxy_cassette_staging``),
             markerless staging files are left untouched — they may belong
             to a concurrent build that hasn't completed yet.
         overwrite_existing: Mode-aware merge for ``refresh`` (vcrpy ``all``).
@@ -484,7 +484,7 @@ def has_completion_marker(staging: Path) -> bool:
 def write_completion_marker(paths: CassettePaths) -> None:
     """Atomically write the completion marker for one staging file.
 
-    Called by the host from :meth:`Course.merge_mitmproxy_cassette_staging`
+    Called by the host from :func:`~clm.infrastructure.http_replay_mitm.cassette_staging.merge_mitmproxy_cassette_staging`
     in the build's ``finally`` — reaching that step is the signal that the
     build (and the proxy's recording session) completed. The marker tells
     the merge that this staging file is safe to fold into the canonical

--- a/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
+++ b/src/clm/infrastructure/http_replay_mitm/proxy_manager.py
@@ -144,7 +144,7 @@ class MitmproxyManager:
         # Per-build id: the addon names its staging files
         # ``<cassette>.staging-mitm-<build_id>`` so the host can mark
         # exactly this build's recordings complete after the proxy stops
-        # (see ``Course.merge_mitmproxy_cassette_staging``).
+        # (see ``cassette_staging.merge_mitmproxy_cassette_staging``).
         self.build_id = uuid.uuid4().hex
         self._process: subprocess.Popen | None = None
         # Reader thread + bounded ring buffer draining mitmdump stdout so the

--- a/src/clm/workers/notebook/cassette_doctor.py
+++ b/src/clm/workers/notebook/cassette_doctor.py
@@ -365,7 +365,7 @@ def diagnose_cassette(
     )
 
     if fix and orphans:
-        from clm.workers.notebook.http_replay_cassette import _atomic_write_text
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import _atomic_write_text
 
         orphan_indexes = {o.index for o in orphans}
         keep_requests = [r for i, r in enumerate(requests) if i not in orphan_indexes]

--- a/src/clm/workers/notebook/notebook_processor.py
+++ b/src/clm/workers/notebook/notebook_processor.py
@@ -1930,7 +1930,7 @@ class NotebookProcessor:
         notebook's own parent while the tag here resolves against
         ``source_topic_dir``; for a notebook nested in a sub-directory of the
         topic the two diverge, so the proxy would write staging to a dir the
-        host-side merge (``Course.merge_mitmproxy_cassette_staging``) does not
+        host-side merge (``cassette_staging.merge_mitmproxy_cassette_staging``) does not
         scan and a record-mode recording would be misplaced (replay is
         unaffected — it reads the committed canonical). Converging nested
         layouts onto per-notebook cassette dirs is a separate follow-up.
@@ -1947,7 +1947,7 @@ class NotebookProcessor:
             target_dir = source_dir
         else:
             return None
-        from .http_replay_cassette import resolve_canonical_path
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import resolve_canonical_path
 
         return str(resolve_canonical_path(target_dir, cassette_name))
 
@@ -2005,7 +2005,7 @@ class NotebookProcessor:
                 # happen entirely outside the worker — the shared replay
                 # proxy writes per-cassette staging files on the host and
                 # the host build merges them after the proxy stops
-                # (Course.merge_mitmproxy_cassette_staging).
+                # (cassette_staging.merge_mitmproxy_cassette_staging).
                 replay_injected = self._maybe_inject_http_replay(processed_nb, payload, source_dir)
                 try:
                     # To silence warnings about frozen modules...

--- a/tests/cli/test_build_command.py
+++ b/tests/cli/test_build_command.py
@@ -1937,7 +1937,7 @@ class TestProcessCourseInvokesCassetteSweep:
     """Regression for issue #145.
 
     The pre-build orphan staging-cassette sweep
-    (:meth:`Course._sweep_orphan_cassette_staging_files`) was documented
+    (now ``cassette_staging.sweep_orphan_cassette_staging_files``) was documented
     to run before every ``clm build`` but was actually only invoked from
     ``Course.process_all`` / ``Course.process_file``. The ``clm build``
     path goes through ``process_course_with_backend`` →
@@ -1953,10 +1953,10 @@ class TestProcessCourseInvokesCassetteSweep:
         from clm.cli.commands.build import process_course_with_backend
 
         source = inspect.getsource(process_course_with_backend)
-        assert "_sweep_orphan_cassette_staging_files" in source, (
+        assert "sweep_orphan_cassette_staging_files" in source, (
             "process_course_with_backend must invoke "
-            "course._sweep_orphan_cassette_staging_files() before the "
-            "stage loop (issue #145). If this assertion fires, the call "
+            "cassette_staging.sweep_orphan_cassette_staging_files() before "
+            "the stage loop (issue #145). If this assertion fires, the call "
             "was removed or moved out of the build entry path — restore "
             "it or the orphan cleanup stops happening during normal builds."
         )

--- a/tests/core/course_test.py
+++ b/tests/core/course_test.py
@@ -906,8 +906,10 @@ def test_sweep_orphan_staging_files_merges_and_deletes(tmp_path, monkeypatch):
     build's ``compute_other_files`` reaches that orphan before
     ``merge_staging_into_canonical`` does, payload b64 encoding crashes
     with ``FileNotFoundError`` because a concurrent worker may delete
-    the staging file mid-glob. The sweep runs eagerly at ``process_all``
-    start so this race is closed before any payload is built.
+    the staging file mid-glob. The build entry points run the sweep before
+    any processing starts (Phase 8 S3: ``clm build``'s pre-stage hook and
+    watch mode's ``FileEventHandler``), closing the race before any
+    payload is built — mirrored explicitly here.
 
     Markerless orphans (aborted sessions, partial chains) are
     *discarded* by the pre-build sweep (issue #115). That contract is
@@ -956,10 +958,15 @@ def test_sweep_orphan_staging_files_merges_and_deletes(tmp_path, monkeypatch):
     assert orphan_one.exists()
     assert orphan_two.exists()
 
+    from clm.infrastructure.http_replay_mitm.cassette_staging import (
+        sweep_orphan_cassette_staging_files,
+    )
+
+    sweep_orphan_cassette_staging_files(course.http_replay_canonical_paths())
     backend = PytestLocalOpsBackend()
     asyncio.run(course.process_all(backend))
 
-    # Both orphan staging files are gone after process_all completes.
+    # Both orphan staging files are gone after the sweep + process_all.
     assert not orphan_one.exists()
     assert not orphan_two.exists()
 
@@ -973,10 +980,11 @@ def test_sweep_orphan_staging_files_merges_and_deletes(tmp_path, monkeypatch):
 def test_sweep_orphan_staging_files_no_replay_topics(tmp_path):
     """A course without ``http-replay`` topics doesn't touch any cassettes.
 
-    Defensive — the sweep runs unconditionally inside ``process_all`` so
-    we make sure it short-circuits cleanly (and never imports
-    ``vcrpy``/``filelock``) when no topic opted in. This also exercises
-    that the sweep does not crash on a course with no notebooks at all.
+    Defensive — the entry points run the sweep unconditionally before
+    processing, so we make sure it short-circuits cleanly (and never
+    imports ``vcrpy``/``filelock``) when no topic opted in. This also
+    exercises that the sweep does not crash on a course with no notebooks
+    at all.
     """
     import asyncio
 
@@ -991,9 +999,11 @@ def test_sweep_orphan_staging_files_no_replay_topics(tmp_path):
     """
     course = _build_course(tmp_path, sections_xml)
 
-    # Sweep is a method so we can call it directly without spinning up
-    # the full process_all pipeline.
-    swept = course._sweep_orphan_cassette_staging_files()
+    from clm.infrastructure.http_replay_mitm.cassette_staging import (
+        sweep_orphan_cassette_staging_files,
+    )
+
+    swept = sweep_orphan_cassette_staging_files(course.http_replay_canonical_paths())
     assert swept == 0
 
     # Full process_all also runs without raising.
@@ -1017,7 +1027,11 @@ def test_sweep_orphan_staging_files_no_orphans_present(tmp_path):
     """
     course = _build_course(tmp_path, sections_xml)
 
-    swept = course._sweep_orphan_cassette_staging_files()
+    from clm.infrastructure.http_replay_mitm.cassette_staging import (
+        sweep_orphan_cassette_staging_files,
+    )
+
+    swept = sweep_orphan_cassette_staging_files(course.http_replay_canonical_paths())
     assert swept == 0
 
 
@@ -1026,7 +1040,7 @@ def test_merge_mitmproxy_cassette_staging_folds_markered_leaves_markerless(tmp_p
 
     The out-of-process transport (issue #165 P2) writes per-cassette
     ``*.staging-mitm-*`` files beside each canonical with a ``.completed``
-    marker on clean shutdown. ``Course.merge_mitmproxy_cassette_staging``
+    marker on clean shutdown. ``cassette_staging.merge_mitmproxy_cassette_staging``
     folds the markered ones (build finished cleanly) and leaves markerless
     ones (mitmdump force-killed) for the next pre-build sweep to discard —
     the same partial-recording protection the vcrpy workers get.
@@ -1055,7 +1069,11 @@ def test_merge_mitmproxy_cassette_staging_folds_markered_leaves_markerless(tmp_p
     """
     course = _build_course(tmp_path, sections_xml)
 
-    folded = course.merge_mitmproxy_cassette_staging()
+    from clm.infrastructure.http_replay_mitm.cassette_staging import (
+        merge_mitmproxy_cassette_staging,
+    )
+
+    folded = merge_mitmproxy_cassette_staging(course.http_replay_canonical_paths())
 
     assert folded == 1
     assert canonical.exists()
@@ -1080,7 +1098,11 @@ def test_merge_mitmproxy_cassette_staging_no_replay_topics(tmp_path):
     </sections>
     """
     course = _build_course(tmp_path, sections_xml)
-    assert course.merge_mitmproxy_cassette_staging() == 0
+    from clm.infrastructure.http_replay_mitm.cassette_staging import (
+        merge_mitmproxy_cassette_staging,
+    )
+
+    assert merge_mitmproxy_cassette_staging(course.http_replay_canonical_paths()) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/infrastructure/test_http_replay_cassette.py
+++ b/tests/infrastructure/test_http_replay_cassette.py
@@ -11,7 +11,7 @@ import io
 
 import pytest
 
-from clm.workers.notebook.http_replay_cassette import (
+from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
     CassettePaths,
     _body_to_dedup_bytes,
     _dedup_key,

--- a/tests/infrastructure/test_http_replay_mitm.py
+++ b/tests/infrastructure/test_http_replay_mitm.py
@@ -377,7 +377,7 @@ def test_routing_demuxes_tagged_requests_to_per_cassette_staging(
     # the staging into its canonical (issue #165 P2). Drive that real merge
     # path against the proxy-written staging and assert the interaction lands
     # in the canonical cassette.
-    from clm.workers.notebook.http_replay_cassette import (
+    from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
         CassettePaths,
         merge_staging_into_canonical,
         write_completion_marker,
@@ -420,7 +420,7 @@ def test_once_mode_starts_without_existing_catchall(
 def _fold_staging_to_canonical(canonical: Path, staging: Path) -> None:
     """Drive the real host marker+merge so the recorded staging lands in the
     canonical cassette (what a subsequent replay-mode proxy loads from)."""
-    from clm.workers.notebook.http_replay_cassette import (
+    from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
         CassettePaths,
         merge_staging_into_canonical,
         write_completion_marker,

--- a/tests/infrastructure/test_http_replay_mitm_cassette_format.py
+++ b/tests/infrastructure/test_http_replay_mitm_cassette_format.py
@@ -378,7 +378,7 @@ def test_filter_constants_and_matchers_are_pinned():
 
 def test_merge_helper_loads_bridge_cassette(tmp_path):
     """The host-side merge must consume a bridge-written cassette unchanged."""
-    from clm.workers.notebook.http_replay_cassette import (
+    from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
         CassettePaths,
         merge_staging_into_canonical,
         write_completion_marker,

--- a/tests/infrastructure/test_http_replay_vcr_format_security.py
+++ b/tests/infrastructure/test_http_replay_vcr_format_security.py
@@ -72,7 +72,7 @@ def test_python_object_tag_does_not_execute_via_load_cassette(monkeypatch, tmp_p
     """Same guarantee through the public file-loading entry point.
 
     ``load_cassette`` is what ``clm build`` actually calls (via
-    ``Course.merge_mitmproxy_cassette_staging``), so the guarantee has to hold
+    ``cassette_staging.merge_mitmproxy_cassette_staging``), so the guarantee has to hold
     here and not only on the string-level helper.
     """
     module = sys.modules[__name__]

--- a/tests/test_architecture_contracts.py
+++ b/tests/test_architecture_contracts.py
@@ -102,16 +102,17 @@ def _current_violations() -> set[str]:
 #: manifest, diagram-tool locators, C++ analysis/emission) → 19 edges over
 #: 17 files. S2 descended the contract seam (Operation hierarchy, Backend
 #: ABC, the messaging/payload package, File, copy-data, build_data_classes,
-#: build_profiling) into clm.core → 5 edges over 4 files: the worker-image
-#: identity reads (S4), the payload-time voiceover merge (S5), and the
-#: cassette staging methods on Course (S3).
+#: build_profiling) into clm.core → 5 edges over 4 files. S3 relocated the
+#: cassette staging maintenance off Course into
+#: infrastructure.http_replay_mitm.cassette_staging (sweeping is the entry
+#: points' job now) → 4 edges over 3 files: the worker-image identity reads
+#: (S4) and the payload-time voiceover merge (S5).
 KNOWN_LAYER_VIOLATIONS = frozenset(
     {
         "core -> infrastructure: core/operations/convert_drawio_file.py",
         "core -> infrastructure: core/operations/convert_plantuml_file.py",
         "core -> infrastructure: core/operations/process_notebook.py",
         "core -> slides: core/operations/process_notebook.py",
-        "core -> workers: core/course.py",
     }
 )
 

--- a/tests/workers/notebook/test_notebook_processor.py
+++ b/tests/workers/notebook/test_notebook_processor.py
@@ -2289,7 +2289,7 @@ class TestCassetteMerge:
     def test_merge_creates_canonical_when_only_staging_exists(self, tmp_path):
         pytest.importorskip("filelock")  # merge path needs the [replay] extra
         pytest.importorskip("filelock")
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             merge_staging_into_canonical,
         )
@@ -2311,7 +2311,7 @@ class TestCassetteMerge:
     def test_merge_is_noop_with_no_staging_files(self, tmp_path):
         pytest.importorskip("filelock")  # merge path needs the [replay] extra
         pytest.importorskip("filelock")
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             merge_staging_into_canonical,
         )
@@ -2330,7 +2330,7 @@ class TestCassetteMerge:
         """Staging files from previously-killed workers must be absorbed too."""
         pytest.importorskip("filelock")  # merge path needs the [replay] extra
         pytest.importorskip("filelock")
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             merge_staging_into_canonical,
         )
@@ -2363,7 +2363,7 @@ class TestCassetteMerge:
         """An interaction already present in canonical must not be appended twice."""
         pytest.importorskip("filelock")  # merge path needs the [replay] extra
         pytest.importorskip("filelock")
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             merge_staging_into_canonical,
         )
@@ -2385,7 +2385,7 @@ class TestCassetteMerge:
     def test_merge_appends_new_interactions_to_existing_canonical(self, tmp_path):
         pytest.importorskip("filelock")  # merge path needs the [replay] extra
         pytest.importorskip("filelock")
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             merge_staging_into_canonical,
         )
@@ -2414,7 +2414,7 @@ class TestCassetteMerge:
         """
         pytest.importorskip("filelock")  # merge path needs the [replay] extra
         pytest.importorskip("filelock")
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             merge_staging_into_canonical,
         )
@@ -2440,7 +2440,7 @@ class TestCassetteMerge:
         pytest.importorskip("filelock")
         import threading
 
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             merge_staging_into_canonical,
         )
@@ -2493,7 +2493,7 @@ class TestCompletionMarker:
     """
 
     def test_marker_path_sits_beside_staging(self, tmp_path):
-        from clm.workers.notebook.http_replay_cassette import marker_path
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import marker_path
 
         staging = tmp_path / "_cassettes" / "slides.http-cassette.yaml.staging-abc"
         expected = tmp_path / "_cassettes" / "slides.http-cassette.yaml.staging-abc.completed"
@@ -2501,7 +2501,7 @@ class TestCompletionMarker:
         assert marker_path(staging) == expected
 
     def test_has_completion_marker_false_when_absent(self, tmp_path):
-        from clm.workers.notebook.http_replay_cassette import has_completion_marker
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import has_completion_marker
 
         staging = tmp_path / "slides.http-cassette.yaml.staging-xyz"
         # Staging file doesn't even exist — marker still reports False.
@@ -2512,7 +2512,7 @@ class TestCompletionMarker:
         assert has_completion_marker(staging) is False
 
     def test_has_completion_marker_true_when_present(self, tmp_path):
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             has_completion_marker,
             marker_path,
         )
@@ -2524,7 +2524,7 @@ class TestCompletionMarker:
         assert has_completion_marker(staging) is True
 
     def test_write_completion_marker_creates_file(self, tmp_path):
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             has_completion_marker,
             marker_path,
@@ -2542,7 +2542,7 @@ class TestCompletionMarker:
         assert has_completion_marker(staging) is True
 
     def test_write_completion_marker_payload_is_valid_json_with_iso_timestamp(self, tmp_path):
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             marker_path,
             write_completion_marker,
@@ -2567,7 +2567,7 @@ class TestCompletionMarker:
         assert abs(delta.total_seconds()) < 60
 
     def test_write_completion_marker_is_idempotent(self, tmp_path):
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             marker_path,
             write_completion_marker,
@@ -2626,7 +2626,7 @@ class TestDiscriminatingMerge:
         """Default per-worker merge folds markered staging into canonical."""
         pytest.importorskip("filelock")  # merge path needs the [replay] extra
         pytest.importorskip("filelock")
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             marker_path,
             merge_staging_into_canonical,
@@ -2659,7 +2659,7 @@ class TestDiscriminatingMerge:
         """
         pytest.importorskip("filelock")  # merge path needs the [replay] extra
         pytest.importorskip("filelock")
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             merge_staging_into_canonical,
         )
@@ -2691,7 +2691,7 @@ class TestDiscriminatingMerge:
         """
         pytest.importorskip("filelock")  # merge path needs the [replay] extra
         pytest.importorskip("filelock")
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             merge_staging_into_canonical,
         )
@@ -2718,7 +2718,7 @@ class TestDiscriminatingMerge:
         """Folded markered staging cleans up both the staging file and the marker."""
         pytest.importorskip("filelock")  # merge path needs the [replay] extra
         pytest.importorskip("filelock")
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             marker_path,
             merge_staging_into_canonical,
@@ -2755,7 +2755,7 @@ class TestDiscriminatingMerge:
         """
         pytest.importorskip("filelock")  # merge path needs the [replay] extra
         pytest.importorskip("filelock")
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             marker_path,
             merge_staging_into_canonical,
@@ -2877,7 +2877,7 @@ class TestIssue115PartialChainRegression:
         """
         pytest.importorskip("filelock")  # merge path needs the [replay] extra
         pytest.importorskip("filelock")
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             marker_path,
             merge_staging_into_canonical,
@@ -2966,7 +2966,7 @@ class TestIssue115PartialChainRegression:
         """
         pytest.importorskip("filelock")  # merge path needs the [replay] extra
         pytest.importorskip("filelock")
-        from clm.workers.notebook.http_replay_cassette import (
+        from clm.infrastructure.http_replay_mitm.http_replay_cassette import (
             CassettePaths,
             marker_path,
             merge_staging_into_canonical,


### PR DESCRIPTION
## Summary

Third step of the approved A1/A3 design (`docs/claude/design/phase8-a1-a3-core-decoupling.md`). Refs #802 — S4–S6 remain.

The HTTP-replay cassette staging maintenance was `Course`'s only reason to import `clm.workers`; every live entry point was already CLI-layer (the design's evidence pass: `build.py`'s pre-stage/finally hooks and watch mode; `Course.process_all` has no `src/` caller at all).

- `workers/notebook/http_replay_cassette.py` → `infrastructure/http_replay_mitm/http_replay_cassette.py` — its dependencies were already downward-only (`vcr_format` + the dependency-free trace leaf); worker-side importers (`notebook_processor`, `cassette_doctor`) now import downward, which is legal.
- The two `Course` methods become functions in `infrastructure/http_replay_mitm/cassette_staging.py` (bodies verbatim), fed by the new **public** `Course.http_replay_canonical_paths()` — so the module carries no course dependency.
- **Sweeping is the entry points' job now**: `clm build` sweeps in its pre-stage hook (as before, but via the new function — this also removes the `course._sweep_orphan…` private-symbol cross-call, an A9 offender), and watch mode sweeps in `FileEventHandler` before `process_file`. `Course.process_file`/`process_all` no longer sweep for themselves; both carry NOTE comments pointing at the contract.
- The issue-#145 source-text pin in `test_build_command` retargets to the new call; the five cassette tests in `course_test.py` exercise the relocated functions through `http_replay_canonical_paths()`.

## Ratchet

`KNOWN_LAYER_VIOLATIONS` shrinks **5 → 4 edges (4 → 3 files)**: `core -> workers: core/course.py` is gone — `course.py` is now fully clean. Remaining: the S4 identity reads (`convert_drawio`, `convert_plantuml`, `process_notebook`) and the S5 voiceover merge.

## Testing

- Fast suite: 9518 passed
- Golden characterization suite: 2 passed — byte-identical
- mypy clean (410 files); ruff clean
- Coverage floors: all six green (checked locally after the #809 floor lesson)

No CLI/spec behavior change → no info-topic update. Changelog fragment + handover status included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh