### PR TITLE
refactor(layering): Phase 8 S4 — worker-identity inversion

### DIFF
--- a/changelog.d/802-s4-worker-identity-inversion.changed.md
+++ b/changelog.d/802-s4-worker-identity-inversion.changed.md
@@ -1,0 +1,7 @@
+- **Internal re-layering (Phase 8 step S4 of the A1/A3 plan, refs #802)**: the
+  effective worker-image identity registry moved to `clm.core.worker_identity`;
+  `clm.infrastructure.workers.image_identity` keeps all fingerprinting, records
+  identities into the core registry, and registers the singleton-config
+  resolver as the registry's fallback provider (eagerly at its own import and
+  lazily via `clm.infrastructure.__init__`). Payload builders read the registry
+  through core only. Cache-key behavior unchanged.

--- a/docs/claude/handovers/adversarial-review-remediation-handover.md
+++ b/docs/claude/handovers/adversarial-review-remediation-handover.md
@@ -1230,8 +1230,19 @@ one PR per step, golden suite green after each.
    (functions take `Course.http_replay_canonical_paths()`; sweeping is the
    entry points' job — build pre-stage hook + watch-mode FileEventHandler);
    `http_replay_cassette` moved workers → infrastructure. Ratchet 5 → 4
-   edges over 3 files. Remaining: S4 (identity inversion), S5 (slide-text
-   cone), S6 (import-linter).
+   edges over 3 files. **S4 DONE 2026-08-06** — worker-image identity
+   inverted through the `clm.core.worker_identity` registry;
+   infrastructure records identities and registers the singleton fallback
+   provider (eager at image_identity import + lazy via
+   `clm.infrastructure.__init__`). Ratchet 4 → 1 edge:
+   `core -> slides: core/operations/process_notebook.py` — S5's
+   slide-text-cone descent (maintainer-approved) is all that remains
+   before S6 (import-linter). LANDMINE learned on #809: the Phase 7
+   coverage-floor list (`scripts/check_coverage_floor.py`) keys by path
+   suffix and runs only in CI's unit job — move the floor entry in the
+   same commit as any floored file, and check floors locally via
+   `pytest -m "not slow and not integration and not e2e and not docker"
+   --cov=src/clm --cov-report=xml` + the script.
 4. **A11 — import-linter contract in CI.** Add it as soon as the first contract
    is true, not at the end — each subsequent step then cannot regress.
 5. **A4 — extract build orchestration** from `cli/commands/build.py` (2694 lines;

--- a/src/clm/core/operations/convert_drawio_file.py
+++ b/src/clm/core/operations/convert_drawio_file.py
@@ -5,6 +5,7 @@ from attrs import frozen
 from clm.core.messaging.correlation_ids import new_correlation_id, note_correlation_id_dependency
 from clm.core.messaging.drawio_classes import DrawioPayload
 from clm.core.operations.convert_source_output_file import ConvertSourceOutputFileOperation
+from clm.core.worker_identity import effective_worker_image_identity
 
 logger = logging.getLogger(__name__)
 
@@ -21,10 +22,6 @@ class ConvertDrawIoFileOperation(ConvertSourceOutputFileOperation):
     async def payload(self) -> DrawioPayload:
         data = self.input_file.source_path.read_text(encoding="utf-8")
         correlation_id = await new_correlation_id()
-        from clm.infrastructure.workers.image_identity import (
-            effective_worker_image_identity,
-        )
-
         payload = DrawioPayload(
             data=data,
             correlation_id=correlation_id,

--- a/src/clm/core/operations/convert_plantuml_file.py
+++ b/src/clm/core/operations/convert_plantuml_file.py
@@ -5,6 +5,7 @@ from attrs import frozen
 from clm.core.messaging.correlation_ids import new_correlation_id, note_correlation_id_dependency
 from clm.core.messaging.plantuml_classes import PlantUmlPayload
 from clm.core.operations.convert_source_output_file import ConvertSourceOutputFileOperation
+from clm.core.worker_identity import effective_worker_image_identity
 
 logger = logging.getLogger(__name__)
 
@@ -21,10 +22,6 @@ class ConvertPlantUmlFileOperation(ConvertSourceOutputFileOperation):
     async def payload(self) -> PlantUmlPayload:
         data = self.input_file.source_path.read_text(encoding="utf-8")
         correlation_id = await new_correlation_id()
-        from clm.infrastructure.workers.image_identity import (
-            effective_worker_image_identity,
-        )
-
         payload = PlantUmlPayload(
             data=data,
             correlation_id=correlation_id,

--- a/src/clm/core/operations/process_notebook.py
+++ b/src/clm/core/operations/process_notebook.py
@@ -22,13 +22,7 @@ from clm.core.utils.path_utils import (
     output_path_for,
     relative_path_to_course_img,
 )
-
-# Re-exported for existing callers/tests; the canonical home is the
-# infrastructure module so the diagram operations and the build's
-# effective-identity registry share one implementation (issue #744).
-from clm.infrastructure.workers.image_identity import (
-    worker_image_identity_for,  # noqa: F401
-)
+from clm.core.worker_identity import effective_worker_image_identity
 
 logger = logging.getLogger(__name__)
 
@@ -119,15 +113,14 @@ def compute_worker_image_identity() -> str:
     under one image must not be replayed under another (issue #321 class 5,
     the xeus-cling → xeus-cpp incident).
 
-    Since #744 this resolves through
-    :mod:`clm.infrastructure.workers.image_identity`, so a build's CLI
+    Since #744 this resolves through the effective-identity registry
+    (:mod:`clm.core.worker_identity` since Phase 8 S4; infrastructure
+    records into it and provides the singleton fallback), so a build's CLI
     image override (``--notebook-image``) is visible to the cache key —
     previously the singleton config was read and the override was not.
-    See that module for the mutable-tag limitation and the defensive
+    See the registry for the mutable-tag limitation and the defensive
     empty-identity contract.
     """
-    from clm.infrastructure.workers.image_identity import effective_worker_image_identity
-
     return effective_worker_image_identity("notebook")
 
 

--- a/src/clm/core/worker_identity.py
+++ b/src/clm/core/worker_identity.py
@@ -1,0 +1,88 @@
+"""Effective worker-image identity registry (Phase 8 S4, #802).
+
+Core operations stamp the execution-environment identity into worker
+payloads at build time — it is a cache-key component (issues #321/#744).
+But *computing* an identity is infrastructure work: Docker image
+resolution and direct-mode binary fingerprinting over the config
+singleton. This module holds only the seam between the two:
+
+- ``clm build`` / ``clm cache explain`` record the post-override
+  identities via :mod:`clm.infrastructure.workers.image_identity`, which
+  writes them here;
+- that same infrastructure module registers itself as the **fallback
+  provider** (both at its own import and lazily via
+  ``clm.infrastructure.__init__``), so callers outside a build (tests,
+  tools) still resolve the singleton-config identity exactly as before
+  #802/S4;
+- core reads via :func:`effective_worker_image_identity` and never
+  imports upward.
+
+With neither a recording nor a provider (a bare-core process that never
+touched infrastructure), the accessor degrades to identity-less keying
+(``""``) — the same defensive contract the resolver already had for
+unreadable worker config.
+"""
+
+import logging
+from collections.abc import Callable, Mapping
+
+logger = logging.getLogger(__name__)
+
+#: Post-override identity per worker type, recorded by ``clm build`` (and
+#: ``clm cache explain``) through the infrastructure resolver.
+_effective: dict[str, str] = {}
+
+_fallback_provider: Callable[[str], str] | None = None
+
+
+def set_effective_worker_identities(identities: Mapping[str, str]) -> None:
+    """Wholesale-replace the recorded identities (one build, one set)."""
+    _effective.clear()
+    _effective.update(identities)
+    logger.debug(f"Effective worker image identities: {_effective}")
+
+
+def reset_effective_worker_identities() -> None:
+    """Drop recorded identities (tests) — accessors fall back to the provider."""
+    _effective.clear()
+
+
+def register_fallback_provider(provider: Callable[[str], str]) -> None:
+    """Install the resolver used when no identity was recorded.
+
+    Called by infrastructure at import time; last registration wins
+    (idempotent in practice — both registration paths install the same
+    singleton-config resolver).
+    """
+    global _fallback_provider
+    _fallback_provider = provider
+
+
+def effective_worker_image_identity(worker_type: str) -> str:
+    """Identity of the environment ``worker_type`` jobs will run in.
+
+    Computed HOST-side at payload construction and folded into the cache
+    keys. Prefers the identities a build recorded via
+    :func:`set_effective_worker_identities`; falls back to the registered
+    provider (the singleton-config resolver) otherwise.
+
+    Limitation: this is the configured image *reference*, not a content
+    digest — a mutable tag (``:latest``) re-pulled to a new image does NOT
+    change the key; pin worker images to versioned tags or digests for the
+    invalidation to be exact.
+
+    Defensive ``""`` when nothing is recorded and no provider is
+    registered: a payload must never fail to build; an empty identity
+    merely reverts that build to identity-less keying for this component.
+    """
+    recorded = _effective.get(worker_type)
+    if recorded is not None:
+        return recorded
+    if _fallback_provider is None:
+        logger.warning(
+            f"No worker-identity provider registered (worker_type={worker_type!r}); "
+            f"using identity-less cache keying. Import clm.infrastructure to "
+            f"register the singleton-config resolver."
+        )
+        return ""
+    return _fallback_provider(worker_type)

--- a/src/clm/infrastructure/__init__.py
+++ b/src/clm/infrastructure/__init__.py
@@ -21,6 +21,30 @@ _LAZY_EXPORTS = {
     "Operation": ("clm.core.operation", "Operation"),
 }
 
+
+def _worker_identity_singleton_fallback(worker_type: str) -> str:
+    """Lazy-bodied fallback provider for the core identity registry (S4).
+
+    Registered at package import so ANY ``clm.infrastructure.*`` import
+    wires the singleton-config resolver into
+    :mod:`clm.core.worker_identity`. The body defers the (heavy) worker
+    package import until a payload is actually built outside a
+    build/cache-explain context — the same import cost the pre-S4 lazy
+    imports in the core operations paid.
+    """
+    from clm.infrastructure.workers.image_identity import singleton_worker_image_identity
+
+    return singleton_worker_image_identity(worker_type)
+
+
+def _register_worker_identity_fallback() -> None:
+    from clm.core.worker_identity import register_fallback_provider
+
+    register_fallback_provider(_worker_identity_singleton_fallback)
+
+
+_register_worker_identity_fallback()
+
 __all__ = [
     "Backend",
     "Operation",

--- a/src/clm/infrastructure/workers/image_identity.py
+++ b/src/clm/infrastructure/workers/image_identity.py
@@ -11,10 +11,13 @@ The cache key must describe the environment that actually executes a job
 - **Diagram payloads had no image component at all** — a rebuilt converter
   image replayed the old image's bytes for every unchanged source.
 
-``clm build`` records the post-override identities here
-(:func:`set_effective_worker_identities`); the per-type accessor falls back
-to the global singleton for callers outside a build (tests, tools), which
-matches the pre-#744 behavior when no override exists.
+``clm build`` records the post-override identities via
+:func:`set_effective_worker_identities`, which writes them into the core
+registry (:mod:`clm.core.worker_identity` — Phase 8 S4: core reads the
+registry, never this module). The singleton-config resolver here is
+registered as the registry's fallback provider, which matches the
+pre-#744 behavior for callers outside a build (tests, tools) when no
+override exists.
 """
 
 from __future__ import annotations
@@ -22,15 +25,20 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from clm.core.worker_identity import register_fallback_provider
+from clm.core.worker_identity import (
+    reset_effective_worker_identities as _core_reset,
+)
+from clm.core.worker_identity import (
+    set_effective_worker_identities as _core_set,
+)
+
 if TYPE_CHECKING:
     from clm.infrastructure.config import WorkersManagementConfig
 
 logger = logging.getLogger(__name__)
 
 _WORKER_TYPES = ("notebook", "plantuml", "drawio")
-
-#: Post-override identity per worker type, recorded by ``clm build``.
-_effective: dict[str, str] = {}
 
 
 def worker_image_identity_for(
@@ -118,42 +126,36 @@ def set_effective_worker_identities(worker_config: WorkersManagementConfig) -> N
     Called by ``clm build`` right after ``load_worker_config`` resolved the
     CLI overrides into its config copy — from here on the cache keys see
     the images that will actually execute, not the singleton's view.
-    Wholesale replacement: one build, one set of identities.
+    Wholesale replacement: one build, one set of identities. Written into
+    the core registry (:mod:`clm.core.worker_identity`), where the payload
+    builders read it.
     """
+    identities = {}
     for worker_type in _WORKER_TYPES:
         type_config = getattr(worker_config, worker_type)
         execution_mode = type_config.execution_mode or worker_config.default_execution_mode
-        _effective[worker_type] = worker_image_identity_for(
+        identities[worker_type] = worker_image_identity_for(
             execution_mode, type_config.image, worker_type
         )
-    logger.debug(f"Effective worker image identities: {_effective}")
+    _core_set(identities)
 
 
 def reset_effective_worker_identities() -> None:
     """Drop recorded identities (tests) — accessors fall back to the singleton."""
-    _effective.clear()
+    _core_reset()
 
 
-def effective_worker_image_identity(worker_type: str) -> str:
-    """Identity of the environment ``worker_type`` jobs will run in.
+def singleton_worker_image_identity(worker_type: str) -> str:
+    """Resolve ``worker_type``'s identity from the global config singleton.
 
-    Computed HOST-side at payload construction and folded into the cache
-    keys. Prefers the identities a build recorded via
-    :func:`set_effective_worker_identities`; falls back to the global
-    config singleton otherwise.
-
-    Limitation: this is the configured image *reference*, not a content
-    digest — a mutable tag (``:latest``) re-pulled to a new image does NOT
-    change the key; pin worker images to versioned tags or digests for the
-    invalidation to be exact.
+    The registry's fallback provider (registered below, and lazily by
+    ``clm.infrastructure.__init__``): used by payload builders outside a
+    build, where nothing recorded post-override identities.
 
     Defensive ``""`` on any config error: a payload must never fail to
     build because worker config is unreadable; an empty identity merely
     reverts that build to identity-less keying for this component.
     """
-    recorded = _effective.get(worker_type)
-    if recorded is not None:
-        return recorded
     try:
         from clm.infrastructure.config import get_config
 
@@ -164,3 +166,6 @@ def effective_worker_image_identity(worker_type: str) -> str:
     except Exception as exc:  # pragma: no cover - defensive
         logger.warning(f"Could not resolve worker image identity for cache key: {exc}")
         return ""
+
+
+register_fallback_provider(singleton_worker_image_identity)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,11 +231,11 @@ def _reset_effective_worker_identities():
     a module-level registry; any test driving it (build-command tests, the
     config-loader tests) would otherwise leak the recording process-wide
     and change what later tests observe from the singleton-fallback path —
-    same reasoning as ``_isolate_db_path_env``.
+    same reasoning as ``_isolate_db_path_env``. The registry lives in core
+    since Phase 8 S4 (#802); resetting it does not touch the registered
+    fallback provider.
     """
-    from clm.infrastructure.workers.image_identity import (
-        reset_effective_worker_identities,
-    )
+    from clm.core.worker_identity import reset_effective_worker_identities
 
     reset_effective_worker_identities()
     yield

--- a/tests/core/operations/test_process_notebook.py
+++ b/tests/core/operations/test_process_notebook.py
@@ -11,8 +11,8 @@ from clm.core.operations.process_notebook import (
     _hash_template_dir,
     compute_template_fingerprint,
     compute_worker_image_identity,
-    worker_image_identity_for,
 )
+from clm.infrastructure.workers.image_identity import worker_image_identity_for
 
 
 class TestComputeTemplateFingerprint:
@@ -135,11 +135,11 @@ class TestWorkerImageIdentity:
         """#744 hole (b): the CLI override lives only in the config COPY —
         the identity must prefer what the build recorded over the
         singleton's stale view."""
-        from clm.infrastructure.workers import image_identity as ii
+        from clm.core import worker_identity as wi
 
-        ii.reset_effective_worker_identities()
+        wi.reset_effective_worker_identities()
         try:
-            ii._effective["notebook"] = "docker:ghcr.io/me/override:1"
+            wi.set_effective_worker_identities({"notebook": "docker:ghcr.io/me/override:1"})
             assert compute_worker_image_identity() == "docker:ghcr.io/me/override:1"
         finally:
-            ii.reset_effective_worker_identities()
+            wi.reset_effective_worker_identities()

--- a/tests/infrastructure/workers/test_image_identity.py
+++ b/tests/infrastructure/workers/test_image_identity.py
@@ -4,9 +4,9 @@ import pytest
 
 from clm.core.messaging.drawio_classes import DrawioPayload
 from clm.core.messaging.plantuml_classes import PlantUmlPayload
+from clm.core.worker_identity import effective_worker_image_identity
 from clm.infrastructure.config import DEFAULT_WORKER_IMAGES
 from clm.infrastructure.workers.image_identity import (
-    effective_worker_image_identity,
     reset_effective_worker_identities,
     set_effective_worker_identities,
     worker_image_identity_for,

--- a/tests/test_architecture_contracts.py
+++ b/tests/test_architecture_contracts.py
@@ -105,13 +105,12 @@ def _current_violations() -> set[str]:
 #: build_profiling) into clm.core → 5 edges over 4 files. S3 relocated the
 #: cassette staging maintenance off Course into
 #: infrastructure.http_replay_mitm.cassette_staging (sweeping is the entry
-#: points' job now) → 4 edges over 3 files: the worker-image identity reads
-#: (S4) and the payload-time voiceover merge (S5).
+#: points' job now) → 4 edges over 3 files. S4 inverted the worker-image
+#: identity reads through the clm.core.worker_identity registry
+#: (infrastructure records + provides the singleton fallback) → 1 edge
+#: over 1 file: the payload-time voiceover merge, S5.
 KNOWN_LAYER_VIOLATIONS = frozenset(
     {
-        "core -> infrastructure: core/operations/convert_drawio_file.py",
-        "core -> infrastructure: core/operations/convert_plantuml_file.py",
-        "core -> infrastructure: core/operations/process_notebook.py",
         "core -> slides: core/operations/process_notebook.py",
     }
 )


### PR DESCRIPTION
## Summary

Fourth step of the approved A1/A3 design (`docs/claude/design/phase8-a1-a3-core-decoupling.md`). Refs #802 — S5 and S6 remain.

The one genuine dependency inversion in the plan: core operations must stamp the execution-environment identity into payloads (cache-key component, #321/#744), but computing it is infrastructure work (Docker image resolution, binary fingerprinting over the config singleton).

- New `clm.core.worker_identity`: the registry — `set/reset_effective_worker_identities`, `register_fallback_provider`, `effective_worker_image_identity`.
- `clm.infrastructure.workers.image_identity` keeps ALL fingerprinting; its writers forward to the core registry; its singleton-config resolver (`singleton_worker_image_identity`, body byte-identical to the old accessor's fallback) registers as the provider — **eagerly** at its own import and **lazily** via `clm.infrastructure.__init__`, so any infrastructure import wires it. The lazy body defers the heavy worker-package import exactly as the pre-S4 lazy imports did.
- Payload builders (`process_notebook`, `convert_drawio_file`, `convert_plantuml_file`) read through core only, module-level. The `worker_image_identity_for` re-export on `process_notebook` is gone (its one consumer was a test, now importing the infrastructure module directly).
- Behavior unchanged on every live path: `clm build` and `clm cache explain` both record identities before payload construction (`build.py:975`, `cache.py:375`); a bare-core process that never touches infrastructure degrades to identity-less keying (`""`) with a warning — the same defensive contract the resolver already had for unreadable config.

## Ratchet

`KNOWN_LAYER_VIOLATIONS` shrinks **4 → 1 edge**: the three identity reads are gone. The sole survivor is `core -> slides: core/operations/process_notebook.py` — the payload-time voiceover merge, which is S5 (the maintainer-approved slide-text-cone descent).

## Testing

- Fast suite: 9518 passed
- Golden characterization suite: 2 passed — byte-identical
- mypy clean (411 files); ruff clean
- Coverage floors: no floored file touched
- The hermetic-reset conftest fixture now targets the core registry; `test_effective_registry_overrides_the_singleton` uses the public setter instead of poking `_effective`

No CLI/spec behavior change → no info-topic update. Changelog fragment + handover status (including the #809 coverage-floor landmine note) included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GCpW1p5tMRY8vrCifj2WKh